### PR TITLE
Add compose option to advertise hosts for specific ports

### DIFF
--- a/libbeat/tests/compose/project.go
+++ b/libbeat/tests/compose/project.go
@@ -43,7 +43,8 @@ type UpOptions struct {
 
 	// Set to true if it should inform the container of the host it should
 	// use to advertise itself to clients
-	SetupAdvertisedHostEnvFile bool
+	SetupAdvertisedHostEnvFile     bool
+	SetupAdvertisedHostEnvFilePort int
 }
 
 // UpOption is a modifier for UpOptions
@@ -58,6 +59,16 @@ func UpWithTimeout(timeout time.Duration) UpOption {
 // host to use to advertise to client as the `SERVICE_HOST` variable
 func UpWithAdvertisedHostEnvFile(options *UpOptions) {
 	options.SetupAdvertisedHostEnvFile = true
+}
+
+// UpWithAdvertisedHostEnvFileForPort adds the /run/compose_env file with the
+// host to use to advertise for an specific port to client as the
+// `SERVICE_HOST` variable
+func UpWithAdvertisedHostEnvFileForPort(port int) UpOption {
+	return func(options *UpOptions) {
+		options.SetupAdvertisedHostEnvFile = true
+		options.SetupAdvertisedHostEnvFilePort = port
+	}
 }
 
 // Filter options for services

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -197,7 +197,7 @@ func (d *wrapperDriver) Up(ctx context.Context, opts UpOptions, service string) 
 		return err
 	}
 	if opts.SetupAdvertisedHostEnvFile {
-		return d.setupAdvertisedHost(ctx, service)
+		return d.setupAdvertisedHost(ctx, service, opts.SetupAdvertisedHostEnvFilePort)
 	}
 	return nil
 }
@@ -236,7 +236,7 @@ func writeToContainer(ctx context.Context, cli *client.Client, id, filename, con
 // setupAdvertisedHost adds a file to a container with its address, this can
 // be used in services that need to configure an address to be advertised to
 // clients.
-func (d *wrapperDriver) setupAdvertisedHost(ctx context.Context, service string) error {
+func (d *wrapperDriver) setupAdvertisedHost(ctx context.Context, service string, port int) error {
 	containers, err := d.containers(ctx, Filter{State: AnyState}, service)
 	if err != nil {
 		return errors.Wrap(err, "setupAdvertisedHost")
@@ -247,7 +247,7 @@ func (d *wrapperDriver) setupAdvertisedHost(ctx context.Context, service string)
 
 	for _, c := range containers {
 		w := &wrapperContainer{info: c}
-		content := fmt.Sprintf("SERVICE_HOST=%s", w.Host())
+		content := fmt.Sprintf("SERVICE_HOST=%s", w.HostForPort(port))
 
 		err := writeToContainer(ctx, d.client, c.ID, "/run/compose_env", content)
 		if err != nil {

--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -32,6 +32,9 @@ class ComposeMixin(object):
     # add advertised host environment file
     COMPOSE_ADVERTISED_HOST = False
 
+    # port to advertise when COMPOSE_ADVERTISED_HOST is set to true
+    COMPOSE_ADVERTISED_PORT = None
+
     @classmethod
     def compose_up(cls):
         """
@@ -104,7 +107,7 @@ class ComposeMixin(object):
         sends the proper address to use to the container by adding a
         environment file with the SERVICE_HOST variable set to this value.
         """
-        host = cls.compose_host(service=service)
+        host = cls.compose_host(service=service, port=cls.COMPOSE_ADVERTISED_PORT)
 
         content = "SERVICE_HOST=%s" % host
         info = tarfile.TarInfo(name="/run/compose_env")

--- a/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
@@ -42,16 +42,16 @@ const (
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(120*time.Second),
-		compose.UpWithAdvertisedHostEnvFile,
+		compose.UpWithAdvertisedHostEnvFileForPort(9092),
 	)
 
-	c, err := startConsumer(t, service.Host(), "metricbeat-test")
+	c, err := startConsumer(t, service.HostForPort(9092), "metricbeat-test")
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "starting kafka consumer"))
 	}
 	defer c.Close()
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.HostForPort(9092)))
 	for retries := 0; retries < 3; retries++ {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {
@@ -63,15 +63,18 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	service := compose.EnsureUp(t, "kafka")
+	service := compose.EnsureUp(t, "kafka",
+		compose.UpWithTimeout(120*time.Second),
+		compose.UpWithAdvertisedHostEnvFileForPort(9092),
+	)
 
-	c, err := startConsumer(t, service.Host(), "metricbeat-test")
+	c, err := startConsumer(t, service.HostForPort(9092), "metricbeat-test")
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "starting kafka consumer"))
 	}
 	defer c.Close()
 
