### PR TITLE
Convert license struct to MapStr

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -248,6 +248,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]
 - Update azure configuration example. {issue}14224[14224]
 - Fix cloudwatch metricset with names and dimensions in config. {issue}14376[14376] {pull}14391[14391]
+- Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -200,10 +200,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return errors.Wrap(err, "failed to determine if cluster needs TLS enabled")
 	}
 
-	l := common.MapStr{
-		"license":           license.ToMapStr(),
-		"cluster_needs_tls": clusterNeedsTLS,
-	}
+	l := license.ToMapStr()
+	l["cluster_needs_tls"] = clusterNeedsTLS
 
 	isAPMFound, err := apmIndicesExist(clusterState)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -33,11 +33,6 @@ import (
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
-type clusterStatsLicense struct {
-	*elasticsearch.License
-	ClusterNeedsTLS bool `json:"cluster_needs_tls"`
-}
-
 func clusterNeedsTLSEnabled(license *elasticsearch.License, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if license type is something other than trial
 	if !license.IsOneOf("trial") {
@@ -205,7 +200,10 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return errors.Wrap(err, "failed to determine if cluster needs TLS enabled")
 	}
 
-	l := clusterStatsLicense{license, clusterNeedsTLS}
+	l := common.MapStr{
+		"license":           license.ToMapStr(),
+		"cluster_needs_tls": clusterNeedsTLS,
+	}
 
 	isAPMFound, err := apmIndicesExist(clusterState)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -480,6 +480,26 @@ func (l *License) IsOneOf(candidateLicenses ...string) bool {
 	return false
 }
 
+// ToMapStr converts the license to a common.MapStr. This is necessary
+// for proper marshaling of the data before it's sent over the wire. In
+// particular it ensures that ms-since-epoch values are marshaled as longs
+// and not floats in scientific notation as Elasticsearch does not like that.
+func (l *License) ToMapStr() common.MapStr {
+	return common.MapStr{
+		"status":                l.Status,
+		"id":                    l.ID,
+		"type":                  l.Type,
+		"issue_date":            l.IssueDate,
+		"issue_date_in_millis":  l.IssueDateInMillis,
+		"expiry_date":           l.ExpiryDate,
+		"expiry_date_in_millis": l.ExpiryDateInMillis,
+		"max_nodes":             l.MaxNodes,
+		"issued_to":             l.IssuedTo,
+		"issuer":                l.Issuer,
+		"start_date_in_millis":  l.StartDateInMillis,
+	}
+}
+
 func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr, error) {
 	hasSettingGroup, err := allSettings.HasKey(groupKey)
 	if err != nil {


### PR DESCRIPTION
Currently when the `elasticsearch` module prepares a `cluster_stats` document to index into `.monitoring-es-*`, it marshals any values representing ms-since-epoch into scientific notation, e.g. `1.572634502804E12`. Elasticsearch needs these values to be preserved as regular integers, e.g. `1572634502804`.

Turns out this only happens when marshaling a `struct` containing such values. Marshaling a `common.MapStr` marshals the values as expected. 

Looking through the `elasticsearch` module code for the `cluster_stats` metricset, the only struct that was being used in preparing the document for ES was the `License` struct. This PR adds a `toMapStr()` method to this struct and uses its results in the document instead.

### Testing this PR

1. Start up Elasticsearch.

2. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

3. Enable the `elasticsearch-xpack` Metricbeat module.
  ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
  
4. Run Metricbeat
   ```
   ./metricbeat -e
   ```

5. Verify that `type:cluster_stats` documents in `.monitoring-es-*` contain regular integer values for ms-since-epoch fields under the `license` field.
   ```
   GET .monitoring-es-*/_search?q=type:cluster_stats&sort=timestamp:desc&filter_path=hits.hits._source.license*
   ```