### PR TITLE
Cherry-pick #14329 to 7.4: [Metricbeat]Kubernetes: add nil check for kubernetes parent object check

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Fix memory leak in kubernetes autodiscover provider and add_kubernetes_metadata processor happening when pods are terminated without sending a delete event. {pull}14259[14259]
 - Kubernetes watcher at `add_kubernetes_metadata` fails with StatefulSets {pull}13905[13905]
+- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over
+  TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
+- Support usage of custom builders without hints and mappers {pull}13839[13839]
+- Fix kubernetes `metaGenerator.ResourceMetadata` when parent reference controller is nil {issue}14320[14320] {pull}14329[14329]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,9 +42,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Fix memory leak in kubernetes autodiscover provider and add_kubernetes_metadata processor happening when pods are terminated without sending a delete event. {pull}14259[14259]
 - Kubernetes watcher at `add_kubernetes_metadata` fails with StatefulSets {pull}13905[13905]
-- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over
-  TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
-- Support usage of custom builders without hints and mappers {pull}13839[13839]
 - Fix kubernetes `metaGenerator.ResourceMetadata` when parent reference controller is nil {issue}14320[14320] {pull}14329[14329]
 
 *Auditbeat*

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -110,7 +110,7 @@ func (g *metaGenerator) ResourceMetadata(obj Resource) common.MapStr {
 	// Add controller metadata if present
 	if g.IncludeCreatorMetadata {
 		for _, ref := range accessor.GetOwnerReferences() {
-			if *ref.Controller {
+			if ref.Controller != nil && *ref.Controller {
 				switch ref.Kind {
 				// TODO grow this list as we keep adding more `state_*` metricsets
 				case "Deployment",


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14329 to 7.4 branch. Original message: 

Any object using libbeat's `common/kubernetes.metagenerator.ResourceMetadata` method will try to grab its parent(s) object(s).

If an object has no parent, `ref.Controller` (pointer to bool) will be nil which is making metricbeat panic in such cases.

https://github.com/elastic/beats/blob/2a526ac503ee2d90b561b61395952b26910459d4/libbeat/common/kubernetes/metadata.go#L112-L122

This PR adds a single liner to make sure the reference is not nil.

Fixes elastic/beats#14320
Related https://discuss.elastic.co/t/metricbeat-7-4-kubernetes-crash-on-startup/205479

