### PR TITLE
Cherry-pick #14316 to 7.5: [Metricbeat] Fix ARN parsing function to work for ELB ANRs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Metricbeat*
 
 - Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
+- Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -204,6 +204,9 @@ func findIdentifierFromARN(resourceARN string) (string, error) {
 	} else if strings.Contains(arnParsed.Resource, "/") {
 		resourceARNSplit = strings.Split(arnParsed.Resource, "/")
 	}
-	identifier := resourceARNSplit[len(resourceARNSplit)-1]
-	return identifier, nil
+
+	if len(resourceARNSplit) <= 1 {
+		return resourceARNSplit[0], nil
+	}
+	return strings.Join(resourceARNSplit[1:], "/"), nil
 }

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -354,6 +354,14 @@ func TestFindIdentifierFromARN(t *testing.T) {
 			"arn:aws:sns:us-east-1:627959692251:notification-topic-1",
 			"notification-topic-1",
 		},
+		{
+			"arn:aws:elasticloadbalancing:eu-central-1:627959692251:loadbalancer/app/ece-ui/b195d6cf21493989",
+			"app/ece-ui/b195d6cf21493989",
+		},
+		{
+			"arn:aws:elasticloadbalancing:eu-central-1:627959692251:loadbalancer/net/ece-es-clusters-nlb/0c5bdb3b96cf1552",
+			"net/ece-es-clusters-nlb/0c5bdb3b96cf1552",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Cherry-pick of PR #14316 to 7.5 branch. Original message: 

This PR is to fix a bug in ARN parser `findIdentifierFromARN`. It used to only work for arns with short resource string with only two parts, such as `instance/i-123`. Now with this change, the parser should work for other resource strings as well with more than two parts, such as `loadbalancer/net/ece-es-clusters-nlb/0c5bdb3b96cf1552`.

Unit test is added for this.