### PR TITLE
[Docker log driver] cleanup output

### DIFF
--- a/x-pack/dockerlogbeat/handlers.go
+++ b/x-pack/dockerlogbeat/handlers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/docker/daemon/logger"
 
-	"github.com/elastic/beats/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/x-pack/dockerlogbeat/pipelinemanager"
 
 	"github.com/pkg/errors"
@@ -27,11 +26,6 @@ type StartLoggingRequest struct {
 // StopLoggingRequest represents the request object we get on a call to //LogDriver.StopLogging
 type StopLoggingRequest struct {
 	File string
-}
-
-// ProcessorPipeline handles a single output pipeline
-type ProcessorPipeline struct {
-	Pipeline *pipeline.Pipeline
 }
 
 // This gets called when a container starts that requests the log driver
@@ -49,7 +43,7 @@ func startLoggingHandler(pm *pipelinemanager.PipelineManager) func(w http.Respon
 		pm.Logger.Debugf("Got a container with the following labels: %#v\n", startReq.Info.ContainerLabels)
 		pm.Logger.Debugf("Got a container with the following log opts: %#v\n", startReq.Info.Config)
 
-		cl, err := pm.CreateClientWithConfig(startReq.Info.Config, startReq.File)
+		cl, err := pm.CreateClientWithConfig(startReq.Info, startReq.File)
 		if err != nil {
 			http.Error(w, errors.Wrap(err, "error creating client").Error(), http.StatusBadRequest)
 			return

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/docker/docker/daemon/logger"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -71,16 +72,16 @@ func (pm *PipelineManager) CloseClientWithFile(file string) error {
 
 // CreateClientWithConfig gets the pipeline linked to the given config, and creates a client
 // If no pipeline for that config exists, it creates one.
-func (pm *PipelineManager) CreateClientWithConfig(logOptsConfig map[string]string, file string) (*ClientLogger, error) {
+func (pm *PipelineManager) CreateClientWithConfig(containerConfig logger.Info, file string) (*ClientLogger, error) {
 
-	hashstring := makeConfigHash(logOptsConfig)
-	pipeline, err := pm.getOrCreatePipeline(logOptsConfig, file, hashstring)
+	hashstring := makeConfigHash(containerConfig.Config)
+	pipeline, err := pm.getOrCreatePipeline(containerConfig.Config, file, hashstring)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting pipeline")
 	}
 
 	//actually get to crafting the new client.
-	cl, err := newClientFromPipeline(pipeline.pipeline, file, hashstring)
+	cl, err := newClientFromPipeline(pipeline.pipeline, file, hashstring, containerConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating client")
 	}


### PR DESCRIPTION
This PR addresses two issues: adding container labels and metadata to events, and making the output of the plugin ECS-compliant.

I added @henrikno to the review list, since I'd like input about any other bits of metadata that could be added. 

Here's what the output looks like now:

```
{
  "_index": "dockerbeat-test",
  "_type": "_doc",
  "_id": "et0WgG4BjXmy5XAyo_2I",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2019-11-18T19:56:36.635Z",
    "message": "This is a test log line",
    "container": {
      "labels": {},
      "id": "c7a30a2ab012c609dbb36fc8773ebcfb553827af4082c30d4f630c8ab79735dd",
      "name": "/fervent_black",
      "image": {
        "name": "debian:jessie"
      }
    }
  },
  "fields": {
    "@timestamp": [
      "2019-11-18T19:56:36.635Z"
    ]
  },
  "sort": [
    1574106996635
  ]
}
```