### PR TITLE
Check license expiry date zero value

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -255,6 +255,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 - Fix checking tagsFilter using length in cloudwatch metricset. {pull}14525[14525]
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
+- Fixed bug with `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. {issue}14541[14541 {pull}14591[14591]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -82,7 +82,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	if ccrUnavailableMessage != "" {
 		if time.Since(m.lastCCRLicenseMessageTimestamp) > 1*time.Minute {
 			m.lastCCRLicenseMessageTimestamp = time.Now()
-			m.Logger().Warn(ccrUnavailableMessage)
+			m.Logger().Debug(ccrUnavailableMessage)
 		}
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -201,6 +201,12 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	}
 
 	l := license.ToMapStr()
+	if license.ExpiryDateInMillis == 0 {
+		// We don't want to record a 0 expiry date as this means the license has expired
+		// in the Stack Monitoring UI
+		l.Delete("expiry_date_in_millis")
+	}
+
 	l["cluster_needs_tls"] = clusterNeedsTLS
 
 	isAPMFound, err := apmIndicesExist(clusterState)

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -201,12 +201,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	}
 
 	l := license.ToMapStr()
-	if license.ExpiryDateInMillis == 0 {
-		// We don't want to record a 0 expiry date as this means the license has expired
-		// in the Stack Monitoring UI
-		l.Delete("expiry_date_in_millis")
-	}
-
 	l["cluster_needs_tls"] = clusterNeedsTLS
 
 	isAPMFound, err := apmIndicesExist(clusterState)

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -485,19 +485,27 @@ func (l *License) IsOneOf(candidateLicenses ...string) bool {
 // particular it ensures that ms-since-epoch values are marshaled as longs
 // and not floats in scientific notation as Elasticsearch does not like that.
 func (l *License) ToMapStr() common.MapStr {
-	return common.MapStr{
-		"status":                l.Status,
-		"id":                    l.ID,
-		"type":                  l.Type,
-		"issue_date":            l.IssueDate,
-		"issue_date_in_millis":  l.IssueDateInMillis,
-		"expiry_date":           l.ExpiryDate,
-		"expiry_date_in_millis": l.ExpiryDateInMillis,
-		"max_nodes":             l.MaxNodes,
-		"issued_to":             l.IssuedTo,
-		"issuer":                l.Issuer,
-		"start_date_in_millis":  l.StartDateInMillis,
+
+	m := common.MapStr{
+		"status":               l.Status,
+		"id":                   l.ID,
+		"type":                 l.Type,
+		"issue_date":           l.IssueDate,
+		"issue_date_in_millis": l.IssueDateInMillis,
+		"expiry_date":          l.ExpiryDate,
+		"max_nodes":            l.MaxNodes,
+		"issued_to":            l.IssuedTo,
+		"issuer":               l.Issuer,
+		"start_date_in_millis": l.StartDateInMillis,
 	}
+
+	if l.ExpiryDateInMillis != 0 {
+		// We don't want to record a 0 expiry date as this means the license has expired
+		// in the Stack Monitoring UI
+		m["expiry_date_in_millis"] = l.ExpiryDateInMillis
+	}
+
+	return m
 }
 
 func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr, error) {

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -149,6 +149,8 @@ class Test(metricbeat.BaseTest):
             issue_date = license["issue_date_in_millis"]
             self.assertIsNot(type(issue_date), float)
 
+            self.assertNotIn("expiry_date_in_millis", license)
+
     def create_ml_job(self):
         # Check if an ml job already exists
         response = self.ml_es.get_jobs()

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -114,6 +114,9 @@ class Test(metricbeat.BaseTest):
         """
         elasticsearch-xpack module test for type:cluster_stats
         """
+
+        self.start_basic()
+
         self.render_config_template(modules=[{
             "name": "elasticsearch",
             "metricsets": [
@@ -296,6 +299,18 @@ class Test(metricbeat.BaseTest):
         except:
             e = sys.exc_info()[0]
             print "Trial already enabled. Error: {}".format(e)
+
+    def start_basic(self):
+        # Check if basic license is already enabled
+        response = self.es.transport.perform_request('GET', self.license_url)
+        if response["license"]["type"] == "basic":
+            return
+
+        try:
+            self.es.transport.perform_request('POST', self.license_url + "/start_basic?acknowledge=true")
+        except:
+            e = sys.exc_info()[0]
+            print "Basic license already enabled. Error: {}".format(e)
 
     def check_skip(self, metricset):
         if metricset == 'ccr' and not self.is_ccr_available():


### PR DESCRIPTION
Resolves #14541. 

Users using Metricbeat to monitor an Elasticsearch cluster with a Basic license will not be able to access that cluster in the Stack Monitoring UI. This is because the `elasticsearch/cluster_stats` metricset is recording a Basic license's expiration date as `0`, which the UI considers to a sentinel value for an expired license.

This PR fixes this bug by not recording the expiration date field at all, if its value is `0`. This mimics what internal monitoring collection is doing.

### Testing this PR

1. Spin up an Elasticsearch node with a Basic license.
2. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats
   mage build
   ```
3. Enable the `elasticsearch-xpack` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
4. Run Metricbeat.
   ```
   ./metricbeat -e
   ```
5. Verify that the latest document in `.monitoring-es-*-mb-*` of `type: cluster_stats` does not record the license expiration date in ms.
   ```
   http://localhost:9200/.monitoring-*-mb-*/_search?q=type:cluster_stats&sort=timestamp:desc&size=1&filter_path=hits.hits._source.license
   ```
