### PR TITLE
Allow users to set just monitoring.cluster_uuid

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -123,6 +123,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Support usage of custom builders without hints and mappers {pull}13839[13839]
 - Fix memory leak in kubernetes autodiscover provider and add_kubernetes_metadata processor happening when pods are terminated without sending a delete event. {pull}14259[14259]
 - Fix kubernetes `metaGenerator.ResourceMetadata` when parent reference controller is nil {issue}14320[14320] {pull}14329[14329]
+- Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -875,7 +875,6 @@ func (b *Beat) clusterUUIDFetchingCallback() (elasticsearch.ConnectCallback, err
 	return callback, nil
 }
 
-
 func (b *Beat) setupMonitoring(settings Settings) error {
 	monitoringCfg, reporterSettings, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
 	if err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -882,7 +882,7 @@ func (b *Beat) setupMonitoring(settings Settings) error {
 		return err
 	}
 
-	monitoringClusterUUID, err := monitoring.GetMonitoringClusterUUID(monitoringCfg)
+	monitoringClusterUUID, err := monitoring.GetClusterUUID(monitoringCfg)
 	if err != nil {
 		return err
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -887,6 +887,7 @@ func (b *Beat) setupMonitoring(settings Settings) error {
 		return err
 	}
 
+	// Expose monitoring.cluster_uuid in state API
 	if monitoringClusterUUID != "" {
 		stateRegistry := monitoring.GetNamespace("state").GetRegistry()
 		monitoringRegistry := stateRegistry.NewRegistry("monitoring")

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -102,8 +102,8 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 	}
 }
 
-// GetMonitoringClusterUUID returns the value of the monitoring.cluster_uuid setting, if it is set.
-func GetMonitoringClusterUUID(monitoringCfg *common.Config) (string, error) {
+// GetClusterUUID returns the value of the monitoring.cluster_uuid setting, if it is set.
+func GetClusterUUID(monitoringCfg *common.Config) (string, error) {
 	if monitoringCfg == nil {
 		return "", nil
 	}

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -102,6 +102,7 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 	}
 }
 
+// GetMonitoringClusterUUID returns the value of the monitoring.cluster_uuid setting, if it is set.
 func GetMonitoringClusterUUID(monitoringCfg *common.Config) (string, error) {
 	if monitoringCfg == nil {
 		return "", nil
@@ -117,6 +118,7 @@ func GetMonitoringClusterUUID(monitoringCfg *common.Config) (string, error) {
 	return config.ClusterUUID, nil
 }
 
+// IsEnabled returns whether the monitoring reporter is enabled or not.
 func IsEnabled(monitoringCfg *common.Config) bool {
 	if monitoringCfg == nil {
 		return false

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -19,6 +19,7 @@ package monitoring
 
 import (
 	"errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/monitoring/report"

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -116,10 +116,20 @@ xpack.monitoring.elasticsearch.state.period: 3s      # to speed up tests
 
 {% if monitoring -%}
 #================================ X-Pack Monitoring (direct) =====================================
-monitoring.elasticsearch.hosts: {{monitoring.elasticsearch.hosts}}
-monitoring.elasticsearch.metrics.period: 2s    # to speed up tests
-monitoring.elasticsearch.state.period: 3s      # to speed up tests
+monitoring:
+    {% if monitoring.elasticsearch -%}
+    elasticsearch.hosts: {{monitoring.elasticsearch.hosts}}
+    elasticsearch.metrics.period: 2s    # to speed up tests
+    elasticsearch.state.period: 3s      # to speed up tests
+    {% endif -%}
+
+    {% if monitoring.cluster_uuid -%}
+    cluster_uuid: {{monitoring.cluster_uuid}}
+    {% endif -%}
 {% endif -%}
 
 # vim: set ft=jinja:
 
+{% if http_enabled -%}
+http.enabled: {{http_enabled}}
+{% endif -%}

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -4,6 +4,9 @@ from elasticsearch import Elasticsearch
 import re
 from nose.plugins.attrib import attr
 import unittest
+import requests
+import random
+import string
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
@@ -150,6 +153,29 @@ class Test(BaseTest):
         self.assert_same_structure(indirect_beats_state_doc['beats_state'], direct_beats_state_doc['beats_state'])
         self.assert_same_structure(indirect_beats_stats_doc['beats_stats'], direct_beats_stats_doc['beats_stats'])
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @attr('integration')
+    def test_cluster_uuid_setting(self):
+        """
+        Test that monitoring.cluster_uuid setting may be set without any other monitoring.* settings
+        """
+        test_cluster_uuid = self.random_string(10)
+        self.render_config_template(
+            "mockbeat",
+            monitoring={
+                    "cluster_uuid": test_cluster_uuid
+            },
+            http_enabled="true"
+        )
+
+        proc = self.start_beat(config="mockbeat.yml")
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+
+        state = self.get_beat_state()
+        proc.check_kill_and_wait()
+
+        self.assertEqual(test_cluster_uuid, state["monitoring"]["cluster_uuid"])
+
     def search_monitoring_doc(self, monitoring_type):
         results = self.es_monitoring.search(
             index='.monitoring-beats-*',
@@ -241,3 +267,12 @@ class Test(BaseTest):
             host=os.getenv("ES_MONITORING_HOST", "localhost"),
             port=os.getenv("ES_MONITORING_PORT", "9210")
         )
+
+    def get_beat_state(self):
+        url = "http://localhost:5066/state"
+        return requests.get(url).json()
+
+
+    def random_string(self, size):
+        char_pool = string.ascii_letters + string.digits
+        return ''.join(random.choice(char_pool) for i in range(size))

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -272,6 +272,10 @@ class Test(BaseTest):
         url = "http://localhost:5066/state"
         return requests.get(url).json()
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> Adding system test
     def random_string(self, size):
         char_pool = string.ascii_letters + string.digits
         return ''.join(random.choice(char_pool) for i in range(size))

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -272,10 +272,6 @@ class Test(BaseTest):
         url = "http://localhost:5066/state"
         return requests.get(url).json()
 
-<<<<<<< HEAD
-=======
-
->>>>>>> Adding system test
     def random_string(self, size):
         char_pool = string.ascii_letters + string.digits
         return ''.join(random.choice(char_pool) for i in range(size))

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -163,7 +163,7 @@ class Test(BaseTest):
         self.render_config_template(
             "mockbeat",
             monitoring={
-                    "cluster_uuid": test_cluster_uuid
+                "cluster_uuid": test_cluster_uuid
             },
             http_enabled="true"
         )
@@ -271,7 +271,6 @@ class Test(BaseTest):
     def get_beat_state(self):
         url = "http://localhost:5066/state"
         return requests.get(url).json()
-
 
     def random_string(self, size):
         char_pool = string.ascii_letters + string.digits


### PR DESCRIPTION
Currently there is a [bug](https://discuss.elastic.co/t/standalone-cluster-using-new-parameter-beat-xpack-in-metricbeat/205820/) in libbeat which allows users to set `monitoring.cluster_uuid` only if there is also a monitoring reporter configured (either via `output.elasticsearch.*` settings or `monitoring.elasticsearch.*` settings). If there are no monitoring reporter settings (but `monitoring.cluster_uuid` is set), the value of `monitoring.cluster_uuid` is not [exposed](https://github.com/elastic/beats/pull/13254) via the `GET state` API. This further does not allow the `monitoring.cluster_uuid`Metricbeat's `beat` module to monitor a beat that has specified the `monitoring.cluster_uuid` setting in it's configuration. Ultimately this results in the monitored beat being shown under a "Standalone Cluster" in the Stack Monitoring UI.

Therefore, we should allow users to configure the `monitoring.cluster_uuid` setting even when no other settings under the `monitoring` namespace are configured.

This PR fixes this bug by:
- parsing out the `monitoring.cluster_uuid` setting before the reporter configuration is done;
- exposing the parsed out value via the monitoring registry, regardless of whether monitoring is enabled or not. This allows the `GET state` API to use, so Metricbeat's `beat` module may be able to fetch it; and
- considering monitoring as disabled if the only setting under `monitoring` is `cluster_uuid`, as we expect the other settings to be related to the reporter (`monitoring.elasticsearch.*`).

This PR also does a bit of cleanup by extracting the monitoring setup code out of `(*Beat).launch` and into its own method.

### Testing this PR
1. Build Filebeat (or any other Beat) with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/filebeat
   mage build
   ```
2. Disable the `elasticsearch` output in your Beat and enable some other output.
   ```
   output.elasticsearch:
     enabled: false
   output.console:
     enabled: true
   ```
3. Start the beat while setting `http.enabled=true` and `monitoring.cluster_uuid=<some value>`.
   ```
   ./filebeat -e -E http.enabled=true -E monitoring.cluster_uuid=foobar
   ```
4. Call the State API for your Beat and check that the `monitoring.cluster_uuid` value is reported.
   ```
   curl -s 'http://localhost:5066/state' | jq .monitoring.cluster_uuid
   ```
