### PR TITLE
[7.5] Fix flaky test_beat.test_xpack Metricbeat system test (#13951)

### DIFF
--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -215,3 +215,17 @@ class ComposeMixin(object):
             class_dir, current = os.path.split(class_dir)
             if current == '':  # We have reached root
                 raise Exception("failed to find a docker-compose.yml file")
+
+    @classmethod
+    def get_service_log(cls, service):
+        container = cls.compose_project().containers(service_names=[service])[0]
+        return container.logs()
+
+    @classmethod
+    def service_log_contains(cls, service, msg):
+        log = cls.get_service_log(service)
+        counter = 0
+        for line in log.splitlines():
+            if line.find(msg) >= 0:
+                counter += 1
+        return counter > 0

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       context: ./module/beat/_meta
       args:
         BEAT_VERSION: ${BEAT_VERSION:-7.3.0}
+    command: '-e'
     ports:
       - 5066
 

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -3,6 +3,7 @@ import metricbeat
 import unittest
 import time
 from parameterized import parameterized
+from elasticsearch import Elasticsearch
 
 
 class Test(metricbeat.BaseTest):
@@ -17,31 +18,35 @@ class Test(metricbeat.BaseTest):
         """
         beat metricset tests
         """
-        self.check_metricset("beat", metricset, self.get_hosts(), self.FIELDS + ["service"])
+        self.check_metricset("beat", metricset, [self.compose_host("metricbeat")], self.FIELDS + ["service"])
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_xpack(self):
         """
         beat-xpack module tests
         """
-        self.render_config_template(modules=[{
-            "name": "beat",
-            "metricsets": self.METRICSETS,
-            "hosts": self.get_hosts(),
-            "period": "1s",
-            "extras": {
-                "xpack.enabled": "true"
-            }
-        }])
 
         # Give the monitored Metricbeat instance enough time to collect metrics and index them
         # into Elasticsearch, so it may establish the connection to Elasticsearch and determine
         # it's cluster UUID in the process. Otherwise, the monitoring Metricbeat instance will
         # show errors in its log about not being able to determine the Elasticsearch cluster UUID
         # to be associated with the monitored Metricbeat instance.
-        time.sleep(30)
+        self.wait_until(cond=self.mb_connected_to_es, max_timeout=30)
+
+        self.render_config_template(modules=[{
+            "name": "beat",
+            "metricsets": self.METRICSETS,
+            "hosts": [self.compose_host("metricbeat")],
+            "period": "1s",
+            "extras": {
+                "xpack.enabled": "true"
+            }
+        }])
 
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
+
+    def mb_connected_to_es(self):
+        return self.service_log_contains('metricbeat', 'Connection to backoff(elasticsearch(')


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Fix flaky test_beat.test_xpack Metricbeat system test  (#13951)