### PR TITLE
[7.4][DOCS] Clarify how to disable the default system module metricsets

### DIFF
--- a/metricbeat/docs/faq-unexpected-metrics.asciidoc
+++ b/metricbeat/docs/faq-unexpected-metrics.asciidoc
@@ -1,0 +1,34 @@
+[[faq-unexpected-metrics]]
+=== {beatname_uc} collects system metrics for interfaces you didn't configure
+
+The <<metricbeat-module-system,System>> module specifies several metricsets
+that are enabled by default unless you explicitly disable them. To disable a
+default metricset, comment it out in the `modules.d/system.yml` configuration
+file. If _all_ metricsets are commented out and the System module is enabled,
+{beatname_uc} uses the default metricsets.
+
+For example, to disable the `network` metricset, comment it out:
+
+[source,yaml]
+----
+  - module: system
+    period: 10s
+    metricsets:
+      - cpu
+      - load
+      - memory
+      #- network
+      - process
+      - process_summary
+      - socket_summary
+      #- entropy
+      #- core
+      #- diskio
+      #- socket
+----
+
+You cannot override the default configuration by adding another module
+definition to the configuration. There is no concept of inheritance.
+{beatname_uc} combines all module configurations at runtime. This enables you to
+specify module definitions that use different combinations of metricsets,
+periods, and hosts.

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -20,6 +20,8 @@ sudo mkdir -p /compat/linux/proc
 sudo mount -t linprocfs /dev/null /compat/linux/proc
 ----
 
+include::faq-unexpected-metrics.asciidoc[]
+
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -8,10 +8,17 @@ This file is generated! See scripts/mage/docs_collector.go
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
+`process_summary`. To disable a default metricset, comment it out in the
+`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
+and the System module is enabled, {beatname_uc} uses the default metricsets.
 
-Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+Note that certain metricsets may access `/proc` to gather process information,
+and the resulting `ptrace_may_access()` call by the kernel to check for
+permissions can be blocked by
+https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor
+and other LSM software], even though the System module doesn't use `ptrace`
+directly.
 
 [float]
 === Dashboard

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -1,10 +1,17 @@
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
+`process_summary`. To disable a default metricset, comment it out in the
+`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
+and the System module is enabled, {beatname_uc} uses the default metricsets.
 
-Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+Note that certain metricsets may access `/proc` to gather process information,
+and the resulting `ptrace_may_access()` call by the kernel to check for
+permissions can be blocked by
+https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor
+and other LSM software], even though the System module doesn't use `ptrace`
+directly.
 
 [float]
 === Dashboard


### PR DESCRIPTION
Backports #13328 to 7.4 branch.