### PR TITLE
Bug - libbeat publisher pipeline output module exits if output returns error.

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -34,6 +34,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 ==== Added
 
+- Make the behavior of clientWorker and netClientWorker consistent when error is returned from publisher pipeline
 - Metricset generator generates beta modules by default now. {pull}10657[10657]
 - The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
 - Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Make the behavior of clientWorker and netClientWorker consistent when error is returned from publisher pipeline
 - Fix a bug, publisher pipeline exits if output returns an error, irrespective of pipeline is closed or not
 - Fix typo in TLS renegotiation configuration and setting the option correctly {issue}10871[10871], {pull}12354[12354]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,7 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
-- Fix a publisher pipeline exits if output returns an error, irrespective of pipeline is closed or not
+- Fix a bug, publisher pipeline exits if output returns an error, irrespective of pipeline is closed or not
 - Fix typo in TLS renegotiation configuration and setting the option correctly {issue}10871[10871], {pull}12354[12354]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]
 - Add missing fields and test cases for libbeat add_kubernetes_metadata processor. {issue}11133[11133], {pull}11134[11134]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Fix a publisher pipeline exits if output returns an error, irrespective of pipeline is closed or not
 - Fix typo in TLS renegotiation configuration and setting the option correctly {issue}10871[10871], {pull}12354[12354]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]
 - Add missing fields and test cases for libbeat add_kubernetes_metadata processor. {issue}11133[11133], {pull}11134[11134]

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -64,7 +64,7 @@ func (w *clientWorker) run() {
 			w.observer.outBatchSend(len(batch.events))
 
 			if err := w.client.Publish(batch); err != nil {
-				return
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Unlike net client worker, the client worker exits if output returns the error.  Ideally it should break the loop, like net client worker if publish of any output type returns error.