### PR TITLE
GA the script processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -312,6 +312,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Marking Central Management deprecated. {pull}14018[14018]
 - Add `keep_null` setting to allow Beats to publish null values in events. {issue}5522[5522] {pull}13928[13928]
 - Add shared_credential_file option in aws related config for specifying credential file directory. {issue}14157[14157] {pull}14178[14178]
+- GA the `script` processor. {pull}14325[14325]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1811,8 +1811,6 @@ ifdef::has_script_processor[]
 [[processor-script]]
 === Script Processor
 
-experimental[]
-
 The script processor executes Javascript code to process an event. The processor
 uses a pure Go implementation of ECMAScript 5.1 and has no external
 dependencies. This can be useful in situations where one of the other processors


### PR DESCRIPTION
Mark the `script` processor as GA.

Since being introduced in 7.2, it has seen a good amount of adoption. Several modules in Filebeat and Winlogbeat are built on top of it.