### PR TITLE
Cherry-pick #14315 to 7.5: [Auditbeat] Fixes for system/socket dataset UDP and DNS

### DIFF
--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -19,8 +19,10 @@ import (
 	"github.com/elastic/beats/x-pack/auditbeat/tracing"
 )
 
-// Enough for padding + mac_hdr + max ip_hdr + udp_hdr
-const pktHeaderDumpBytes = 8 * 12
+// This is how many data we dump from sk_buff->data to read full packet headers
+// (IP + UDP header). This has been observed to include up to 100 bytes of
+// padding.
+const skBuffDataDumpBytes = 256
 
 // ProbeTransform transforms a probe before its installed.
 type ProbeTransform func(helper.ProbeDef) helper.ProbeDef
@@ -300,7 +302,7 @@ var sharedKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "udp_queue_rcv_skb",
 			Address:   "udp_queue_rcv_skb",
-			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, pktHeaderDumpBytes),
+			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpQueueRcvSkb) }),
 	},
@@ -463,7 +465,7 @@ var ipv6KProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "udpv6_queue_rcv_skb",
 			Address:   "udpv6_queue_rcv_skb",
-			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, pktHeaderDumpBytes),
+			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6QueueRcvSkb) }),
 	},

--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -3,6 +3,7 @@ import operator
 import platform
 import random
 import socket
+import struct
 import time
 import unittest
 from auditbeat_xpack import *
@@ -119,6 +120,18 @@ class Test(AuditbeatXPackTest):
             extra_conf={
                 'socket.flow_inactive_timeout': '2s'
             })
+
+    def test_dns_udp_ipv6(self):
+        """
+        test DNS enrichment of UDP/IPv6 session
+        """
+        self.with_runner(DNSTestCase(network="ipv6", transport="udp"))
+
+    def test_dns_unidirectional_udp(self):
+        """
+        test DNS enrichment of unidirectional UDP
+        """
+        self.with_runner(DNSTestCase(transport="udp", bidirectional=False))
 
     def with_runner(self, test, extra_conf=dict()):
         enable_ipv6_loopback()
@@ -484,41 +497,113 @@ class MultiUDP4TestCase:
         ])
 
 
+class SocketFactory:
+
+    def __init__(self, network, transport):
+        self.network = network
+        self.transport = transport
+        if self.network == "ipv4":
+            self.fn = socket_ipv4
+        elif self.network == "ipv6":
+            self.fn = socket_ipv6
+        else:
+            raise Exception("invalid network: " + self.network)
+        if self.transport == "tcp":
+            self.sock_type = socket.SOCK_STREAM
+            self.sock_proto = socket.IPPROTO_TCP
+        elif self.transport == "udp":
+            self.sock_type = socket.SOCK_DGRAM
+            self.sock_proto = socket.IPPROTO_UDP
+        else:
+            raise Exception("invalid transport: " + self.transport)
+
+    def __call__(self, **kwargs):
+        return self.fn(self.sock_type, self.sock_proto, **kwargs)
+
+
+def transaction_udp(client, client_addr, server, server_addr, req, resp):
+    client.sendto(req, server_addr)
+    msg, _ = server.recvfrom(len(req))
+    server.sendto(resp, client_addr)
+    msg, _ = client.recvfrom(len(resp))
+
+
+def transaction_tcp(client, client_addr, server, server_addr, req, resp):
+    server.listen(8)
+    client.connect(server_addr)
+    accepted, _ = server.accept()
+    client.send(req)
+    accepted.recv(len(req))
+    accepted.send(resp)
+    client.recv(len(resp))
+    accepted.close()
+
+
+def transaction_udp_oneway(client, client_addr, server, server_addr, req, resp):
+    client.sendto(req, server_addr)
+    msg, _ = server.recvfrom(len(req))
+
+
 class DNSTestCase:
-    def __init__(self, enabled=True, delay_seconds=0):
+
+    def __init__(self, enabled=True, delay_seconds=0, network="ipv4", transport="tcp", bidirectional=True):
         self.dns_enabled = enabled
         self.delay = delay_seconds
