### PR TITLE
Fix docker client in tests so it performs API version negotiation.

### DIFF
--- a/libbeat/common/docker/client.go
+++ b/libbeat/common/docker/client.go
@@ -51,3 +51,25 @@ func NewClient(host string, httpClient *http.Client, httpHeaders map[string]stri
 
 	return client.NewClientWithOpts(opts...)
 }
+
+// NewClientFromEnv builds and returns a new Docker client from environment
+// variables. In the case that DOCKER_API_VERSION is not set in the
+// environment, upon first request it perform API version negotiation.
+func NewClientFromEnv() (*client.Client, error) {
+	log := logp.NewLogger("docker")
+
+	opts := []client.Opt{
+		client.FromEnv,
+	}
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version != "" {
+		log.Debugf("Docker client will use API version %v as set by the DOCKER_API_VERSION environment variable.", version)
+		opts = append(opts, client.WithVersion(version))
+	} else {
+		log.Debug("Docker client will negotiate the API version on the first request.")
+		opts = append(opts, client.WithAPIVersionNegotiation())
+	}
+
+	return client.NewClientWithOpts(opts...)
+}

--- a/libbeat/common/docker/client.go
+++ b/libbeat/common/docker/client.go
@@ -34,32 +34,17 @@ import (
 func NewClient(host string, httpClient *http.Client, httpHeaders map[string]string) (*client.Client, error) {
 	log := logp.NewLogger("docker")
 
+	if host == "" {
+		host = os.Getenv("DOCKER_HOST")
+		if host == "" {
+			host = "unix:///var/run/docker.sock"
+		}
+	}
+
 	opts := []client.Opt{
 		client.WithHost(host),
 		client.WithHTTPClient(httpClient),
 		client.WithHTTPHeaders(httpHeaders),
-	}
-
-	version := os.Getenv("DOCKER_API_VERSION")
-	if version != "" {
-		log.Debugf("Docker client will use API version %v as set by the DOCKER_API_VERSION environment variable.", version)
-		opts = append(opts, client.WithVersion(version))
-	} else {
-		log.Debug("Docker client will negotiate the API version on the first request.")
-		opts = append(opts, client.WithAPIVersionNegotiation())
-	}
-
-	return client.NewClientWithOpts(opts...)
-}
-
-// NewClientFromEnv builds and returns a new Docker client from environment
-// variables. In the case that DOCKER_API_VERSION is not set in the
-// environment, upon first request it perform API version negotiation.
-func NewClientFromEnv() (*client.Client, error) {
-	log := logp.NewLogger("docker")
-
-	opts := []client.Opt{
-		client.FromEnv,
 	}
 
 	version := os.Getenv("DOCKER_API_VERSION")

--- a/libbeat/common/docker/client.go
+++ b/libbeat/common/docker/client.go
@@ -34,13 +34,6 @@ import (
 func NewClient(host string, httpClient *http.Client, httpHeaders map[string]string) (*client.Client, error) {
 	log := logp.NewLogger("docker")
 
-	if host == "" {
-		host = os.Getenv("DOCKER_HOST")
-		if host == "" {
-			host = "unix:///var/run/docker.sock"
-		}
-	}
-
 	opts := []client.Opt{
 		client.WithHost(host),
 		client.WithHTTPClient(httpClient),

--- a/libbeat/common/docker/client_test.go
+++ b/libbeat/common/docker/client_test.go
@@ -53,39 +53,7 @@ func TestNewClient(t *testing.T) {
 	// Test we can hardcode version
 	os.Setenv("DOCKER_API_VERSION", "1.22")
 
-	client, err = NewClient(host, nil, nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, client)
-	assert.Equal(t, "1.22", client.ClientVersion())
-
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
-	assert.NoError(t, err)
-}
-
-func TestNewClientFromEnv(t *testing.T) {
-	os.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
-
-	client, err := NewClientFromEnv()
-	assert.NoError(t, err)
-	assert.NotNil(t, client)
-
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
-	assert.NoError(t, err)
-
-	// This test only works on newer Docker versions (any supported one really)
-	switch client.ClientVersion() {
-	case "1.22":
-		t.Skip("Docker version is too old for this test")
-	case api.DefaultVersion:
-		t.Logf("Using default API version: %s", api.DefaultVersion)
-	default:
-		t.Logf("Negotiated version: %s", client.ClientVersion())
-	}
-
-	// Test we can hardcode version
-	os.Setenv("DOCKER_API_VERSION", "1.22")
-
-	client, err = NewClientFromEnv()
+	client, err = NewClient("", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 	assert.Equal(t, "1.22", client.ClientVersion())

--- a/libbeat/common/docker/client_test.go
+++ b/libbeat/common/docker/client_test.go
@@ -26,38 +26,37 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestNewClient(t *testing.T) {
-	host := "unix:///var/run/docker.sock"
-
-	client, err := NewClient(host, nil, nil)
+	c, err := NewClient(client.DefaultDockerHost, nil, nil)
 	assert.NoError(t, err)
-	assert.NotNil(t, client)
+	assert.NotNil(t, c)
 
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
+	_, err = c.ContainerList(context.Background(), types.ContainerListOptions{})
 	assert.NoError(t, err)
 
 	// This test only works on newer Docker versions (any supported one really)
-	switch client.ClientVersion() {
+	switch c.ClientVersion() {
 	case "1.22":
 		t.Skip("Docker version is too old for this test")
 	case api.DefaultVersion:
 		t.Logf("Using default API version: %s", api.DefaultVersion)
 	default:
-		t.Logf("Negotiated version: %s", client.ClientVersion())
+		t.Logf("Negotiated version: %s", c.ClientVersion())
 	}
 
 	// Test we can hardcode version
 	os.Setenv("DOCKER_API_VERSION", "1.22")
 
-	client, err = NewClient("", nil, nil)
+	c, err = NewClient(client.DefaultDockerHost, nil, nil)
 	assert.NoError(t, err)
-	assert.NotNil(t, client)
-	assert.Equal(t, "1.22", client.ClientVersion())
+	assert.NotNil(t, c)
+	assert.Equal(t, "1.22", c.ClientVersion())
 
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
+	_, err = c.ContainerList(context.Background(), types.ContainerListOptions{})
 	assert.NoError(t, err)
 }

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -35,8 +35,9 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 const (

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/pkg/errors"
 )
 
@@ -53,14 +54,7 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	opts := []client.Opt{
-		client.FromEnv,
-	}
-	version := os.Getenv("DOCKER_API_VERSION")
-	if version == "" {
-		opts = append(opts, client.WithAPIVersionNegotiation())
-	}
-	c, err := client.NewClientWithOpts(opts...)
+	c, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -55,7 +55,7 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	c, err := docker.NewClient("", nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -54,7 +54,7 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	c, err := docker.NewClientFromEnv()
+	c, err := docker.NewClient("", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -53,7 +53,14 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	c, err := client.NewEnvClient()
+	opts := []client.Opt{
+		client.FromEnv,
+	}
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		opts = append(opts, client.WithAPIVersionNegotiation())
+	}
+	c, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+
 	"github.com/elastic/beats/libbeat/common/docker"
 )
 

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -33,7 +33,7 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	c, err := docker.NewClientFromEnv()
+	c, err := docker.NewClient("", nil, nil)
 	return Client{cli: c}, err
 }
 

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -34,7 +34,7 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	c, err := docker.NewClient("", nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	return Client{cli: c}, err
 }
 

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -19,11 +19,11 @@ package docker
 
 import (
 	"context"
-	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 // Client for Docker
@@ -33,14 +33,7 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	opts := []client.Opt{
-		client.FromEnv,
-	}
-	version := os.Getenv("DOCKER_API_VERSION")
-	if version == "" {
-		opts = append(opts, client.WithAPIVersionNegotiation())
-	}
-	c, err := client.NewClientWithOpts(opts...)
+	c, err := docker.NewClientFromEnv()
 	return Client{cli: c}, err
 }
 

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -19,6 +19,7 @@ package docker
 
 import (
 	"context"
+	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -32,7 +33,14 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	c, err := client.NewEnvClient()
+	opts := []client.Opt{
+		client.FromEnv,
+	}
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		opts = append(opts, client.WithAPIVersionNegotiation())
+	}
+	c, err := client.NewClientWithOpts(opts...)
 	return Client{cli: c}, err
 }
 

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 
 	"github.com/elastic/beats/auditbeat/core"
 	"github.com/elastic/beats/libbeat/common/docker"
@@ -69,20 +70,20 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	client, err := docker.NewClient("", nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Close()
+	defer c.Close()
 
-	reader, err := client.ImagePull(context.Background(), "busybox", types.ImagePullOptions{})
+	reader, err := c.ImagePull(context.Background(), "busybox", types.ImagePullOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	io.Copy(os.Stdout, reader)
 	reader.Close()
 
-	resp, err := client.ContainerCreate(context.Background(), &container.Config{
+	resp, err := c.ContainerCreate(context.Background(), &container.Config{
 		Image: "busybox",
 		Cmd:   []string{"echo", "foo"},
 	}, nil, nil, "")
@@ -90,7 +91,7 @@ func createEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{})
+	c.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{})
 }
 
 func getConfig() map[string]interface{} {

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 
 	"github.com/elastic/beats/auditbeat/core"
+	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
@@ -69,14 +69,7 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	opts := []client.Opt{
-		client.FromEnv,
-	}
-	version := os.Getenv("DOCKER_API_VERSION")
-	if version == "" {
-		opts = append(opts, client.WithAPIVersionNegotiation())
-	}
-	client, err := client.NewClientWithOpts(opts...)
+	client, err := docker.NewClientFromEnv()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -69,7 +69,14 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	client, err := client.NewEnvClient()
+	opts := []client.Opt{
+		client.FromEnv,
+	}
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		opts = append(opts, client.WithAPIVersionNegotiation())
+	}
+	client, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -69,7 +69,7 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	client, err := docker.NewClientFromEnv()
+	client, err := docker.NewClient("", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Running the unit tests locally I was running into an issue where docker usage inside of the tests was not negotiating API version with my version of docker.

`Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.38`

This fixes the issue and is the same way the docker module works in libbeat/common/docker.