### PR TITLE
Increase timeouts in filebeat shutdown tests

### DIFF
--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -54,7 +54,7 @@ class Test(BaseTest):
 
         self.wait_log_contains(
             "Continue shutdown: All enqueued events being published.",
-            max_timeout=60)
+            max_timeout=15)
 
         # validate registry entry offset matches last published event
         registry = self.get_registry()
@@ -100,7 +100,7 @@ class Test(BaseTest):
 
         self.wait_log_contains(
             "Continue shutdown: Time out waiting for events being published.",
-            max_timeout=60)
+            max_timeout=15)
 
         # check registry being really empty
         reg = self.get_registry()
@@ -139,7 +139,7 @@ class Test(BaseTest):
         # Waits for filebeat to stop
         self.wait_until(
             lambda: self.log_contains("filebeat stopped."),
-            max_timeout=60)
+            max_timeout=15)
 
         # Checks that registry was written
         data = self.get_registry()

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -36,7 +36,7 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             ignore_older="1h",
-            shutdown_timeout="10s",
+            shutdown_timeout="30s",
         )
         filebeat = self.start_beat()
 
@@ -54,7 +54,7 @@ class Test(BaseTest):
         try:
             self.wait_log_contains(
                 "Continue shutdown: All enqueued events being published.",
-                max_timeout=15)
+                max_timeout=35)
         except:
             print self.get_log()
             raise

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -47,14 +47,17 @@ class Test(BaseTest):
 
         filebeat.check_kill_and_wait()
 
-        self.get_log()
         self.wait_log_contains(
             "Shutdown output timer started.",
             max_timeout=15)
 
-        self.wait_log_contains(
-            "Continue shutdown: All enqueued events being published.",
-            max_timeout=15)
+        try:
+            self.wait_log_contains(
+                "Continue shutdown: All enqueued events being published.",
+                max_timeout=15)
+        except:
+            print self.get_log()
+            raise
 
         # validate registry entry offset matches last published event
         registry = self.get_registry()

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -36,7 +36,7 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             ignore_older="1h",
-            shutdown_timeout="30s",
+            shutdown_timeout="120s",
         )
         filebeat = self.start_beat()
 
@@ -54,7 +54,7 @@ class Test(BaseTest):
         try:
             self.wait_log_contains(
                 "Continue shutdown: All enqueued events being published.",
-                max_timeout=35)
+                max_timeout=125)
         except:
             print self.get_log()
             raise

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -54,7 +54,7 @@ class Test(BaseTest):
 
         self.wait_log_contains(
             "Continue shutdown: All enqueued events being published.",
-            max_timeout=15)
+            max_timeout=60)
 
         # validate registry entry offset matches last published event
         registry = self.get_registry()
@@ -100,7 +100,7 @@ class Test(BaseTest):
 
         self.wait_log_contains(
             "Continue shutdown: Time out waiting for events being published.",
-            max_timeout=15)
+            max_timeout=60)
 
         # check registry being really empty
         reg = self.get_registry()
@@ -139,7 +139,7 @@ class Test(BaseTest):
         # Waits for filebeat to stop
         self.wait_until(
             lambda: self.log_contains("filebeat stopped."),
-            max_timeout=15)
+            max_timeout=60)
 
         # Checks that registry was written
         data = self.get_registry()


### PR DESCRIPTION
Filebeat shutdown tests are quite flaky, try to reduce flakiness by
increasing the timeouts used to wait for shutdown messages in the logs.