### PR TITLE
Add CommunityProject variable to beats generator's magefile.go

### DIFF
--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -22,6 +22,7 @@ func init() {
 
 	devtools.BeatDescription = "One sentence description of the Beat."
 	devtools.BeatVendor = "{full_name}"
+	devtools.BeatProjectType = devtools.CommunityProject
 }
 
 // VendorUpdate updates elastic/beats in the vendor dir


### PR DESCRIPTION
This is required from version 7.4.0 to make sure `mage check` will not
generate License headers for community projects.

Discussed and tested with @andrewkroh 
