### PR TITLE
Pass GENERATE env var to `mage pythonIntegTest`

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -55,9 +55,6 @@ var (
 	// to use (like snapshot (default), latest, 5x). Formerly known as
 	// TESTING_ENVIRONMENT.
 	StackEnvironment = EnvOr("STACK_ENVIRONMENT", "snapshot")
-
-	// Generate env var enables data generation in several tests
-	Generate = EnvOr("GENERATE", "")
 )
 
 // AddIntegTestUsage increments the use count for the integration test
@@ -195,7 +192,6 @@ func runInIntegTestEnv(mageTarget string, test func() error, passThroughEnvVars 
 		// compose.EnsureUp needs to know the environment type.
 		"-e", "STACK_ENVIRONMENT=" + StackEnvironment,
 		"-e", "TESTING_ENVIRONMENT=" + StackEnvironment,
-		"-e", "GENERATE=" + Generate,
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -55,6 +55,9 @@ var (
 	// to use (like snapshot (default), latest, 5x). Formerly known as
 	// TESTING_ENVIRONMENT.
 	StackEnvironment = EnvOr("STACK_ENVIRONMENT", "snapshot")
+
+	// Generate env var enables data generation in several tests
+	Generate = EnvOr("GENERATE", "")
 )
 
 // AddIntegTestUsage increments the use count for the integration test
@@ -192,6 +195,7 @@ func runInIntegTestEnv(mageTarget string, test func() error, passThroughEnvVars 
 		// compose.EnsureUp needs to know the environment type.
 		"-e", "STACK_ENVIRONMENT=" + StackEnvironment,
 		"-e", "TESTING_ENVIRONMENT=" + StackEnvironment,
+		"-e", "GENERATE=" + Generate,
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -215,5 +215,5 @@ func PythonIntegTest(ctx context.Context) error {
 		args := devtools.DefaultPythonTestIntegrationArgs()
 		args.Env["MODULES_PATH"] = devtools.CWD("module")
 		return devtools.PythonNoseTest(args)
-	})
+	}, "GENERATE")
 }

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -181,5 +181,5 @@ func PythonIntegTest(ctx context.Context) error {
 		args := devtools.DefaultPythonTestIntegrationArgs()
 		args.Env["MODULES_PATH"] = devtools.CWD("module")
 		return devtools.PythonNoseTest(args)
-	})
+	}, "GENERATE")
 }


### PR DESCRIPTION
Several tests use this env var as a flag for reference data generation.
For example filebeat tests. Running them like this would produce the
expected files:

```
GENERATE=1 mage pythonIntegTest
```