### PR TITLE
Use string concat instead of fmt.Sprintf for MapStr.Flatten

### DIFF
--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -237,7 +237,7 @@ func flatten(prefix string, in, out MapStr) MapStr {
 		if prefix == "" {
 			fullKey = k
 		} else {
-			fullKey = fmt.Sprintf("%s.%s", prefix, k)
+			fullKey = prefix + "." + k
 		}
 
 		if m, ok := tryToMapStr(v); ok {


### PR DESCRIPTION
As seen in https://github.com/elastic/beats/pull/14421, concat seems a lot more performant with fewer allocations as compared to `fmt.Sprintf`.