### PR TITLE
[docker log driver] Move pipeline check + creation to single atomic operation

### DIFF
--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -74,7 +74,7 @@ func (pm *PipelineManager) CloseClientWithFile(file string) error {
 func (pm *PipelineManager) CreateClientWithConfig(logOptsConfig map[string]string, file string) (*ClientLogger, error) {
 
 	hashstring := makeConfigHash(logOptsConfig)
-	pipeline, err := pm.checkAndCreatePipeline(logOptsConfig, file)
+	pipeline, err := pm.getOrCreatePipeline(logOptsConfig, file, hashstring)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting pipeline")
 	}
@@ -95,11 +95,9 @@ func (pm *PipelineManager) CreateClientWithConfig(logOptsConfig map[string]strin
 
 // checkAndCreatePipeline performs the pipeline check and creation as one atomic operation
 // It will either return a new pipeline, or an existing one from the pipeline map
-func (pm *PipelineManager) checkAndCreatePipeline(logOptsConfig map[string]string, file string) (*Pipeline, error) {
+func (pm *PipelineManager) getOrCreatePipeline(logOptsConfig map[string]string, file string, hashstring string) (*Pipeline, error) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-
-	hashstring := makeConfigHash(logOptsConfig)
 
 	var pipeline *Pipeline
 	var err error

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -115,41 +115,12 @@ func (pm *PipelineManager) checkAndCreatePipeline(logOptsConfig map[string]strin
 	return pipeline, nil
 }
 
-// getPipeline gets a pipeline based on a confighash
-func (pm *PipelineManager) getPipeline(hashstring string) (*Pipeline, bool) {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	pipeline, exists := pm.pipelines[hashstring]
-	return pipeline, exists
-}
-
 // getClient gets a pipeline client based on a file handle
 func (pm *PipelineManager) getClient(file string) (*ClientLogger, bool) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	cli, exists := pm.clients[file]
 	return cli, exists
-}
-
-// checkIfHashExists is a short atomic function to see if a pipeline alread exists inside the PM. Thread-safe.
-func (pm *PipelineManager) checkIfHashExists(logOptsConfig map[string]string) bool {
-	hashstring := makeConfigHash(logOptsConfig)
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	_, test := pm.pipelines[hashstring]
-	if test {
-		return true
-	}
-	return false
-}
-
-// registerPipeline is a small atomic function that registers a new pipeline with the managers
-// TODO: What happens if we try to register a pipeline that already exists? Which pipeline "wins"?
-func (pm *PipelineManager) registerPipeline(pipeline *Pipeline, hashstring string) {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	pm.pipelines[hashstring] = pipeline
-
 }
 
 // removePipeline removes a pipeline from the manager if it's refcount is zero.

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -75,11 +75,14 @@ func (pm *PipelineManager) CreateClientWithConfig(logOptsConfig map[string]strin
 
 	hashstring := makeConfigHash(logOptsConfig)
 	pipeline, err := pm.checkAndCreatePipeline(logOptsConfig, file)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting pipeline")
+	}
 
 	//actually get to crafting the new client.
 	cl, err := newClientFromPipeline(pipeline.pipeline, file, hashstring)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error creating client")
 	}
 
 	pm.registerClient(cl, hashstring, file)


### PR DESCRIPTION
Thanks to @urso for reminding me about this. I noticed it a while ago, but somehow it never made it into #13990. 

The operation for checking if a pipeline exists, creating a new pipeline, and registering a new pipeline was three separate operations. This allowed a new thread to potentially squeeze in a create an identical pipeline before another thread registered it.

I'm still worried about the performance implications of this, since we're throwing around a global lock quite a lot. However, the most common use case will be one config with one pipeline.