### PR TITLE
[Heartbeat] Correctly store HTTP bodies with validation (#14223)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,6 +21,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Removed the `add_host_metadata` and `add_cloud_metadata` processors from the default config. These don't fit well with ECS for Heartbeat and were rarely used.
+- Fixed/altered redirect behavior. `max_redirects` now defaults to 0 (no redirects). Following redirects now works across hosts, but some timing fields will not be reported. {pull}14125[14125]
+- Removed `host.name` field that should never have been included. Heartbeat uses `observer.*` fields instead. {pull}14140[14140]
+- JSON/Regex checks against HTTP bodies will only consider the first 100MiB of the HTTP body to prevent excessive memory usage. {pull}14223[pull]
 
 *Journalbeat*
 
@@ -53,6 +57,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
+- Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
+- Fix integer comparison on JSON responses. {pull}13348[13348]
+- Fix storage of HTTP bodies to work when JSON/Regex body checks are enabled. {pull}14223[14223]
 
 *Journalbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,9 +21,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Removed the `add_host_metadata` and `add_cloud_metadata` processors from the default config. These don't fit well with ECS for Heartbeat and were rarely used.
-- Fixed/altered redirect behavior. `max_redirects` now defaults to 0 (no redirects). Following redirects now works across hosts, but some timing fields will not be reported. {pull}14125[14125]
-- Removed `host.name` field that should never have been included. Heartbeat uses `observer.*` fields instead. {pull}14140[14140]
 - JSON/Regex checks against HTTP bodies will only consider the first 100MiB of the HTTP body to prevent excessive memory usage. {pull}14223[pull]
 
 *Journalbeat*
@@ -57,9 +54,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
-- Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
-- Fix integer comparison on JSON responses. {pull}13348[13348]
 - Fix storage of HTTP bodies to work when JSON/Regex body checks are enabled. {pull}14223[14223]
 
 *Journalbeat*

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -500,7 +500,8 @@ Under `check.response`, specify these options:
 
 *`status`*:: The expected status code. 4xx and 5xx codes are considered `down` by default. Other codes are considered `up`.
 *`headers`*:: The required response headers.
-*`body`*:: A list of regular expressions to match the the body output. Only a single expression needs to match.
+*`body`*:: A list of regular expressions to match the the body output. Only a single expression needs to match. HTTP response
+bodies of up to 100MiB are supported.
 
 Example configuration:
 This monitor examines the
@@ -524,7 +525,8 @@ response body for the strings `saved` or `Saved`
       - saved
 -------------------------------------------------------------------------------
 
-*`json`*:: A list of <<conditions,condition>> expressions executed against the body when parsed as JSON.
+*`json`*:: A list of <<conditions,condition>> expressions executed against the body when parsed as JSON. Body sizes
+must be less than or equal to 100 MiB.
 
 The following configuration shows how to check the response when the body
 contains JSON:

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -27,68 +27,82 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 
+	"github.com/elastic/beats/heartbeat/reason"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/jsontransform"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/conditions"
 )
 
-type RespCheck func(*http.Response) error
+// multiValidator combines multiple validations of each type into a single easy to use object.
+type multiValidator struct {
+	respValidators []respValidator
+	bodyValidators []bodyValidator
+}
+
+func (rv multiValidator) wantsBody() bool {
+	return len(rv.bodyValidators) > 0
+}
+
+func (rv multiValidator) validate(resp *http.Response, body string) reason.Reason {
+	for _, respValidator := range rv.respValidators {
+		if err := respValidator(resp); err != nil {
+			return reason.ValidateFailed(err)
+		}
+	}
+
+	for _, bodyValidator := range rv.bodyValidators {
+		if err := bodyValidator(resp, body); err != nil {
+			return reason.ValidateFailed(err)
+		}
+	}
+
+	return nil
+}
+
+// respValidator is used for validating using only the non-body fields of the *http.Response.
+// Accessing the body of the response in such a validator should not be done due, use bodyValidator
+// for those purposes instead.
+type respValidator func(*http.Response) error
+
+// bodyValidator lets you validate a stringified version of the body along with other metadata in
+// *http.Response.
+type bodyValidator func(*http.Response, string) error
 
 var (
 	errBodyMismatch = errors.New("body mismatch")
 )
 
