### PR TITLE
[7.5] Set default umask of 0027 for all Beats-created files (#14119)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,15 +11,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Update to Golang 1.12.1. {pull}11330[11330]
-- Update to Golang 1.12.4. {pull}11782[11782]
-- Update to ECS 1.0.1. {pull}12284[12284] {pull}12317[12317]
-- Default of output.kafka.metadata.full is set to false by now. This reduced the amount of metadata to be queried from a kafka cluster. {pull}12738[12738]
-- Fixed a crash under Windows when fetching processes information. {pull}12833[12833]
-- Update to Golang 1.12.7. {pull}12931[12931]
-- Remove `in_cluster` configuration parameter for Kuberentes, now in-cluster configuration is used only if no other kubeconfig is specified {pull}13051[13051]
-- Disable Alibaba Cloud and Tencent Cloud metadata providers by default. {pull}13812[12812]
-- Libbeat HTTP's Server can listen to a unix socket using the `unix:///tmp/hello.sock` syntax. {pull}13655[13655]
-- Libbeat HTTP's Server can listen to a Windows named pipe using the `npipe:///hello` syntax. {pull}13655[13655]
 - By default, all Beats-created files and folders will have a umask of 0027 (on POSIX systems). {pull}14119[14119]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,6 +11,16 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Update to Golang 1.12.1. {pull}11330[11330]
+- Update to Golang 1.12.4. {pull}11782[11782]
+- Update to ECS 1.0.1. {pull}12284[12284] {pull}12317[12317]
+- Default of output.kafka.metadata.full is set to false by now. This reduced the amount of metadata to be queried from a kafka cluster. {pull}12738[12738]
+- Fixed a crash under Windows when fetching processes information. {pull}12833[12833]
+- Update to Golang 1.12.7. {pull}12931[12931]
+- Remove `in_cluster` configuration parameter for Kuberentes, now in-cluster configuration is used only if no other kubeconfig is specified {pull}13051[13051]
+- Disable Alibaba Cloud and Tencent Cloud metadata providers by default. {pull}13812[12812]
+- Libbeat HTTP's Server can listen to a unix socket using the `unix:///tmp/hello.sock` syntax. {pull}13655[13655]
+- Libbeat HTTP's Server can listen to a Windows named pipe using the `npipe:///hello` syntax. {pull}13655[13655]
+- By default, all Beats-created files and folders will have a umask of 0027 (on POSIX systems). {pull}14119[14119]
 
 *Auditbeat*
 

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -42,13 +42,15 @@ NOTE: The content stored in filebeat/data.json is compatible to the old registry
 
 The permissions mask to apply on registry data file. The default value is 0600. The permissions option must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to a umask of 0027.
+
 This option is not supported on Windows.
 
 Examples:
 
-    0644: give read and write access to the file owner, and read access to all others.
+    0640: give read and write access to the file owner, and read access to members of the group associated with the file.
     0600: give read and write access to the file owner, and no access to all others.
-    0664: give read and write access to the file owner and members of the group associated with the file, as well as read access to all other users.
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -206,7 +206,7 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             registry_home=registry_home,
-            registry_file_permissions=0644,
+            registry_file_permissions=0640,
         )
         os.mkdir(self.working_dir + "/log/")
         testfile_path = self.working_dir + "/log/test.log"
@@ -223,7 +223,7 @@ class Test(BaseTest):
             max_timeout=1)
         filebeat.check_kill_and_wait()
 
