### PR TITLE
Cherry-pick #14394 to 7.x: Ensure that init containers are no longer tailed after they stop

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -318,6 +318,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - GA the `script` processor. {pull}14325[14325]
 - Add `fingerprint` processor. {issue}11173[11173] {pull}14205[14205]
 - Add support for API keys in Elasticsearch outputs. {pull}14324[14324]
+- Ensure that init containers are no longer tailed after they stop {pull}14394[14394]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -198,6 +198,9 @@ func TestEmitEvent(t *testing.T) {
 						{
 							Name:        name,
 							ContainerID: containerID,
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14394 to 7.x branch. Original message: 

Init containers are killed off immediately after their work is done. So, ideally we should stop polling their endpoints and tailing their log files. The lack of this check impacted one of our builders that didnt have container in the log file path. Which caused the same path to be tailed multiple times.