### PR TITLE
[libbeat] Fix documentation of output.kafka.key

### DIFF
--- a/libbeat/docs/outputs/output-kafka.asciidoc
+++ b/libbeat/docs/outputs/output-kafka.asciidoc
@@ -123,7 +123,7 @@ the specified string:
 ------------------------------------------------------------------------------
 output.kafka:
   hosts: ["localhost:9092"]
-  topic: "logs-%{[beat.version]}" 
+  topic: "logs-%{[beat.version]}"
   topics:
     - topic: "critical-%{[beat.version]}"
       when.contains:
@@ -139,7 +139,11 @@ This configuration results in topics named +critical-{version}+,
 
 ===== `key`
 
-Optional Kafka event key. If configured, the event key must be unique and can be extracted from the event using a format string.
+Optional formatted string specifying the Kafka event key. If configured, the
+event key can be extracted from the event using a format string.
+
+See the Kafka documentation for the implications of a particular choice of key;
+by default, the key is chosen by the Kafka cluster.
 
 ===== `partition`
 


### PR DESCRIPTION
A [recent discuss post](https://discuss.elastic.co/t/why-kafka-event-key-must-be-unique/205330) pointed out an inaccuracy in the docs for `output.kafka.key`. I've clarified the description of the field.