### PR TITLE
Remove beta flag for some filebeat modules

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -384,6 +384,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Kibana Dashboard for MISP module. {pull}14147[14147]
 - Add JSON options to autodiscover hints {pull}14208[14208]
 - Add more filesets to Zeek module. {pull}14150[14150]
+- Remove beta flag for some filebeat modules. {pull}14374[14374]
 
 *Heartbeat*
 - Add non-privileged icmp on linux and darwin(mac). {pull}13795[13795] {issue}11498[11498]

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == Cisco module
 
-beta[]
-
 This is a module for Cisco network device's logs. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == Palo Alto Networks module
 
-beta[]
-
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.

--- a/x-pack/filebeat/module/cisco/README.md
+++ b/x-pack/filebeat/module/cisco/README.md
@@ -1,6 +1,2 @@
 # Cisco module
 
-## Caveats
-
-* Module is to be considered _beta_.
-

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -5,8 +5,6 @@
 
 == Cisco module
 
-beta[]
-
 This is a module for Cisco network device's logs. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/x-pack/filebeat/module/coredns/README.md
+++ b/x-pack/filebeat/module/coredns/README.md
@@ -3,10 +3,6 @@
 This is a filebeat module for coredns. It supports both standalone coredns deployment and 
 coredns deployment in Kubernetes.
 
-## Caveats
-
-* Module is to be considered _beta_.
-
 ## Download and install Filebeat
 
 Grab the filebeat binary from elastic.co, and install it by following the instructions.

--- a/x-pack/filebeat/module/envoyproxy/README.md
+++ b/x-pack/filebeat/module/envoyproxy/README.md
@@ -2,10 +2,6 @@
 
 This is a filebeat module for Envoy proxy access log. 
 
-## Caveats
-
-* Module is to be considered _beta_.
-
 ## Download and install Filebeat
 
 Grab the filebeat binary from elastic.co, and install it by following the instructions.

--- a/x-pack/filebeat/module/iptables/README.md
+++ b/x-pack/filebeat/module/iptables/README.md
@@ -1,6 +1,3 @@
 # iptables module
 
-## Caveats
-
-* Module is to be considered _beta_.
 

--- a/x-pack/filebeat/module/panw/README.md
+++ b/x-pack/filebeat/module/panw/README.md
@@ -1,6 +1,2 @@
 # Palo Alto Networks module
 
-## Caveats
-
-* Module is to be considered _beta_.
-

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -5,8 +5,6 @@
 
 == Palo Alto Networks module
 
-beta[]
-
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.

--- a/x-pack/filebeat/module/suricata/README.md
+++ b/x-pack/filebeat/module/suricata/README.md
@@ -2,8 +2,6 @@
 
 ## Caveats
 
-* Module is to be considered _beta_.
-* Field names will be changing for 7.0 to comply with Elastic Common Schema (ECS).
 * Original Suricata event shoved as is `suricata.eve.`
 
 ## How to try the module from source

--- a/x-pack/filebeat/module/zeek/README-developer.md
+++ b/x-pack/filebeat/module/zeek/README-developer.md
@@ -1,9 +1,5 @@
 # Zeek (Bro) module
 
-## Caveats
-
-* Module is to be considered _beta_.
-
 ## Install and Configure Zeek/Bro
 
 ### Install Zeek/Bro (for MacOS with Brew)

--- a/x-pack/filebeat/module/zeek/README.md
+++ b/x-pack/filebeat/module/zeek/README.md
@@ -1,9 +1,5 @@
 # Zeek (Bro) module
 
-## Caveats
-
-* Module is to be considered _beta_.
-
 ## Install and Configure Zeek/Bro
 
 ### Install Zeek/Bro (for MacOS with Brew)


### PR DESCRIPTION
Remove beta flag for some filebeat modules:
- coredns
- envoyproxy
- iptables
- suricata
- zeek
- cisco
- panw