### PR TITLE
[Heartbeat] Remove host.name field from events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Heartbeat*
 
 - Removed the `add_host_metadata` and `add_cloud_metadata` processors from the default config. These don't fit well with ECS for Heartbeat and were rarely used.
+- Removed `host.name` field that should never have been included. Heartbeat uses `observer.*` fields instead. {pull}14140[14140]
 
 *Journalbeat*
 

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -19,6 +19,9 @@ package cmd
 
 import (
 	"fmt"
+
+	"github.com/elastic/beats/libbeat/publisher/processing"
+
 	// register default heartbeat monitors
 	_ "github.com/elastic/beats/heartbeat/autodiscover"
 	"github.com/elastic/beats/heartbeat/beater"
@@ -34,7 +37,11 @@ var Name = "heartbeat"
 var RootCmd *cmd.BeatsRootCmd
 
 func init() {
-	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+	settings := instance.Settings{
+		Name:       Name,
+		Processing: processing.MakeDefaultSupport(true, processing.WithECS, processing.WithBeatMeta("agent")),
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
 
 	// remove dashboard from export commands
 	for _, cmd := range RootCmd.ExportCmd.Commands() {

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -20,14 +20,13 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/elastic/beats/libbeat/publisher/processing"
-
-	// register default heartbeat monitors
 	_ "github.com/elastic/beats/heartbeat/autodiscover"
 	"github.com/elastic/beats/heartbeat/beater"
+	// register default heartbeat monitors
 	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
 	cmd "github.com/elastic/beats/libbeat/cmd"
 	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/libbeat/publisher/processing"
 )
 
 // Name of this beat

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -85,6 +85,29 @@ class Test(BaseTest):
                 "fields.env": "dev"
             }
         )
+    def test_host_fields_not_present(self):
+        """
+        Ensure that libbeat isn't adding any host.* fields
+        """
+        monitor = {
+            "type": "http",
+            "urls": ["http://localhost:9200"],
+        }
+        config = {
+            "monitors": [monitor]
+        }
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/*",
+            **config
+        )
+
+        heartbeat_proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0)
+        heartbeat_proc.check_kill_and_wait()
+        doc = self.read_output()[0]
+
+        assert not doc.has_key("host.name")
 
     def run_fields(self, expected, local=None, top=None):
         monitor = {

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -85,6 +85,7 @@ class Test(BaseTest):
                 "fields.env": "dev"
             }
         )
+
     def test_host_fields_not_present(self):
         """
         Ensure that libbeat isn't adding any host.* fields


### PR DESCRIPTION
This field should never have been present, and is a distraction from the
observer.* fields.

Resolves #12107