### PR TITLE
Add AWS_SHARED_CREDENTIALS_FILE to get aws config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -294,6 +294,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add condition to the config file template for add_kubernetes_metadata {pull}14056[14056]
 - Marking Central Management deprecated. {pull}14018[14018]
 - Add `keep_null` setting to allow Beats to publish null values in events. {issue}5522[5522] {pull}13928[13928]
+- Add shared_credential_file option in aws related config for specifying credential file directory. {issue}14157[14157] {pull}14178[14178]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -45,20 +45,21 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 	// If accessKeyID, secretAccessKey or sessionToken is not given, then load from default config
 	// Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 	// with more details.
+	// If credential_profile_name is empty, then default profile is used.
+	var options []external.Config
 	if config.ProfileName != "" {
-		if config.SharedCredentialFile != "" {
-			// If shared_credential_file is empty, then external.LoadDefaultAWSConfig
-			// function will load AWS config from current user's home directory.
-			// Linux/OSX: "$HOME/.aws/credentials"
-			// Windows:   "%USERPROFILE%\.aws\credentials"
-			return external.LoadDefaultAWSConfig(
-				external.WithSharedConfigProfile(config.ProfileName),
-				external.WithSharedConfigFiles([]string{config.SharedCredentialFile}),
-			)
-		}
-		return external.LoadDefaultAWSConfig(
-			external.WithSharedConfigProfile(config.ProfileName),
-		)
+		options = append(options, external.WithSharedConfigProfile(config.ProfileName))
+	}
+	// If shared_credential_file is empty, then external.LoadDefaultAWSConfig
+	// function will load AWS config from current user's home directory.
+	// Linux/OSX: "$HOME/.aws/credentials"
+	// Windows:   "%USERPROFILE%\.aws\credentials"
+	if config.SharedCredentialFile != "" {
+		options = append(options, external.WithSharedConfigFiles([]string{config.SharedCredentialFile}))
+	}
+
+	if options != nil {
+		return external.LoadDefaultAWSConfig(options...)
 	}
 	return external.LoadDefaultAWSConfig()
 }

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -57,9 +57,5 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 	if config.SharedCredentialFile != "" {
 		options = append(options, external.WithSharedConfigFiles([]string{config.SharedCredentialFile}))
 	}
-
-	if options != nil {
-		return external.LoadDefaultAWSConfig(options...)
-	}
-	return external.LoadDefaultAWSConfig()
+	return external.LoadDefaultAWSConfig(options...)
 }

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -17,7 +17,7 @@ type ConfigAWS struct {
 	SecretAccessKey string `config:"secret_access_key"`
 	SessionToken    string `config:"session_token"`
 	ProfileName     string `config:"credential_profile_name"`
-	CredentialFileDirectory string `config:"credential_file_directory"`
+	SharedCredentialFile string `config:"shared_credential_file"`
 }
 
 // GetAWSCredentials function gets aws credentials from the config.
@@ -43,12 +43,12 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 		return awsConfig, nil
 	}
 
-	// If credential_file_directory is empty, then external.LoadDefaultAWSConfig
+	// If shared_credential_file is empty, then external.LoadDefaultAWSConfig
 	// function will load AWS config from current user's home directory.
 	// Linux/OSX: "$HOME/.aws/credentials"
 	// Windows:   "%USERPROFILE%\.aws\credentials"
-	if config.CredentialFileDirectory != "" {
-		os.Setenv(external.AWSSharedCredentialsFileEnvVar, config.CredentialFileDirectory)
+	if config.SharedCredentialFile != "" {
+		os.Setenv(external.AWSSharedCredentialsFileEnvVar, config.SharedCredentialFile)
 	}
 
 	// If accessKeyID, secretAccessKey or sessionToken is not given, then load from default config

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -12,8 +12,13 @@ environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 
 include::../../../{beatname_lc}/docs/aws-credentials-examples.asciidoc[]
 
-`credential_profile_name` is optional. If there is no `credential_profile_name`
+`credential_profile_name` is optional. If you use different credentials for
+different tools or applications, you can use profiles to configure multiple
+access keys in the same configuration file. If there is no `credential_profile_name`
 given, the default profile will be used.
+
+`shared_credential_file` is optional to specify the directory of your shared
+credentials file. If it's empty, the default directory will be used.
 In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.
 For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -91,12 +91,12 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	output, err := req.Send(context.TODO())
 	if err != nil {
 		base.Logger().Warn("failed to list account aliases, please check permission setting: ", err)
-	}
-
-	// There can be more than one aliases for each account, for now we are only
-	// collecting the first one.
-	if output.AccountAliases != nil {
-		metricSet.AccountName = output.AccountAliases[0]
+	} else {
+		// There can be more than one aliases for each account, for now we are only
+		// collecting the first one.
+		if output.AccountAliases != nil {
+			metricSet.AccountName = output.AccountAliases[0]
+		}
 	}
 
 	// Get IAM account id
@@ -105,8 +105,9 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	outputIdentity, err := reqIdentity.Send(context.TODO())
 	if err != nil {
 		base.Logger().Warn("failed to get caller identity, please check permission setting: ", err)
+	} else {
+		metricSet.AccountID = *outputIdentity.Account
 	}
-	metricSet.AccountID = *outputIdentity.Account
 
 	// Construct MetricSet with a full regions list
 	if config.Regions == nil {


### PR DESCRIPTION
`shared_credential_file` can be set for the path to the shared credentials file. If empty/not set, it will be default to current user's home directory. For Linux/OSX is `$HOME/.aws/credentials` and for Windows is `%USERPROFILE%\.aws\credentials`.

closes https://github.com/elastic/beats/issues/14157

## How to test this:
Copy your aws credential to some other directory or change the name. I change mine to _credentials-backup_ instead. 

### case1
Enable aws module in Metricbeat and change aws.yml to:
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  regions:
    - us-east-1
  credential_profile_name: test-mb
  shared_credential_file: /Users/kaiyansheng/.aws/credentials-backup
```
You should see EC2 metrics flowing into ES with no credential error.

### case2
Either with specified `credential_profile_name` but no `shared_credential_file` or specified `shared_credential_file` but no `credential_profile_name` should work.

Set valid credentials under `[test-mb]` profile in default credential file `~/.aws/credentials` and test with config below:
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  regions:
    - us-east-1
  credential_profile_name: test-mb
```

### case3
Set valid credentials under `[default]` profile in credential file `~/.aws/credentials-backup` and test with config below:
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  regions:
    - us-east-1
  shared_credential_file: /Users/kaiyansheng/.aws/credentials-backup
```

### case4
Set valid credentials under `[default]` profile in default credential file `~/.aws/credentials` and test with config below without credential_profile_name or shared_credential_file:
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  regions:
    - us-east-1
```