### PR TITLE
Add emptydir builder for filebeat to support log tailing from emptyDir

### DIFF
--- a/filebeat/autodiscover/builder/emptydir/config.go
+++ b/filebeat/autodiscover/builder/emptydir/config.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package emptydir
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type inputConfig struct {
+	RootDir       string         `config:"root_dir"`
+	Key           string         `config:"key"`
+	DefaultConfig *common.Config `config:"default_config"`
+}
+
+func defaultConfig() inputConfig {
+	return inputConfig{
+		RootDir:       "/var/lib/kubelet/pods/",
+		Key:           "logs",
+		DefaultConfig: getBaseConfig(),
+	}
+}
+
+func getBaseConfig() *common.Config {
+	config := common.MapStr{
+		"type":  "log",
+		"paths": "${data.paths}",
+	}
+
+	cfg, _ := common.NewConfigFrom(&config)
+	return cfg
+}
+
+// Unpack is needed here as go-ucfg fails to unpack the Config object by default
+func (c *inputConfig) Unpack(from *common.Config) error {
+	tmpConfig := struct {
+		RootDir string `config:"root_dir"`
+		Key     string `config:"key"`
+	}{
+		Key:     c.Key,
+		RootDir: c.RootDir,
+	}
+	if err := from.Unpack(&tmpConfig); err != nil {
+		return err
+	}
+
+	if config, err := from.Child("default_config", -1); err == nil {
+		c.DefaultConfig = config
+	}
+
+	c.Key = tmpConfig.Key
+	c.RootDir = tmpConfig.RootDir
+	return nil
+}

--- a/filebeat/autodiscover/builder/emptydir/emptydir.go
+++ b/filebeat/autodiscover/builder/emptydir/emptydir.go
@@ -1,0 +1,150 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package emptydir
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/filebeat/autodiscover/builder/hints"
+	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+)
+
+const (
+	emptyDir = "emptydir"
+	key      = "hints"
+)
+
+func init() {
+	autodiscover.Registry.AddBuilder(emptyDir, NewEmptyDirBuilder)
+}
+
+type logPath struct {
+	rootDir        string
+	key            string
+	defaultEnabled bool
+	logBuilder     autodiscover.Builder
+}
+
+//NewEmptyDirBuilder creates an autodiscover Builder that can understand emptydir hints.
+func NewEmptyDirBuilder(cfg *common.Config) (autodiscover.Builder, error) {
+	config := defaultConfig()
+	err := cfg.Unpack(&config)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to unpack config due to error: %v", err)
+	}
+
+	newCfg := common.MapStr{
+		"key":            config.Key,
+		"default_config": config.DefaultConfig,
+		"type":           key,
+	}
+
+	newC, _ := common.NewConfigFrom(&newCfg)
+	logBuilder, err := hints.NewLogHints(newC)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate logs builder due to error: %v", err)
+	}
+
+	defaultEnabled := false
+	if newC.Enabled() == true {
+		defaultEnabled = true
+	}
+
+	return &logPath{config.RootDir, config.Key, defaultEnabled, logBuilder}, nil
+}
+
+//CreateConfig creates input configs basede on emptydir hints.
+func (l *logPath) CreateConfig(event bus.Event) []*common.Config {
+	var config []*common.Config
+
+	host, _ := event["host"].(string)
+	if host == "" {
+		return config
+	}
+
+	var hints common.MapStr
+	hIface, ok := event["hints"]
+	if ok {
+		hints, _ = hIface.(common.MapStr)
+	}
+	if l.defaultEnabled == false && builder.IsEnabled(hints, l.key) == false {
+		return config
+	}
+
+	e := common.MapStr(event)
+
+	id, _ := e.GetValue("kubernetes.pod.uid")
+	if id == nil {
+		return config
+	}
+
+	config = append(config, l.getInputConfigs(hints, host, id.(string))...)
+	return config
+}
+
+func (l *logPath) getInputConfigs(hints common.MapStr, host, id string) []*common.Config {
+	var config []*common.Config
+
+	// Extract all entries that are stored under emptydir
+	cfgMap := builder.GetHintMapStr(hints, l.key, emptyDir)
+	for k, v := range cfgMap {
+		// For each empty dir, get all prospector configurations
+		hints := common.MapStr{
+			l.key: common.MapStr{
+				k: v,
+			},
+		}
+		configs := builder.GetConfigs(hints, l.key, k)
+		for _, cfg := range configs {
+			hints := common.MapStr{
+				l.key: cfg,
+			}
+
+			files := builder.GetHintAsList(hints, l.key, "paths")
+			// If no paths are configured then
+			if len(files) == 0 {
+				continue
+			}
+
+			var paths []string
+			for _, file := range files {
+				paths = append(paths, fmt.Sprintf("%s%s/volumes/kubernetes.io~empty-dir/%s%s", l.rootDir, id, k, file))
+			}
+
+			// If there are no paths then don't generate a config.
+			if len(paths) == 0 {
+				continue
+			}
+
+			e := bus.Event{
+				"host":  host,
+				"hints": hints,
+				"paths": paths,
+			}
+
+			cfgs := l.logBuilder.CreateConfig(e)
+			config = append(config, cfgs...)
+		}
+	}
+
+	return config
+}

