### PR TITLE
[Metricbeat] Check length of the slice instead of comparing with nil in cloudwatch

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -251,6 +251,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update azure configuration example. {issue}14224[14224]
 - Fix cloudwatch metricset with names and dimensions in config. {issue}14376[14376] {pull}14391[14391]
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
+- Fix checking tagsFilter using length in cloudwatch metricset. {pull}14525[14525]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -450,7 +450,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 			m.Logger().Info(errors.Wrap(err, "getResourcesTags failed, skipping region "+regionName))
 		}
 
-		if tagsFilter != nil && resourceTagMap == nil {
+		if len(tagsFilter) != 0 && resourceTagMap == nil {
 			continue
 		}
 
@@ -472,7 +472,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 					labels := strings.Split(*output.Label, labelSeperator)
 					if len(labels) != 5 {
 						// if there is no tag in labels but there is a tagsFilter, then no event should be reported.
-						if tagsFilter != nil {
+						if len(tagsFilter) != 0 {
 							continue
 						}
 						eventNew := aws.InitEvent(regionName, m.AccountName, m.AccountID)
@@ -483,7 +483,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 
 					identifierValue := labels[identifierValueIdx]
 					tags := resourceTagMap[identifierValue]
-					if tagsFilter != nil && tags == nil {
+					if len(tagsFilter) != 0 && tags == nil {
 						continue
 					}
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -450,7 +450,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 			m.Logger().Info(errors.Wrap(err, "getResourcesTags failed, skipping region "+regionName))
 		}
 
-		if len(tagsFilter) != 0 && resourceTagMap == nil {
+		if len(tagsFilter) != 0 && len(resourceTagMap) == 0 {
 			continue
 		}
 
@@ -483,7 +483,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 
 					identifierValue := labels[identifierValueIdx]
 					tags := resourceTagMap[identifierValue]
-					if len(tagsFilter) != 0 && tags == nil {
+					if len(tagsFilter) != 0 && len(tags) == 0 {
 						continue
 					}
 


### PR DESCRIPTION
When working on https://github.com/elastic/beats/pull/14123, I realized when `tagsFilter` is empty, `tagsFilter != nil` still returns true. This PR is to fix this issue with using checking length of the slice instead.

Empty slice and nil slice are different but both of them have zero length and capacity. For my own reference: https://yourbasic.org/golang/clear-slice/

