### PR TITLE
[Filebeat] Fix parsing of Cisco ASA/FTD message 302021

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -192,6 +192,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Decode hex values in auditd module. {pull}14471[14471]
 - Fix handling multiline log entries in nginx module. {issue}14349[14349] {pull}14499[14499]
 - Fix parsing of Elasticsearch node name by `elasticsearch/slowlog` fileset. {pull}14547[14547]
+- cisco/asa fileset: Fix parsing of 302021 message code. {pull}14519[14519]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log
@@ -1,1 +1,2 @@
 Oct 10 2019 10:21:36 localhost: %ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0
+Jun 04 2011 21:59:52 MYHOSTNAME : %ASA-6-302021: Teardown ICMP connection for faddr 192.0.2.15/0 gaddr 192.0.2.134/57808 laddr 192.0.2.134/57808 type 8 code 0

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
@@ -1,7 +1,6 @@
 [
     {
         "@timestamp": "2019-10-10T10:21:36.000-02:00",
-        "cisco.asa.icmp_code": 0,
         "cisco.asa.mapped_source_ip": "10.0.55.66",
         "cisco.asa.message_id": "302021",
         "destination.domain": "target.destination.hostname.local",
@@ -22,6 +21,34 @@
         "service.type": "cisco",
         "source.domain": "Prod-host.name.addr",
         "source.nat.ip": "10.0.55.66",
+        "tags": [
+            "cisco-asa"
+        ]
+    },
+    {
+        "@timestamp": "2011-06-04T21:59:52.000-02:00",
+        "cisco.asa.mapped_source_ip": "192.0.2.134",
+        "cisco.asa.message_id": "302021",
+        "cisco.asa.source_username": "type",
+        "destination.address": "192.0.2.15",
+        "destination.ip": "192.0.2.15",
+        "event.action": "flow-expiration",
+        "event.code": 302021,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-302021: Teardown ICMP connection for faddr 192.0.2.15/0 gaddr 192.0.2.134/57808 laddr 192.0.2.134/57808 type 8 code 0",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "fileset.name": "asa",
+        "host.hostname": "MYHOSTNAME",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 169,
+        "network.iana_number": 1,
+        "network.transport": "icmp",
+        "service.type": "cisco",
+        "source.address": "192.0.2.134",
+        "source.ip": "192.0.2.134",
         "tags": [
             "cisco-asa"
         ]

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -343,7 +343,6 @@
     },
     {
         "@timestamp": "2011-06-04T21:59:52.000-02:00",
-        "cisco.asa.icmp_code": 17233,
         "cisco.asa.mapped_source_ip": "192.168.132.46",
         "cisco.asa.message_id": "302021",
         "destination.address": "172.24.177.29",

--- a/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
@@ -343,7 +343,6 @@
     },
     {
         "@timestamp": "2011-06-04T21:59:52.000-02:00",
-        "cisco.ftd.icmp_code": 17233,
         "cisco.ftd.mapped_source_ip": "192.168.132.46",
         "cisco.ftd.message_id": "302021",
         "destination.address": "172.24.177.29",

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -413,7 +413,7 @@ processors:
      if: "[\"302014\", \"302016\", \"302018\", \"302021\", \"302036\", \"302304\", \"302306\"].contains(ctx._temp_.cisco.message_id)"
      patterns:
       - "Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int} (?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int} (?:%{NOTSPACE:_temp_.cisco.destination_username} )?(?:duration %{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes:int})%{GREEDYDATA}"
-      - "Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER} (?:%{NOTSPACE:_temp_.cisco.destination_username} )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER:_temp_.cisco.icmp_code:int}(?: %{NOTSPACE:_temp_.cisco.source_username})?%{GREEDYDATA}"
+      - "Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER} (?:%{NOTSPACE:_temp_.cisco.destination_username} )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}(?: %{NOTSPACE:_temp_.cisco.source_username})?%{GREEDYDATA}"
      pattern_definitions:
       NOTCOLON: "[^:]*"
       ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"


### PR DESCRIPTION
This fixes (again) the format of ASA/FTD message code 302021 which wasn't clear between Cisco's docs and Logstash pattern in #13259.

Seems that a field can be either a port number or an ICMP code. To be safe it's better to just ignore this value.