### PR TITLE
Adding system test for meta file

### DIFF
--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -2,9 +2,7 @@ from base import BaseTest
 
 import os
 import stat
-
-
-INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+from beat.beat import INTEGRATION_TESTS
 
 
 class TestMetaFile(BaseTest):
@@ -22,12 +20,14 @@ class TestMetaFile(BaseTest):
         self.wait_until(lambda: self.log_contains("Beat metadata path: " + self.meta_file_path))
         proc.check_kill_and_wait()
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_is_created(self):
         """
         Test that the meta file is created
         """
         self.assertTrue(os.path.exists(self.meta_file_path))
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_has_correct_perms(self):
         """
         Test that the meta file has correct permissions

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -18,7 +18,7 @@ class TestMetaFile(BaseTest):
 
         self.render_config_template()
         proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Beat metadata path: " + self.meta_file_path))
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
         proc.check_kill_and_wait()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -36,4 +36,3 @@ class TestMetaFile(BaseTest):
         """
         perms = oct(stat.S_IMODE(os.lstat(self.meta_file_path).st_mode))
         self.assertEqual(perms, "0600")
-

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -21,7 +21,7 @@ class TestMetaFile(BaseTest):
 
         self.render_config_template()
         proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Beat metadata path"))
+        self.wait_until(lambda: self.log_contains("Beat metadata path: " + self.meta_file_path))
         proc.check_kill_and_wait()
 
     def test_is_created(self):

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -1,7 +1,5 @@
 from base import BaseTest
-from elasticsearch import Elasticsearch, TransportError
 
-import logging
 import os
 import stat
 

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -2,6 +2,7 @@ from base import BaseTest
 
 import os
 import stat
+import unittest
 from beat.beat import INTEGRATION_TESTS
 
 

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -1,0 +1,39 @@
+from base import BaseTest
+from elasticsearch import Elasticsearch, TransportError
+
+import logging
+import os
+import stat
+
+
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+
+class TestMetaFile(BaseTest):
+    """
+    Test meta file
+    """
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+
+        self.meta_file_path = os.path.join(self.working_dir, "data", "meta.json")
+
+        self.render_config_template()
+        proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("Beat metadata path"))
+        proc.check_kill_and_wait()
+
+    def test_is_created(self):
+        """
+        Test that the meta file is created
+        """
+        self.assertTrue(os.path.exists(self.meta_file_path))
+
+    def test_has_correct_perms(self):
+        """
+        Test that the meta file has correct permissions
+        """
+        perms = oct(stat.S_IMODE(os.lstat(self.meta_file_path).st_mode))
+        self.assertEqual(perms, "0600")
+


### PR DESCRIPTION
This PR adds `libbeat` system tests around the creation of the `${path.data}/meta.json` file. Specifically the tests check if:
- the meta file is created upon Beat start up, and
- the meta file has the correct permissions (`0600`).

