### PR TITLE
Add timezone support for haproxy logs

### DIFF
--- a/filebeat/module/haproxy/log/ingest/pipeline.json
+++ b/filebeat/module/haproxy/log/ingest/pipeline.json
@@ -21,6 +21,7 @@
         },
         {
             "date": {
+                "if": "ctx.event.timezone == null",
                 "field": "haproxy.request_date",
                 "target_field": "@timestamp",
                 "formats": [

--- a/filebeat/module/haproxy/log/ingest/pipeline.json
+++ b/filebeat/module/haproxy/log/ingest/pipeline.json
@@ -30,6 +30,26 @@
             }
         },
         {
+            "date": {
+                "formats": [
+                    "dd/MMM/yyyy:HH:mm:ss.SSS",
+                    "MMM dd HH:mm:ss"
+                ],
+                "timezone" : "{{ event.timezone }}",
+                "on_failure" : [
+                    {
+                        "append" : {
+                            "field" : "error.message",
+                            "value" : "{{ _ingest.on_failure_message }}"
+                        }
+                    }
+                ],
+                "if" : "ctx.event.timezone != null",
+                "field" : "haproxy.request_date",
+                "target_field" : "@timestamp"
+            }
+        },
+        {
             "remove": {
                 "field": "haproxy.request_date"
             }


### PR DESCRIPTION
Mimic the timezone logic in the base syslog ingest pipeline to add timezone support for haproxy.