### PR TITLE
Remove kbn-version header from requests to Kibana.

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -194,9 +194,6 @@ func (conn *Connection) Send(method, extraPath string,
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Set("kbn-xsrf", "1")
-	if method != "GET" {
-		req.Header.Set("kbn-version", conn.Version.String())
-	}
 
 	for header, values := range headers {
 		for _, value := range values {


### PR DESCRIPTION
Non-browser clients are expected to use only `kbn-xsrf` for CSRF protection, and not `kbn-version`.
`kbn-version` is problematic when Kibana is upgraded, since the version is only pinned at startup when libbeat establishes the connection.

Fixes #14481 