### PR TITLE
Docs: Fix monitoring privileges

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -147,7 +147,7 @@ If you don't use the +{beat_monitoring_user}+ user:
 |Create monitoring indices in {es}
 
 |Index
-|`create` on `.monitoring-beats-*` indices
+|`create_doc` on `.monitoring-beats-*` indices
 |Write monitoring events into {es}
 |====
 

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -143,6 +143,16 @@ If you don't use the +{beat_monitoring_user}+ user:
 |Retrieve cluster details (e.g. version)
 |====
 
+|Index
+|`create_index` on `.monitoring-beats-*` indices
+|Create monitoring indices in {es}
+|====
+
+|Index
+|`create` on `.monitoring-beats-*` indices
+|Write monitoring events into {es}
+|====
+
 . Assign the *monitoring role*, along with the following built-in roles, to
 users who need to monitor {beatname_uc}: 
 +

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -141,12 +141,10 @@ If you don't use the +{beat_monitoring_user}+ user:
 |Cluster
 |`monitor`
 |Retrieve cluster details (e.g. version)
-|====
 
 |Index
 |`create_index` on `.monitoring-beats-*` indices
 |Create monitoring indices in {es}
-|====
 
 |Index
 |`create` on `.monitoring-beats-*` indices


### PR DESCRIPTION
I noticed that the monitoring role on https://www.elastic.co/guide/en/beats/filebeat/master/feature-roles.html#privileges-to-publish-monitoring only contains the `monitor` cluster privilege. This is the lowest level cluster privilege that gives access to basic cluster APIs to retrieve things like cluster health and version, but does not allow writing data.

This PR adds `create_index` and `create_doc` on `.monitoring-beats-*` as required privileges to the monitoring role.