### PR TITLE
Flaky test: temporarily disable checking some user_agent fields

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -232,7 +232,8 @@ def clean_keys(obj):
     }
 
     # flaky test, temporarily remove user_agent fields
-    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name", "user_agent.device.name", "user_agent.original"]
+    user_agent_keys = ["user_agent.os.name", "user_agent.version",
+                       "user_agent.name", "user_agent.device.name", "user_agent.original"]
 
     # Keep source log filename for exceptions
     filename = None

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -231,8 +231,8 @@ def clean_keys(obj):
         ('system.auth', 'timestamp.log')
     }
 
-    # flaky test, temporarily remove user_agent.os.name, user_agent.version and user_agent.name
-    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name"]
+    # flaky test, temporarily remove user_agent.os.name, user_agent.version, user_agent.device.name and user_agent.name
+    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name", "user_agent.device.name"]
 
     # Keep source log filename for exceptions
     filename = None

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -231,12 +231,15 @@ def clean_keys(obj):
         ('system.auth', 'timestamp.log')
     }
 
+    # flaky test, temporarily remove user_agent.os.name and user_agent.version
+    user_agent_keys = ["user_agent.os.name", "user_agent.version"]
+
     # Keep source log filename for exceptions
     filename = None
     if "log.file.path" in obj:
         filename = os.path.basename(obj["log.file.path"]).lower()
 
-    for key in host_keys + time_keys + other_keys + ecs_key:
+    for key in host_keys + time_keys + other_keys + ecs_key + user_agent_keys:
         delete_key(obj, key)
 
     # Most logs from syslog need their timestamp removed because it doesn't

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -231,8 +231,8 @@ def clean_keys(obj):
         ('system.auth', 'timestamp.log')
     }
 
-    # flaky test, temporarily remove user_agent.os.name and user_agent.version
-    user_agent_keys = ["user_agent.os.name", "user_agent.version"]
+    # flaky test, temporarily remove user_agent.os.name, user_agent.version and user_agent.name
+    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name"]
 
     # Keep source log filename for exceptions
     filename = None

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -231,8 +231,8 @@ def clean_keys(obj):
         ('system.auth', 'timestamp.log')
     }
 
-    # flaky test, temporarily remove user_agent.os.name, user_agent.version, user_agent.device.name and user_agent.name
-    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name", "user_agent.device.name"]
+    # flaky test, temporarily remove user_agent fields
+    user_agent_keys = ["user_agent.os.name", "user_agent.version", "user_agent.name", "user_agent.device.name", "user_agent.original"]
 
     # Keep source log filename for exceptions
     filename = None


### PR DESCRIPTION
Beats CI filebeat tests start failing caused by something changed with the user_agent plugin or regex, specifically `user_agent.os.name`, `user_agent.name` and `user_agent.version` field: https://travis-ci.org/elastic/beats/jobs/600418441#L2184

Removing some specific user_agent fields from checking instead of disabling the whole `test_modules.py` test.

Elasticsearch issue is created to track the real fix for the failing tests: https://github.com/elastic/elasticsearch/issues/48318