+        self.socket_factory = SocketFactory(network, transport)
+        self.transaction = transaction_tcp if transport == "tcp" else transaction_udp
+        self.bidirectional = bidirectional
+        if not self.bidirectional:
+            assert transport == "udp"
+            self.transaction = transaction_udp_oneway
 
     def run(self):
-        req = "\x74\xba\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07elastic" \
-              "\x02co\x00\x00\x01\x00\x01"
-        resp = "\x74\xba\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00\x07elastic" \
-               "\x02co\x00\x00\x01\x00\x01\xc0\x0c\x00\x01\x00\x01\x00\x00" \
-               "\x00\x9c\x00\x04"  # Append IPv4 ip here
+        A = "\x00\x01"
+        AAAA = "\x00\x1c"
+        q = A if self.socket_factory.network == "ipv4" else AAAA
 
-        dns_cli, self.dns_client_addr = socket_ipv4(socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-        dns_srv, self.dns_server_addr = socket_ipv4(socket.SOCK_DGRAM, socket.IPPROTO_UDP, port=53)
-        client, self.client_addr = socket_ipv4(socket.SOCK_STREAM, socket.IPPROTO_TCP)
-        server, self.server_addr = socket_ipv4(socket.SOCK_STREAM, socket.IPPROTO_TCP)
-        dns_cli.sendto(req, self.dns_server_addr)
-        msg, _ = dns_srv.recvfrom(64)
-        dns_srv.sendto(resp + ipv4_str_to_raw(self.server_addr[0]), self.dns_client_addr)
-        msg, _ = dns_cli.recvfrom(64)
+        dns_factory = SocketFactory(self.socket_factory.network, "udp")
+        dns_cli, self.dns_client_addr = dns_factory()
+        dns_srv, self.dns_server_addr = dns_factory(port=53)
+        client, self.client_addr = self.socket_factory()
+        server, self.server_addr = self.socket_factory()
+
+        raw_addr = ip_str_to_raw(self.server_addr[0])
+        req = "\x74\xba\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07elastic" \
+              "\x02co\x00" + q + "\x00\x01"
+        resp = "\x74\xba\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00\x07elastic" \
+               "\x02co\x00" + q + "\x00\x01\xc0\x0c" + q + "\x00\x01\x00\x00" \
+               "\x00\x9c" + struct.pack(">H", len(raw_addr)) + raw_addr
+
+        transaction_udp(dns_cli, self.dns_client_addr,
+                        dns_srv, self.dns_server_addr,
+                        req, resp)
         dns_cli.close()
         dns_srv.close()
         time.sleep(self.delay)
-        server.listen(8)
-        client.connect(self.server_addr)
-        accepted, _ = server.accept()
-        client.send("GET / HTTP/1.1\r\nHost: elastic.co\r\n\r\n")
-        accepted.recv(64)
-        accepted.send("HTTP/1.1 404 Not Found\r\n\r\n")
-        client.recv(64)
-        accepted.close()
+        self.transaction(client, self.client_addr,
+                         server, self.server_addr,
+                         "GET / HTTP/1.1\r\nHost: elastic.co\r\n\r\n",
+                         "HTTP/1.1 404 Not Found\r\n\r\n")
         client.close()
         server.close()
 
     def expected(self):
+
+        if self.socket_factory.transport == "tcp":
+            client_bytes = Comparison(operator.gt, 80)
+            client_packets = Comparison(operator.gt, 2)
+            server_bytes = Comparison(operator.gt, 2)
+            server_packets = Comparison(operator.gt, 2)
+            net_bytes = Comparison(operator.gt, 83)
+            net_packets = Comparison(operator.gt, 5)
+        else:
+            client_bytes = Comparison(operator.gt, 5)
+            client_packets = 1
+            server_bytes = Comparison(operator.gt, 5) if self.bidirectional else 0
+            server_packets = 0 + self.bidirectional
+            net_bytes = Comparison(operator.gt, 5 + 6 * self.bidirectional)
+            net_packets = 1 + self.bidirectional
+
         expected_events = [
             {
                 "agent.type": "auditbeat",
@@ -539,7 +624,7 @@ class DNSTestCase:
                 "network.direction": "inbound",
                 "network.packets": 2,
                 "network.transport": "udp",
-                "network.type": "ipv4",
+                "network.type": self.socket_factory.network,
                 "process.pid": os.getpid(),
                 "server.bytes": Comparison(operator.gt, 30),
                 "server.ip": self.dns_server_addr[0],
@@ -552,34 +637,35 @@ class DNSTestCase:
                 "user.id": str(os.getuid()),
             }, {
                 "agent.type": "auditbeat",
-                "client.bytes":  Comparison(operator.gt, 80),
+                "client.bytes":  client_bytes,
                 "client.ip": self.client_addr[0],
-                "client.packets": Comparison(operator.gt, 2),
+                "client.packets": client_packets,
                 "client.port": self.client_addr[1],
-                "destination.bytes": Comparison(operator.gt, 80),
+                "destination.bytes": server_bytes,
                 "destination.domain": "elastic.co",
                 "destination.ip": self.server_addr[0],
-                "destination.packets": Comparison(operator.gt, 2),
+                "destination.packets": server_packets,
                 "destination.port": self.server_addr[1],
                 "event.action": "network_flow",
                 "event.category": "network_traffic",
                 "event.dataset": "socket",
                 "event.kind": "event",
                 "event.module": "system",
+                "network.packets": net_bytes,
                 "network.direction": "inbound",
-                "network.packets": Comparison(operator.gt, 5),
-                "network.transport": "tcp",
-                "network.type": "ipv4",
+                "network.packets": net_packets,
+                "network.transport": self.socket_factory.transport,
+                "network.type": self.socket_factory.network,
                 "process.pid": os.getpid(),
-                "server.bytes": Comparison(operator.gt, 80),
+                "server.bytes": server_bytes,
                 "server.domain": "elastic.co",
                 "server.ip": self.server_addr[0],
-                "server.packets": Comparison(operator.gt, 2),
+                "server.packets": server_packets,
                 "server.port": self.server_addr[1],
                 "service.type": "system",
-                "source.bytes":  Comparison(operator.gt, 80),
+                "source.bytes":  client_bytes,
                 "source.ip": self.client_addr[0],
-                "source.packets": Comparison(operator.gt, 2),
+                "source.packets": client_packets,
                 "source.port": self.client_addr[1],
             },
         ]
@@ -601,11 +687,11 @@ def random_address_ipv4():
     return '127.{}.{}.{}'.format(random.randint(0, 255), random.randint(0, 255), random.randint(1, 254))
 
 
-def ipv4_str_to_raw(ip):
-    return ''.join(map(lambda x: chr(int(x)), ip.split('.')))
+def ip_str_to_raw(ip):
+    return socket.inet_pton(socket.AF_INET6 if ':' in ip else socket.AF_INET, ip)
 
 
-def socket_ipv6(type, proto):
+def socket_ipv6(type, proto, port=0):
     if not socket.has_ipv6:
         raise Exception('No IPv6 support!')
     addr = random_address_ipv6()
@@ -613,7 +699,7 @@ def socket_ipv6(type, proto):
     if rv != 0:
         raise Exception("add ip returned {}".format(rv))
     sock = socket.socket(socket.AF_INET6, type, proto)
-    sock.bind((addr, 0))
+    sock.bind((addr, port))
     return sock, sock.getsockname()
 
 


### PR DESCRIPTION
Cherry-pick of PR #14315 to 7.5 branch. Original message: 

This fixes a couple of problems with the dataset:
- In some cases incoming UDP packets won't be processed by the dataset due to padding. Seems that some systems add more padding that others and some devices (eth) add more padding than loopback, and tests are run on loopback.
- Single packet flows didn't have proper process and DNS enrichment.
