### PR TITLE
Regenerate expected user agent fields

### DIFF
--- a/filebeat/module/apache/access/test/test-vhost.log-expected.json
+++ b/filebeat/module/apache/access/test/test-vhost.log-expected.json
@@ -22,6 +22,6 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     }
 ]

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -39,7 +39,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T14:16:48.000Z",
@@ -74,7 +74,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {
@@ -97,7 +99,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {

--- a/filebeat/module/apache/access/test/ubuntu-2.2.22.log-expected.json
+++ b/filebeat/module/apache/access/test/ubuntu-2.2.22.log-expected.json
@@ -19,6 +19,7 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Wget",
         "user_agent.original": "Wget/1.13.4 (linux-gnu)",
+        "user_agent.os.name": "Linux",
         "user_agent.version": "1.13.4"
     },
     {
@@ -44,7 +45,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-26T16:22:00.000Z",
@@ -69,7 +70,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-26T16:22:08.000Z",
@@ -94,7 +95,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T16:22:08.000Z",
@@ -119,7 +120,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T16:22:08.000Z",
@@ -144,7 +145,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T16:22:10.000Z",
@@ -169,7 +170,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T16:22:13.000Z",
@@ -194,7 +195,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     },
     {
         "@timestamp": "2016-12-26T16:22:17.000Z",
@@ -219,6 +220,6 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0"
+        "user_agent.version": "50.0."
     }
 ]

--- a/filebeat/module/iis/access/test/test-iis-7.2.log-expected.json
+++ b/filebeat/module/iis/access/test/test-iis-7.2.log-expected.json
@@ -24,7 +24,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     },
     {
@@ -52,7 +54,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     },
     {
@@ -80,7 +84,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     },
     {
@@ -108,7 +114,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     },
     {
@@ -136,7 +144,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     }
 ]

--- a/filebeat/module/iis/access/test/test-iis-7.5.log-expected.json
+++ b/filebeat/module/iis/access/test/test-iis-7.5.log-expected.json
@@ -23,8 +23,10 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR[ 2.0.50727](tel: 2050727); .NET CLR 3.0.30729)",
-        "user_agent.os.name": "Windows 8.1",
-        "user_agent.version": "7.0"
+        "user_agent.os.full": "Windows 8.1",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "8.1",
+        "user_agent.version": "11.0"
     },
     {
         "@timestamp": "2019-03-06T18:43:17.000Z",

--- a/filebeat/module/iis/access/test/test-ipv6zone.log-expected.json
+++ b/filebeat/module/iis/access/test/test-ipv6zone.log-expected.json
@@ -34,6 +34,6 @@
         "user_agent.os.full": "Mac OS X 10.14.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14.0",
-        "user_agent.version": "70.0.3538"
+        "user_agent.version": "70.0.3538.102"
     }
 ]

--- a/filebeat/module/iis/access/test/test.log-expected.json
+++ b/filebeat/module/iis/access/test/test.log-expected.json
@@ -33,8 +33,10 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0",
-        "user_agent.os.name": "Windows 7",
-        "user_agent.version": "57.0"
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
+        "user_agent.version": "57.0."
     },
     {
         "@timestamp": "2018-01-01T09:10:11.000Z",
@@ -64,8 +66,10 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0",
-        "user_agent.os.name": "Windows 7",
-        "user_agent.version": "57.0"
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
+        "user_agent.version": "57.0."
     },
     {
         "@timestamp": "2018-01-01T10:11:12.000Z",
@@ -111,7 +115,7 @@
         "user_agent.os.full": "Mac OS X 10.14.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14.0",
-        "user_agent.version": "70.0.3538"
+        "user_agent.version": "70.0.3538.102"
     },
     {
         "@timestamp": "2018-12-31T12:52:33.000Z",
@@ -138,7 +142,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     },
     {
@@ -166,7 +172,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "IE",
         "user_agent.original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-        "user_agent.os.name": "Windows XP",
+        "user_agent.os.full": "Windows XP",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "XP",
         "user_agent.version": "8.0"
     }
 ]

--- a/filebeat/module/nginx/access/test/access.log-expected.json
+++ b/filebeat/module/nginx/access/test/access.log-expected.json
@@ -32,7 +32,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.59"
     },
     {
         "@timestamp": "2016-10-25T12:49:34.000Z",
@@ -67,7 +67,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.59"
     },
     {
         "@timestamp": "2016-10-25T12:50:44.000Z",
@@ -102,7 +102,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.59"
     },
     {
         "@timestamp": "2016-12-07T09:34:43.000Z",
@@ -137,7 +137,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T09:34:43.000Z",
@@ -172,7 +172,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T09:43:18.000Z",
@@ -207,7 +207,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T09:43:21.000Z",
@@ -242,7 +242,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T09:43:23.000Z",
@@ -277,7 +277,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T10:04:37.000Z",
@@ -306,7 +306,7 @@
         "user_agent.os.full": "Mac OS X 10.12.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12.0",
-        "user_agent.version": "54.0.2840"
+        "user_agent.version": "54.0.2840.98"
     },
     {
         "@timestamp": "2016-12-07T10:04:58.000Z",
@@ -335,7 +335,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2016-12-07T10:04:59.000Z",
@@ -364,7 +364,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",
@@ -393,6 +393,6 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     }
 ]

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -28,7 +28,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2017-05-29T19:02:48.000Z",
@@ -54,7 +54,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {
@@ -95,7 +97,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",
@@ -133,7 +135,7 @@
         "user_agent.os.full": "Mac OS X 10.14.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14.0",
-        "user_agent.version": "70.0.3538"
+        "user_agent.version": "70.0.3538.102"
     },
     {
         "@timestamp": "2016-01-22T13:18:29.000Z",
@@ -266,7 +268,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {
@@ -289,7 +293,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     }
 ]

--- a/filebeat/module/traefik/access/test/test.log-expected.json
+++ b/filebeat/module/traefik/access/test/test.log-expected.json
@@ -25,7 +25,7 @@
         "user_agent.name": "Chrome",
         "user_agent.original": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36",
         "user_agent.os.name": "Linux",
-        "user_agent.version": "61.0.3163"
+        "user_agent.version": "61.0.3163.100"
     },
     {
         "@timestamp": "2017-10-02T20:22:08.000Z",
@@ -62,7 +62,7 @@
         "user_agent.name": "Chrome",
         "user_agent.original": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36",
         "user_agent.os.name": "Linux",
-        "user_agent.version": "61.0.3163"
+        "user_agent.version": "61.0.3163.100"
     },
     {
         "@timestamp": "2018-02-28T17:30:33.000Z",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
@@ -116,7 +116,7 @@
         "user_agent.os.full": "Mac OS X 10.13.5",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.13.5",
-        "user_agent.version": "67.0.3396"
+        "user_agent.version": "67.0.3396.99"
     },
     {
         "@timestamp": "2018-07-05T19:44:33.222Z",
@@ -168,7 +168,7 @@
         "user_agent.os.full": "Mac OS X 10.13.5",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.13.5",
-        "user_agent.version": "67.0.3396"
+        "user_agent.version": "67.0.3396.99"
     },
     {
         "@timestamp": "2018-07-05T19:51:20.213Z",


### PR DESCRIPTION
User agent plugin seems to have changed, and some expected
fields are different. Regenerate expected fields in golden files.

See https://github.com/elastic/beats/pull/14179 and https://github.com/elastic/elasticsearch/issues/48318 for more details.