### PR TITLE
Cherry-pick #14137 to 7.5: [Filebeat] Support '-' as http.response.body.bytes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -50,7 +50,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix azure fields names. {pull}14098[14098] {pull}14132[14132]
 - Fix calculation of `network.bytes` and `network.packets` for bi-directional netflow events. {pull}14111[14111]
 - Accept '-' as http.response.body.bytes in apache module. {pull}14137[14137]
-- Fix timezone parsing of MySQL module ingest pipelines. {pull}14130[14130]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix azure fields names. {pull}14098[14098] {pull}14132[14132]
 - Fix calculation of `network.bytes` and `network.packets` for bi-directional netflow events. {pull}14111[14111]
+- Accept '-' as http.response.body.bytes in apache module. {pull}14137[14137]
+- Fix timezone parsing of MySQL module ingest pipelines. {pull}14130[14130]
 
 *Heartbeat*
 

--- a/filebeat/module/apache/access/ingest/default.json
+++ b/filebeat/module/apache/access/ingest/default.json
@@ -8,7 +8,7 @@
                   "%{IPORHOST:destination.domain} %{IPORHOST:source.ip} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"(?:%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}|-)?\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)( \"%{DATA:http.request.referrer}\")?( \"%{DATA:user_agent.original}\")?",
                   "%{IPORHOST:source.address} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"(?:%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}|-)?\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)( \"%{DATA:http.request.referrer}\")?( \"%{DATA:user_agent.original}\")?",
                   "%{IPORHOST:source.address} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"-\" %{NUMBER:http.response.status_code:long} -",
-                  "\\[%{HTTPDATE:apache.access.time}\\] %{IPORHOST:source.address} %{DATA:apache.access.ssl.protocol} %{DATA:apache.access.ssl.cipher} \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.body.bytes:long}"
+                  "\\[%{HTTPDATE:apache.access.time}\\] %{IPORHOST:source.address} %{DATA:apache.access.ssl.protocol} %{DATA:apache.access.ssl.cipher} \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" (-|%{NUMBER:http.response.body.bytes:long})"
               ],
               "ignore_missing": true
           }

--- a/filebeat/module/apache/access/test/ssl-request.log
+++ b/filebeat/module/apache/access/test/ssl-request.log
@@ -1,1 +1,2 @@
 [10/Aug/2018:09:45:56 +0200] 172.30.0.119 TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 "GET /nagiosxi/ajaxhelper.php?cmd=getxicoreajax&amp;opts=%7B%22func%22%3A%22get_admin_tasks_html%22%2C%22args%22%3A%22%22%7D&amp;nsp=b5c7d5d4b6f7d0cf0c92f9cbdf737f6a5c838218425e6ae21 HTTP/1.1" 1375
+[16/Oct/2019:11:53:47 +0200] 11.19.0.217 TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 "GET /appl/ajaxhelper.php?cmd=getxicoreajax&opts=%7B%22func%22%3A%22get_pagetop_alert_content_html%22%2C%22args%22%3A%22%22%7D&nsp=c2700eab9797eda8a9f65a3ab17a6adbceccd60a6cca7708650a5923950d HTTP/1.1" -

--- a/filebeat/module/apache/access/test/ssl-request.log-expected.json
+++ b/filebeat/module/apache/access/test/ssl-request.log-expected.json
@@ -15,5 +15,25 @@
         "source.address": "172.30.0.119",
         "source.ip": "172.30.0.119",
         "url.original": "/nagiosxi/ajaxhelper.php?cmd=getxicoreajax&amp;opts=%7B%22func%22%3A%22get_admin_tasks_html%22%2C%22args%22%3A%22%22%7D&amp;nsp=b5c7d5d4b6f7d0cf0c92f9cbdf737f6a5c838218425e6ae21"
+    },
+    {
+        "@timestamp": "2019-10-16T09:53:47.000Z",
+        "apache.access.ssl.cipher": "ECDHE-RSA-AES128-GCM-SHA256",
+        "apache.access.ssl.protocol": "TLSv1.2",
+        "event.dataset": "apache.access",
+        "event.module": "apache",
+        "fileset.name": "access",
+        "http.request.method": "GET",
+        "http.version": "1.1",
+        "input.type": "log",
+        "log.offset": 276,
+        "service.type": "apache",
+        "source.address": "11.19.0.217",
+        "source.geo.continent_name": "North America",
+        "source.geo.country_iso_code": "US",
+        "source.geo.location.lat": 37.751,
+        "source.geo.location.lon": -97.822,
+        "source.ip": "11.19.0.217",
+        "url.original": "/appl/ajaxhelper.php?cmd=getxicoreajax&opts=%7B%22func%22%3A%22get_pagetop_alert_content_html%22%2C%22args%22%3A%22%22%7D&nsp=c2700eab9797eda8a9f65a3ab17a6adbceccd60a6cca7708650a5923950d"
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #14137 to 7.5 branch. Original message: 

This is an issue brought up by @willemdh in https://github.com/elastic/beats/issues/8088#issuecomment-542627903:
For ssl_request_log in apache module, we are not supporting `-` as a possible `http.response.body.bytes` value. This PR is to enhance the grok pattern to accept `-` for this field.
