### PR TITLE
[metricbeat] Add empty response check to haproxy run method

### DIFF
--- a/metricbeat/module/haproxy/haproxy.go
+++ b/metricbeat/module/haproxy/haproxy.go
@@ -260,9 +260,12 @@ func (p *unixProto) run(cmd string) (*bytes.Buffer, error) {
 		return response, err
 	}
 
-	_, err = io.Copy(response, conn)
+	recv, err := io.Copy(response, conn)
 	if err != nil {
 		return response, err
+	}
+	if recv == 0 {
+		return response, errors.New("Got empty response from HAProxy")
 	}
 
 	if strings.HasPrefix(response.String(), "Unknown command") {


### PR DESCRIPTION
See  #14134

This checks to make sure we have a non-empty response from haproxy before we continue. The rest of the haproxy code will gleefully ignore empty byte buffers, so we need some kind of check lest we send the user bizarre parsing errors later on.