### PR TITLE
[7.x][DOCS] Backport: Add temporary files to support doc build changes

### DIFF
--- a/libbeat/processors/actions/docs/placeholder.asciidoc
+++ b/libbeat/processors/actions/docs/placeholder.asciidoc
@@ -1,0 +1,2 @@
+Placeholder file to support adding a new resource to the conf.yaml in the docs
+repo.

--- a/x-pack/filebeat/processors/decode_cef/docs/placeholder.asciidoc
+++ b/x-pack/filebeat/processors/decode_cef/docs/placeholder.asciidoc
@@ -1,0 +1,2 @@
+Placeholder file to support adding a new resource to the conf.yaml in the docs
+repo.


### PR DESCRIPTION
Backports #14488 and #14489 to avoid borking the build when the conf.yaml file is updated to pull content from under  `*/processors/*/docs`