### PR TITLE
[DOCS] Deprecate central management

### DIFF
--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -17,8 +17,6 @@ The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
 See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
-include::../../libbeat/docs/shared-cm-tip.asciidoc[]
-
 The following topics describe how to configure Filebeat:
 
 * <<configuration-filebeat-modules>>

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -195,8 +195,6 @@ include::{libbeat-dir}/docs/step-test-config.asciidoc[]
 
 include::{libbeat-dir}/docs/step-look-at-config.asciidoc[]
 
-include::../../libbeat/docs/shared-cm-tip.asciidoc[]
-
 [[filebeat-template]]
 === Step 3: Load the index template in Elasticsearch
 

--- a/libbeat/docs/shared-central-management.asciidoc
+++ b/libbeat/docs/shared-central-management.asciidoc
@@ -5,9 +5,7 @@
 [partintro]
 --
 
-deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
-
-beta[]
+include::{asciidoc-dir}/../../shared/discontinued.asciidoc[tag=cm-discontinued]
 
 [WARNING]
 =======================================
@@ -40,9 +38,7 @@ include::shared-license-statement.asciidoc[]
 [role="xpack"]
 == How central management works
 
-deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
-
-beta[]
+include::{asciidoc-dir}/../../shared/discontinued.asciidoc[tag=cm-discontinued]
 
 {beats} central management uses a mechanism called configuration tags to group
 related configurations. You define configuration tags in the {cm-ui} UI in {kib}
@@ -109,9 +105,7 @@ the Beat to troubleshoot the problem.
 [role="xpack"]
 == Enroll {beats} in central management
 
-deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
-
-beta[]
+include::{asciidoc-dir}/../../shared/discontinued.asciidoc[tag=cm-discontinued]
 
 You need to enroll {beats} to register them in
 <<configuration-central-management,central management>> and establish

--- a/libbeat/docs/shared-central-management.asciidoc
+++ b/libbeat/docs/shared-central-management.asciidoc
@@ -5,6 +5,8 @@
 [partintro]
 --
 
+deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
+
 beta[]
 
 [WARNING]
@@ -37,6 +39,8 @@ include::shared-license-statement.asciidoc[]
 [[how-central-managment-works]]
 [role="xpack"]
 == How central management works
+
+deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
 
 beta[]
 
@@ -104,6 +108,8 @@ the Beat to troubleshoot the problem.
 [[enroll-beats]]
 [role="xpack"]
 == Enroll {beats} in central management
+
+deprecated[7.5.0,Beats central management is now deprecated. We’re working on a comprehensive solution to replace this feature.]
 
 beta[]
 

--- a/libbeat/docs/shared-cm-tip.asciidoc
+++ b/libbeat/docs/shared-cm-tip.asciidoc
@@ -1,3 +1,0 @@
-TIP: Starting with {beatname_uc} 6.5, you can define and manage {beatname_uc}
-configurations in a central location in {kib}. For more information, see
-<<configuration-central-management,{beats} central management>>.

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -17,8 +17,6 @@ The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
 See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
-include::../../libbeat/docs/shared-cm-tip.asciidoc[]
-
 The following topics describe how to configure {beatname_uc}:
 
 * <<configuration-metricbeat>>

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -224,8 +224,6 @@ include::{libbeat-dir}/docs/step-test-config.asciidoc[]
 
 include::{libbeat-dir}/docs/step-look-at-config.asciidoc[]
 
-include::../../libbeat/docs/shared-cm-tip.asciidoc[]
-
 [id="{beatname_lc}-template"]
 === Step 3: Load the index template in Elasticsearch
 


### PR DESCRIPTION
Closes #14045. Adds deprecation statement to the topics about central management. Also removes docs that points users to central management because I don't think we should be directing users to use a feature that's not deprecated. We will replace the references when docs for our CM replacement are in place.

TODO:

- [x] Merge https://github.com/elastic/docs/pull/1354 before merging this PR.
- [x] Add the shared statement to the Kibana docs: https://www.elastic.co/guide/en/kibana/7.4/managing-beats.html