### PR TITLE
Cherry-pick #14359 to 7.5: [Filebeat] Race condition fix in S3 input plugin

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix timezone parsing of MySQL module ingest pipelines. {pull}14130[14130]
 - Improve error message in s3 input when handleSQSMessage failed. {pull}14113[14113]
+- Fix race condition in S3 input plugin. {pull}14359[14359]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -521,16 +521,21 @@ func s3ObjectHash(s3Info s3Info) string {
 }
 
 func (c *s3Context) Fail(err error) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
-	// only care about the last error for now
-	// TODO: add "Typed" error to error for context
-	c.err = err
+	c.setError(err)
 	c.done()
 }
 
+func (c *s3Context) setError(err error) {
+	// only care about the last error for now
+	// TODO: add "Typed" error to error for context
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	c.err = err
+}
+
 func (c *s3Context) done() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
 	c.refs--
 	if c.refs == 0 {
 		c.errC <- c.err


### PR DESCRIPTION
Cherry-pick of PR #14359 to 7.5 branch. Original message: 

During high load, Filebeat may crash due to the error channel `c.errC` having been closed before the last event has been acknowledged. This is caused by a missing critical section in `done()` which can result in `c.refs` no longer counting as expected.