### PR TITLE
[Filebeat] Race condition fix in S3 input plugin

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -186,6 +186,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Accept '-' as http.response.body.bytes in apache module. {pull}14137[14137]
 - Fix timezone parsing of MySQL module ingest pipelines. {pull}14130[14130]
 - Improve error message in s3 input when handleSQSMessage failed. {pull}14113[14113]
+- Fix race condition in S3 input plugin. {pull}14359[14359]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -531,6 +531,8 @@ func (c *s3Context) Fail(err error) {
 }
 
 func (c *s3Context) done() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
 	c.refs--
 	if c.refs == 0 {
 		c.errC <- c.err

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -521,13 +521,16 @@ func s3ObjectHash(s3Info s3Info) string {
 }
 
 func (c *s3Context) Fail(err error) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
+	c.setError(err)
+	c.done()
+}
 
+func (c *s3Context) setError(err error) {
 	// only care about the last error for now
 	// TODO: add "Typed" error to error for context
+	c.mux.Lock()
+	defer c.mux.Unlock()
 	c.err = err
-	c.done()
 }
 
 func (c *s3Context) done() {


### PR DESCRIPTION
During high load, Filebeat may crash due to the error channel `c.errC` having been closed before the last event has been acknowledged. This is caused by a missing critical section in `done()` which can result in `c.refs` no longer counting as expected.