### PR TITLE
Load index pattern before dashboards during setup

### DIFF
--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -298,17 +298,17 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 
 	versionPath := "7"
 
+	// Loads the internal index pattern
+	if imp.fields != nil {
+		imp.loader.ImportIndex(imp.fields)
+	}
+
 	dir = path.Join(dir, versionPath)
 
 	imp.loader.statusMsg("Importing directory %v", dir)
 
 	if _, err := os.Stat(dir); err != nil {
 		return newErrNotFound("No directory %s", dir)
-	}
-
-	// Loads the internal index pattern
-	if imp.fields != nil {
-		imp.loader.ImportIndex(imp.fields)
 	}
 	check := []string{}
 	if !imp.cfg.OnlyDashboards {


### PR DESCRIPTION
During setup, if dashboards dir doesn't exist (like in development mode) we will not push the
index pattern.

This change makes sure we deploy the index pattern first, then proceed with dashboards, making sure that at least the index pattern will be present.