### PR TITLE
[DOCS] Updates links to Stack Overview

### DIFF
--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{ref}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{ref}/secure-cluster.html[Secure a cluster] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -58,5 +58,4 @@ output.elasticsearch:
 --------------------------------------------------
 
 To learn more about {stack} security features and other types of
-authentication, see {ref}/elasticsearch-security.html[Securing the
-{stack}].
+authentication, see {ref}/secure-cluster.html[Secure a cluster].

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -1,15 +1,14 @@
 [role="xpack"]
 [[securing-beats]]
-== Configure {beatname_uc} to use {security}
+== Configure {beatname_uc} to use {security-features}
 
 [subs="attributes"]
 ++++
-<titleabbrev>Use {security}</titleabbrev>
+<titleabbrev>Use {security-features}</titleabbrev>
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{ref}/elasticsearch-security.html[{security}] enabled, there are extra
-configuration steps:
+{security-features} enabled, there are extra configuration steps:
 
 . <<feature-roles>>.
 +
@@ -26,8 +25,8 @@ authentication credentials or present a client certificate.
 If encryption is enabled on the cluster, you need to enable HTTPS in the
 {beatname_uc} configuration.
 
-For more information about {security}, see
-{xpack-ref}/elasticsearch-security.html[Securing the {stack}].
+For more information about {security-features}, see
+{ref}/secure-cluster.html[Secure a cluster].
 
 include::users.asciidoc[]
 

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -340,7 +340,7 @@ endif::apm-server[]
 ==== Learn more about users and roles
 
 Want to learn more about creating users and roles? See
-{ref}/elasticsearch-security.html[Securing the {stack}]. Also see:
+{ref}/secure-cluster.html[Secure a cluster]. Also see:
 
 * {ref}/security-privileges.html[Security privileges] for a description of
 available privileges

--- a/libbeat/docs/shared-central-management.asciidoc
+++ b/libbeat/docs/shared-central-management.asciidoc
@@ -11,8 +11,8 @@ beta[]
 =======================================
 When you use central management, configurations are stored centrally in {es}. To
 prevent an attacker from leveraging the configurations to attack your
-infrastructure, you must {es}/elasticsearch-security.html[secure {es} and
-{kib}] before using central management.
+infrastructure, you must secure {es} and {kib} before using central management.
+See {ref}/secure-cluster.html[Secure a cluster].
 =======================================
 
 {beats} central management provides a way to define and manage configurations in

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -11,9 +11,9 @@ There are two modules that collect metrics about {es}:
 monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {ref}/monitor-elasticsearch-cluster.html[monitoring] feature. The
-default metricsets in this module are `ccr`, `cluster_stats`, `index`,
-`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
+metrics with our {stack} {monitor-features}. The default metricsets in this
+module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
+`ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -10,8 +10,7 @@ There are two modules that collect metrics about {kib}:
 * The Kibana module tracks only the high-level metrics. The default metricset in
 this module is `status`.
 * The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{ref}/monitor-elasticsearch-cluster.html[monitoring] feature. The default metricset in
-this module is `stats`.
+{stack} {monitor-features}. The default metricset in this module is `stats`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/beat/docs.asciidoc
+++ b/metricbeat/module/beat/docs.asciidoc
@@ -1,5 +1,6 @@
 The Beat module contains a minimal set of metrics to enable monitoring of any Beat or other software based on libbeat across
-multiple versions. To monitor more Beat metrics, use our {ref}/monitor-elasticsearch-cluster.html[monitoring] feature.
+multiple versions. To monitor more Beat metrics, use our {stack}
+{monitor-features}.
 
 The default metricset is `stats`.
 

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -4,9 +4,9 @@ There are two modules that collect metrics about {es}:
 monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {ref}/monitor-elasticsearch-cluster.html[monitoring] feature. The
-default metricsets in this module are `ccr`, `cluster_stats`, `index`,
-`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
+metrics with our {stack} {monitor-features}. The default metricsets in this
+module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
+`ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -3,8 +3,7 @@ There are two modules that collect metrics about {kib}:
 * The Kibana module tracks only the high-level metrics. The default metricset in
 this module is `status`.
 * The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{ref}/monitor-elasticsearch-cluster.html[monitoring] feature. The default metricset in
-this module is `stats`.
+{stack} {monitor-features}. The default metricset in this module is `stats`.
 
 [float]
 === Compatibility


### PR DESCRIPTION
This PR updates or removes links from the Beats books to the Stack Overview in the cases where the content has moved to a new location.

Deleted pages exist in the Stack Overview and redirects will be created by the web team, but it seems wise to fix these links at the source in master.