### PR TITLE
[7.x] Changes to support the split of the Metrics Guide and the Logs Guide (#14158)

### DIFF
--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -128,12 +128,12 @@ If no paths are specified, {beatname_uc} reads from the default journal.
 {beatname_uc} starts reading at the beginning of the file, but continues reading
 at the last known position after a reload or restart. For more detail about
 the settings, see the reference docs for the
-<<seek,`seek` option>>. 
+<<seek,`seek` option>>.
 
 . (Optional) Set the <<include-matches,`include_matches`>> option
 to filter entries in journald before collecting any log events. This reduces the
 number of events that {beatname_uc} needs to process. For example, to fetch only
-Redis events from a Docker container tagged as `redis`, use: 
+Redis events from a Docker container tagged as `redis`, use:
 +
 ["source","sh",subs="attributes"]
 ----
@@ -206,9 +206,12 @@ _{kibana-ref}/index.html[{kib} User Guide]_.
 [role="xpack"]
 ==== Want to tail logs in real time?
 
-Use the {infra-guide}/logs-ui-overview.html[Logs UI] in {kib}. The UI shows logs
+Use the Logs app in {kib}.
+For more details, see the {logs-guide}[Logs Monitoring Guide].
+
+The Logs app shows logs
 from `filebeat-*` indices by default. To show {beatname_uc} indices, configure
-the source to include `journalbeat-*`. You can do this in the Logs UI when you
+the source to include `journalbeat-*`. You can do this in the Logs app when you
 configure the source, or you can modify the {kib} configuration. For example:
 
 [source,yaml]

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -10,10 +10,10 @@
 //////////////////////////////////////////////////////////////////////////
 
 ifdef::has_solutions[]
-TIP: For deeper observability into your infrastructure, use the
-{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
-{infra-guide}/logs-ui-overview.html[Logs] UIs in {kib}. For setup details, see
-the {infra-guide}/index.html[Infrastructure Monitoring Guide].
+TIP: For deeper observability into your infrastructure, you can use the
+Metrics app and the Logs app in {kib}.
+For more details, see the {metrics-guide}[Metrics Monitoring Guide]
+and the {logs-guide}[Logs Monitoring Guide].
 endif::has_solutions[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
@@ -25,7 +25,7 @@ command (as described here) or
 +{beatname_lc}.yml+ config file.
 
 This requires a Kibana endpoint configuration. If you didn't already configure
-a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>. 
+a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>.
 
 Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in
@@ -142,7 +142,7 @@ ifdef::mac_os[]
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username={beat_default_index_prefix}_internal \
   -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601 
+  -E setup.kibana.host=localhost:5601
 ----
 
 *brew:*
@@ -154,7 +154,7 @@ ifdef::mac_os[]
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username={beat_default_index_prefix}_internal \
   -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601 
+  -E setup.kibana.host=localhost:5601
 ----
 endif::mac_os[]
 
@@ -168,7 +168,7 @@ ifdef::linux_os[]
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username={beat_default_index_prefix}_internal \
   -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601 
+  -E setup.kibana.host=localhost:5601
 ----
 endif::linux_os[]
 
@@ -204,7 +204,7 @@ PS > .{backslash}{beatname_lc}.exe setup -e `
   -E output.elasticsearch.hosts=['localhost:9200'] `
   -E output.elasticsearch.username={beat_default_index_prefix}_internal `
   -E output.elasticsearch.password={pwd} `
-  -E setup.kibana.host=localhost:5601 
+  -E setup.kibana.host=localhost:5601
 ----
 endif::win_os[]
 

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -15,7 +15,7 @@ https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
 Service for free].
 ==============
 
-After installing the {stack}, see the {beats} getting started guides: 
+After installing the {stack}, see the {beats} getting started guides:
 
 * {auditbeat-ref}/auditbeat-getting-started.html[Auditbeat]
 * {filebeat-ref}/filebeat-getting-started.html[Filebeat]
@@ -26,7 +26,6 @@ After installing the {stack}, see the {beats} getting started guides:
 * {packetbeat-ref}/packetbeat-getting-started.html[Packetbeat]
 * {winlogbeat-ref}/winlogbeat-getting-started.html[Winlogbeat]
 
-If you're planning to use the
-{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
-{infra-guide}/logs-ui-overview.html[Logs] UIs in {kib}, also see the
-{infra-guide}/index.html[Infrastructure Monitoring Guide].
+If you're planning to use the Metrics app or the Logs app in {kib},
+also see the {metrics-guide}[Metrics Monitoring Guide]
+and the {logs-guide}[Logs Monitoring Guide].

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -30,11 +30,10 @@ image::./images/beats-platform.png[Beats Platform]
 To get started, see <<getting-started>>.
 
 Want to get up and running quickly with infrastructure metrics monitoring and
-centralized log analytics? Try out the
-{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
-{infra-guide}/logs-ui-overview.html[Logs] UIs
-in {kib}. For setup details, see the {infra-guide}/index.html[Infrastructure
-Monitoring Guide].
+centralized log analytics?
+Try out the Metrics app and the Logs app in {kib}.
+For more details, see the {metrics-guide}[Metrics Monitoring Guide]
+and the {logs-guide}[Logs Monitoring Guide].
 
 [float]
 === Need to capture other kinds of data?


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Changes to support the split of the Metrics Guide and the Logs Guide (#14158)