### PR TITLE
Cherry-pick #14162 to 7.5: Stop using mage:import in custom beats

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -25,6 +25,8 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 ==== Bugfixes
 
+- Stop using `mage:import` in community beats. This was ignoring the vendorized beats directory for some mage targets, using the code available in GOPATH, this causes inconsistencies and compilation problems if the version of the code in the GOPATH is different to the vendored one. Use of `mage:import` will continue to be unsupported in custom beats till beats is migrated to go modules, or mage supports vendored dependencies. {issue}13998[13998] {pull}14162[14162]
+
 ==== Added
 
 - Metricset generator generates beta modules by default now. {pull}10657[10657]

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -9,19 +9,11 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
-
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/common"
-	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/build"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/update"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/test"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
-	// mage:import
+	"github.com/elastic/beats/dev-tools/mage/target/common"
 	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/dev-tools/mage/target/unittest"
+	"github.com/elastic/beats/dev-tools/mage/target/update"
 )
 
 func init() {
@@ -53,4 +45,35 @@ func Config() error {
 //Fields generates a fields.yml for the Beat.
 func Fields() error {
 	return devtools.GenerateFieldsYAML()
+}
+
+// Clean cleans all generated files and build artifacts.
+func Clean() error {
+	return devtools.Clean()
+}
+
+// Check formats code, updates generated content, check for common errors, and
+// checks for any modified files.
+func Check() {
+	common.Check()
+}
+
+// Fmt formats source code (.go and .py) and adds license headers.
+func Fmt() {
+	common.Fmt()
+}
+
+// Test runs all available tests
+func Test() {
+	mg.Deps(unittest.GoUnitTest)
+}
+
+// Build builds the Beat binary.
+func Build() error {
+	return build.Build()
+}
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	return build.CrossBuild()
 }

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -9,24 +9,13 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
-	metricbeat "github.com/elastic/beats/metricbeat/scripts/mage"
-
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/common"
-	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/build"
-	// mage:import
-	"github.com/elastic/beats/dev-tools/mage/target/pkg"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/test"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
-	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
-	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/collectors"
-	// mage:import
+	"github.com/elastic/beats/dev-tools/mage/target/common"
+	"github.com/elastic/beats/dev-tools/mage/target/pkg"
+	"github.com/elastic/beats/dev-tools/mage/target/unittest"
 	"github.com/elastic/beats/dev-tools/mage/target/update"
+	metricbeat "github.com/elastic/beats/metricbeat/scripts/mage"
 )
 
 func init() {
@@ -86,4 +75,40 @@ func configYML() error {
 		ExtraVars:      map[string]interface{}{"BeatName": devtools.BeatName},
 	}
 	return devtools.Config(devtools.AllConfigTypes, customDeps, ".")
+}
+
+// Clean cleans all generated files and build artifacts.
+func Clean() error {
+	return devtools.Clean()
+}
+
+// Check formats code, updates generated content, check for common errors, and
+// checks for any modified files.
+func Check() {
+	common.Check()
+}
+
+// Fmt formats source code (.go and .py) and adds license headers.
+func Fmt() {
+	common.Fmt()
+}
+
+// Update updates the generated files (aka make update).
+func Update() error {
+	return update.Update()
+}
+
+// Test runs all available tests
+func Test() {
+	mg.Deps(unittest.GoUnitTest)
+}
+
+// Build builds the Beat binary.
+func Build() error {
+	return build.Build()
+}
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	return build.CrossBuild()
 }


### PR DESCRIPTION
Cherry-pick of PR #14162 to 7.5 branch. Original message: 

`mage:import` doesn't take into account vendorized dependencies, this is a
problen for custom beats, because by default they have libbeat as a
vendorized dependency. The solution would be to use go modules, but in
the meantime lets remove the use of `mage:import` from the magefiles
intended to be used by custom beats.

Fix #13998