### PR TITLE
[Debug only] [filebeat] Workaround for missing offsets in Azure event hub response

### DIFF
--- a/vendor/github.com/Shopify/sarama/offset_fetch_response.go
+++ b/vendor/github.com/Shopify/sarama/offset_fetch_response.go
@@ -115,7 +115,12 @@ func (r *OffsetFetchResponse) decode(pd packetDecoder, version int16) (err error
 			}
 
 			if numBlocks == 0 {
-				r.Blocks[name] = nil
+				//r.Blocks[name] = nil
+				// HACK: Azure is returning an empty block table for consumer groups
+				// that haven't committed an explicit offset yet. Add a placeholder
+				// to unstick things.
+				r.Blocks[name] = make(map[int32]*OffsetFetchResponseBlock)
+				r.Blocks[name][0] = &OffsetFetchResponseBlock{Offset: -1}
 				continue
 			}
 			r.Blocks[name] = make(map[int32]*OffsetFetchResponseBlock, numBlocks)

--- a/vendor/github.com/Shopify/sarama/offset_fetch_response.go
+++ b/vendor/github.com/Shopify/sarama/offset_fetch_response.go
@@ -115,12 +115,12 @@ func (r *OffsetFetchResponse) decode(pd packetDecoder, version int16) (err error
 			}
 
 			if numBlocks == 0 {
-				//r.Blocks[name] = nil
+				r.Blocks[name] = nil
 				// HACK: Azure is returning an empty block table for consumer groups
 				// that haven't committed an explicit offset yet. Add a placeholder
 				// to unstick things.
-				r.Blocks[name] = make(map[int32]*OffsetFetchResponseBlock)
-				r.Blocks[name][0] = &OffsetFetchResponseBlock{Offset: -1}
+				//r.Blocks[name] = make(map[int32]*OffsetFetchResponseBlock)
+				//r.Blocks[name][0] = &OffsetFetchResponseBlock{Offset: -1}
 				continue
 			}
 			r.Blocks[name] = make(map[int32]*OffsetFetchResponseBlock, numBlocks)


### PR DESCRIPTION
This is a simple workaround for #14536. It's for testing only, while we decide next steps. So far this only works on event hubs with a single partition. If we want to make this into a "real" fix we would at minimum need to inspect the outgoing request and only add placeholder offsets for the specific partitions that are missing in the response.