### PR TITLE
[libbeat] clarify behavior of pipeline.Load in godoc

### DIFF
--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -55,7 +55,7 @@ func init() {
 }
 
 // Load uses a Config object to create a new complete Pipeline instance with
-// configured queue and outputs.
+// configured queue and outputs. This is a non-blocking operation, and outputs should connect lazily.
 func Load(
 	beatInfo beat.Info,
 	monitors Monitors,


### PR DESCRIPTION
@urso requested this as I was a tad confused over the behavior of `pipeline.Load`. Perhaps due to the name and other factors, it's not entirely clear that output connections are lazy and that this is non-blocking.