-func makeValidateResponse(config *responseParameters) (RespCheck, error) {
-	var checks []RespCheck
+func makeValidateResponse(config *responseParameters) (multiValidator, error) {
+	var respValidators []respValidator
+	var bodyValidators []bodyValidator
 
 	if config.Status > 0 {
-		checks = append(checks, checkStatus(config.Status))
+		respValidators = append(respValidators, checkStatus(config.Status))
 	} else {
-		checks = append(checks, checkStatusOK)
+		respValidators = append(respValidators, checkStatusOK)
 	}
 
 	if len(config.RecvHeaders) > 0 {
-		checks = append(checks, checkHeaders(config.RecvHeaders))
+		respValidators = append(respValidators, checkHeaders(config.RecvHeaders))
 	}
 
 	if len(config.RecvBody) > 0 {
-		checks = append(checks, checkBody(config.RecvBody))
+		bodyValidators = append(bodyValidators, checkBody(config.RecvBody))
 	}
 
 	if len(config.RecvJSON) > 0 {
 		jsonChecks, err := checkJSON(config.RecvJSON)
 		if err != nil {
-			return nil, err
+			return multiValidator{}, err
 		}
-		checks = append(checks, jsonChecks)
+		bodyValidators = append(bodyValidators, jsonChecks)
 	}
 
-	return checkAll(checks...), nil
+	return multiValidator{respValidators, bodyValidators}, nil
 }
 
-func checkOK(_ *http.Response) error { return nil }
-
-// TODO: collect all errors into on error message.
-func checkAll(checks ...RespCheck) RespCheck {
-	switch len(checks) {
-	case 0:
-		return checkOK
-	case 1:
-		return checks[0]
-	}
-
-	return func(r *http.Response) error {
-		for _, check := range checks {
-			if err := check(r); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-func checkStatus(status uint16) RespCheck {
+func checkStatus(status uint16) respValidator {
 	return func(r *http.Response) error {
 		if r.StatusCode == int(status) {
 			return nil
@@ -104,7 +118,7 @@ func checkStatusOK(r *http.Response) error {
 	return nil
 }
 
-func checkHeaders(headers map[string]string) RespCheck {
+func checkHeaders(headers map[string]string) respValidator {
 	return func(r *http.Response) error {
 		for k, v := range headers {
 			value := r.Header.Get(k)
@@ -116,14 +130,10 @@ func checkHeaders(headers map[string]string) RespCheck {
 	}
 }
 
-func checkBody(body []match.Matcher) RespCheck {
-	return func(r *http.Response) error {
-		content, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return err
-		}
-		for _, m := range body {
-			if m.Match(content) {
+func checkBody(matcher []match.Matcher) bodyValidator {
+	return func(r *http.Response, body string) error {
+		for _, m := range matcher {
+			if m.MatchString(body) {
 				return nil
 			}
 		}
@@ -131,7 +141,7 @@ func checkBody(body []match.Matcher) RespCheck {
 	}
 }
 
-func checkJSON(checks []*jsonResponseCheck) (RespCheck, error) {
+func checkJSON(checks []*jsonResponseCheck) (bodyValidator, error) {
 	type compiledCheck struct {
 		description string
 		condition   conditions.Condition
@@ -147,9 +157,9 @@ func checkJSON(checks []*jsonResponseCheck) (RespCheck, error) {
 		compiledChecks = append(compiledChecks, compiledCheck{check.Description, cond})
 	}
 
-	return func(r *http.Response) error {
+	return func(r *http.Response, body string) error {
 		decoded := &common.MapStr{}
-		decoder := json.NewDecoder(r.Body)
+		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		err := decoder.Decode(decoded)
 

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -19,15 +19,15 @@ package http
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/conditions"
 )
@@ -118,7 +118,9 @@ func TestCheckBody(t *testing.T) {
 			for _, pattern := range test.patterns {
 				patterns = append(patterns, match.MustCompile(pattern))
 			}
-			check := checkBody(patterns)(res)
+			body, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
+			check := checkBody(patterns)(res, string(body))
 
 			if result := (check == nil); result != test.result {
 				if test.result {
@@ -183,7 +185,9 @@ func TestCheckJson(t *testing.T) {
 
 			checker, err := checkJSON([]*jsonResponseCheck{{test.condDesc, test.condConf}})
 			require.NoError(t, err)
-			checkRes := checker(res)
+			body, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
+			checkRes := checker(res, string(body))
 
 			if result := checkRes == nil; result != test.result {
 				if test.result {
@@ -249,7 +253,9 @@ func TestCheckJsonWithIntegerComparison(t *testing.T) {
 
 			checker, err := checkJSON([]*jsonResponseCheck{{test.condDesc, test.condConf}})
 			require.NoError(t, err)
-			checkRes := checker(res)
+			body, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
+			checkRes := checker(res, string(body))
 
 			if result := checkRes == nil; result != test.result {
 				if test.result {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -41,8 +41,6 @@ import (
 	btesting "github.com/elastic/beats/libbeat/testing"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/isdef"
-	"github.com/elastic/go-lookslike/llpath"
-	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
 )
@@ -112,18 +110,7 @@ func respondingHTTPChecks(url string, statusCode int) validator.Validator {
 				"response.status_code": statusCode,
 				"response.body.hash":   isdef.IsString,
 				// TODO add this isdef to lookslike in a robust way
-				"response.body.bytes": isdef.Is("an int64 greater than 0", func(path llpath.Path, v interface{}) *llresult.Results {
-					raw, ok := v.(int64)
-					if !ok {
-						return llresult.SimpleResult(path, false, "%s is not an int64", reflect.TypeOf(v))
-					}
-					if raw >= 0 {
-						return llresult.ValidResult(path)
-					}
-
-					return llresult.SimpleResult(path, false, "value %v not >= 0 ", raw)
-
-				}),
+				"response.body.bytes":    isdef.IsIntGt(-1),
 				"rtt.content.us":         isdef.IsDuration,
 				"rtt.response_header.us": isdef.IsDuration,
 				"rtt.total.us":           isdef.IsDuration,
@@ -134,10 +121,30 @@ func respondingHTTPChecks(url string, statusCode int) validator.Validator {
 	)
 }
 
+func minimalRespondingHTTPChecks(url string, statusCode int) validator.Validator {
+	return lookslike.Compose(
+		httpBaseChecks(url),
+		httpBodyChecks(),
+		lookslike.MustCompile(map[string]interface{}{
+			"http": map[string]interface{}{
+				"response.status_code": statusCode,
+				"rtt.total.us":         isdef.IsDuration,
+			},
+		}),
+	)
+}
+
+func httpBodyChecks() validator.Validator {
+	return lookslike.MustCompile(map[string]interface{}{
+		"http.response.body.bytes": isdef.IsIntGt(-1),
+		"http.response.body.hash":  isdef.IsString,
+	})
+}
+
 func respondingHTTPBodyChecks(body string) validator.Validator {
 	return lookslike.MustCompile(map[string]interface{}{
 		"http.response.body.content": body,
-		"http.response.body.bytes":   int64(len(body)),
+		"http.response.body.bytes":   len(body),
 	})
 }
 

--- a/heartbeat/monitors/active/http/respbody.go
+++ b/heartbeat/monitors/active/http/respbody.go
@@ -20,69 +20,79 @@ package http
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"net/http"
 	"unicode/utf8"
 
-	"github.com/elastic/beats/heartbeat/eventext"
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/elastic/beats/heartbeat/reason"
-	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
-func handleRespBody(event *beat.Event, resp *http.Response, responseConfig responseConfig, errReason reason.Reason) error {
-	defer resp.Body.Close()
+// maxBufferBodyBytes sets a hard limit on how much we're willing to buffer for any reason internally.
+// since we must buffer the whole body for body validators this is effectively a cap on that.
+// 100MiB out to be enough for everybody.
+const maxBufferBodyBytes = 100 * 1024 * 1024
 
-	sampleMaxBytes := responseConfig.IncludeBodyMaxBytes
-
-	includeSample := responseConfig.IncludeBody == "always" || (responseConfig.IncludeBody == "on_error" && errReason != nil)
-
-	// No need to return any actual body bytes if we'll discard them anyway. This should save on allocation
-	if !includeSample {
-		sampleMaxBytes = 0
+func processBody(resp *http.Response, config responseConfig, validator multiValidator) (common.MapStr, reason.Reason) {
+	// Determine how much of the body to actually buffer in memory
+	var bufferBodyBytes int
+	if validator.wantsBody() {
+		bufferBodyBytes = maxBufferBodyBytes
+	} else if config.IncludeBody == "always" || config.IncludeBody == "on_error" {
+		// If the user has asked for bodies to be recorded we only need to buffer that much
+		bufferBodyBytes = config.IncludeBodyMaxBytes
+	} else {
+		// Otherwise, we buffer nothing
+		bufferBodyBytes = 0
 	}
 
-	sampleStr, bodyBytes, bodyHash, err := readResp(resp, sampleMaxBytes)
-	if err != nil {
-		return err
+	respBody, bodyLenBytes, bodyHash, respErr := readBody(resp, bufferBodyBytes)
+	// If we encounter an error while reading the body just fail early
+	if respErr != nil {
+		return nil, reason.IOFailed(respErr)
 	}
 
-	evtBodyMap := common.MapStr{
+	// Run any validations
+	errReason := validator.validate(resp, respBody)
+
+	bodyFields := common.MapStr{
 		"hash":  bodyHash,
-		"bytes": bodyBytes,
+		"bytes": bodyLenBytes,
 	}
-	if includeSample {
-		evtBodyMap["content"] = sampleStr
+	if config.IncludeBody == "always" ||
+		(config.IncludeBody == "on_error" && errReason != nil) {
+
+		// Do not store more bytes than the config specifies. We may
+		// have read extra bytes for the validators
+		sampleNumBytes := len(respBody)
+		if bodyLenBytes < sampleNumBytes {
+			sampleNumBytes = bodyLenBytes
+		}
+		if config.IncludeBodyMaxBytes < sampleNumBytes {
+			sampleNumBytes = config.IncludeBodyMaxBytes
+		}
+
+		bodyFields["content"] = respBody[0:sampleNumBytes]
 	}
 
-	eventext.MergeEventFields(event, common.MapStr{
-		"http": common.MapStr{
-			"response": common.MapStr{"body": evtBodyMap},
-		},
-	})
-
-	return nil
+	return bodyFields, errReason
 }
 
-// readResp reads the first sampleSize bytes from the httpResponse,
+// readBody reads the first sampleSize bytes from the httpResponse,
 // then closes the body (which closes the connection). It doesn't return any errors
 // but does log them. During an error case the return values will be (nil, -1).
 // The maxBytes params controls how many bytes will be returned in a string, not how many will be read.
 // We always read the full response here since we want to time downloading the full thing.
 // This may return a nil body if the response is not valid UTF-8
-func readResp(resp *http.Response, maxSampleBytes int) (bodySample string, bodySize int64, hashStr string, err error) {
-	if resp == nil {
-		return "", -1, "", fmt.Errorf("cannot readResp of nil HTTP response")
-	}
+func readBody(resp *http.Response, maxSampleBytes int) (bodySample string, bodySize int, hashStr string, err error) {
+	defer resp.Body.Close()
 
 	respSize, bodySample, hash, err := readPrefixAndHash(resp.Body, maxSampleBytes)
 
 	return bodySample, respSize, hash, err
 }
 
-func readPrefixAndHash(body io.ReadCloser, maxPrefixSize int) (respSize int64, prefix string, hashStr string, err error) {
+func readPrefixAndHash(body io.ReadCloser, maxPrefixSize int) (respSize int, prefix string, hashStr string, err error) {
 	hash := sha256.New()
 	// Function to lazily get the body of the response
 	rawBuf := make([]byte, 1024)
@@ -94,7 +104,7 @@ func readPrefixAndHash(body io.ReadCloser, maxPrefixSize int) (respSize int64, p
 	for {
 		readSize, readErr := body.Read(rawBuf)
 
-		respSize += int64(readSize)
+		respSize += readSize
 		hash.Write(rawBuf[:readSize])
 
 		if prefixRemainingBytes > 0 {

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -27,22 +27,25 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/go-lookslike"
-	"github.com/elastic/go-lookslike/testslike"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/beats/heartbeat/reason"
-	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common/match"
+	"github.com/elastic/go-lookslike"
+	"github.com/elastic/go-lookslike/testslike"
 )
 
 func Test_handleRespBody(t *testing.T) {
+	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")})
+	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")})
+
+	matchingComboValidator := multiValidator{bodyValidators: []bodyValidator{matchingBodyValidator}}
+	failingComboValidator := multiValidator{bodyValidators: []bodyValidator{failingBodyValidator}}
+
 	type args struct {
-		event          *beat.Event
 		resp           *http.Response
 		responseConfig responseConfig
-		errReason      reason.Reason
+		validator      multiValidator
 	}
 	tests := []struct {
 		name          string
@@ -53,21 +56,19 @@ func Test_handleRespBody(t *testing.T) {
 		{
 			"on_error with error",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "on_error", IncludeBodyMaxBytes: 3},
-				reason.IOFailed(fmt.Errorf("something happened")),
+				failingComboValidator,
 			},
-			false,
+			true,
 			true,
 		},
 		{
 			"on_error with success",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "on_error", IncludeBodyMaxBytes: 3},
-				nil,
+				matchingComboValidator,
 			},
 			false,
 			false,
@@ -75,21 +76,19 @@ func Test_handleRespBody(t *testing.T) {
 		{
 			"always with error",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "always", IncludeBodyMaxBytes: 3},
-				reason.IOFailed(fmt.Errorf("something happened")),
+				failingComboValidator,
 			},
-			false,
+			true,
 			true,
 		},
 		{
 			"always with success",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "always", IncludeBodyMaxBytes: 3},
-				nil,
+				matchingComboValidator,
 			},
 			false,
 			true,
@@ -97,21 +96,19 @@ func Test_handleRespBody(t *testing.T) {
 		{
 			"never with error",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "never", IncludeBodyMaxBytes: 3},
-				reason.IOFailed(fmt.Errorf("something happened")),
+				failingComboValidator,
 			},
-			false,
+			true,
 			false,
 		},
 		{
 			"never with success",
 			args{
-				&beat.Event{},
 				simpleHTTPResponse("hello"),
 				responseConfig{IncludeBody: "never", IncludeBodyMaxBytes: 3},
-				nil,
+				matchingComboValidator,
 			},
 			false,
 			false,
@@ -120,25 +117,20 @@ func Test_handleRespBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			event := tt.args.event
-			if err := handleRespBody(tt.args.event, tt.args.resp, tt.args.responseConfig, tt.args.errReason); (err != nil) != tt.wantErr {
+			fields, err := processBody(tt.args.resp, tt.args.responseConfig, tt.args.validator)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("handleRespBody() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			bodyMatch := map[string]interface{}{
 				"hash":  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-				"bytes": int64(5),
+				"bytes": 5,
 			}
 			if tt.wantFieldsSet {
 				bodyMatch["content"] = "hel"
 			}
 
-			testslike.Test(t,
-				lookslike.MustCompile(
-					map[string]interface{}{
-						"http.response.body": bodyMatch,
-					}),
-				event.Fields)
+			testslike.Test(t, lookslike.MustCompile(bodyMatch), fields)
 		})
 	}
 }
@@ -152,7 +144,7 @@ func Test_readResp(t *testing.T) {
 		name           string
 		args           args
 		wantBodySample string
-		wantBodySize   int64
+		wantBodySize   int
 		wantHashStr    string
 		wantErr        bool
 	}{
@@ -167,33 +159,22 @@ func Test_readResp(t *testing.T) {
 			wantHashStr:    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 			wantErr:        false,
 		},
-		{
-			name: "no resp",
-			args: args{
-				resp:           nil,
-				maxSampleBytes: 3,
-			},
-			wantBodySample: "",
-			wantBodySize:   -1,
-			wantHashStr:    "",
-			wantErr:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBodySample, gotBodySize, gotHashStr, err := readResp(tt.args.resp, tt.args.maxSampleBytes)
+			gotBodySample, gotBodySize, gotHashStr, err := readBody(tt.args.resp, tt.args.maxSampleBytes)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("readResp() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("readBody() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotBodySample != tt.wantBodySample {
-				t.Errorf("readResp() gotBodySample = %v, want %v", gotBodySample, tt.wantBodySample)
+				t.Errorf("readBody() gotBodySample = %v, want %v", gotBodySample, tt.wantBodySample)
 			}
 			if gotBodySize != tt.wantBodySize {
-				t.Errorf("readResp() gotBodySize = %v, want %v", gotBodySize, tt.wantBodySize)
+				t.Errorf("readBody() gotBodySize = %v, want %v", gotBodySize, tt.wantBodySize)
 			}
 			if gotHashStr != tt.wantHashStr {
-				t.Errorf("readResp() gotHashStr = %v, want %v", gotHashStr, tt.wantHashStr)
+				t.Errorf("readBody() gotHashStr = %v, want %v", gotHashStr, tt.wantHashStr)
 			}
 		})
 	}
@@ -255,7 +236,7 @@ func Test_readPrefixAndHash(t *testing.T) {
 				require.Error(t, err)
 			}
 
-			assert.Equal(t, int64(len(tt.body)), gotRespSize)
+			assert.Equal(t, len(tt.body), gotRespSize)
 			if tt.len <= len(tt.body) {
 				assert.Equal(t, tt.body[0:tt.len], gotPrefix)
 			} else {

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -131,30 +131,6 @@ func makeTestHTTPRequest(t *testing.T) *http.Request {
 	return req
 }
 
-func TestZeroMaxRedirectShouldError(t *testing.T) {
-	checker := makeCheckRedirect(0)
-	req := makeTestHTTPRequest(t)
-
-	res := checker(req, nil)
-	assert.Equal(t, http.ErrUseLastResponse, res)
-}
-
-func TestNonZeroRedirect(t *testing.T) {
-	limit := 5
-	checker := makeCheckRedirect(limit)
-
-	var via []*http.Request
-	// Test requests within the limit
-	for i := 0; i < limit; i++ {
-		req := makeTestHTTPRequest(t)
-		assert.Nil(t, checker(req, via))
-		via = append(via, req)
-	}
-
-	// We are now at the limit, this request should fail
-	assert.Equal(t, http.ErrUseLastResponse, checker(makeTestHTTPRequest(t), via))
-}
-
 func TestRequestBuildingWithCustomHost(t *testing.T) {
 	var config = Config{}
 	var encoder = nilEncoder{}

--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -124,6 +124,10 @@ class Test(BaseTest):
                 proc.check_kill_and_wait()
 
             self.assert_last_status(expected_status)
+            if expected_status == "down":
+                nose.tools.eq_(self.last_output_line()["http.response.body.content"], body)
+            else:
+                assert not self.last_output_line().has_key("http.response.body.content")
         finally:
             server.shutdown()
 


### PR DESCRIPTION
Currently, when using an HTTP body validator (either regexp or JSON) will break the storage of HTTP bodies with response.include_body (introduced in #13022).

The root cause is that both validation and reading the body for inclusion in the event share the same ReadCloser provided by *http.Response.

This patch looks at both validation and body settings to determine how much of the body to read, reads that much, then passes that to the validation and body inclusion code as a []byte.

Resolves #13751

(cherry picked from commit 6c6b3969bb848e789e8f4f3e4a27b400bac22da9)