### PR TITLE
Stop using mage:import in custom beats

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -28,6 +28,8 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 ==== Bugfixes
 
+- Stop using `mage:import` in community beats. This was ignoring the vendorized beats directory for some mage targets, using the code available in GOPATH, this causes inconsistencies and compilation problems if the version of the code in the GOPATH is different to the vendored one. Use of `mage:import` will continue to be unsupported in custom beats till beats is migrated to go modules, or mage supports vendored dependencies. {issue}13998[13998] {pull}14162[14162]
+
 ==== Added
 
 - Metricset generator generates beta modules by default now. {pull}10657[10657]

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -78,3 +78,13 @@ func Fmt() {
 func Test() {
 	mg.Deps(unittest.GoUnitTest)
 }
+
+// Build builds the Beat binary.
+func Build() error {
+	return build.Build()
+}
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	return build.CrossBuild()
+}

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/dev-tools/mage/target/build"
 	"github.com/elastic/beats/dev-tools/mage/target/common"
 	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/dev-tools/mage/target/unittest"
 	"github.com/elastic/beats/generator/common/beatgen"
 )
 
@@ -71,4 +72,9 @@ func Check() {
 // Fmt formats source code (.go and .py) and adds license headers.
 func Fmt() {
 	common.Fmt()
+}
+
+// Test runs all available tests
+func Test() {
+	mg.Deps(unittest.GoUnitTest)
 }

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -10,20 +10,10 @@ import (
 	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
-	"github.com/elastic/beats/generator/common/beatgen"
-
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/pkg"
-	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/build"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/common"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/test"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
+	"github.com/elastic/beats/dev-tools/mage/target/common"
+	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/generator/common/beatgen"
 )
 
 func init() {
@@ -65,4 +55,20 @@ func Fields() error {
 // Config generates both the short/reference/docker configs.
 func Config() error {
 	return devtools.Config(devtools.AllConfigTypes, devtools.ConfigFileParams{}, ".")
+}
+
+// Clean cleans all generated files and build artifacts.
+func Clean() error {
+	return devtools.Clean()
+}
+
+// Check formats code, updates generated content, check for common errors, and
+// checks for any modified files.
+func Check() {
+	common.Check()
+}
+
+// Fmt formats source code (.go and .py) and adds license headers.
+func Fmt() {
+	common.Fmt()
 }

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/dev-tools/mage/target/collectors"
 	"github.com/elastic/beats/dev-tools/mage/target/common"
 	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/dev-tools/mage/target/unittest"
 	"github.com/elastic/beats/dev-tools/mage/target/update"
 	"github.com/elastic/beats/generator/common/beatgen"
 	metricbeat "github.com/elastic/beats/metricbeat/scripts/mage"
@@ -101,4 +102,9 @@ func Fmt() {
 // Update updates the generated files (aka make update).
 func Update() error {
 	return update.Update()
+}
+
+// Test runs all available tests
+func Test() {
+	mg.Deps(unittest.GoUnitTest)
 }

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -9,25 +9,13 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
+	"github.com/elastic/beats/dev-tools/mage/target/build"
+	"github.com/elastic/beats/dev-tools/mage/target/collectors"
+	"github.com/elastic/beats/dev-tools/mage/target/common"
+	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/dev-tools/mage/target/update"
 	"github.com/elastic/beats/generator/common/beatgen"
 	metricbeat "github.com/elastic/beats/metricbeat/scripts/mage"
-
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/common"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/build"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/pkg"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/test"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/collectors"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/update"
 )
 
 func init() {
@@ -92,4 +80,25 @@ func configYML() error {
 		ExtraVars:      map[string]interface{}{"BeatName": devtools.BeatName},
 	}
 	return devtools.Config(devtools.AllConfigTypes, customDeps, ".")
+}
+
+// Clean cleans all generated files and build artifacts.
+func Clean() error {
+	return devtools.Clean()
+}
+
+// Check formats code, updates generated content, check for common errors, and
+// checks for any modified files.
+func Check() {
+	common.Check()
+}
+
+// Fmt formats source code (.go and .py) and adds license headers.
+func Fmt() {
+	common.Fmt()
+}
+
+// Update updates the generated files (aka make update).
+func Update() error {
+	return update.Update()
 }

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -108,3 +108,13 @@ func Update() error {
 func Test() {
 	mg.Deps(unittest.GoUnitTest)
 }
+
+// Build builds the Beat binary.
+func Build() error {
+	return build.Build()
+}
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	return build.CrossBuild()
+}


### PR DESCRIPTION
`mage:import` doesn't take into account vendorized dependencies, this is a
problen for custom beats, because by default they have libbeat as a
vendorized dependency. The solution would be to use go modules, but in
the meantime lets remove the use of `mage:import` from the magefiles
intended to be used by custom beats.

Fix #13998