### PR TITLE
Cherry-pick #14424 to 7.x: Remove add_docker_metadata from Functionbeat configuration

### DIFF
--- a/dev-tools/mage/config.go
+++ b/dev-tools/mage/config.go
@@ -115,6 +115,7 @@ func Config(types ConfigFileType, args ConfigFileParams, targetDir string) error
 		"ExcludeLogstash":                false,
 		"ExcludeRedis":                   false,
 		"UseObserverProcessor":           false,
+		"UseDockerMetadataProcessor":     true,
 		"UseKubernetesMetadataProcessor": false,
 		"ExcludeDashboards":              false,
 	}

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -96,7 +96,8 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
-  - add_docker_metadata: ~
+{{- if .UseDockerMetadataProcessor }}
+  - add_docker_metadata: ~{{ end }}
 
 {{- if .UseKubernetesMetadataProcessor }}
   - add_kubernetes_metadata: ~

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -347,7 +347,6 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
-  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/functionbeat/scripts/mage/config.go
+++ b/x-pack/functionbeat/scripts/mage/config.go
@@ -20,10 +20,11 @@ func XPackConfigFileParams() devtools.ConfigFileParams {
 			devtools.LibbeatDir("_meta/config.reference.yml.tmpl"),
 		},
 		ExtraVars: map[string]interface{}{
-			"ExcludeConsole":    true,
-			"ExcludeFileOutput": true,
-			"ExcludeKafka":      true,
-			"ExcludeRedis":      true,
+			"ExcludeConsole":             true,
+			"ExcludeFileOutput":          true,
+			"ExcludeKafka":               true,
+			"ExcludeRedis":               true,
+			"UseDockerMetadataProcessor": false,
 		},
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #14424 to 7.x branch. Original message: 

The PR #13374 adds `add_docker_metadata` for all Beats. However, this results in the following error in Functionbeat when deployed to AWS:
```
Exiting: error initializing processors: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Thus, the function fails to start and process messages.

This PR removes the processor from the configuration of Functionbeat. So the function is able to start with the default processor configuration.