-        self.assertEqual(self.file_permissions(registry_file), "0644")
+        self.assertEqual(self.file_permissions(registry_file), "0640")
 
     def test_registry_file_update_permissions(self):
         """
@@ -262,7 +262,7 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             registry_home="a/b/c/registry_x",
-            registry_file_permissions=0644
+            registry_file_permissions=0640
         )
 
         filebeat = self.start_beat()
@@ -280,7 +280,7 @@ class Test(BaseTest):
 
         filebeat.check_kill_and_wait()
 
-        self.assertEqual(self.file_permissions(registry_file), "0644")
+        self.assertEqual(self.file_permissions(registry_file), "0640")
 
     def test_rotating_file(self):
         """

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -147,6 +147,11 @@ func initRand() {
 // instance.
 // XXX Move this as a *Beat method?
 func Run(settings Settings, bt beat.Creator) error {
+	err := setUmaskWithSettings(settings)
+	if err != nil && err != errNotImplemented {
+		return errw.Wrap(err, "could not set umask")
+	}
+
 	name := settings.Name
 	idxPrefix := settings.IndexPrefix
 	version := settings.Version
@@ -1036,4 +1041,11 @@ func initPaths(cfg *common.Config) error {
 		return fmt.Errorf("error setting default paths: %+v", err)
 	}
 	return nil
+}
+
+func setUmaskWithSettings(settings Settings) error {
+	if settings.Umask != nil {
+		return setUmask(*settings.Umask)
+	}
+	return setUmask(0027) // 0640 for files | 0750 for dirs
 }

--- a/libbeat/cmd/instance/umask_other.go
+++ b/libbeat/cmd/instance/umask_other.go
@@ -15,34 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build !windows
+
 package instance
 
 import (
-	"github.com/spf13/pflag"
-
-	"github.com/elastic/beats/libbeat/cfgfile"
-	"github.com/elastic/beats/libbeat/idxmgmt"
-	"github.com/elastic/beats/libbeat/idxmgmt/ilm"
-	"github.com/elastic/beats/libbeat/monitoring/report"
-	"github.com/elastic/beats/libbeat/publisher/processing"
+	"errors"
+	"syscall"
 )
 
-// Settings contains basic settings for any beat to pass into GenRootCmd
-type Settings struct {
-	Name            string
-	IndexPrefix     string
-	Version         string
-	Monitoring      report.Settings
-	RunFlags        *pflag.FlagSet
-	ConfigOverrides []cfgfile.ConditionalOverride
+var errNotImplemented = errors.New("not implemented on platform")
 
-	DisableConfigResolver bool
-
-	// load custom index manager. The config object will be the Beats root configuration.
-	IndexManagement idxmgmt.SupportFactory
-	ILM             ilm.SupportFactory
-
-	Processing processing.SupportFactory
-
-	Umask *int
+func setUmask(newmask int) error {
+	syscall.Umask(newmask)
+	return nil // the umask syscall always succeeds: http://man7.org/linux/man-pages/man2/umask.2.html#RETURN_VALUE
 }

--- a/libbeat/cmd/instance/umask_windows.go
+++ b/libbeat/cmd/instance/umask_windows.go
@@ -17,32 +17,11 @@
 
 package instance
 
-import (
-	"github.com/spf13/pflag"
+import "errors"
 
-	"github.com/elastic/beats/libbeat/cfgfile"
-	"github.com/elastic/beats/libbeat/idxmgmt"
-	"github.com/elastic/beats/libbeat/idxmgmt/ilm"
-	"github.com/elastic/beats/libbeat/monitoring/report"
-	"github.com/elastic/beats/libbeat/publisher/processing"
-)
+var errNotImplemented = errors.New("not implemented on windows")
 
-// Settings contains basic settings for any beat to pass into GenRootCmd
-type Settings struct {
-	Name            string
-	IndexPrefix     string
-	Version         string
-	Monitoring      report.Settings
-	RunFlags        *pflag.FlagSet
-	ConfigOverrides []cfgfile.ConditionalOverride
-
-	DisableConfigResolver bool
-
-	// load custom index manager. The config object will be the Beats root configuration.
-	IndexManagement idxmgmt.SupportFactory
-	ILM             ilm.SupportFactory
-
-	Processing processing.SupportFactory
-
-	Umask *int
+func setUmask(newmask int) error {
+	// No way to set umask on Windows
+	return errNotImplemented
 }

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -62,6 +62,9 @@ output:
     path: {{ output_file_path|default(beat.working_dir + "/output") }}
     filename: "{{ output_file_filename|default("mockbeat") }}"
     rotate_every_kb: 1000
+    {% if output_file_permissions %}
+    permissions: {{ output_file_permissions }}
+    {% endif %}
     #number_of_files: 7
   {%- endif %}
 

--- a/libbeat/tests/system/test_umask.py
+++ b/libbeat/tests/system/test_umask.py
@@ -1,0 +1,36 @@
+from base import BaseTest
+
+import os
+import stat
+import unittest
+import sys
+
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+
+class TestUmask(BaseTest):
+    """
+    Test default umask
+    """
+
+    DEFAULT_UMASK = 0027
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+
+        self.output_file_permissions = 0666
+
+        self.render_config_template(output_file_permissions=self.output_file_permissions)
+        proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0, max_timeout=2)
+        proc.check_kill_and_wait()
+
+    @unittest.skipIf(sys.platform.startswith("win"), "umask is not available on Windows")
+    def test_output_file_perms(self):
+        """
+        Test that output file permissions respect default umask
+        """
+        output_file_path = os.path.join(self.working_dir, "output", "mockbeat")
+        perms = stat.S_IMODE(os.lstat(output_file_path).st_mode)
+
+        self.assertEqual(perms, self.output_file_permissions & ~TestUmask.DEFAULT_UMASK)


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Set default umask of 0027 for all Beats-created files  (#14119)