### PR TITLE
Cherry-pick #14128 to 7.5: [Auditbeat] Fix system/socket DNS capture on x86 32-bit

### DIFF
--- a/vendor/github.com/google/gopacket/afpacket/afpacket.go
+++ b/vendor/github.com/google/gopacket/afpacket/afpacket.go
@@ -337,20 +337,18 @@ func (h *TPacket) Stats() (Stats, error) {
 func (h *TPacket) InitSocketStats() error {
 	if h.tpVersion == TPacketVersion3 {
 		socklen := unsafe.Sizeof(h.socketStatsV3)
-		slt := C.socklen_t(socklen)
 		var ssv3 SocketStatsV3
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), &socklen)
 		if err != nil {
 			return err
 		}
 		h.socketStatsV3 = SocketStatsV3{}
 	} else {
 		socklen := unsafe.Sizeof(h.socketStats)
-		slt := C.socklen_t(socklen)
 		var ss SocketStats
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), &socklen)
 		if err != nil {
 			return err
 		}
@@ -366,10 +364,9 @@ func (h *TPacket) SocketStats() (SocketStats, SocketStatsV3, error) {
 	// We need to save the counters since asking for the stats will clear them
 	if h.tpVersion == TPacketVersion3 {
 		socklen := unsafe.Sizeof(h.socketStatsV3)
-		slt := C.socklen_t(socklen)
 		var ssv3 SocketStatsV3
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), &socklen)
 		if err != nil {
 			return SocketStats{}, SocketStatsV3{}, err
 		}
@@ -380,10 +377,9 @@ func (h *TPacket) SocketStats() (SocketStats, SocketStatsV3, error) {
 		return h.socketStats, h.socketStatsV3, nil
 	}
 	socklen := unsafe.Sizeof(h.socketStats)
-	slt := C.socklen_t(socklen)
 	var ss SocketStats
 
-	err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), uintptr(unsafe.Pointer(&slt)))
+	err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), &socklen)
 	if err != nil {
 		return SocketStats{}, SocketStatsV3{}, err
 	}

--- a/vendor/github.com/google/gopacket/afpacket/sockopt_linux.go
+++ b/vendor/github.com/google/gopacket/afpacket/sockopt_linux.go
@@ -9,44 +9,38 @@
 package afpacket
 
 import (
+	"errors"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
+const maxOptSize = 8192
+
+var errSockoptTooBig = errors.New("socket option too big")
+
 // setsockopt provides access to the setsockopt syscall.
 func setsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
-	_, _, errno := unix.Syscall6(
-		unix.SYS_SETSOCKOPT,
-		uintptr(fd),
-		uintptr(level),
-		uintptr(name),
-		uintptr(val),
-		vallen,
-		0,
-	)
-	if errno != 0 {
-		return error(errno)
+	if vallen > maxOptSize {
+		return errSockoptTooBig
 	}
-
-	return nil
+	slice := (*[maxOptSize]byte)(val)[:]
+	return syscall.SetsockoptString(fd, level, name, string(slice[:vallen]))
 }
 
 // getsockopt provides access to the getsockopt syscall.
-func getsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
-	_, _, errno := unix.Syscall6(
-		unix.SYS_GETSOCKOPT,
-		uintptr(fd),
-		uintptr(level),
-		uintptr(name),
-		uintptr(val),
-		vallen,
-		0,
-	)
-	if errno != 0 {
-		return error(errno)
+func getsockopt(fd, level, name int, val unsafe.Pointer, vallen *uintptr) error {
+	s, err := unix.GetsockoptString(fd, level, name)
+	if err != nil {
+		return err
 	}
-
+	rcvLen := uintptr(len(s))
+	if rcvLen > *vallen {
+		return errSockoptTooBig
+	}
+	copy((*[maxOptSize]byte)(val)[:rcvLen], s)
+	*vallen = rcvLen
 	return nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2273,10 +2273,11 @@
 			"revisionTime": "2019-10-09T16:37:24Z"
 		},
 		{
-			"checksumSHA1": "sN9Kuv7R0K4gjRYnyG95vEb0k9s=",
+			"checksumSHA1": "msNKeCHS4V89szexDN6/ixw1gYs=",
+			"origin": "github.com/adriansr/gopacket/afpacket",
 			"path": "github.com/google/gopacket/afpacket",
-			"revision": "0ad7f2610e344e58c1c95e2adda5c3258da8e97b",
-			"revisionTime": "2019-10-09T16:37:24Z"
+			"revision": "a13a1c6078605c1b528df079debf4ffe33be7f8d",
+			"revisionTime": "2019-10-18T08:38:32Z"
 		},
 		{
 			"checksumSHA1": "CElVSky7n3cuKstd4LrIxGUREuA=",


### PR DESCRIPTION
Cherry-pick of PR #14128 to 7.5 branch. Original message: 

Vendor adriansr/gopacket/afpacket as google/gopacket/afpacket, containing a fix for the afpacket feature under x86 32-bit.

Currently in review at https://github.com/google/gopacket/pull/720