### PR TITLE
Change default interval for all azure visualizations (#14063)

### DIFF
--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vm-guestmetrics-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vm-guestmetrics-overview.json
@@ -198,8 +198,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-10-11T06:37:20.491Z",
-      "version": "WzE0ODcsMV0="
+      "updated_at": "2019-10-15T11:58:39.685Z",
+      "version": "WzMyMjQsMV0="
     },
     {
       "attributes": {
@@ -347,7 +347,7 @@
             "gauge_width": 10,
             "id": "d1acb8f0-eaa2-11e9-a229-c9171499dcc6",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -389,8 +389,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:29:55.108Z",
-      "version": "WzE0MzAsMV0="
+      "updated_at": "2019-10-15T11:56:33.857Z",
+      "version": "WzMyMTEsMV0="
     },
     {
       "attributes": {
@@ -422,7 +422,7 @@
             },
             "id": "da495db0-eaa7-11e9-a88b-4b683ca3087b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -463,8 +463,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:30:56.351Z",
-      "version": "WzE0MzQsMV0="
+      "updated_at": "2019-10-15T11:56:54.774Z",
+      "version": "WzMyMTMsMV0="
     },
     {
       "attributes": {
@@ -496,7 +496,7 @@
             },
             "id": "be74e9e0-eaa4-11e9-8923-850d87d8e766",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -603,8 +603,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:29:31.133Z",
-      "version": "WzE0MjgsMV0="
+      "updated_at": "2019-10-15T11:57:11.237Z",
+      "version": "WzMyMTUsMV0="
     },
     {
       "attributes": {
@@ -636,7 +636,7 @@
             },
             "id": "29576400-eaa4-11e9-a2d3-e7a00bbd3c18",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -681,8 +681,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:29:16.193Z",
-      "version": "WzE0MjcsMV0="
+      "updated_at": "2019-10-15T11:57:29.302Z",
+      "version": "WzMyMTcsMV0="
     },
     {
       "attributes": {
@@ -714,7 +714,7 @@
             },
             "id": "94af6a00-eaa8-11e9-9269-d92e2d3f77fd",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -755,8 +755,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:30:43.799Z",
-      "version": "WzE0MzMsMV0="
+      "updated_at": "2019-10-15T11:57:45.878Z",
+      "version": "WzMyMTksMV0="
     },
     {
       "attributes": {
@@ -788,7 +788,7 @@
             },
             "id": "6d6575a0-eaa5-11e9-84ad-5919a47b8f34",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -895,8 +895,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:29:42.801Z",
-      "version": "WzE0MjksMV0="
+      "updated_at": "2019-10-15T11:58:04.891Z",
+      "version": "WzMyMjEsMV0="
     },
     {
       "attributes": {
@@ -928,7 +928,7 @@
             },
             "id": "35459a30-eaa8-11e9-a379-c33a712c0373",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -991,8 +991,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:30:29.692Z",
-      "version": "WzE0MzIsMV0="
+      "updated_at": "2019-10-15T11:58:24.951Z",
+      "version": "WzMyMjMsMV0="
     }
   ],
   "version": "7.4.0"

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vm-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vm-overview.json
@@ -213,8 +213,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-10-11T06:25:28.771Z",
-      "version": "WzE0NzEsMV0="
+      "updated_at": "2019-10-15T11:53:03.300Z",
+      "version": "WzMxOTAsMV0="
     },
     {
       "attributes": {
@@ -344,7 +344,7 @@
             },
             "id": "4f6c1610-ea8e-11e9-8c73-71740bcf3d8b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=60s",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -391,8 +391,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:27:01.167Z",
-      "version": "WzE0MTksMV0="
+      "updated_at": "2019-10-15T11:52:01.637Z",
+      "version": "WzMxODQsMV0="
     },
     {
       "attributes": {
@@ -424,7 +424,7 @@
             },
             "id": "c7e12030-ea94-11e9-bf06-bfc27258c9ad",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -466,8 +466,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:27:17.064Z",
-      "version": "WzE0MjAsMV0="
+      "updated_at": "2019-10-15T11:52:22.085Z",
+      "version": "WzMxODYsMV0="
     },
     {
       "attributes": {
@@ -499,7 +499,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -542,8 +542,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:03:59.835Z",
-      "version": "WzE0MzcsMV0="
+      "updated_at": "2019-10-15T11:50:30.820Z",
+      "version": "WzMxNzgsMV0="
     },
     {
       "attributes": {
@@ -575,7 +575,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -617,8 +617,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:28:22.044Z",
-      "version": "WzE0MjQsMV0="
+      "updated_at": "2019-10-15T11:52:40.578Z",
+      "version": "WzMxODgsMV0="
     },
     {
       "attributes": {
@@ -650,7 +650,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -693,8 +693,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:27:55.869Z",
-      "version": "WzE0MjIsMV0="
+      "updated_at": "2019-10-15T11:49:45.582Z",
+      "version": "WzMxNzQsMV0="
     },
     {
       "attributes": {
@@ -726,7 +726,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -769,8 +769,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:04:19.809Z",
-      "version": "WzE0MzgsMV0="
+      "updated_at": "2019-10-15T11:50:07.876Z",
+      "version": "WzMxNzYsMV0="
     },
     {
       "attributes": {
@@ -802,7 +802,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -845,8 +845,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:28:53.708Z",
-      "version": "WzE0MjYsMV0="
+      "updated_at": "2019-10-15T11:50:55.337Z",
+      "version": "WzMxODAsMV0="
     },
     {
       "attributes": {
@@ -878,7 +878,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -921,8 +921,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:28:34.591Z",
-      "version": "WzE0MjUsMV0="
+      "updated_at": "2019-10-15T11:51:33.545Z",
+      "version": "WzMxODIsMV0="
     }
   ],
   "version": "7.4.0"

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vmss-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-vmss-overview.json
@@ -219,8 +219,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-10-10T12:55:19.764Z",
-      "version": "WzE0MDAsMV0="
+      "updated_at": "2019-10-15T11:55:55.792Z",
+      "version": "WzMyMDksMV0="
     },
     {
       "attributes": {
@@ -350,7 +350,7 @@
             },
             "id": "7666abc0-eaae-11e9-a083-57ad7f0b1ec1",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -393,8 +393,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:23:06.329Z",
-      "version": "WzE0MTEsMV0="
+      "updated_at": "2019-10-15T11:53:31.250Z",
+      "version": "WzMxOTMsMV0="
     },
     {
       "attributes": {
@@ -426,7 +426,7 @@
             },
             "id": "e25fa710-eb3e-11e9-8bf6-ff656bce9010",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -468,8 +468,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:22:18.944Z",
-      "version": "WzE0MDgsMV0="
+      "updated_at": "2019-10-15T11:53:55.061Z",
+      "version": "WzMxOTUsMV0="
     },
     {
       "attributes": {
@@ -501,7 +501,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -544,8 +544,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:13:33.244Z",
-      "version": "WzE0MzksMV0="
+      "updated_at": "2019-10-15T11:55:06.753Z",
+      "version": "WzMyMDMsMV0="
     },
     {
       "attributes": {
@@ -577,7 +577,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -620,8 +620,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:21:59.870Z",
-      "version": "WzE0MDcsMV0="
+      "updated_at": "2019-10-15T11:54:14.745Z",
+      "version": "WzMxOTcsMV0="
     },
     {
       "attributes": {
@@ -653,7 +653,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -696,8 +696,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T13:21:44.001Z",
-      "version": "WzE0MDYsMV0="
+      "updated_at": "2019-10-15T11:54:30.361Z",
+      "version": "WzMxOTksMV0="
     },
     {
       "attributes": {
@@ -729,7 +729,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -772,8 +772,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:02:36.055Z",
-      "version": "WzE0MzYsMV0="
+      "updated_at": "2019-10-15T11:54:48.472Z",
+      "version": "WzMyMDEsMV0="
     },
     {
       "attributes": {
@@ -805,7 +805,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -848,8 +848,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:32:53.909Z",
-      "version": "WzE0NDMsMV0="
+      "updated_at": "2019-10-15T11:55:26.389Z",
+      "version": "WzMyMDUsMV0="
     },
     {
       "attributes": {
@@ -881,7 +881,7 @@
             },
             "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
             "index_pattern": "metricbeat-*",
-            "interval": "\u003e=1m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -924,8 +924,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-10-10T14:32:39.110Z",
-      "version": "WzE0NDIsMV0="
+      "updated_at": "2019-10-15T11:55:48.348Z",
+      "version": "WzMyMDcsMV0="
     }
   ],
   "version": "7.4.0"


### PR DESCRIPTION
(cherry picked from commit e9f3c57417fda1d5372e35fe55b4d6e5a0e801c4)

Recommended default interval for the azure metricsets is 5min. Initial interval values for all azure visualization were set to 60 seconds. This changes the default values to 5m.

