### PR TITLE
Add light modules of oss as source in docs collector

### DIFF
--- a/metricbeat/scripts/msetlists/cmd/main.go
+++ b/metricbeat/scripts/msetlists/cmd/main.go
@@ -23,9 +23,8 @@ import (
 	"os"
 
 	"github.com/elastic/beats/libbeat/paths"
-	"github.com/elastic/beats/metricbeat/mb"
-
 	_ "github.com/elastic/beats/metricbeat/include"
+	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/scripts/msetlists"
 )
 

--- a/metricbeat/scripts/msetlists/cmd/main.go
+++ b/metricbeat/scripts/msetlists/cmd/main.go
@@ -22,11 +22,21 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/metricbeat/mb"
+
 	_ "github.com/elastic/beats/metricbeat/include"
 	"github.com/elastic/beats/metricbeat/scripts/msetlists"
 )
 
 func main() {
+	// Disable permission checks so it reads light modules in any case
+	os.Setenv("BEAT_STRICT_PERMS", "false")
+
+	path := paths.Resolve(paths.Home, "../metricbeat/module")
+	lm := mb.NewLightModulesSource(path)
+	mb.Registry.SetSecondarySource(lm)
+
 	msList := msetlists.DefaultMetricsets()
 
 	raw, err := json.MarshalIndent(msList, "", "  ")


### PR DESCRIPTION
This PR is a follow-up of https://github.com/elastic/beats/pull/14369 and adds the light modules as a `SecondarySource` in oss msetlists script.

Initial implementation and concerns around this can be found on https://github.com/elastic/beats/pull/12648