### PR TITLE
Add missing testing.Init calls

### DIFF
--- a/x-pack/heartbeat/main_test.go
+++ b/x-pack/heartbeat/main_test.go
@@ -15,6 +15,7 @@ import (
 var systemTest *bool
 
 func init() {
+	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))

--- a/x-pack/journalbeat/main_test.go
+++ b/x-pack/journalbeat/main_test.go
@@ -15,6 +15,7 @@ import (
 var systemTest *bool
 
 func init() {
+	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))

--- a/x-pack/packetbeat/main_test.go
+++ b/x-pack/packetbeat/main_test.go
@@ -15,6 +15,7 @@ import (
 var systemTest *bool
 
 func init() {
+	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))

--- a/x-pack/winlogbeat/main_test.go
+++ b/x-pack/winlogbeat/main_test.go
@@ -15,6 +15,7 @@ import (
 var systemTest *bool
 
 func init() {
+	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))


### PR DESCRIPTION
Some tests have been failing in CI. I found a few places where `testing.Init()` was still missing.