### PR TITLE
[DOCS] Add placeholder for filebeat processors

### DIFF
--- a/x-pack/filebeat/processors/decode_cef/docs/placeholder.asciidoc
+++ b/x-pack/filebeat/processors/decode_cef/docs/placeholder.asciidoc
@@ -1,0 +1,2 @@
+Placeholder file to support adding a new resource to the conf.yaml in the docs
+repo.


### PR DESCRIPTION
Adds a placeholder file so the build isn't borked when it looks for files under x-pack/filebeat/processors/*/docs