### PR TITLE
Cherry-pick #14249 to 7.x: Add Enterprise license type

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Disable Alibaba Cloud and Tencent Cloud metadata providers by default. {pull}13812[12812]
 - Libbeat HTTP's Server can listen to a unix socket using the `unix:///tmp/hello.sock` syntax. {pull}13655[13655]
 - Libbeat HTTP's Server can listen to a Windows named pipe using the `npipe:///hello` syntax. {pull}13655[13655]
+- Adding new `Enterprise` license type to the licenser. {issue}14246[14246]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/licenser/elastic_fetcher.go
+++ b/x-pack/libbeat/licenser/elastic_fetcher.go
@@ -27,20 +27,6 @@ var params = map[string]string{
 	"human": "false",
 }
 
-var stateLookup = map[string]State{
-	"inactive": Inactive,
-	"active":   Active,
-}
-
-var licenseLookup = map[string]LicenseType{
-	"oss":      OSS,
-	"trial":    Trial,
-	"standard": Standard,
-	"basic":    Basic,
-	"gold":     Gold,
-	"platinum": Platinum,
-}
-
 // UnmarshalJSON takes a bytes array and convert it to the appropriate license type.
 func (t *LicenseType) UnmarshalJSON(b []byte) error {
 	if len(b) <= 2 {

--- a/x-pack/libbeat/licenser/licensetype_string.go
+++ b/x-pack/libbeat/licenser/licensetype_string.go
@@ -8,9 +8,22 @@ package licenser
 
 import "strconv"
 
-const _LicenseType_name = "Open sourceTrialBasicStandardGoldPlatinum"
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[OSS-0]
+	_ = x[Trial-1]
+	_ = x[Basic-2]
+	_ = x[Standard-3]
+	_ = x[Gold-4]
+	_ = x[Platinum-5]
+	_ = x[Enterprise-6]
+}
 
-var _LicenseType_index = [...]uint8{0, 11, 16, 21, 29, 33, 41}
+const _LicenseType_name = "Open sourceTrialBasicStandardGoldPlatinumEnterprise"
+
+var _LicenseType_index = [...]uint8{0, 11, 16, 21, 29, 33, 41, 51}
 
 func (i LicenseType) String() string {
 	if i < 0 || i >= LicenseType(len(_LicenseType_index)-1) {

--- a/x-pack/libbeat/licenser/state_string.go
+++ b/x-pack/libbeat/licenser/state_string.go
@@ -8,6 +8,14 @@ package licenser
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Inactive-0]
+	_ = x[Active-1]
+}
+
 const _State_name = "InactiveActive"
 
 var _State_index = [...]uint8{0, 8, 14}

--- a/x-pack/libbeat/licenser/testdata/xpack-with-enterprise.json
+++ b/x-pack/libbeat/licenser/testdata/xpack-with-enterprise.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "hash": "053779d",
+    "date": "2018-07-20T05:25:16.206115Z"
+  },
+  "license": {
+    "uid": "936183d8-f48c-4a3f-959a-a52aa2563279",
+    "type": "enterprise",
+    "mode": "enterprise",
+    "status": "active",
+    "expiry_date_in_millis": 1588291199999
+  },
+  "features": {
+    "graph": {
+      "available": false,
+      "enabled": true
+    },
+    "logstash": {
+      "available": false,
+      "enabled": true
+    },
+    "ml": {
+      "available": false,
+      "enabled": true
+    },
+    "monitoring": {
+      "available": true,
+      "enabled": true
+    },
+    "rollup": {
+      "available": true,
+      "enabled": true
+    },
+    "security": {
+      "available": false,
+      "enabled": true
+    },
+    "watcher": {
+      "available": false,
+      "enabled": true
+    }
+  }
+}

--- a/x-pack/libbeat/licenser/types.go
+++ b/x-pack/libbeat/licenser/types.go
@@ -9,12 +9,13 @@ type LicenseType int
 
 //go:generate stringer -type=LicenseType -linecomment=true
 const (
-	OSS      LicenseType = iota // Open source
-	Trial                       // Trial
-	Basic                       // Basic
-	Standard                    // Standard
-	Gold                        // Gold
-	Platinum                    // Platinum
+	OSS        LicenseType = iota // Open source
+	Trial                         // Trial
+	Basic                         // Basic
+	Standard                      // Standard
+	Gold                          // Gold
+	Platinum                      // Platinum
+	Enterprise                    // Enterprise
 )
 
 // State of the license can be active or inactive.
@@ -25,3 +26,18 @@ const (
 	Inactive State = iota
 	Active
 )
+
+var stateLookup = map[string]State{
+	"inactive": Inactive,
+	"active":   Active,
+}
+
+var licenseLookup = map[string]LicenseType{
+	"oss":        OSS,
+	"trial":      Trial,
+	"standard":   Standard,
+	"basic":      Basic,
+	"gold":       Gold,
+	"platinum":   Platinum,
+	"enterprise": Enterprise,
+}


### PR DESCRIPTION
Cherry-pick of PR #14249 to 7.x branch. Original message: 

Add the Enterprise license type and regenerate the types files.

Fixes: #14246