### PR TITLE
[Monitoring] Use op_type = create with ES version >= 7.5.0

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -32,6 +32,8 @@ import (
 	"github.com/elastic/beats/libbeat/testing"
 )
 
+var createDocPrivAvailableESVersion = common.MustNewVersion("7.5.0")
+
 type publishClient struct {
 	es     *esout.Client
 	params map[string]string
@@ -185,13 +187,19 @@ func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 		"_routing": nil,
 	}
 
-	if c.es.GetVersion().Major < 7 {
+	esVersion := c.es.GetVersion()
+	if esVersion.Major < 7 {
 		meta["_type"] = "doc"
 	}
 
-	action := common.MapStr{
-		"index": meta,
+	var action common.MapStr
+	var opType string
+	if esVersion.LessThan(createDocPrivAvailableESVersion) {
+		opType = "index"
+	} else {
+		opType = "create"
 	}
+	action[opType] = meta
 
 	event.Content.Fields.Put("timestamp", event.Content.Timestamp)
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -192,7 +192,7 @@ func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 		meta["_type"] = "doc"
 	}
 
-	var action common.MapStr
+	action := common.MapStr{}
 	var opType string
 	if esVersion.LessThan(createDocPrivAvailableESVersion) {
 		opType = "index"

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -210,7 +210,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests || ${DOCKER_COMPOSE} logs --tail 200
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -210,7 +210,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel


### PR DESCRIPTION
Follow up to #13936.

In #13936, we taught the Elasticsearch output client in libbeat to use the `create` op_type in bulk requests to Elasticsearch if the Elasticsearch cluster's version was 7.5.0 or newer. This PR similarly teaches the Elasticsearch monitoring client to do the same.

Here's what the bulk request from the monitoring client looks like with Elasticsearch 7.4.0:

<img width="1328" alt="7_4_0" src="https://user-images.githubusercontent.com/51061/67801568-aab2a580-fa46-11e9-913d-51df049614e7.png">

And here's what it looks like with Elasticsearch 8.0.0:

<img width="1328" alt="8_0_0" src="https://user-images.githubusercontent.com/51061/67801582-b1d9b380-fa46-11e9-9893-3c0d4919bdea.png">