--- a/filebeat/autodiscover/builder/emptydir/emptydir_test.go
+++ b/filebeat/autodiscover/builder/emptydir/emptydir_test.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package emptydir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/elastic/beats/filebeat/autodiscover/builder/hints"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+)
+
+func TestEmptyDir(t *testing.T) {
+	tests := []struct {
+		event  bus.Event
+		len    int
+		result common.MapStr
+	}{
+		// Hints without host should return nothing
+		{
+			event: bus.Event{
+				"hints": common.MapStr{
+					"logs": common.MapStr{},
+				},
+			},
+			len:    0,
+			result: common.MapStr{},
+		},
+		// Hints with emptydir log path for kubernetes should return appropriate config
+		{
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"pod": common.MapStr{
+						"name": "podname",
+						"uid":  "pid",
+					},
+					"container": common.MapStr{
+						"name": "containername",
+						"id":   "abc",
+					},
+					"namespace": "foo",
+				},
+				"container": common.MapStr{
+					"name": "containername",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"emptydir": common.MapStr{
+							"testdir": common.MapStr{
+								"1": common.MapStr{
+									"name":      "foo.log",
+									"namespace": "test",
+									"paths":     "/var/log/foo*log",
+								},
+							},
+						},
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type":  "log",
+				"paths": []interface{}{"/var/lib/kubelet/pods/pid/volumes/kubernetes.io~empty-dir/testdir/var/log/foo*log"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		cfg := defaultConfig()
+		c, err := common.NewConfigFrom(&cfg)
+		assert.Nil(t, err)
+		l, err := NewEmptyDirBuilder(c)
+		assert.Nil(t, err)
+		cfgs := l.CreateConfig(test.event)
+		assert.Equal(t, len(cfgs), test.len)
+
+		if len(cfgs) != 0 {
+			config := common.MapStr{}
+			err := cfgs[0].Unpack(&config)
+			assert.Nil(t, err)
+			assert.Equal(t, test.result, config)
+		}
+
+	}
+}


### PR DESCRIPTION
This PR allows tailing of logs from emptyDir of a pod. Why is this needed? Lot of times logging to stdout is not performant enough which can be replaced by logging to a file on the host. There are many containers that have log files that are on the container itself like MySQL's slow logs and error logs. Those can be mounted on an emptyDir.

```
co.elastic.logs/emptydir.1.logdir.paths: /mysql/slow_query.log
```

If an emptyDir named `logdir` is mounted by the pod on `/var/log` then the above annotation can be placed on the pod to ensure that `/var/log/mysql/slow_query.log` is tailed and shipped out by filebeat. 