### PR TITLE
Remove Support for Deprecated SSLv3

### DIFF
--- a/libbeat/common/transport/tlscommon/types.go
+++ b/libbeat/common/transport/tlscommon/types.go
@@ -104,10 +104,9 @@ type TLSVersion uint16
 
 // Define all the possible TLS version.
 const (
-	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
-	TLSVersion10    TLSVersion = tls.VersionTLS10
-	TLSVersion11    TLSVersion = tls.VersionTLS11
-	TLSVersion12    TLSVersion = tls.VersionTLS12
+	TLSVersion10 TLSVersion = tls.VersionTLS10
+	TLSVersion11 TLSVersion = tls.VersionTLS11
+	TLSVersion12 TLSVersion = tls.VersionTLS12
 )
 
 // TLSDefaultVersions list of versions of TLS we should support.
@@ -131,8 +130,6 @@ var tlsClientAuthTypes = map[string]tlsClientAuth{
 }
 
 var tlsProtocolVersions = map[string]TLSVersion{
-	"SSLv3":   TLSVersionSSL30,
-	"SSLv3.0": TLSVersionSSL30,
 	"TLSv1":   TLSVersion10,
 	"TLSv1.0": TLSVersion10,
 	"TLSv1.1": TLSVersion11,
@@ -140,10 +137,9 @@ var tlsProtocolVersions = map[string]TLSVersion{
 }
 
 var tlsProtocolVersionsInverse = map[TLSVersion]string{
-	TLSVersionSSL30: "SSLv3",
-	TLSVersion10:    "TLSv1.0",
-	TLSVersion11:    "TLSv1.1",
-	TLSVersion12:    "TLSv1.2",
+	TLSVersion10: "TLSv1.0",
+	TLSVersion11: "TLSv1.1",
+	TLSVersion12: "TLSv1.2",
 }
 
 // TLSVerificationMode represents the type of verification to do on the remote host,

--- a/libbeat/outputs/transport/tls.go
+++ b/libbeat/outputs/transport/tls.go
@@ -37,10 +37,9 @@ type TLSVersion = tlscommon.TLSVersion
 
 // Define all the possible TLS version.
 const (
-	TLSVersionSSL30 = tlscommon.TLSVersionSSL30
-	TLSVersion10    = tlscommon.TLSVersion10
-	TLSVersion11    = tlscommon.TLSVersion11
-	TLSVersion12    = tlscommon.TLSVersion12
+	TLSVersion10 = tlscommon.TLSVersion10
+	TLSVersion11 = tlscommon.TLSVersion11
+	TLSVersion12 = tlscommon.TLSVersion12
 )
 
 // Constants of the supported verification mode.


### PR DESCRIPTION
The Go authors deprecated support for SSLv3 in go 1.13. They've decided to remove it in go 1.14, and have already merged the commit. 

See: https://golang.org/issue/32716

This PR, or something like it, should probably land before February 2020.