-	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.HostForPort(9092)))
 
 	var data []mb.Event
 	var errors []error

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -45,12 +45,13 @@ const (
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(120*time.Second),
-		compose.UpWithAdvertisedHostEnvFile,
+		compose.UpWithAdvertisedHostEnvFileForPort(9092),
 	)
 
-	generateKafkaData(t, service.Host(), "metricbeat-generate-data")
+	// Create initial topic
+	generateKafkaData(t, service.HostForPort(9092), "metricbeat-generate-data")
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host(), ""))
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.HostForPort(9092), ""))
 	err := mbtest.WriteEventsReporterV2Error(ms, t, "")
 	if err != nil {
 		t.Fatal("write", err)
@@ -58,7 +59,10 @@ func TestData(t *testing.T) {
 }
 
 func TestTopic(t *testing.T) {
-	service := compose.EnsureUp(t, "kafka")
+	service := compose.EnsureUp(t, "kafka",
+		compose.UpWithTimeout(120*time.Second),
+		compose.UpWithAdvertisedHostEnvFileForPort(9092),
+	)
 
 	logp.TestingSetup(logp.WithSelectors("kafka"))
 
@@ -66,9 +70,9 @@ func TestTopic(t *testing.T) {
 	testTopic := fmt.Sprintf("test-metricbeat-%s", id)
 
 	// Create initial topic
-	generateKafkaData(t, service.Host(), testTopic)
+	generateKafkaData(t, service.HostForPort(9092), testTopic)
 
-	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host(), testTopic))
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.HostForPort(9092), testTopic))
 	dataBefore, err := mbtest.ReportingFetchV2Error(f)
 	if err != nil {
 		t.Fatal("write", err)
@@ -82,7 +86,7 @@ func TestTopic(t *testing.T) {
 	var i int64 = 0
 	// Create n messages
 	for ; i < n; i++ {
-		generateKafkaData(t, service.Host(), testTopic)
+		generateKafkaData(t, service.HostForPort(9092), testTopic)
 	}
 
 	dataAfter, err := mbtest.ReportingFetchV2Error(f)

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -8,6 +8,7 @@ from nose.plugins.skip import SkipTest
 class KafkaTest(metricbeat.BaseTest):
     COMPOSE_SERVICES = ['kafka']
     COMPOSE_ADVERTISED_HOST = True
+    COMPOSE_ADVERTISED_PORT = "9092/tcp"
 
     VERSION = "2.0.0"
 
@@ -56,6 +57,10 @@ class KafkaTest(metricbeat.BaseTest):
             sasl_plain_password=self.PRODUCER_PASSWORD,
             retries=20, retry_backoff_ms=500)
         producer.send('foobar', b'some_message_bytes')
+
+    @classmethod
+    def get_hosts(cls):
+        return [cls.compose_host(port=cls.COMPOSE_ADVERTISED_PORT)]
 
 
 class Kafka_1_1_0_Test(KafkaTest):


### PR DESCRIPTION
Docker compose framework for integration tests allows to pass the host
and port exposed in the host network for services that advertise the
address that clients must use to connect to them. This way metricbeat
tests running in the host can connect to them after the initial
negotiation. The only service that uses this at the moment is Kafka,
that after an initial connection it can tell the client to connect to a
different address, this is the address that we need to inject into
the service.

Add an option so for services that expose multiple ports, the test can
select what is the port it needs to connect.

Address issues found on testing on #14330, where multiple ports are
added to the Kafka service.