### PR TITLE
[6.8] Convert license struct to MapStr (#14378)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,7 +47,6 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Metricbeat*
 
-- Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,11 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Metricbeat*
 
+- Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
+- Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]
+- Update azure configuration example. {issue}14224[14224]
+- Fix cloudwatch metricset with names and dimensions in config. {issue}14376[14376] {pull}14391[14391]
+- Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,9 +48,6 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 *Metricbeat*
 
 - Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
-- Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]
-- Update azure configuration example. {issue}14224[14224]
-- Fix cloudwatch metricset with names and dimensions in config. {issue}14376[14376] {pull}14391[14391]
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 
 *Packetbeat*

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -33,11 +33,6 @@ import (
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
-type clusterStatsLicense struct {
-	*elasticsearch.License
-	ClusterNeedsTLS bool `json:"cluster_needs_tls"`
-}
-
 func clusterNeedsTLSEnabled(license *elasticsearch.License, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if license type is something other than trial
 	if !license.IsOneOf("trial") {
@@ -205,7 +200,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return errors.Wrap(err, "failed to determine if cluster needs TLS enabled")
 	}
 
-	l := clusterStatsLicense{license, clusterNeedsTLS}
+	l := license.ToMapStr()
+	l["cluster_needs_tls"] = clusterNeedsTLS
 
 	isAPMFound, err := apmIndicesExist(clusterState)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -476,6 +476,26 @@ func (l *License) IsOneOf(candidateLicenses ...string) bool {
 	return false
 }
 
+// ToMapStr converts the license to a common.MapStr. This is necessary
+// for proper marshaling of the data before it's sent over the wire. In
+// particular it ensures that ms-since-epoch values are marshaled as longs
+// and not floats in scientific notation as Elasticsearch does not like that.
+func (l *License) ToMapStr() common.MapStr {
+	return common.MapStr{
+		"status":                l.Status,
+		"id":                    l.ID,
+		"type":                  l.Type,
+		"issue_date":            l.IssueDate,
+		"issue_date_in_millis":  l.IssueDateInMillis,
+		"expiry_date":           l.ExpiryDate,
+		"expiry_date_in_millis": l.ExpiryDateInMillis,
+		"max_nodes":             l.MaxNodes,
+		"issued_to":             l.IssuedTo,
+		"issuer":                l.Issuer,
+		"start_date_in_millis":  l.StartDateInMillis,
+	}
+}
+
 func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr, error) {
 	hasSettingGroup, err := allSettings.HasKey(groupKey)
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Convert license struct to MapStr  (#14378)