### PR TITLE
Adding publisher event cache

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak in kubernetes autodiscover provider and add_kubernetes_metadata processor happening when pods are terminated without sending a delete event. {pull}14259[14259]
 - Fix kubernetes `metaGenerator.ResourceMetadata` when parent reference controller is nil {issue}14320[14320] {pull}14329[14329]
 - Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
+- Fix bug with potential concurrent reads and writes from event.Meta map by Kafka output. {issue}14542[14542] {pull}14568[14568]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -165,6 +165,7 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 
 	value, err := data.Cache.GetValue("partition")
 	if err == nil {
+		logp.Debug("kafka", "Got event.Meta[\"partition\"] = %v", value)
 		if partition, ok := value.(int32); ok {
 			msg.partition = partition
 		}
@@ -172,6 +173,7 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 
 	value, err = data.Cache.GetValue("topic")
 	if err == nil {
+		logp.Debug("kafka", "Got event.Meta[\"topic\"] = %v", value)
 		if topic, ok := value.(string); ok {
 			msg.topic = topic
 		}
@@ -186,6 +188,7 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 			return nil, errNoTopicsSelected
 		}
 		msg.topic = topic
+		logp.Debug("kafka", "Setting event.Meta[\"topic\"] = %v", topic)
 		if _, err := data.Cache.Put("topic", topic); err != nil {
 			return nil, fmt.Errorf("setting kafka topic in publisher event failed: %v", err)
 		}

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -162,19 +162,21 @@ func (c *client) String() string {
 func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 	event := &data.Content
 	msg := &message{partition: -1, data: *data}
-	if event.Meta != nil {
-		if value, ok := event.Meta["partition"]; ok {
-			if partition, ok := value.(int32); ok {
-				msg.partition = partition
-			}
-		}
 
-		if value, ok := event.Meta["topic"]; ok {
-			if topic, ok := value.(string); ok {
-				msg.topic = topic
-			}
+	value, err := data.Cache.GetValue("partition")
+	if err == nil {
+		if partition, ok := value.(int32); ok {
+			msg.partition = partition
 		}
 	}
+
+	value, err = data.Cache.GetValue("topic")
+	if err == nil {
+		if topic, ok := value.(string); ok {
+			msg.topic = topic
+		}
+	}
+
 	if msg.topic == "" {
 		topic, err := c.topic.Select(event)
 		if err != nil {
@@ -184,10 +186,9 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 			return nil, errNoTopicsSelected
 		}
 		msg.topic = topic
-		if event.Meta == nil {
-			event.Meta = map[string]interface{}{}
+		if _, err := data.Cache.Put("topic", topic); err != nil {
+			return nil, fmt.Errorf("setting kafka topic in publisher event failed: %v", err)
 		}
-		event.Meta["topic"] = topic
 	}
 
 	serializedEvent, err := c.codec.Encode(c.index, event)

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -165,7 +165,9 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 
 	value, err := data.Cache.GetValue("partition")
 	if err == nil {
-		logp.Debug("kafka", "Got event.Meta[\"partition\"] = %v", value)
+		if logp.IsDebug(debugSelector) {
+			debugf("got event.Meta[\"partition\"] = %v", value)
+		}
 		if partition, ok := value.(int32); ok {
 			msg.partition = partition
 		}
@@ -173,7 +175,9 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 
 	value, err = data.Cache.GetValue("topic")
 	if err == nil {
-		logp.Debug("kafka", "Got event.Meta[\"topic\"] = %v", value)
+		if logp.IsDebug(debugSelector) {
+			debugf("got event.Meta[\"topic\"] = %v", value)
+		}
 		if topic, ok := value.(string); ok {
 			msg.topic = topic
 		}
@@ -188,7 +192,9 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 			return nil, errNoTopicsSelected
 		}
 		msg.topic = topic
-		logp.Debug("kafka", "Setting event.Meta[\"topic\"] = %v", topic)
+		if logp.IsDebug(debugSelector) {
+			debugf("setting event.Meta[\"topic\"] = %v", topic)
+		}
 		if _, err := data.Cache.Put("topic", topic); err != nil {
 			return nil, fmt.Errorf("setting kafka topic in publisher event failed: %v", err)
 		}
@@ -196,7 +202,9 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 
 	serializedEvent, err := c.codec.Encode(c.index, event)
 	if err != nil {
-		logp.Debug("kafka", "Failed event: %v", event)
+		if logp.IsDebug(debugSelector) {
+			debugf("failed event: %v", event)
+		}
 		return nil, err
 	}
 

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -37,9 +37,11 @@ const (
 	// NOTE: maxWaitRetry has no effect on mode, as logstash client currently does
 	// not return ErrTempBulkFailure
 	defaultMaxWaitRetry = 60 * time.Second
+
+	debugSelector = "kafka"
 )
 
-var debugf = logp.MakeDebug("kafka")
+var debugf = logp.MakeDebug(debugSelector)
 
 var (
 	errNoTopicSet = errors.New("No topic configured")

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -380,7 +380,10 @@ func testReadFromKafkaTopic(
 		go func(p int32, pc sarama.PartitionConsumer) {
 			for {
 				select {
-				case msg := <-pc.Messages():
+				case msg, ok := <-pc.Messages():
+					if !ok {
+						break
+					}
 					testTopicOffsets.SetOffset(topic, p, msg.Offset+1)
 					msgs <- msg
 				case <-done:

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -307,7 +307,49 @@ func newTestConsumer(t *testing.T) sarama.Consumer {
 	return consumer
 }
 
-var testTopicOffsets = map[string]int64{}
+// topicOffsetMap is threadsafe map from topic => partition => offset
+type topicOffsetMap struct {
+	m  map[string]map[int32]int64
+	mu sync.RWMutex
+}
+
+func (m *topicOffsetMap) GetOffset(topic string, partition int32) int64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.m == nil {
+		return sarama.OffsetOldest
+	}
+
+	topicMap, ok := m.m[topic]
+	if !ok {
+		return sarama.OffsetOldest
+	}
+
+	offset, ok := topicMap[partition]
+	if !ok {
+		return sarama.OffsetOldest
+	}
+
+	return offset
+}
+
+func (m *topicOffsetMap) SetOffset(topic string, partition int32, offset int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.m == nil {
+		m.m = map[string]map[int32]int64{}
+	}
+
+	if _, ok := m.m[topic]; !ok {
+		m.m[topic] = map[int32]int64{}
+	}
+
+	m.m[topic][partition] = offset
+}
+
+var testTopicOffsets topicOffsetMap
 
 func testReadFromKafkaTopic(
 	t *testing.T, topic string, nMessages int,
@@ -318,31 +360,50 @@ func testReadFromKafkaTopic(
 		consumer.Close()
 	}()
 
-	offset, found := testTopicOffsets[topic]
-	if !found {
-		offset = sarama.OffsetOldest
-	}
-
-	partitionConsumer, err := consumer.ConsumePartition(topic, 0, offset)
+	partitions, err := consumer.Partitions(topic)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		partitionConsumer.Close()
-	}()
 
-	timer := time.After(timeout)
+	done := make(chan struct{})
+	msgs := make(chan *sarama.ConsumerMessage)
+	for _, partition := range partitions {
+		go func(p int32) {
+			offset := testTopicOffsets.GetOffset(topic, p)
+
+			partitionConsumer, err := consumer.ConsumePartition(topic, p, offset)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				partitionConsumer.Close()
+			}()
+
+			for {
+				select {
+				case msg := <-partitionConsumer.Messages():
+					testTopicOffsets.SetOffset(topic, p, msg.Offset+1)
+					msgs <- msg
+				case <-done:
+					break
+				}
+			}
+		}(partition)
+	}
+
 	var messages []*sarama.ConsumerMessage
-	for i := 0; i < nMessages; i++ {
+	timer := time.After(timeout)
+
+	for len(messages) < nMessages {
 		select {
-		case msg := <-partitionConsumer.Messages():
+		case msg := <-msgs:
 			messages = append(messages, msg)
-			testTopicOffsets[topic] = msg.Offset + 1
 		case <-timer:
 			break
 		}
 	}
 
+	close(done)
 	return messages
 }
 

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -127,11 +127,11 @@ func (p *messagePartitioner) Partition(
 	}
 
 	msg.partition = partition
-	event := &msg.data.Content
-	if event.Meta == nil {
-		event.Meta = map[string]interface{}{}
+
+	if _, err := msg.data.Cache.Put("partition", partition); err != nil {
+		return 0, fmt.Errorf("setting kafka partition in publisher event failed: %v", err)
 	}
-	event.Meta["partition"] = partition
+
 	p.partitions = numPartitions
 	return msg.partition, nil
 }

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -128,7 +128,9 @@ func (p *messagePartitioner) Partition(
 
 	msg.partition = partition
 
-	logp.Debug("kafka", "Setting event.Meta[\"partition\"] = %v", partition)
+	if logp.IsDebug(debugSelector) {
+		debugf("setting event.Meta[\"partition\"] = %v", partition)
+	}
 	if _, err := msg.data.Cache.Put("partition", partition); err != nil {
 		return 0, fmt.Errorf("setting kafka partition in publisher event failed: %v", err)
 	}

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -128,6 +128,7 @@ func (p *messagePartitioner) Partition(
 
 	msg.partition = partition
 
+	logp.Debug("kafka", "Setting event.Meta[\"partition\"] = %v", partition)
 	if _, err := msg.data.Cache.Put("partition", partition); err != nil {
 		return 0, fmt.Errorf("setting kafka partition in publisher event failed: %v", err)
 	}

--- a/libbeat/publisher/event.go
+++ b/libbeat/publisher/event.go
@@ -18,8 +18,6 @@
 package publisher
 
 import (
-	"sync"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -44,44 +42,14 @@ type Batch interface {
 type Event struct {
 	Content beat.Event
 	Flags   EventFlags
-	Cache   *EventCache
+
+	// Cache provides a threadsafe space for outputs to define per-event metadata
+	// that's intended to be used only within the scope of an output
+	Cache common.MapStr
 }
 
 // EventFlags provides additional flags/option types  for used with the outputs.
 type EventFlags uint8
-
-// EventCache provides a threadsafe space for outputs to define per-event metadata
-// that's intended to be used only within the scope of an output
-type EventCache struct {
-	m  common.MapStr
-	mu sync.RWMutex
-}
-
-// Put lets outputs put key-value pairs into the event cache
-func (ec *EventCache) Put(key string, value interface{}) (interface{}, error) {
-	ec.mu.Lock()
-	defer ec.mu.Unlock()
-
-	if ec.m == nil {
-		// uninitialized map
-		ec.m = common.MapStr{}
-	}
-
-	return ec.m.Put(key, value)
-}
-
-// GetValue lets outputs retrieve values from the event cache by key
-func (ec *EventCache) GetValue(key string) (interface{}, error) {
-	ec.mu.RLock()
-	defer ec.mu.RUnlock()
-
-	if ec.m == nil {
-		// uninitialized map
-		return nil, common.ErrKeyNotFound
-	}
-
-	return ec.m.GetValue(key)
-}
 
 const (
 	// GuaranteedSend requires an output to not drop the event on failure, but

--- a/libbeat/publisher/event.go
+++ b/libbeat/publisher/event.go
@@ -55,7 +55,7 @@ type EventCache struct {
 }
 
 // Put lets outputs put key-value pairs into the event cache
-func (ec EventCache) Put(key string, value interface{}) (interface{}, error) {
+func (ec *EventCache) Put(key string, value interface{}) (interface{}, error) {
 	if ec.m == nil {
 		// uninitialized map
 		ec.m = common.MapStr{}
@@ -65,7 +65,7 @@ func (ec EventCache) Put(key string, value interface{}) (interface{}, error) {
 }
 
 // GetValue lets outputs retrieve values from the event cache by key
-func (ec EventCache) GetValue(key string) (interface{}, error) {
+func (ec *EventCache) GetValue(key string) (interface{}, error) {
 	if ec.m == nil {
 		// uninitialized map
 		return nil, common.ErrKeyNotFound

--- a/libbeat/publisher/event.go
+++ b/libbeat/publisher/event.go
@@ -18,7 +18,10 @@
 package publisher
 
 import (
+	"sync"
+
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // Batch is used to pass a batch of events to the outputs and asynchronously listening
@@ -41,10 +44,44 @@ type Batch interface {
 type Event struct {
 	Content beat.Event
 	Flags   EventFlags
+	Cache   EventCache
 }
 
 // EventFlags provides additional flags/option types  for used with the outputs.
 type EventFlags uint8
+
+// EventCache provides a threadsafe space for outputs to define per-event metadata
+// that's intended to be used only within the scope of an output
+type EventCache struct {
+	m  common.MapStr
+	mu sync.RWMutex
+}
+
+// Put lets outputs put key-value pairs into the event cache
+func (ec *EventCache) Put(key string, value interface{}) (interface{}, error) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+
+	if ec.m == nil {
+		// uninitialized map
+		ec.m = common.MapStr{}
+	}
+
+	return ec.m.Put(key, value)
+}
+
+// GetValue lets outputs retrieve values from the event cache by key
+func (ec *EventCache) GetValue(key string) (interface{}, error) {
+	ec.mu.RLock()
+	defer ec.mu.RUnlock()
+
+	if ec.m == nil {
+		// uninitialized map
+		return nil, common.ErrKeyNotFound
+	}
+
+	return ec.m.GetValue(key)
+}
 
 const (
 	// GuaranteedSend requires an output to not drop the event on failure, but

--- a/libbeat/publisher/event.go
+++ b/libbeat/publisher/event.go
@@ -44,7 +44,7 @@ type Batch interface {
 type Event struct {
 	Content beat.Event
 	Flags   EventFlags
-	Cache   EventCache
+	Cache   *EventCache
 }
 
 // EventFlags provides additional flags/option types  for used with the outputs.

--- a/libbeat/publisher/event.go
+++ b/libbeat/publisher/event.go
@@ -42,14 +42,37 @@ type Batch interface {
 type Event struct {
 	Content beat.Event
 	Flags   EventFlags
-
-	// Cache provides a threadsafe space for outputs to define per-event metadata
-	// that's intended to be used only within the scope of an output
-	Cache common.MapStr
+	Cache   EventCache
 }
 
 // EventFlags provides additional flags/option types  for used with the outputs.
 type EventFlags uint8
+
+// EventCache provides a space for outputs to define per-event metadata
+// that's intended to be used only within the scope of an output
+type EventCache struct {
+	m common.MapStr
+}
+
+// Put lets outputs put key-value pairs into the event cache
+func (ec EventCache) Put(key string, value interface{}) (interface{}, error) {
+	if ec.m == nil {
+		// uninitialized map
+		ec.m = common.MapStr{}
+	}
+
+	return ec.m.Put(key, value)
+}
+
+// GetValue lets outputs retrieve values from the event cache by key
+func (ec EventCache) GetValue(key string) (interface{}, error) {
+	if ec.m == nil {
+		// uninitialized map
+		return nil, common.ErrKeyNotFound
+	}
+
+	return ec.m.GetValue(key)
+}
 
 const (
 	// GuaranteedSend requires an output to not drop the event on failure, but

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -183,7 +183,7 @@ unit: ## @testing Runs the unit tests without coverage reports.
 integration-tests: ## @testing Run integration tests. Unit tests are run as part of the integration tests.
 integration-tests: prepare-tests
 	rm -f docker-compose.yml.lock
-	$(COVERAGE_TOOL) -timeout=20s -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
+	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
 
 #
 .PHONY: integration-tests-environment
@@ -194,7 +194,7 @@ integration-tests-environment: prepare-tests build-image
 	#
 	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
 	# by default because it can create noise if the test inside the container fails.
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
 
 # Runs the system tests
 .PHONY: system-tests

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -183,7 +183,7 @@ unit: ## @testing Runs the unit tests without coverage reports.
 integration-tests: ## @testing Run integration tests. Unit tests are run as part of the integration tests.
 integration-tests: prepare-tests
 	rm -f docker-compose.yml.lock
-	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
+	$(COVERAGE_TOOL) -timeout=20s -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
 
 #
 .PHONY: integration-tests-environment

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -194,7 +194,7 @@ integration-tests-environment: prepare-tests build-image
 	#
 	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
 	# by default because it can create noise if the test inside the container fails.
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
 
 # Runs the system tests
 .PHONY: system-tests

--- a/testing/environments/docker/kafka/run.sh
+++ b/testing/environments/docker/kafka/run.sh
@@ -21,7 +21,8 @@ mkdir -p ${KAFKA_LOGS_DIR}
 ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
     --override delete.topic.enable=true --override advertised.host.name=${KAFKA_ADVERTISED_HOST} \
     --override listeners=PLAINTEXT://0.0.0.0:9092 \
-    --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 &
+    --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 \
+    --override num.partitions=15 &
 
 wait_for_port 9092
 

--- a/testing/environments/docker/kafka/run.sh
+++ b/testing/environments/docker/kafka/run.sh
@@ -22,7 +22,7 @@ ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
     --override delete.topic.enable=true --override advertised.host.name=${KAFKA_ADVERTISED_HOST} \
     --override listeners=PLAINTEXT://0.0.0.0:9092 \
     --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 \
-    --override num.partitions=15 &
+    --override num.partitions=3 &
 
 wait_for_port 9092
 


### PR DESCRIPTION
Resolves #14542.

Per the suggestion from @urso in https://github.com/elastic/beats/issues/14542#issuecomment-554437972, this PR introduces a `Cache` field in `publisher.Event`. This field provides a space for for outputs to store arbitrary per-event information useful within the scope of the output. For example, the `kafka` output will use this to store partition IDs and topic names.

This PR also:
- adds debug logging to the Kafka output code at points where `publisher.Event.Cache` is written to or read from. 
- changes the default # of partitions for the Kafka cluster used in tests to 15 (previously, it was using the out-of-the-box default of 1).
- updates several tests to account for the change in the # of partitions.