### PR TITLE
[7.3][DOCS] Backport: Remove has_ml_jobs for Beats that don't support ML (#13930)

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -13,7 +13,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
-:has_ml_jobs: yes
 :deb_os:
 :rpm_os:
 :mac_os:

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -13,7 +13,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
-:has_ml_jobs: yes
 :deb_os:
 :rpm_os:
 :mac_os:

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -13,7 +13,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
-:has_ml_jobs: yes
 :has_central_config:
 :has_solutions:
 :has_docker_label_ex:

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -13,7 +13,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
-:has_ml_jobs: yes
 :requires-sudo:
 :has_map:
 :deb_os:

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -13,7 +13,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
-:has_ml_jobs: yes
 :has_registry:
 :ignores_max_retries:
 :has_script_processor:


### PR DESCRIPTION
Backports #13930 to 7.3 branch.