### PR TITLE
ca cannot be used as a shorthand

### DIFF
--- a/x-pack/agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/agent/pkg/agent/cmd/enroll.go
@@ -32,7 +32,7 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 		},
 	}
 
-	cmd.Flags().StringP("", "ca", "", "Comma separated list of root certificate for server verifications")
+	cmd.Flags().StringP("ca", "", "", "Comma separated list of root certificate for server verifications")
 
 	return cmd
 }


### PR DESCRIPTION
code builds but cobra has a runtime check for length of a shorthand which needs to be one if used. 