### PR TITLE
Log monitoring bulk failures

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -250,6 +250,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update azure configuration example. {issue}14224[14224]
 - Fix cloudwatch metricset with names and dimensions in config. {issue}14376[14376] {pull}14391[14391]
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
+- Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 
 *Packetbeat*
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -235,7 +235,7 @@ func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 		return err
 	}
 
-	handleBulkResult(result, []report.Event{document})
+	logBulkFailures(result, []report.Event{document})
 	return err
 }
 
@@ -245,7 +245,7 @@ func getMonitoringIndexName() string {
 	return fmt.Sprintf(".monitoring-beats-%v-%s", version, date)
 }
 
-func handleBulkResult(result *esout.BulkResult, events []report.Event) {
+func logBulkFailures(result *esout.BulkResult, events []report.Event) {
 	items := result.Items
 
 	reader := esout.NewJSONReader(items)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -249,21 +249,21 @@ func logBulkFailures(result esout.BulkResult, events []report.Event) {
 	reader := esout.NewJSONReader(result)
 	err := esout.BulkReadToItems(reader)
 	if err != nil {
-		logp.Err("failed to parse bulk items: %v", err)
+		logp.Err("failed to parse monitoring bulk items: %v", err)
 		return
 	}
 
 	for i := range events {
 		status, msg, err := esout.BulkReadItemStatus(reader)
 		if err != nil {
-			logp.Err("failed to parse item status: %v", err)
+			logp.Err("failed to parse monitoring bulk item status: %v", err)
 			return
 		}
 		switch {
 		case status < 300, status == http.StatusConflict:
 			continue
 		default:
-			logp.Warn("bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
+			logp.Warn("monitoring bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
 		}
 	}
 }

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -253,7 +253,7 @@ func logBulkFailures(result esout.BulkResult, events []report.Event) {
 		return
 	}
 
-	for i, _ := range events {
+	for i := range events {
 		status, msg, err := esout.BulkReadItemStatus(reader)
 		if err != nil {
 			logp.Err("failed to parse item status: %v", err)

--- a/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
@@ -34,7 +34,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	expectedResp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", ID: "1", Version: 1, Created: true})
+	expectedResp, err := json.Marshal(BulkResult{7, false, []byte(`[]`)})
 
 	ops := []map[string]interface{}{
 		{
@@ -65,8 +65,8 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	if err != nil {
 		t.Errorf("Bulk() returns error: %s", err)
 	}
-	if !resp.Created {
-		t.Errorf("Bulk() fails: %s", resp)
+	if resp.Errors {
+		t.Errorf("Bulk() fails: %v", resp)
 	}
 }
 

--- a/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
@@ -20,7 +20,6 @@
 package elasticsearch
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -34,7 +33,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	expectedResp, err := json.Marshal(BulkResult{7, false, []byte(`[]`)})
+	expectedResp := []byte(`{"took":7,"errors":false,"items":[]}`)
 
 	ops := []map[string]interface{}{
 		{
@@ -61,12 +60,9 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	resp, err := client.Bulk(index, "type1", params, body)
+	_, err := client.Bulk(index, "type1", params, body)
 	if err != nil {
 		t.Errorf("Bulk() returns error: %s", err)
-	}
-	if resp.Errors {
-		t.Errorf("Bulk() fails: %v", resp)
 	}
 }
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -527,6 +527,7 @@ func bulkCollectPublishFails(
 	return failed, stats
 }
 
+// BulkReadToItems reads the bulk response up to (but not including) items
 func BulkReadToItems(reader *JSONReader) error {
 	if err := reader.ExpectDict(); err != nil {
 		return errExpectedObject
@@ -559,6 +560,7 @@ func BulkReadToItems(reader *JSONReader) error {
 	return nil
 }
 
+// BulkReadItemStatus reads the status and error fields from the bulk item
 func BulkReadItemStatus(reader *JSONReader) (int, []byte, error) {
 	// skip outer dictionary
 	if err := reader.ExpectDict(); err != nil {

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -448,3 +448,11 @@ func TestClientWithAPIKey(t *testing.T) {
 	client.Ping()
 	assert.Equal(t, "ApiKey aHlva0hHNEJmV2s1dmlLWjE3Mlg6bzQ1SlVreXVTLS15aVNBdXV4bDhVdw==", headers.Get("Authorization"))
 }
+
+func TestBulkReadToItems(t *testing.T) {
+	// TODO
+}
+
+func TestBulkReadItemStatus(t *testing.T) {
+	// TODO
+}

--- a/libbeat/outputs/elasticsearch/json_read.go
+++ b/libbeat/outputs/elasticsearch/json_read.go
@@ -25,12 +25,12 @@ import (
 
 // SAX like json parser. But instead of relying on callbacks, state machine
 // returns raw item plus entity. On top of state machine additional helper methods
-// like expectDict, expectArray, nextFieldName and nextInt are available for
+// like ExpectDict, ExpectArray, nextFieldName and nextInt are available for
 // low-level parsing/stepping through a json document.
 //
 // Due to parser simply stepping through the input buffer, almost no additional
 // allocations are required.
-type jsonReader struct {
+type JSONReader struct {
 	streambuf.Buffer
 
 	// parser state machine
@@ -133,13 +133,13 @@ func (s state) String() string {
 	return "unknown"
 }
 
-func newJSONReader(in []byte) *jsonReader {
-	r := &jsonReader{}
+func NewJSONReader(in []byte) *JSONReader {
+	r := &JSONReader{}
 	r.init(in)
 	return r
 }
 
-func (r *jsonReader) init(in []byte) {
+func (r *JSONReader) init(in []byte) {
 	r.Buffer.Init(in, true)
 	r.currentState = startState
 	r.states = r.statesBuf[:0]
@@ -147,18 +147,18 @@ func (r *jsonReader) init(in []byte) {
 
 var whitespace = []byte(" \t\r\n")
 
-func (r *jsonReader) skipWS() {
+func (r *JSONReader) skipWS() {
 	r.IgnoreSymbols(whitespace)
 }
 
-func (r *jsonReader) pushState(next state) {
+func (r *JSONReader) pushState(next state) {
 	if r.currentState != failedState {
 		r.states = append(r.states, r.currentState)
 	}
 	r.currentState = next
 }
 
-func (r *jsonReader) popState() {
+func (r *JSONReader) popState() {
 	if len(r.states) == 0 {
 		r.currentState = failedState
 	} else {
@@ -168,7 +168,7 @@ func (r *jsonReader) popState() {
 	}
 }
 
-func (r *jsonReader) expectDict() error {
+func (r *JSONReader) ExpectDict() error {
 	e, _, err := r.step()
 
 	if err != nil {
@@ -182,7 +182,7 @@ func (r *jsonReader) expectDict() error {
 	return nil
 }
 
-func (r *jsonReader) expectArray() error {
+func (r *JSONReader) ExpectArray() error {
 	e, _, err := r.step()
 	if err != nil {
 		return err
@@ -195,7 +195,7 @@ func (r *jsonReader) expectArray() error {
 	return nil
 }
 
-func (r *jsonReader) nextFieldName() (entity, []byte, error) {
+func (r *JSONReader) nextFieldName() (entity, []byte, error) {
 	e, raw, err := r.step()
 	if err != nil {
 		return e, raw, err
@@ -208,7 +208,7 @@ func (r *jsonReader) nextFieldName() (entity, []byte, error) {
 	return e, raw, err
 }
 
-func (r *jsonReader) nextInt() (int, error) {
+func (r *JSONReader) nextInt() (int, error) {
 	e, raw, err := r.step()
 	if err != nil {
 		return 0, err
@@ -224,7 +224,7 @@ func (r *jsonReader) nextInt() (int, error) {
 }
 
 // ignore type of next element and return raw content.
-func (r *jsonReader) ignoreNext() (raw []byte, err error) {
+func (r *JSONReader) ignoreNext() (raw []byte, err error) {
 	r.skipWS()
 
 	snapshot := r.Snapshot()
@@ -253,7 +253,7 @@ func (r *jsonReader) ignoreNext() (raw []byte, err error) {
 	return bytes, nil
 }
 
-func ignoreKind(r *jsonReader, kind entity) error {
+func ignoreKind(r *JSONReader, kind entity) error {
 	for {
 		e, _, err := r.step()
 		if err != nil {
@@ -276,7 +276,7 @@ func ignoreKind(r *jsonReader, kind entity) error {
 }
 
 // step continues the JSON parser state machine until next entity has been parsed.
-func (r *jsonReader) step() (entity, []byte, error) {
+func (r *JSONReader) step() (entity, []byte, error) {
 	r.skipWS()
 	switch r.currentState {
 	case failedState:
@@ -298,11 +298,11 @@ func (r *jsonReader) step() (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) stepFailing() (entity, []byte, error) {
+func (r *JSONReader) stepFailing() (entity, []byte, error) {
 	return failEntity, nil, r.Err()
 }
 
-func (r *jsonReader) stepStart() (entity, []byte, error) {
+func (r *JSONReader) stepStart() (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(err)
@@ -311,11 +311,11 @@ func (r *jsonReader) stepStart() (entity, []byte, error) {
 	return r.tryStepPrimitive(c)
 }
 
-func (r *jsonReader) stepArray() (entity, []byte, error) {
+func (r *JSONReader) stepArray() (entity, []byte, error) {
 	return r.doStepArray(true)
 }
 
-func (r *jsonReader) stepArrayNext() (entity, []byte, error) {
+func (r *JSONReader) stepArrayNext() (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(errFailing)
@@ -334,7 +334,7 @@ func (r *jsonReader) stepArrayNext() (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) doStepArray(allowArrayEnd bool) (entity, []byte, error) {
+func (r *JSONReader) doStepArray(allowArrayEnd bool) (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(err)
@@ -351,11 +351,11 @@ func (r *jsonReader) doStepArray(allowArrayEnd bool) (entity, []byte, error) {
 	return r.tryStepPrimitive(c)
 }
 
-func (r *jsonReader) stepDict() (entity, []byte, error) {
+func (r *JSONReader) stepDict() (entity, []byte, error) {
 	return r.doStepDict(true)
 }
 
-func (r *jsonReader) doStepDict(allowEnd bool) (entity, []byte, error) {
+func (r *JSONReader) doStepDict(allowEnd bool) (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(err)
@@ -375,7 +375,7 @@ func (r *jsonReader) doStepDict(allowEnd bool) (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) stepDictValue() (entity, []byte, error) {
+func (r *JSONReader) stepDictValue() (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(err)
@@ -385,7 +385,7 @@ func (r *jsonReader) stepDictValue() (entity, []byte, error) {
 	return r.tryStepPrimitive(c)
 }
 
-func (r *jsonReader) stepDictValueEnd() (entity, []byte, error) {
+func (r *JSONReader) stepDictValueEnd() (entity, []byte, error) {
 	c, err := r.PeekByte()
 	if err != nil {
 		return r.failWith(err)
@@ -404,7 +404,7 @@ func (r *jsonReader) stepDictValueEnd() (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) tryStepPrimitive(c byte) (entity, []byte, error) {
+func (r *JSONReader) tryStepPrimitive(c byte) (entity, []byte, error) {
 	switch c {
 	case '{': // start dictionary
 		return r.startDict()
@@ -432,19 +432,19 @@ func (r *jsonReader) tryStepPrimitive(c byte) (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) stepNull() (entity, []byte, error) {
+func (r *JSONReader) stepNull() (entity, []byte, error) {
 	return stepSymbol(r, nullValue, nullSymbol, errExpectedNull)
 }
 
-func (r *jsonReader) stepTrue() (entity, []byte, error) {
+func (r *JSONReader) stepTrue() (entity, []byte, error) {
 	return stepSymbol(r, trueValue, trueSymbol, errExpectedTrue)
 }
 
-func (r *jsonReader) stepFalse() (entity, []byte, error) {
+func (r *JSONReader) stepFalse() (entity, []byte, error) {
 	return stepSymbol(r, falseValue, falseSymbol, errExpectedFalse)
 }
 
-func stepSymbol(r *jsonReader, e entity, symb []byte, fail error) (entity, []byte, error) {
+func stepSymbol(r *JSONReader, e entity, symb []byte, fail error) (entity, []byte, error) {
 	ok, err := r.MatchASCII(symb)
 	if err != nil {
 		return failEntity, nil, err
@@ -457,7 +457,7 @@ func stepSymbol(r *jsonReader, e entity, symb []byte, fail error) (entity, []byt
 	return e, nil, nil
 }
 
-func (r *jsonReader) stepMapKey() (entity, []byte, error) {
+func (r *JSONReader) stepMapKey() (entity, []byte, error) {
 	e, key, err := r.stepString()
 	if err != nil {
 		return e, key, err
@@ -479,7 +479,7 @@ func (r *jsonReader) stepMapKey() (entity, []byte, error) {
 	return mapKeyEntity, key, nil
 }
 
-func (r *jsonReader) stepString() (entity, []byte, error) {
+func (r *JSONReader) stepString() (entity, []byte, error) {
 	start := 1
 	for {
 		idxQuote := r.IndexByteFrom(start, '"')
@@ -499,36 +499,36 @@ func (r *jsonReader) stepString() (entity, []byte, error) {
 	}
 }
 
-func (r *jsonReader) startDict() (entity, []byte, error) {
+func (r *JSONReader) startDict() (entity, []byte, error) {
 	r.Advance(1)
 	r.pushState(dictState)
 	return dictStart, nil, nil
 }
 
-func (r *jsonReader) endDict() (entity, []byte, error) {
+func (r *JSONReader) endDict() (entity, []byte, error) {
 	r.Advance(1)
 	r.popState()
 	return dictEnd, nil, nil
 }
 
-func (r *jsonReader) startArray() (entity, []byte, error) {
+func (r *JSONReader) startArray() (entity, []byte, error) {
 	r.Advance(1)
 	r.pushState(arrState)
 	return arrStart, nil, nil
 }
 
-func (r *jsonReader) endArray() (entity, []byte, error) {
+func (r *JSONReader) endArray() (entity, []byte, error) {
 	r.Advance(1)
 	r.popState()
 	return arrEnd, nil, nil
 }
 
-func (r *jsonReader) failWith(err error) (entity, []byte, error) {
+func (r *JSONReader) failWith(err error) (entity, []byte, error) {
 	r.currentState = failedState
 	return failEntity, nil, r.SetError(err)
 }
 
-func (r *jsonReader) stepNumber() (entity, []byte, error) {
+func (r *JSONReader) stepNumber() (entity, []byte, error) {
 	snapshot := r.Snapshot()
 	lenBefore := r.Len()
 	isDouble := false

--- a/libbeat/outputs/elasticsearch/json_read.go
+++ b/libbeat/outputs/elasticsearch/json_read.go
@@ -133,6 +133,7 @@ func (s state) String() string {
 	return "unknown"
 }
 
+// NewJSONReader returns a new JSONReader initialized with in
 func NewJSONReader(in []byte) *JSONReader {
 	r := &JSONReader{}
 	r.init(in)
@@ -168,6 +169,7 @@ func (r *JSONReader) popState() {
 	}
 }
 
+// ExpectDict checks if the next entity is a json object
 func (r *JSONReader) ExpectDict() error {
 	e, _, err := r.step()
 
@@ -182,6 +184,7 @@ func (r *JSONReader) ExpectDict() error {
 	return nil
 }
 
+// ExpectArray checks if the next entity is a json array
 func (r *JSONReader) ExpectArray() error {
 	e, _, err := r.step()
 	if err != nil {


### PR DESCRIPTION
Resolves #14303.

As reported in #14303, when the Elasticsearch monitoring reporter in libbeat sends a bulk API request to Elasticsearch, and that request fails, the errors are currently swallowed. This is because the actual response code for the bulk API request is `200 OK`; the actual errors are embedded in the request's response body.

This PR teaches the Elasticsearch monitoring reporter to parse the bulk API response and log any errors. For the parsing, the same code as the Elasticsearch output is reused.

## Testing this PR
1. Start up Elasticsearch with security enabled. Make sure you know the password for the `elastic` superuser.

2. Create a role that grants necessary privileges for managing and writing to `metricbeat-*` indices.
   ```
   curl -s -u elastic -H 'Content-Type: application/json' 'http://localhost:9200/_security/role/mb_writer' -d '{ "cluster": [ "monitor", "manage_ilm", "manage_index_templates" ], "indices": [ { "names": [ "metricbeat-*" ], "privileges": [ "all" ] } ] }'
   ```

3. Create a user with the above role.
   ```
   curl -s -u elastic -H 'Content-Type: application/json' 'http://localhost:9200/_security/user/mb_writer' -d '{ "password": "mb_writer", "roles": [ "mb_writer" ] }'
   ```

4. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

5. Start Metricbeat with monitoring enabled and specifying the credentials of the above user for the `elasticsearch` output.
   ```
   ./metricbeat -e -E output.elasticsearch.username=mb_writer -E output.elasticsearch.password=mb_writer -E monitoring.enabled=true
   ```

6. Verify that `metricbeat-*` indices are being created and populated in Elasticsearch but no `.monitoring-beats-*`  indices are being created.
   ```
   curl -s -u elastic 'http://localhost:9200/_cat/indices'
   ```

7. Verify that there **are** warnings in the log like so:
   ```
   2019-11-01T08:57:43.910-0700    WARN    elasticsearch/client.go:258     monitoring bulk item insert failed (i=0, status=403): {"type":"security_exception","reason":"action [indices:admin/create] is unauthorized for user [mb_writer]"}
   ```