### PR TITLE
Fix license ID field name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -258,6 +258,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. {issue}14541[14541] {pull}14591[14591]
 - Vshpere module splits `virtualmachine.host` into `virtualmachine.host.id` and `virtualmachine.host.hostname`. {issue}7187[7187] {pull}7213[7213]
+- Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -485,10 +485,9 @@ func (l *License) IsOneOf(candidateLicenses ...string) bool {
 // particular it ensures that ms-since-epoch values are marshaled as longs
 // and not floats in scientific notation as Elasticsearch does not like that.
 func (l *License) ToMapStr() common.MapStr {
-
 	m := common.MapStr{
 		"status":               l.Status,
-		"id":                   l.ID,
+		"uid":                  l.ID,
 		"type":                 l.Type,
 		"issue_date":           l.IssueDate,
 		"issue_date_in_millis": l.IssueDateInMillis,


### PR DESCRIPTION
This PR fixes the license ID field name from `id` to `uid`.  This makes Metricbeat-indexed stack monitoring documents have parity with internally-indexed ones.

### Testing this PR

1. Spin up an Elasticsearch node.
2. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats
   mage build
   ```
3. Enable the `elasticsearch-xpack` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
4. Run Metricbeat.
   ```
   ./metricbeat -e
   ```
5. Verify that the latest document in `.monitoring-es-*-mb-*` of `type: cluster_stats` has the `license.uid` field.
   ```
   http://localhost:9200/.monitoring-*-mb-*/_search?q=type:cluster_stats&sort=timestamp:desc&size=1&filter_path=hits.hits._source.license
   ```