### PR TITLE
Skip libbeat logstash output tests until Logstash ES output plugin is updated

### DIFF
--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -373,6 +373,7 @@ func TestSendMultipleSmallBatchesViaLogstashTCP(t *testing.T) {
 }
 
 func TestSendMultipleSmallBatchesViaLogstashTLS(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleSmallBatchesViaLogstash(t, "multiple-small-tls", true)
 }
 
@@ -433,6 +434,7 @@ func TestLogstashElasticOutputPluginCompatibleMessageTCP(t *testing.T) {
 }
 
 func TestLogstashElasticOutputPluginCompatibleMessageTLS(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testLogstashElasticOutputPluginCompatibleMessage(t, "cmp-tls", true)
 }
 
@@ -481,6 +483,7 @@ func testLogstashElasticOutputPluginCompatibleMessage(t *testing.T, name string,
 }
 
 func TestLogstashElasticOutputPluginBulkCompatibleMessageTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testLogstashElasticOutputPluginBulkCompatibleMessage(t, "cmpblk-tcp", false)
 }
 

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -276,10 +276,12 @@ func checkAll(checks ...func() bool) func() bool {
 }
 
 func TestSendMessageViaLogstashTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMessageViaLogstash(t, "basic-tcp", false)
 }
 
 func TestSendMessageViaLogstashTLS(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMessageViaLogstash(t, "basic-tls", true)
 }
 
@@ -314,10 +316,12 @@ func testSendMessageViaLogstash(t *testing.T, name string, tls bool) {
 }
 
 func TestSendMultipleViaLogstashTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleViaLogstash(t, "multiple-tcp", false)
 }
 
 func TestSendMultipleViaLogstashTLS(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleViaLogstash(t, "multiple-tls", true)
 }
 

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -354,6 +354,7 @@ func testSendMultipleViaLogstash(t *testing.T, name string, tls bool) {
 }
 
 func TestSendMultipleBigBatchesViaLogstashTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleBigBatchesViaLogstash(t, "multiple-big-tcp", false)
 }
 
@@ -362,10 +363,12 @@ func TestSendMultipleBigBatchesViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleBatchesViaLogstash(t, name, 15, 4*integrationTestWindowSize, tls)
 }
 
 func TestSendMultipleSmallBatchesViaLogstashTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testSendMultipleSmallBatchesViaLogstash(t, "multiple-small-tcp", false)
 }
 
@@ -425,6 +428,7 @@ func testSendMultipleBatchesViaLogstash(
 }
 
 func TestLogstashElasticOutputPluginCompatibleMessageTCP(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testLogstashElasticOutputPluginCompatibleMessage(t, "cmp-tcp", false)
 }
 

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -488,6 +488,7 @@ func TestLogstashElasticOutputPluginBulkCompatibleMessageTCP(t *testing.T) {
 }
 
 func TestLogstashElasticOutputPluginBulkCompatibleMessageTLS(t *testing.T) {
+	t.Skip("skipped until https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 is resolved")
 	testLogstashElasticOutputPluginBulkCompatibleMessage(t, "cmpblk-tls", true)
 }
 

--- a/testing/environments/docker/logstash/pipeline/default.conf
+++ b/testing/environments/docker/logstash/pipeline/default.conf
@@ -17,7 +17,6 @@ output {
   elasticsearch {
       hosts => ["${ES_HOST:elasticsearch}:${ES_PORT:9200}"]
       index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
-      document_type => "%{[@metadata][type]}"
   }
 
   # Used for easier debugging


### PR DESCRIPTION
The `libbeat` CI build is failing like so:
```
07:40:09 command [go test -race -tags integration -cover -coverprofile /tmp/gotestcover-111073901 github.com/elastic/beats/libbeat/outputs/logstash]: exit status 1
07:40:09 --- FAIL: TestSendMessageViaLogstashTCP (5.80s)
07:40:09     logstash_integration_test.go:312: wrong number of results: 0
07:40:09 make: *** [integration-tests] Error 1
07:40:09 --- FAIL: TestSendMessageViaLogstashTLS (6.42s)
07:40:09     logstash_integration_test.go:312: wrong number of results: 0
07:40:09 --- FAIL: TestSendMultipleViaLogstashTCP (5.90s)
07:40:09     logstash_integration_test.go:348: wrong number of results: 0
07:40:09 --- FAIL: TestSendMultipleViaLogstashTLS (6.57s)
07:40:09     logstash_integration_test.go:348: wrong number of results: 0
```

This is happening because the `elasticsearch` output plugin in Logstash needs to be updated. See https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/887 for details.

This PR skips the failing tests until the update has been made. It also removes the `document_type` setting from the `elasticsearch` output in the Logstash pipeline used by these tests.