### PR TITLE
[Metricbeat] Convert millis-since-epoch timestamps in `elasticsearch/ml_job` metricset to ints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -236,6 +236,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change kubernetes.event.message to text. {pull}13964[13964]
 - Fix performance counter values for windows/perfmon metricset. {issue}14036[14036] {pull}14039[14039]
 - Add FailOnRequired when applying schema and fix metric names in mongodb metrics metricset. {pull}14143[14143]
+- Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
 
 *Packetbeat*
 

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -107,10 +107,10 @@ func ReportAndLogError(err error, r mb.ReporterV2, l *logp.Logger) {
 	l.Error(err)
 }
 
-// FixTimestampField converts the given timestamp field in the given map from a float64
-// to an int, so that it is not serialized in scientific notation in the event. This is
-// because Elasticsearch no longer accepts scientific notation for it's date fields any
-// more: https://github.com/elastic/elasticsearch/pull/36691
+// FixTimestampField converts the given timestamp field in the given map from a float64 to an
+// int, so that it is not serialized in scientific notation in the event. This is because
+// Elasticsearch cannot accepts scientific notation to represent millis-since-epoch values
+// for it's date fields: https://github.com/elastic/elasticsearch/pull/36691
 func FixTimestampField(m common.MapStr, field string) error {
 	v, err := m.GetValue(field)
 	if err == common.ErrKeyNotFound {

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -107,9 +107,10 @@ func ReportAndLogError(err error, r mb.ReporterV2, l *logp.Logger) {
 	l.Error(err)
 }
 
-// FixTimestampField converts the given timestamp field in the given map from a float64 to an int, so that it
-// is not serialized in scientific notation in the event. This is because Elasticsearch no longer accepts
-// scientific notation for it's date fields any more: https://github.com/elastic/elasticsearch/pull/36691
+// FixTimestampField converts the given timestamp field in the given map from a float64
+// to an int, so that it is not serialized in scientific notation in the event. This is
+// because Elasticsearch no longer accepts scientific notation for it's date fields any
+// more: https://github.com/elastic/elasticsearch/pull/36691
 func FixTimestampField(m common.MapStr, field string) error {
 	v, err := m.GetValue(field)
 	if err == common.ErrKeyNotFound {

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -106,3 +106,23 @@ func ReportAndLogError(err error, r mb.ReporterV2, l *logp.Logger) {
 	r.Error(err)
 	l.Error(err)
 }
+
+// FixTimestampField converts the given timestamp field in the given map from a float64 to an int, so that it
+// is not serialized in scientific notation in the event. This is because Elasticsearch no longer accepts
+// scientific notation for it's date fields any more: https://github.com/elastic/elasticsearch/pull/36691
+func FixTimestampField(m common.MapStr, field string) error {
+	v, err := m.GetValue(field)
+	if err == common.ErrKeyNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	switch vv := v.(type) {
+	case float64:
+		_, err := m.Put(field, int(vv))
+		return err
+	}
+	return nil
+}

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -87,3 +87,56 @@ func TestReportErrorForMissingField(t *testing.T) {
 	assert.Equal(t, expectedError, err)
 	assert.Equal(t, expectedError, currentErr)
 }
+
+func TestFixTimestampField(t *testing.T) {
+	tests := []struct {
+		Name          string
+		OriginalValue map[string]interface{}
+		ExpectedValue map[string]interface{}
+	}{
+		{
+			"converts float64s in scientific notation to ints",
+			map[string]interface{}{
+				"foo": 1.571284349E12,
+			},
+			map[string]interface{}{
+				"foo": 1571284349000,
+			},
+		},
+		{
+			"converts regular notation float64s to ints",
+			map[string]interface{}{
+				"foo": float64(1234),
+			},
+			map[string]interface{}{
+				"foo": 1234,
+			},
+		},
+		{
+			"ignores missing fields",
+			map[string]interface{}{
+				"bar": 12345,
+			},
+			map[string]interface{}{
+				"bar": 12345,
+			},
+		},
+		{
+			"leaves strings untouched",
+			map[string]interface{}{
+				"foo": "bar",
+			},
+			map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := FixTimestampField(test.OriginalValue, "foo")
+			assert.NoError(t, err)
+			assert.Equal(t, test.ExpectedValue, test.OriginalValue)
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/ml_job/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ml_job/data_xpack.go
@@ -49,10 +49,19 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 	}
 
 	var errs multierror.Errors
-	for _, job := range jobsArr {
-		job, ok = job.(map[string]interface{})
+	for _, j := range jobsArr {
+		job, ok := j.(map[string]interface{})
 		if !ok {
 			errs = append(errs, fmt.Errorf("job is not a map"))
+			continue
+		}
+
+		if err := elastic.FixTimestampField(job, "data_counts.earliest_record_timestamp"); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if err := elastic.FixTimestampField(job, "data_counts.latest_record_timestamp"); err != nil {
+			errs = append(errs, err)
 			continue
 		}
 


### PR DESCRIPTION
Resolves #14220.

The `elasticsearch/ml_job` metricset calls the `GET "/anomaly_detectors/_all/_stats` Elasticsearch API to collect monitoring metrics about ML jobs running in Elasticsearch. This API's response contains several fields that are timestamps represented as milliseconds-since-epoch; see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html#ml-get-job-stats-example.

Of these fields, two are actually indexed in `.monitoring-es-*`: [`job_stats.data_counts.earliest_record_timestamp`](https://github.com/elastic/elasticsearch/blob/7e6199e7f263e5bf283610b36d815fa015b179f4/x-pack/plugin/core/src/main/resources/monitoring-es.json#L903-L905) and [`job_stats.data_counts.latest_record_timestamp`](https://github.com/elastic/elasticsearch/blob/7e6199e7f263e5bf283610b36d815fa015b179f4/x-pack/plugin/core/src/main/resources/monitoring-es.json#L906-L908).

As the mappings indicate, these fields are of `type: "date"`. Per https://github.com/elastic/elasticsearch/pull/36691, the Elasticsearch date parser can no longer accept millis-since-epoch values in scientific notation (e.g. `1.571647285959e+12`). However, during the unmarshalling of the ML API response JSON into memory, the `json.Unmarshal` function will, by default, produce `float64` values. These values, when marshalled back into JSON for indexing into Elasticsearch may be represented in scientific notation if they are sufficiently large, which will be rejected by the Elasticsearch date parser with an error like so:

<details>
<pre>
```
[2019-10-17T13:00:44,628][DEBUG][o.e.a.b.TransportShardBulkAction] [node-1] [.monitoring-es-7-mb-2019.10.17][0] failed to execute bulk item (index) index {[.monitoring-es-7-mb-2019.10.17][_doc][csbg120B1fyMIM-CAGdJ], source[n/a, actual length: [2.8kb], max length: 2kb]}
org.elasticsearch.index.mapper.MapperParsingException: failed to parse field [job_stats.data_counts.latest_record_timestamp] of type [date] in document with id 'csbg120B1fyMIM-CAGdJ'. Preview of field's value: '1.571284349E12'
        at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:299) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:488) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseValue(DocumentParser.java:614) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:427) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:395) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:485) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:505) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:418) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:395) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:485) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:505) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:418) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:395) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.internalParseDocument(DocumentParser.java:112) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:71) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DocumentMapper.parse(DocumentMapper.java:267) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShard.prepareIndex(IndexShard.java:776) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:753) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShard.applyIndexOperationOnPrimary(IndexShard.java:725) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.bulk.TransportShardBulkAction.executeBulkItemRequest(TransportShardBulkAction.java:258) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.bulk.TransportShardBulkAction$2.doRun(TransportShardBulkAction.java:161) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.bulk.TransportShardBulkAction.performOnPrimary(TransportShardBulkAction.java:193) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.bulk.TransportShardBulkAction.shardOperationOnPrimary(TransportShardBulkAction.java:118) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.bulk.TransportShardBulkAction.shardOperationOnPrimary(TransportShardBulkAction.java:79) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryShardReference.perform(TransportReplicationAction.java:917) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.ReplicationOperation.execute(ReplicationOperation.java:108) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.runWithPrimaryShardReference(TransportReplicationAction.java:394) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.lambda$doRun$0(TransportReplicationAction.java:316) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$21(IndexShard.java:2753) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$3.onResponse(ActionListener.java:112) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:285) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:237) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2727) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction.acquirePrimaryOperationPermit(TransportReplicationAction.java:858) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.doRun(TransportReplicationAction.java:312) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.replication.TransportReplicationAction.handlePrimaryRequest(TransportReplicationAction.java:275) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.transport.SecurityServerTransportInterceptor$ProfileSecuredRequestHandler$1.doRun(SecurityServerTransportInterceptor.java:257) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.transport.SecurityServerTransportInterceptor$ProfileSecuredRequestHandler.lambda$messageReceived$0(SecurityServerTransportInterceptor.java:306) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$runRequestInterceptors$15(AuthorizationService.java:342) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:99) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:93) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.ArrayList.forEach(ArrayList.java:1507) [?:?]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:144) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:114) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.StepListener.innerOnResponse(StepListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:40) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.ResizeRequestInterceptor.intercept(ResizeRequestInterceptor.java:82) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$runRequestInterceptors$14(AuthorizationService.java:337) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:99) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:93) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.ArrayList.forEach(ArrayList.java:1507) [?:?]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:144) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:114) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.StepListener.innerOnResponse(StepListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:40) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.IndicesAliasesRequestInterceptor.intercept(IndicesAliasesRequestInterceptor.java:102) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$runRequestInterceptors$14(AuthorizationService.java:337) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:99) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:93) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.ArrayList.forEach(ArrayList.java:1507) [?:?]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:144) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:114) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.StepListener.innerOnResponse(StepListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:40) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.FieldAndDocumentLevelSecurityRequestInterceptor.intercept(FieldAndDocumentLevelSecurityRequestInterceptor.java:61) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.SearchRequestInterceptor.intercept(SearchRequestInterceptor.java:19) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$runRequestInterceptors$14(AuthorizationService.java:337) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:99) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:93) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.ArrayList.forEach(ArrayList.java:1507) [?:?]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:144) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:114) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.StepListener.innerOnResponse(StepListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:40) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.FieldAndDocumentLevelSecurityRequestInterceptor.intercept(FieldAndDocumentLevelSecurityRequestInterceptor.java:61) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.UpdateRequestInterceptor.intercept(UpdateRequestInterceptor.java:23) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$runRequestInterceptors$14(AuthorizationService.java:337) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:99) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:225) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:93) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.ArrayList.forEach(ArrayList.java:1507) [?:?]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:85) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:144) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:114) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.StepListener.innerOnResponse(StepListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:40) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.interceptor.BulkShardRequestInterceptor.intercept(BulkShardRequestInterceptor.java:71) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.runRequestInterceptors(AuthorizationService.java:343) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.handleIndexActionAuthorizationResult(AuthorizationService.java:320) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$9(AuthorizationService.java:261) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:613) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:588) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:43) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.buildIndicesAccessControl(RBACEngine.java:507) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.lambda$authorizeIndexAction$3(RBACEngine.java:298) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$CachingAsyncSupplier.lambda$getAsync$0(AuthorizationService.java:650) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.resolveIndexNames(AuthorizationService.java:551) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$6(AuthorizationService.java:249) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$CachingAsyncSupplier.lambda$getAsync$0(AuthorizationService.java:650) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.loadAuthorizedIndices(RBACEngine.java:329) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$5(AuthorizationService.java:245) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$CachingAsyncSupplier.getAsync(AuthorizationService.java:648) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$8(AuthorizationService.java:248) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService$CachingAsyncSupplier.getAsync(AuthorizationService.java:648) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.lambda$authorizeIndexAction$4(RBACEngine.java:290) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.authorizeIndexActionName(RBACEngine.java:314) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.authorizeIndexAction(RBACEngine.java:287) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.authorizeAction(AuthorizationService.java:259) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.maybeAuthorizeRunAs(AuthorizationService.java:225) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorize$1(AuthorizationService.java:191) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:43) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.lambda$resolveAuthorizationInfo$1(RBACEngine.java:117) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.getRoles(CompositeRolesStore.java:229) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.getRoles(RBACEngine.java:123) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.RBACEngine.resolveAuthorizationInfo(RBACEngine.java:111) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authz.AuthorizationService.authorize(AuthorizationService.java:193) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.transport.ServerTransportFilter$NodeProfile.lambda$inbound$1(ServerTransportFilter.java:130) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService$Authenticator.lambda$authenticateAsync$2(AuthenticationService.java:246) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService$Authenticator.lambda$lookForExistingAuthentication$6(AuthenticationService.java:306) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService$Authenticator.lookForExistingAuthentication(AuthenticationService.java:317) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService$Authenticator.authenticateAsync(AuthenticationService.java:244) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService$Authenticator.access$000(AuthenticationService.java:196) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:139) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.transport.ServerTransportFilter$NodeProfile.inbound(ServerTransportFilter.java:121) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.xpack.security.transport.SecurityServerTransportInterceptor$ProfileSecuredRequestHandler.messageReceived(SecurityServerTransportInterceptor.java:313) [x-pack-security-7.4.0.jar:7.4.0]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:63) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.transport.TransportService$7.doRun(TransportService.java:752) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:773) [elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.0.jar:7.4.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:830) [?:?]
Caused by: java.lang.IllegalArgumentException: failed to parse date field [1.571284349e+12] with format [strict_date_optional_time||epoch_millis]
        at org.elasticsearch.common.time.JavaDateFormatter.parse(JavaDateFormatter.java:123) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DateFieldMapper$DateFieldType.parse(DateFieldMapper.java:331) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DateFieldMapper.parseCreateField(DateFieldMapper.java:538) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:277) ~[elasticsearch-7.4.0.jar:7.4.0]
        ... 168 more
Caused by: java.time.format.DateTimeParseException: Failed to parse with all enclosed parsers
        at org.elasticsearch.common.time.JavaDateFormatter.doParse(JavaDateFormatter.java:150) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.common.time.JavaDateFormatter.parse(JavaDateFormatter.java:121) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DateFieldMapper$DateFieldType.parse(DateFieldMapper.java:331) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.DateFieldMapper.parseCreateField(DateFieldMapper.java:538) ~[elasticsearch-7.4.0.jar:7.4.0]
        at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:277) ~[elasticsearch-7.4.0.jar:7.4.0]
        ... 168 more
```
</pre>
</details>

This PR fixes the problem by converting both these fields to `int`s from `float64`s before they are written to the event.