### PR TITLE
Cherry-pick #14111 to 7.5: Set source.bytes/packets for uni-directional netflow

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - Fix azure fields names. {pull}14098[14098] {pull}14132[14132]
+- Fix calculation of `network.bytes` and `network.packets` for bi-directional netflow events. {pull}14111[14111]
 
 *Heartbeat*
 
@@ -80,6 +81,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - `container` and `docker` inputs now support reading of labels and env vars written by docker JSON file logging driver. {issue}8358[8358]
 - Add filebeat azure module with activitylogs, auditlogs, signinlogs filesets. {pull}13776[13776] {pull}14033[14033] {pull}14107[14107]
 - Add support for all the ObjectCreated events in S3 input. {pull}14077[14077]
+- Add `source.bytes` and `source.packets` for uni-directional netflow events. {pull}14111[14111]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -262,26 +262,23 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 		revPkts, hasRevPkts = getKeyUint64(flow.Fields, "reversePacketTotalCount")
 	}
 
-	if hasRevBytes || hasRevPkts {
-		if hasBytes {
-			ecsSource["bytes"] = countBytes
-			ecsDest["bytes"] = revBytes
-		}
-		if hasPkts {
-			ecsSource["packets"] = revBytes
-			ecsDest["packets"] = revPkts
-		}
-		countBytes += revBytes
-		countPkts += revPkts
+	if hasRevBytes {
+		ecsDest["bytes"] = revBytes
+	}
+
+	if hasRevPkts {
+		ecsDest["packets"] = revPkts
 	}
 
 	if hasBytes {
+		ecsSource["bytes"] = countBytes
 		if hasRevBytes {
 			countBytes += revBytes
 		}
 		ecsNetwork["bytes"] = countBytes
 	}
 	if hasPkts {
+		ecsSource["packets"] = countPkts
 		if hasRevPkts {
 			countPkts += revPkts
 		}

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -71,13 +71,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "10.236.5.4",
           "locality": "private",
           "mac": "00:50:56:b9:26:46",
+          "packets": 0,
           "port": 51917
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-18T08:16:47Z",
@@ -149,13 +152,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "64.235.151.76",
           "locality": "public",
           "mac": "00:00:00:00:00:00",
+          "packets": 0,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -59,13 +59,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "10.99.130.239",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 0,
           "port": 65105
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -125,13 +128,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 81,
           "ip": "10.99.252.50",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -191,13 +197,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "10.99.130.239",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 0,
           "port": 65105
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -257,13 +266,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 81,
           "ip": "10.98.243.20",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -323,13 +335,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "10.99.168.140",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 0,
           "port": 52344
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -389,13 +404,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 113,
           "ip": "10.98.243.20",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -455,13 +473,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "10.99.168.140",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 0,
           "port": 50294
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-29T13:58:28Z",
@@ -521,13 +542,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 113,
           "ip": "10.98.243.20",
           "locality": "private",
           "mac": "00:00:00:00:00:00",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -58,12 +58,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "10.10.8.197",
           "locality": "private",
+          "packets": 2,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -122,12 +125,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 502,
           "ip": "192.168.35.143",
           "locality": "private",
+          "packets": 8,
           "port": 46518
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -186,12 +192,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2233,
           "ip": "10.10.6.11",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -250,12 +259,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "192.168.128.17",
           "locality": "private",
+          "packets": 2,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -314,12 +326,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 79724,
           "ip": "10.10.8.220",
           "locality": "private",
+          "packets": 57,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -378,12 +393,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 161,
           "ip": "172.20.4.199",
           "locality": "private",
+          "packets": 3,
           "port": 10240
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -442,12 +460,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 245,
           "ip": "172.20.4.1",
           "locality": "private",
+          "packets": 3,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -506,12 +527,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 504,
           "ip": "172.20.4.30",
           "locality": "private",
+          "packets": 6,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -570,12 +594,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 784,
           "ip": "10.10.8.105",
           "locality": "private",
+          "packets": 6,
           "port": 22
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -634,12 +661,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 433,
           "ip": "172.20.4.30",
           "locality": "private",
+          "packets": 8,
           "port": 59571
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -698,12 +728,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 196,
           "ip": "10.10.7.11",
           "locality": "private",
+          "packets": 3,
           "port": 48378
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -762,12 +795,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 206,
           "ip": "192.168.183.199",
           "locality": "private",
+          "packets": 3,
           "port": 6667
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -826,12 +862,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 504,
           "ip": "10.10.8.34",
           "locality": "private",
+          "packets": 6,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -890,12 +929,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3539,
           "ip": "172.20.5.191",
           "locality": "private",
+          "packets": 58,
           "port": 42502
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -954,12 +996,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "172.20.4.1",
           "locality": "private",
+          "packets": 3,
           "port": 33332
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1018,12 +1063,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "172.20.4.1",
           "locality": "private",
+          "packets": 2,
           "port": 33332
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1082,12 +1130,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 435,
           "ip": "172.30.0.1",
           "locality": "private",
+          "packets": 3,
           "port": 53298
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1146,12 +1197,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 290,
           "ip": "172.30.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 53298
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1210,12 +1264,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "10.10.6.1",
           "locality": "private",
+          "packets": 3,
           "port": 48172
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1274,12 +1331,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "10.10.6.1",
           "locality": "private",
+          "packets": 2,
           "port": 48172
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1338,12 +1398,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "10.10.7.1",
           "locality": "private",
+          "packets": 3,
           "port": 48935
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1402,12 +1465,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "10.10.7.1",
           "locality": "private",
+          "packets": 2,
           "port": 48935
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1466,12 +1532,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "10.10.8.1",
           "locality": "private",
+          "packets": 3,
           "port": 51931
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1530,12 +1599,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "10.10.8.1",
           "locality": "private",
+          "packets": 2,
           "port": 51931
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1594,12 +1666,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "10.20.0.1",
           "locality": "private",
+          "packets": 3,
           "port": 43454
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1658,12 +1733,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "10.20.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 43454
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1722,12 +1800,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
           "ip": "10.10.10.1",
           "locality": "private",
+          "packets": 3,
           "port": 52837
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1786,12 +1867,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
           "ip": "10.10.10.1",
           "locality": "private",
+          "packets": 2,
           "port": 52837
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1846,10 +1930,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1904,10 +1991,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -1962,10 +2052,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 495,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2020,10 +2113,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 330,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2078,10 +2174,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2136,10 +2235,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2194,10 +2296,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2252,10 +2357,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2310,10 +2418,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2368,10 +2479,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2426,10 +2540,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2484,10 +2601,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2542,10 +2662,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2600,10 +2723,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2658,10 +2784,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2716,10 +2845,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2774,10 +2906,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 555,
+          "packets": 3,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-19T16:18:08Z",
@@ -2832,10 +2967,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 370,
+          "packets": 2,
           "port": 5678
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -81,12 +81,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 40,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 1,
           "port": 51053
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-11-11T12:09:19Z",
@@ -156,12 +159,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1525,
           "ip": "10.0.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-11-11T12:09:19Z",
@@ -243,12 +249,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1541,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 51053
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -56,7 +56,8 @@
           "port": 5878
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -54,12 +54,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64020
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -114,12 +117,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6634,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -174,12 +180,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 453,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 9,
           "port": 64021
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -234,12 +243,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 10893,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 11,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -294,12 +306,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 453,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 9,
           "port": 64021
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -354,12 +369,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 10893,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 11,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -414,12 +432,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64022
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -474,12 +495,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6780,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -534,12 +558,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64022
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -594,12 +621,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6780,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -654,12 +684,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64023
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -714,12 +747,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 7319,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 9,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -774,12 +810,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64023
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -834,12 +873,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 7319,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 9,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -894,12 +936,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 333,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 6,
           "port": 64024
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -954,12 +999,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1833,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 5,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1014,12 +1062,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 333,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 6,
           "port": 64024
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1074,12 +1125,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1833,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 5,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1134,12 +1188,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 453,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 9,
           "port": 64025
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1194,12 +1251,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 10550,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 11,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1254,12 +1314,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 453,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 9,
           "port": 64025
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1314,12 +1377,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 10550,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 11,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1374,12 +1440,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64026
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1434,12 +1503,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6425,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1494,12 +1566,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 373,
           "ip": "192.168.0.17",
           "locality": "private",
+          "packets": 7,
           "port": 64026
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:30:37Z",
@@ -1554,12 +1629,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6425,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 8,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -68,7 +68,8 @@
           "port": 53787
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -137,7 +138,8 @@
           "port": 136
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -206,7 +208,8 @@
           "port": 44155
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -275,7 +278,8 @@
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -344,7 +348,8 @@
           "port": 136
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -413,7 +418,8 @@
           "port": 55869
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -482,7 +488,8 @@
           "port": 9430
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-04-15T03:30:00Z",
@@ -551,7 +558,8 @@
           "port": 33689
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -63,12 +63,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 100,
           "ip": "172.18.65.21",
           "locality": "private",
+          "packets": 2,
           "port": 61209
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-22T12:17:56Z",
@@ -132,12 +135,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 229,
           "ip": "172.18.65.91",
           "locality": "private",
+          "packets": 1,
           "port": 138
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-22T12:17:56Z",
@@ -201,12 +207,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 229,
           "ip": "172.18.65.91",
           "locality": "private",
+          "packets": 1,
           "port": 138
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-22T12:26:04Z",
@@ -270,12 +279,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 104,
           "ip": "172.18.65.21",
           "locality": "private",
+          "packets": 2,
           "port": 61329
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-22T12:26:04Z",
@@ -337,10 +349,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 144,
+          "packets": 2,
           "port": 61329
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -53,11 +53,11 @@
           "vlan_id": 0
         },
         "network": {
-          "bytes": 532,
+          "bytes": 332,
           "community_id": "1:3NQ+f2IICsvUP3F8oQM9Js9FO6Q=",
           "direction": "unknown",
           "iana_number": 17,
-          "packets": 6,
+          "packets": 4,
           "transport": "udp"
         },
         "observer": {
@@ -67,11 +67,12 @@
           "bytes": 132,
           "ip": "172.16.32.201",
           "locality": "private",
-          "packets": 200,
+          "packets": 2,
           "port": 46086
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-25T12:58:38Z",
@@ -131,11 +132,11 @@
           "vlan_id": 0
         },
         "network": {
-          "bytes": 356,
+          "bytes": 264,
           "community_id": "1:H1pHO7CtjIP7Q5Rljq4l4EH1wf4=",
           "direction": "unknown",
           "iana_number": 6,
-          "packets": 8,
+          "packets": 6,
           "transport": "tcp"
         },
         "observer": {
@@ -145,11 +146,12 @@
           "bytes": 172,
           "ip": "172.16.32.100",
           "locality": "private",
-          "packets": 92,
+          "packets": 4,
           "port": 63499
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-25T13:03:33Z",
@@ -193,7 +195,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -81,12 +81,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 40,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 1,
           "port": 51053
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-11-11T12:09:19Z",
@@ -156,12 +159,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1525,
           "ip": "10.0.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-11-11T12:09:19Z",
@@ -243,12 +249,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1541,
           "ip": "192.168.0.1",
           "locality": "private",
+          "packets": 2,
           "port": 51053
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
@@ -40,7 +40,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -66,12 +66,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 775,
           "ip": "10.113.7.54",
           "locality": "private",
+          "packets": 8,
           "port": 41717
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -34,7 +34,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -93,12 +94,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 260,
           "ip": "192.168.253.1",
           "locality": "private",
+          "packets": 5,
           "port": 60560
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -157,12 +161,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1000,
           "ip": "192.168.253.128",
           "locality": "private",
+          "packets": 6,
           "port": 22
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -221,12 +228,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 601,
           "ip": "192.168.253.2",
           "locality": "private",
+          "packets": 2,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -285,12 +295,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 148,
           "ip": "192.168.253.132",
           "locality": "private",
+          "packets": 2,
           "port": 35262
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -349,12 +362,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 5946,
           "ip": "54.214.9.161",
           "locality": "public",
+          "packets": 14,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -413,12 +429,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2608,
           "ip": "192.168.253.132",
           "locality": "private",
+          "packets": 13,
           "port": 49935
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:26Z",
@@ -477,12 +496,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 60,
           "ip": "192.168.253.130",
           "locality": "private",
+          "packets": 1,
           "port": 38254
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:28Z",
@@ -541,12 +563,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 256,
           "ip": "192.168.253.1",
           "locality": "private",
+          "packets": 4,
           "port": 60560
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:28Z",
@@ -605,12 +630,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1916,
           "ip": "192.168.253.128",
           "locality": "private",
+          "packets": 3,
           "port": 22
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:28Z",
@@ -669,12 +697,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 168,
           "ip": "192.168.253.1",
           "locality": "private",
+          "packets": 2,
           "port": 65308
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:28Z",
@@ -733,12 +764,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 84,
           "ip": "192.168.253.128",
           "locality": "private",
+          "packets": 1,
           "port": 22
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-05-13T11:20:28Z",
@@ -797,12 +831,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 232,
           "ip": "192.168.253.1",
           "locality": "private",
+          "packets": 1,
           "port": 5353
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -57,13 +57,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 75,
           "ip": "192.168.0.111",
           "locality": "private",
           "mac": "ec:1f:72:11:9f:c1",
+          "packets": 1,
           "port": 37301
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -121,13 +124,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 75,
           "ip": "192.168.0.111",
           "locality": "private",
           "mac": "ec:1f:72:11:9f:c1",
+          "packets": 1,
           "port": 58411
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -185,13 +191,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 75,
           "ip": "192.168.0.111",
           "locality": "private",
           "mac": "ec:1f:72:11:9f:c1",
+          "packets": 1,
           "port": 37661
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -249,13 +258,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 75,
           "ip": "192.168.0.111",
           "locality": "private",
           "mac": "ec:1f:72:11:9f:c1",
+          "packets": 1,
           "port": 60212
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -313,13 +325,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 964,
           "ip": "158.85.58.115",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 10,
           "port": 5222
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -377,13 +392,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2748,
           "ip": "192.168.0.88",
           "locality": "private",
           "mac": "a4:d1:8c:e9:30:2c",
+          "packets": 8,
           "port": 61490
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -441,13 +459,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2023,
           "ip": "216.58.212.195",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 9,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -505,13 +526,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2180,
           "ip": "192.168.1.201",
           "locality": "private",
           "mac": "98:01:a7:9f:8d:5f",
+          "packets": 9,
           "port": 50299
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -569,13 +593,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 700,
           "ip": "216.58.201.106",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 9,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -633,13 +660,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 161,
           "ip": "52.236.33.163",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -697,13 +727,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1764,
           "ip": "192.168.3.34",
           "locality": "private",
           "mac": "1c:5c:f2:07:0f:2a",
+          "packets": 21,
           "port": 61674
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -761,13 +794,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 13811,
           "ip": "209.197.3.19",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 30,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -825,13 +861,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4717,
           "ip": "52.216.130.237",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 16,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -889,13 +928,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2419,
           "ip": "192.168.0.157",
           "locality": "private",
           "mac": "b0:34:95:0d:d2:5d",
+          "packets": 13,
           "port": 51209
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -953,13 +995,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 5551,
           "ip": "172.217.23.232",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 10,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1017,13 +1062,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 187,
           "ip": "107.21.232.174",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 3,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1081,13 +1129,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 104,
           "ip": "192.168.3.178",
           "locality": "private",
           "mac": "dc:ef:ca:4c:da:57",
+          "packets": 2,
           "port": 45584
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1145,13 +1196,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4050,
           "ip": "192.168.2.118",
           "locality": "private",
           "mac": "70:18:8b:5c:c9:b5",
+          "packets": 72,
           "port": 64233
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1209,13 +1263,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3719,
           "ip": "95.0.145.242",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 72,
           "port": 2222
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1273,13 +1330,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1402,
           "ip": "192.168.0.79",
           "locality": "private",
           "mac": "8c:29:37:7a:28:c0",
+          "packets": 16,
           "port": 54275
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1337,13 +1397,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1538,
           "ip": "192.168.0.79",
           "locality": "private",
           "mac": "8c:29:37:7a:28:c0",
+          "packets": 17,
           "port": 54276
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1401,13 +1464,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 13002,
           "ip": "23.5.100.66",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 14,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1465,13 +1531,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1194,
           "ip": "170.251.180.15",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 4,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1529,13 +1598,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 682,
           "ip": "192.168.0.61",
           "locality": "private",
           "mac": "90:61:ae:76:e5:e9",
+          "packets": 2,
           "port": 57007
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1593,13 +1665,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1804,
           "ip": "192.168.3.34",
           "locality": "private",
           "mac": "1c:5c:f2:07:0f:2a",
+          "packets": 11,
           "port": 61694
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1657,13 +1732,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4774,
           "ip": "185.60.218.19",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 9,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1721,13 +1799,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "192.168.3.200",
           "locality": "private",
           "mac": "18:20:32:bb:1d:62",
+          "packets": 2,
           "port": 64493
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1785,13 +1866,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "185.60.218.15",
           "locality": "public",
           "mac": "00:23:04:18:ef:40",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-03T17:03:39Z",
@@ -1849,13 +1933,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 194,
           "ip": "192.168.0.95",
           "locality": "private",
           "mac": "a0:39:f7:4d:49:d5",
+          "packets": 3,
           "port": 35053
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -65,7 +65,8 @@
           "port": 61775
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -131,7 +132,8 @@
           "port": 61776
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -197,7 +199,8 @@
           "port": 61776
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -263,7 +266,8 @@
           "port": 56635
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -329,7 +333,8 @@
           "port": 56635
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -395,7 +400,8 @@
           "port": 61773
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -461,7 +467,8 @@
           "port": 61773
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -528,7 +535,8 @@
           "port": 56649
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -594,7 +602,8 @@
           "port": 56649
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -660,7 +669,8 @@
           "port": 56649
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -727,7 +737,8 @@
           "port": 61777
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -793,7 +804,8 @@
           "port": 61777
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -859,7 +871,8 @@
           "port": 61777
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -926,7 +939,8 @@
           "port": 56650
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -992,7 +1006,8 @@
           "port": 56650
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -1058,7 +1073,8 @@
           "port": 56650
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -1125,7 +1141,8 @@
           "port": 56651
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -1191,7 +1208,8 @@
           "port": 56651
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-07-21T13:50:37Z",
@@ -1257,7 +1275,8 @@
           "port": 56651
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -63,12 +63,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.14.1",
           "locality": "private",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -132,12 +134,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.23.22",
           "locality": "private",
           "port": 17549
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -201,12 +205,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "164.164.37.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -270,12 +276,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.23.20",
           "locality": "private",
           "port": 17805
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -339,12 +347,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "164.164.37.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -408,12 +418,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.14.11",
           "locality": "private",
           "port": 17805
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -477,12 +489,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "2.2.2.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -546,12 +560,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "2.2.2.11",
           "locality": "public",
           "port": 17805
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -615,12 +631,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.14.1",
           "locality": "private",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -684,12 +702,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 160,
           "ip": "164.164.37.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -753,12 +773,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.23.22",
           "locality": "private",
           "port": 18061
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -822,12 +844,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "164.164.37.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -891,12 +915,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "192.168.23.20",
           "locality": "private",
           "port": 18061
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-09T09:47:51Z",
@@ -960,12 +986,14 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 56,
           "ip": "164.164.37.11",
           "locality": "public",
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
@@ -32,7 +32,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -65,7 +66,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -98,7 +100,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -131,7 +134,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -164,7 +168,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -197,7 +202,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -230,7 +236,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -263,7 +270,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -296,7 +304,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -329,7 +338,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -362,7 +372,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -395,7 +406,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -428,7 +440,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -461,7 +474,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -494,7 +508,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -527,7 +542,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -560,7 +576,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -593,7 +610,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:48Z",
@@ -626,7 +644,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -67,12 +67,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 40,
           "ip": "10.0.9.146",
           "locality": "private",
+          "packets": 1,
           "port": 54017
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -140,12 +143,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 104,
           "ip": "10.0.17.42",
           "locality": "private",
+          "packets": 2,
           "port": 36484
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -213,12 +219,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 52,
           "ip": "10.0.22.111",
           "locality": "private",
+          "packets": 1,
           "port": 16814
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -286,12 +295,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 435,
           "ip": "10.0.23.59",
           "locality": "private",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -359,12 +371,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 969,
           "ip": "10.0.34.71",
           "locality": "private",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -432,12 +447,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 104,
           "ip": "10.0.10.133",
           "locality": "private",
+          "packets": 2,
           "port": 35273
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -505,12 +523,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 52,
           "ip": "10.0.37.29",
           "locality": "private",
+          "packets": 1,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -578,12 +599,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 614,
           "ip": "10.0.32.176",
           "locality": "private",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -651,12 +675,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4350,
           "ip": "10.0.12.21",
           "locality": "private",
+          "packets": 3,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -724,12 +751,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 533,
           "ip": "10.0.4.212",
           "locality": "private",
+          "packets": 2,
           "port": 50691
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -797,12 +827,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 13660,
           "ip": "10.0.33.122",
           "locality": "private",
+          "packets": 325,
           "port": 58814
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -870,12 +903,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 89,
           "ip": "10.0.20.242",
           "locality": "private",
+          "packets": 1,
           "port": 2013
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -943,12 +979,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 833,
           "ip": "10.0.13.25",
           "locality": "private",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1016,12 +1055,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1625,
           "ip": "10.0.25.59",
           "locality": "private",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1089,12 +1131,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 142184,
           "ip": "10.0.7.73",
           "locality": "private",
+          "packets": 97,
           "port": 60312
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1162,12 +1207,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3016,
           "ip": "10.0.19.50",
           "locality": "private",
+          "packets": 58,
           "port": 34452
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1235,12 +1283,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 31500,
           "ip": "10.0.28.150",
           "locality": "private",
+          "packets": 21,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1308,12 +1359,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2919,
           "ip": "10.0.26.188",
           "locality": "private",
+          "packets": 3,
           "port": 993
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1381,12 +1435,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4514,
           "ip": "10.0.29.34",
           "locality": "private",
+          "packets": 5,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1454,12 +1511,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 326,
           "ip": "10.0.8.200",
           "locality": "private",
+          "packets": 1,
           "port": 23128
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-06T10:09:24Z",
@@ -1527,12 +1587,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 112,
           "ip": "10.0.29.46",
           "locality": "private",
+          "packets": 2,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -57,12 +57,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 965,
           "ip": "10.111.111.242",
           "locality": "private",
+          "packets": 7,
           "port": 52444
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -120,12 +123,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 284,
           "ip": "10.10.4.29",
           "locality": "private",
+          "packets": 1,
           "port": 161
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -183,12 +189,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 670,
           "ip": "10.12.100.13",
           "locality": "private",
+          "packets": 6,
           "port": 53218
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -246,12 +255,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.12.104.239",
           "locality": "private",
+          "packets": 2,
           "port": 1720
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -309,12 +321,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.10.11.21",
           "locality": "private",
+          "packets": 2,
           "port": 61440
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -372,12 +387,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 101,
           "ip": "10.100.101.45",
           "locality": "private",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -435,12 +453,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1134,
           "ip": "10.100.101.43",
           "locality": "private",
+          "packets": 14,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -498,12 +519,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 237,
           "ip": "31.13.71.7",
           "locality": "public",
+          "packets": 4,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -561,12 +585,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 91,
           "ip": "10.11.21.60",
           "locality": "private",
+          "packets": 1,
           "port": 161
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -624,12 +651,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 41,
           "ip": "10.12.92.102",
           "locality": "private",
+          "packets": 1,
           "port": 50766
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -687,12 +717,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 111,
           "ip": "10.100.105.86",
           "locality": "private",
+          "packets": 1,
           "port": 58843
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -750,12 +783,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1164,
           "ip": "10.10.4.234",
           "locality": "private",
+          "packets": 4,
           "port": 161
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -813,12 +849,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.12.106.83",
           "locality": "private",
+          "packets": 2,
           "port": 1720
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -876,12 +915,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 52,
           "ip": "172.217.11.5",
           "locality": "public",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -939,12 +981,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.10.11.21",
           "locality": "private",
+          "packets": 2,
           "port": 61440
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1002,12 +1047,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3088,
           "ip": "10.12.81.86",
           "locality": "private",
+          "packets": 10,
           "port": 58657
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1065,12 +1113,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 5306,
           "ip": "10.14.121.98",
           "locality": "private",
+          "packets": 24,
           "port": 50174
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1128,12 +1179,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 116,
           "ip": "10.11.21.60",
           "locality": "private",
+          "packets": 1,
           "port": 161
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1191,12 +1245,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 22764,
           "ip": "10.12.100.13",
           "locality": "private",
+          "packets": 30,
           "port": 389
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1254,12 +1311,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.12.102.125",
           "locality": "private",
+          "packets": 2,
           "port": 1720
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1317,12 +1377,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 75,
           "ip": "10.100.105.86",
           "locality": "private",
+          "packets": 1,
           "port": 58844
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1380,12 +1443,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 80,
           "ip": "10.10.11.21",
           "locality": "private",
+          "packets": 2,
           "port": 61443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1443,12 +1509,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 160,
           "ip": "10.100.105.85",
           "locality": "private",
+          "packets": 2,
           "port": 37265
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1506,12 +1575,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "10.14.25.80",
           "locality": "private",
+          "packets": 1,
           "port": 62427
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-10-09T20:22:35Z",
@@ -1569,12 +1641,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1340,
           "ip": "10.12.150.13",
           "locality": "private",
+          "packets": 2,
           "port": 61792
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -71,13 +71,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 44,
           "ip": "10.30.18.62",
           "locality": "private",
           "mac": "00:50:56:91:56:86",
+          "packets": 1,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:10:36Z",
@@ -149,13 +152,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 106,
           "ip": "10.30.18.62",
           "locality": "private",
           "mac": "00:50:56:91:56:86",
+          "packets": 1,
           "port": 34220
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:10:36Z",
@@ -227,13 +233,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 44,
           "ip": "10.10.172.60",
           "locality": "private",
           "mac": "00:18:19:9e:6c:01",
+          "packets": 1,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:10:36Z",
@@ -305,13 +314,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "10.10.172.60",
           "locality": "private",
           "mac": "00:18:19:9e:6c:01",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:10:36Z",
@@ -383,13 +395,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2794,
           "ip": "10.10.172.60",
           "locality": "private",
           "mac": "00:18:19:9e:6c:01",
+          "packets": 36,
           "port": 45269
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
@@ -33,7 +33,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -67,7 +68,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -101,7 +103,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -135,7 +138,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -169,7 +173,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -203,7 +208,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -237,7 +243,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -271,7 +278,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -305,7 +313,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -339,7 +348,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -373,7 +383,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -407,7 +418,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -441,7 +453,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -475,7 +488,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-02-14T11:09:59Z",
@@ -509,7 +523,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
@@ -49,12 +49,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3320,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 83
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -106,10 +109,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 3320,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 83
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -159,12 +165,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 7760,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 69
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -216,10 +225,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 10229,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 69
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -269,12 +281,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 215,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 1
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -324,12 +339,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 40854,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 225
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -381,10 +399,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 35866,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 154
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -434,12 +455,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 12279,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 63
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -491,10 +515,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 27287,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 61
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -544,12 +571,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 147145,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 773
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -601,10 +631,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 1182695,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 1379
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -654,12 +687,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6777,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 26
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -711,10 +747,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 8625,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 26
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -764,12 +803,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2433001,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 20434
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -821,10 +863,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 56599680,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 40726
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -874,12 +919,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1658,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 15
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -931,10 +979,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 950,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 14
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -984,12 +1035,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1495567,
           "ip": "192.168.20.121",
           "locality": "private",
-          "mac": "34:02:86:75:c0:51"
+          "mac": "34:02:86:75:c0:51",
+          "packets": 16145
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-06-22T06:31:14Z",
@@ -1041,10 +1095,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
-          "mac": "00:f6:63:cc:80:60"
+          "bytes": 80973880,
+          "mac": "00:f6:63:cc:80:60",
+          "packets": 53362
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -37,7 +37,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-07-18T05:41:59Z",
@@ -93,12 +94,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "192.168.99.7",
           "locality": "private",
+          "packets": 3,
           "port": 61910
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -65,12 +65,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 748,
           "ip": "192.168.100.151",
           "locality": "private",
+          "packets": 6,
           "port": 45380
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -136,12 +139,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6948,
           "ip": "208.100.17.187",
           "locality": "public",
+          "packets": 10,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -207,12 +213,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1584,
           "ip": "192.168.100.151",
           "locality": "private",
+          "packets": 14,
           "port": 44778
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -278,12 +287,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 8201,
           "ip": "208.100.17.189",
           "locality": "public",
+          "packets": 11,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -349,12 +361,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1729,
           "ip": "192.168.100.151",
           "locality": "private",
+          "packets": 15,
           "port": 50618
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -420,12 +435,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1122,
           "ip": "178.255.83.1",
           "locality": "public",
+          "packets": 5,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -491,12 +509,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 705,
           "ip": "192.168.100.151",
           "locality": "private",
+          "packets": 5,
           "port": 33660
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -562,12 +583,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1123,
           "ip": "178.255.83.1",
           "locality": "public",
+          "packets": 5,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -633,12 +657,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 706,
           "ip": "192.168.100.151",
           "locality": "private",
+          "packets": 5,
           "port": 33646
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -700,12 +727,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 74,
           "ip": "192.168.100.111",
           "locality": "private",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -767,12 +797,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 58,
           "ip": "192.168.100.150",
           "locality": "private",
+          "packets": 1,
           "port": 52970
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -834,12 +867,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 74,
           "ip": "192.168.100.111",
           "locality": "private",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -901,12 +937,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 58,
           "ip": "192.168.100.150",
           "locality": "private",
+          "packets": 1,
           "port": 49311
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -968,12 +1007,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1071,
           "ip": "192.168.100.111",
           "locality": "private",
+          "packets": 5,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -1035,12 +1077,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1147,
           "ip": "192.168.100.150",
           "locality": "private",
+          "packets": 6,
           "port": 51746
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -1102,12 +1147,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1980,
           "ip": "192.168.100.111",
           "locality": "private",
+          "packets": 6,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-11T00:54:11Z",
@@ -1169,12 +1217,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2164,
           "ip": "192.168.100.150",
           "locality": "private",
+          "packets": 8,
           "port": 51745
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -71,12 +71,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 702,
           "ip": "20.20.20.20",
           "locality": "public",
+          "packets": 9,
           "port": 137
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -70,12 +70,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1027087,
           "ip": "10.22.166.30",
           "locality": "private",
+          "packets": 697,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -146,12 +149,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 6200,
           "ip": "10.22.166.12",
           "locality": "private",
+          "packets": 6,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -222,12 +228,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 11896,
           "ip": "10.22.166.33",
           "locality": "private",
+          "packets": 21,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -298,12 +307,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1041,
           "ip": "10.22.166.35",
           "locality": "private",
+          "packets": 3,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -374,12 +386,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1740,
           "ip": "10.22.166.36",
           "locality": "private",
+          "packets": 20,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -450,12 +465,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2998,
           "ip": "10.22.166.36",
           "locality": "private",
+          "packets": 16,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -526,12 +544,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 55773,
           "ip": "10.22.166.28",
           "locality": "private",
+          "packets": 37,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -602,12 +623,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3239438,
           "ip": "10.22.166.35",
           "locality": "private",
+          "packets": 2135,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -678,12 +702,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 5701,
           "ip": "10.22.166.15",
           "locality": "private",
+          "packets": 20,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -754,12 +781,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 4255012,
           "ip": "10.22.166.2",
           "locality": "private",
+          "packets": 2804,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -830,12 +860,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 37557,
           "ip": "10.22.166.28",
           "locality": "private",
+          "packets": 25,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -906,12 +939,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 23676,
           "ip": "10.22.166.25",
           "locality": "private",
+          "packets": 68,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -982,12 +1018,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 22821,
           "ip": "10.22.166.25",
           "locality": "private",
+          "packets": 30,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -1058,12 +1097,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 526,
           "ip": "10.22.166.12",
           "locality": "private",
+          "packets": 2,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -1134,12 +1176,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 33129,
           "ip": "10.22.166.17",
           "locality": "private",
+          "packets": 220,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-05-21T09:25:04Z",
@@ -1210,12 +1255,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 5092,
           "ip": "10.22.166.36",
           "locality": "private",
+          "packets": 9,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -70,12 +70,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 200,
           "ip": "10.108.219.53",
           "locality": "private",
+          "packets": 4,
           "port": 45587
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -57,12 +57,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 78,
           "ip": "192.168.0.3",
           "locality": "private",
+          "packets": 1,
           "port": 137
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-12-01T17:04:39Z",
@@ -120,12 +123,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 232,
           "ip": "192.168.0.4",
           "locality": "private",
+          "packets": 1,
           "port": 58130
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -63,12 +63,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 363,
           "ip": "134.220.2.6",
           "locality": "public",
+          "packets": 3,
           "port": 88
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -63,12 +63,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 70,
           "ip": "23.35.171.27",
           "locality": "public",
+          "packets": 1,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -132,12 +135,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 111,
           "ip": "10.32.105.103",
           "locality": "private",
+          "packets": 1,
           "port": 39702
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -201,12 +207,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 70,
           "ip": "10.32.144.145",
           "locality": "private",
+          "packets": 1,
           "port": 52069
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -270,12 +279,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 70,
           "ip": "23.209.52.99",
           "locality": "public",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -339,12 +351,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 78,
           "ip": "10.50.97.57",
           "locality": "private",
+          "packets": 1,
           "port": 55481
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -408,12 +423,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 78,
           "ip": "10.50.96.20",
           "locality": "private",
+          "packets": 1,
           "port": 5432
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -477,12 +495,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 70,
           "ip": "34.234.173.147",
           "locality": "public",
+          "packets": 1,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-11-13T14:39:31Z",
@@ -546,12 +567,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 70,
           "ip": "10.130.167.43",
           "locality": "private",
+          "packets": 1,
           "port": 62196
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -58,12 +58,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 128,
           "ip": "100.78.40.201",
           "locality": "public",
+          "packets": 3,
           "port": 8080
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-01-11T11:48:15Z",
@@ -122,12 +125,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 172,
           "ip": "10.231.128.150",
           "locality": "private",
+          "packets": 4,
           "port": 50073
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-01-11T11:23:51Z",
@@ -186,12 +192,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3943,
           "ip": "100.78.40.201",
           "locality": "public",
+          "packets": 10,
           "port": 8080
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2017-01-11T11:23:51Z",
@@ -250,12 +259,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3052,
           "ip": "10.27.8.20",
           "locality": "private",
+          "packets": 11,
           "port": 53483
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -66,13 +66,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 174,
           "ip": "10.1.0.135",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 2,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -139,13 +142,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 87,
           "ip": "10.1.0.136",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -212,13 +218,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1920,
           "ip": "10.1.0.232",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 15,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -285,13 +294,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 610,
           "ip": "10.1.0.232",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 8,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -358,13 +370,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 2420,
           "ip": "10.5.0.91",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 21,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -431,13 +446,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 10204,
           "ip": "10.1.0.30",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 30,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -504,13 +522,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 216,
           "ip": "10.3.0.100",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 4,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:23:30Z",
@@ -577,13 +598,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "10.1.0.135",
           "locality": "private",
           "mac": "06:be:ef:be:ef:4f",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -649,12 +673,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 260,
           "ip": "192.168.1.98",
           "locality": "private",
+          "packets": 5,
           "port": 55105
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -720,12 +747,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 32,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 42506
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -791,12 +821,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 40295
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -862,12 +895,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 36071
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -933,12 +969,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 49829
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -1004,12 +1043,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 35059
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -1075,12 +1117,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 135,
           "ip": "10.4.0.251",
           "locality": "private",
+          "packets": 1,
           "port": 38231
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-09-10T16:24:08Z",
@@ -1146,12 +1191,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 3668,
           "ip": "192.168.1.102",
           "locality": "private",
+          "packets": 21,
           "port": 47690
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -62,12 +62,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 52,
           "ip": "192.168.200.136",
           "locality": "private",
+          "packets": 1,
           "port": 61926
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -66,13 +66,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 156,
           "ip": "37.122.1.226",
           "locality": "public",
           "mac": "90:e2:ba:23:09:fc",
+          "packets": 3,
           "port": 27622
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -139,13 +142,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 48,
           "ip": "5.141.231.166",
           "locality": "public",
           "mac": "90:e2:ba:23:09:fc",
+          "packets": 1,
           "port": 31178
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -212,13 +218,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 584,
           "ip": "10.233.128.4",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 11,
           "port": 53688
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -285,13 +294,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 577,
           "ip": "193.151.192.46",
           "locality": "public",
           "mac": "00:1a:4a:16:01:81",
+          "packets": 4,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -358,13 +370,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "10.235.197.6",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 3,
           "port": 57505
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -431,13 +446,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "10.236.31.7",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 3,
           "port": 61471
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -504,13 +522,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1809,
           "ip": "10.233.151.8",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 15,
           "port": 58044
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -577,13 +598,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 234,
           "ip": "10.234.22.4",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 3,
           "port": 60583
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -650,13 +674,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1681,
           "ip": "10.233.36.7",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 22,
           "port": 51399
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -723,13 +750,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 152,
           "ip": "10.233.200.7",
           "locality": "private",
           "mac": "00:04:96:97:b8:cd",
+          "packets": 3,
           "port": 61820
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -796,13 +826,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 1866,
           "ip": "23.43.139.27",
           "locality": "public",
           "mac": "90:e2:ba:23:09:fc",
+          "packets": 3,
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-02-18T05:47:09Z",
@@ -869,13 +902,16 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 187,
           "ip": "2.17.140.47",
           "locality": "public",
           "mac": "90:e2:ba:23:09:fc",
+          "packets": 3,
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -32,7 +32,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -87,7 +88,8 @@
           "port": 65058
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -142,7 +144,8 @@
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -197,7 +200,8 @@
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -252,7 +256,8 @@
           "port": 59157
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -307,7 +312,8 @@
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -362,7 +368,8 @@
           "port": 59158
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -417,7 +424,8 @@
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -472,7 +480,8 @@
           "port": 59159
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -527,7 +536,8 @@
           "port": 139
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -582,7 +592,8 @@
           "port": 59160
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -637,7 +648,8 @@
           "port": 23
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -692,7 +704,8 @@
           "port": 59161
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -747,7 +760,8 @@
           "port": 995
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -802,7 +816,8 @@
           "port": 59162
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -857,7 +872,8 @@
           "port": 443
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -912,7 +928,8 @@
           "port": 59163
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -967,7 +984,8 @@
           "port": 135
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1022,7 +1040,8 @@
           "port": 59164
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1077,7 +1096,8 @@
           "port": 110
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1132,7 +1152,8 @@
           "port": 59165
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1187,7 +1208,8 @@
           "port": 111
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1242,7 +1264,8 @@
           "port": 59166
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1297,7 +1320,8 @@
           "port": 143
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1352,7 +1376,8 @@
           "port": 59167
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1407,7 +1432,8 @@
           "port": 3389
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1462,7 +1488,8 @@
           "port": 59168
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1517,7 +1544,8 @@
           "port": 80
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1572,7 +1600,8 @@
           "port": 59169
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-10T08:47:01Z",
@@ -1627,7 +1656,8 @@
           "port": 25
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -32,7 +32,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -92,12 +93,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -157,12 +161,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.248",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -222,12 +229,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -287,12 +297,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.201",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -352,12 +365,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -417,12 +433,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.202",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -480,10 +499,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 672,
+          "packets": 7,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:06:29Z",
@@ -547,12 +569,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 200,
           "ip": "172.16.32.201",
           "locality": "private",
+          "packets": 2,
           "port": 22
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
@@ -53,12 +53,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 82,
           "ip": "0.0.0.0",
           "locality": "private",
+          "packets": 1,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
@@ -32,7 +32,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -63,12 +63,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "239.255.255.250",
           "locality": "public",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -132,12 +135,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "192.168.1.80",
           "locality": "private",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -201,12 +207,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "239.255.255.250",
           "locality": "public",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -270,12 +279,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 32,
           "ip": "192.168.1.95",
           "locality": "private",
+          "packets": 1,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -339,12 +351,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "239.255.255.250",
           "locality": "public",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -408,12 +423,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "192.168.1.95",
           "locality": "private",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -477,12 +495,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "239.255.255.250",
           "locality": "public",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -546,12 +567,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 32,
           "ip": "192.168.1.33",
           "locality": "private",
+          "packets": 1,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -615,12 +639,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "239.255.255.250",
           "locality": "public",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2016-12-23T01:35:31Z",
@@ -684,12 +711,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 0,
           "ip": "192.168.1.33",
           "locality": "private",
+          "packets": 0,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -59,12 +59,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -124,12 +127,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.248",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -189,12 +195,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -254,12 +263,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.201",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -319,12 +331,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.100",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -384,12 +399,15 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 76,
           "ip": "172.16.32.202",
           "locality": "private",
+          "packets": 1,
           "port": 123
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2015-10-08T19:04:30Z",
@@ -447,10 +465,13 @@
           "ip": "192.0.2.1"
         },
         "source": {
+          "bytes": 672,
+          "packets": 7,
           "port": 0
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
@@ -30,7 +30,8 @@
           "ip": "192.0.2.1"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
@@ -65,7 +65,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -131,7 +132,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -197,7 +199,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -263,7 +266,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -329,7 +333,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -395,7 +400,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -461,7 +467,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -527,7 +534,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -593,7 +601,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -659,7 +668,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -725,7 +735,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -791,7 +802,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -857,7 +869,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -923,7 +936,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -989,7 +1003,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1055,7 +1070,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1121,7 +1137,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1187,7 +1204,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1253,7 +1271,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1319,7 +1338,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1385,7 +1405,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1451,7 +1472,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1517,7 +1539,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1583,7 +1606,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1649,7 +1673,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1715,7 +1740,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1781,7 +1807,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1847,7 +1874,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-07-03T10:47:00Z",
@@ -1913,7 +1941,8 @@
           "ip": "10.101.255.2"
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -65,12 +65,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 421,
           "ip": "10.100.5.2",
           "locality": "private",
+          "packets": 6,
           "port": 43376
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -136,12 +139,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 7621,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 131,
           "port": 54520
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -207,12 +213,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 95,
           "ip": "10.100.4.1",
           "locality": "private",
+          "packets": 1,
           "port": 53
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -278,12 +287,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 3162,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 30,
           "port": 54497
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -349,12 +361,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 2711,
           "ip": "10.100.6.80",
           "locality": "private",
+          "packets": 13,
           "port": 50030
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -420,12 +435,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 20855,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 346,
           "port": 54517
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -491,12 +509,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 7495,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 129,
           "port": 54518
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -562,12 +583,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 7049,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 119,
           "port": 54519
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -633,12 +657,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 1348,
           "ip": "10.100.6.93",
           "locality": "private",
+          "packets": 13,
           "port": 54521
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     },
     {
       "Timestamp": "2018-08-09T16:49:04Z",
@@ -704,12 +731,15 @@
           "ip": "10.100.4.1"
         },
         "source": {
+          "bytes": 82,
           "ip": "192.168.1.4",
           "locality": "private",
+          "packets": 1,
           "port": 57253
         }
       },
-      "Private": null
+      "Private": null,
+      "TimeSeries": false
     }
   ]
 }


### PR DESCRIPTION
Cherry-pick of PR #14111 to 7.5 branch. Original message: 

This populates the `source.bytes` and `source.packets` fields for uni-directional netflow events. Previously only `network.bytes`/`network.packets` would be set. The input would already populate the source fields for bi-directional flows.

This also fixes an issue where the totals in `network.bytes` and `network.packets` were incorrectly calculated for bi-directional flows.