### PR TITLE
Refactor: Rename pipeline into stream

### DIFF
--- a/x-pack/agent/pkg/agent/application/application.go
+++ b/x-pack/agent/pkg/agent/application/application.go
@@ -63,7 +63,7 @@ func createApplication(
 		return nil, err
 	}
 
-	router, err := newRouter(log, pipelineFactory(config, client, reporter))
+	router, err := newRouter(log, streamFactory(config, client, reporter))
 	if err != nil {
 		return nil, errors.Wrap(err, "initiating application")
 	}

--- a/x-pack/agent/pkg/agent/application/stream.go
+++ b/x-pack/agent/pkg/agent/application/stream.go
@@ -55,7 +55,7 @@ func (b *operatorStream) Execute(cfg *configRequest) error {
 
 func streamFactory(cfg *config.Config, client sender, r reporter) func(*logger.Logger, routingKey) (stream, error) {
 	return func(log *logger.Logger, id routingKey) (stream, error) {
-		// new operator per pipeline to isolate processes without using tags
+		// new operator per stream to isolate processes without using tags
 		operator, err := newOperator(log, cfg, r)
 		if err != nil {
 			return nil, err

--- a/x-pack/agent/pkg/agent/application/stream.go
+++ b/x-pack/agent/pkg/agent/application/stream.go
@@ -40,28 +40,28 @@ type sender interface {
 	) (*http.Response, error)
 }
 
-type operatorPipeline struct {
+type operatorStream struct {
 	configHandler ConfigHandler
 	log           *logger.Logger
 }
 
-func (b *operatorPipeline) Close() error {
+func (b *operatorStream) Close() error {
 	return nil
 }
 
-func (b *operatorPipeline) Execute(cfg *configRequest) error {
+func (b *operatorStream) Execute(cfg *configRequest) error {
 	return b.configHandler.HandleConfig(cfg)
 }
 
-func pipelineFactory(cfg *config.Config, client sender, r reporter) func(*logger.Logger, routingKey) (pipeline, error) {
-	return func(log *logger.Logger, id routingKey) (pipeline, error) {
+func streamFactory(cfg *config.Config, client sender, r reporter) func(*logger.Logger, routingKey) (stream, error) {
+	return func(log *logger.Logger, id routingKey) (stream, error) {
 		// new operator per pipeline to isolate processes without using tags
 		operator, err := newOperator(log, cfg, r)
 		if err != nil {
 			return nil, err
 		}
 
-		return &operatorPipeline{
+		return &operatorStream{
 			log:           log,
 			configHandler: operator,
 		}, nil


### PR DESCRIPTION
To align the code base with the multiple output strategy we will rename
the pipeline concept into the streams.

See elastic/beats#14445