### PR TITLE
docs: add azure module known issue

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -81,6 +81,12 @@ https://github.com/elastic/beats/compare/v7.4.1...v7.5.0[View commits]
 
 - Fix parsing of the HTTP host header when it contains a port or an IPv6 address. {pull}14215[14215]
 
+==== Known issues
+
+*Filebeat*
+
+- The Azure module (beta) has stopped working due to recent changes in Azure.
+We are working with Microsoft to find and fix the root cause.
 
 ==== Added
 


### PR DESCRIPTION
Adds Azure module known issue to `7.5` release notes. Needs to be cherrypicked to `7.x` and `master`.

@dedemorton, not sure where you want _known issues_ in relation to the other topics. Happy to move it to wherever you'd like.