### PR TITLE
Added browserbeat to the community beats documentation page.

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -26,6 +26,7 @@ NOTE: Elastic provides no warranty or support for community-sourced Beats.
 https://github.com/awormuth/amazonbeat[amazonbeat]:: Reads data from a specified Amazon product.
 https://github.com/radoondas/apachebeat[apachebeat]:: Reads status from Apache HTTPD server-status.
 https://github.com/verticle-io/apexbeat[apexbeat]:: Extracts configurable contextual data and metrics from Java applications via the  http://toolkits.verticle.io[APEX] toolkit.
+https://github.com/MelonSmasher/browserbeat[browserbeat]:: Reads and ships browser history (Chrome, Firefox, & Safari) to an Elastic output.
 https://github.com/hsngerami/hsnburrowbeat[hsnburrowbeat]:: Monitors Kafka consumer lag for Burrow V1.0.0(API V3).
 https://github.com/hartfordfive/cloudflarebeat[cloudflarebeat]:: Indexes log entries from the Cloudflare Enterprise Log Share API.
 https://github.com/jarl-tornroos/cloudfrontbeat[cloudfrontbeat]:: Reads log events from Amazon Web Services https://aws.amazon.com/cloudfront/[CloudFront].


### PR DESCRIPTION
Hi all,

I've created a beat that reads browser history for Chrome, Firefox, and Safari and ships it to the output of your choice. I had to learn Go to pull this off, so be nice :-) .