### PR TITLE
[DOCS] Add missing line to fix list formatting in relnotes

### DIFF
--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
+
 * <<release-notes-7.5.0>>
 * <<release-notes-7.4.1>>
 * <<release-notes-7.4.0>>


### PR DESCRIPTION
An empty line is required for the list formatting to work correctly.