### PR TITLE
Disable permission checks when generating default metricset docs

### DIFF
--- a/x-pack/metricbeat/scripts/msetlists/main.go
+++ b/x-pack/metricbeat/scripts/msetlists/main.go
@@ -18,6 +18,9 @@ import (
 )
 
 func main() {
+	// Disable permission checks so it reads light modules in any case
+	os.Setenv("BEAT_STRICT_PERMS", "false")
+
 	path := paths.Resolve(paths.Home, "../x-pack/metricbeat/module")
 	lm := xpackmb.NewLightModulesSource(path)
 	mb.Registry.SetSecondarySource(lm)


### PR DESCRIPTION
Light modules are read as configuration files, and same permission
checks are applied. If they don't have the expected permissions they are
not read. This affects documentation generation for default metricset,
as information about default metricset is not generated for light
modules if the checks are enabled and permissions are not the expected
ones.