### PR TITLE
Negotiate Docker API version in client

### DIFF
--- a/libbeat/common/docker/client.go
+++ b/libbeat/common/docker/client.go
@@ -23,39 +23,31 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-// NewClient builds and returns a new Docker client
-// It uses version 1.32 by default, and negotiates it with the server so it is downgraded if 1.32 is too high.
+// NewClient builds and returns a new Docker client. On the first request the
+// client will negotiate the API version with the server unless
+// DOCKER_API_VERSION is set in the environment.
 func NewClient(host string, httpClient *http.Client, httpHeaders map[string]string) (*client.Client, error) {
-	version, versionOverride := os.LookupEnv("DOCKER_API_VERSION")
-	if version == "" {
-		version = api.DefaultVersion
-		versionOverride = false
-	}
-
-	c, err := client.NewClient(host, version, httpClient, nil)
-	if err != nil {
-		return c, err
-	}
-
 	log := logp.NewLogger("docker")
 
-	if versionOverride {
-		log.Debug("Negotiating Docker client version.")
-		ping, err := c.Ping(context.Background())
-		if err != nil {
-			log.Debugf("Failed to perform ping: %v", err)
-		} else {
-			c.NegotiateAPIVersionPing(ping)
-		}
+	opts := []client.Opt{
+		client.WithHost(host),
+		client.WithHTTPClient(httpClient),
+		client.WithHTTPHeaders(httpHeaders),
 	}
 
-	log.Debugf("Docker client version set to %s.", c.ClientVersion())
-	return c, nil
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version != "" {
+		log.Debugf("Docker client will use API version %v as set by the DOCKER_API_VERSION environment variable.", version)
+		opts = append(opts, client.WithVersion(version))
+	} else {
+		log.Debug("Docker client will negotiate the API version on the first request.")
+		opts = append(opts, client.WithAPIVersionNegotiation())
+	}
+
+	return client.NewClientWithOpts(opts...)
 }


### PR DESCRIPTION
The libbeat Docker client wasn't negotiating the Docker API version after updating the Docker package versions. This changes the Docker client to use the `NewClientWithOpts` function rather than the deprecated `NewClient` function.

When the client is constructed we will pass in the `WithAPIVersionNegotiation` option if no version is explicitly configured in the DOCKER_API_VERSION environment variable. Upon the first request the client will negotiate the API version.

Fixes changes made in #13415.