### PR TITLE
Cherry-pick #14141 to 7.5: [Metricbeat] Fix cloudwatch config params in documentation

### DIFF
--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -105,20 +105,14 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 metricbeat.modules:
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - sqs
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-west-1
 - module: aws
@@ -129,18 +123,14 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
+  metrics:
     - namespace: AWS/EC2
-      metricname: CPUUtilization
+      name: ["CPUUtilization"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
@@ -149,12 +139,9 @@ metricbeat.modules:
       tags.resource_type_filter: elasticloadbalancing
 - module: aws
   period: 60s
+  credential_profile_name: test-mb
   metricsets:
     - rds
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 ----
 
 [float]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -168,20 +168,14 @@ metricbeat.modules:
 #--------------------------------- Aws Module ---------------------------------
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - sqs
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-west-1
 - module: aws
@@ -192,18 +186,14 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
+  metrics:
     - namespace: AWS/EC2
-      metricname: CPUUtilization
+      name: ["CPUUtilization"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
@@ -212,12 +202,9 @@ metricbeat.modules:
       tags.resource_type_filter: elasticloadbalancing
 - module: aws
   period: 60s
+  credential_profile_name: test-mb
   metricsets:
     - rds
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 
 #-------------------------------- Azure Module --------------------------------
 - module: azure

--- a/x-pack/metricbeat/module/aws/_meta/config.reference.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.reference.yml
@@ -1,19 +1,13 @@
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - sqs
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-west-1
 - module: aws
@@ -24,18 +18,14 @@
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
+  credential_profile_name: test-mb
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
+  metrics:
     - namespace: AWS/EC2
-      metricname: CPUUtilization
+      name: ["CPUUtilization"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
@@ -44,9 +34,6 @@
       tags.resource_type_filter: elasticloadbalancing
 - module: aws
   period: 60s
+  credential_profile_name: test-mb
   metricsets:
     - rds
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'

--- a/x-pack/metricbeat/module/aws/mtest/scripts/test_cloudwatch_metricset.yml
+++ b/x-pack/metricbeat/module/aws/mtest/scripts/test_cloudwatch_metricset.yml
@@ -10,6 +10,6 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
+  metrics:
     - namespace: AWS/EC2
       resource_type_filter: ec2


### PR DESCRIPTION
Cherry-pick of PR #14141 to 7.5 branch. Original message: 

Just realized when I switched namings in cloudwatch metricset like `cloudwatch_metrics` to `metrics`, some documentation didn't get updated. This PR is to fix that and needs to get backported.