### PR TITLE
[7.4][DOCS] Backport: Fix typo (#13973)

### DIFF
--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -117,7 +117,7 @@ metricbeat.modules:
 [[config-variants]]
 == Configuration variants
 
-Every module come with a default configuration file. Some modules also come with
+Every module comes with a default configuration file. Some modules also come with
 one or more variant configuration files containing common alternative configurations
 for that module.
 


### PR DESCRIPTION
Backports #13973 to 7.4 branch.