### PR TITLE
Add missing colon

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -462,7 +462,7 @@ For example, to configure the condition `NOT status = OK`:
 
 [source,yaml]
 ------
-not
+not:
   equals:
     status: OK
 ------


### PR DESCRIPTION
A colon was inadvertently removed while updating files during the processor refactoring recently.

I've made the changes in the backports already.