### PR TITLE
Run mage fmt for x-pack/libbeat

### DIFF
--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -12,10 +12,10 @@ import (
 
 // ConfigAWS is a structure defined for AWS credentials
 type ConfigAWS struct {
-	AccessKeyID     string `config:"access_key_id"`
-	SecretAccessKey string `config:"secret_access_key"`
-	SessionToken    string `config:"session_token"`
-	ProfileName     string `config:"credential_profile_name"`
+	AccessKeyID          string `config:"access_key_id"`
+	SecretAccessKey      string `config:"secret_access_key"`
+	SessionToken         string `config:"session_token"`
+	ProfileName          string `config:"credential_profile_name"`
 	SharedCredentialFile string `config:"shared_credential_file"`
 }
 


### PR DESCRIPTION
This is to fix ci error:
```
14:26:57 Error: some files are not up-to-date. Run 'mage fmt update' then review and commit the changes. Modified: [x-pack/libbeat/common/aws/credentials.go]
```