### PR TITLE
[Heartbeat] Record TLS Metadata for expired/invalid certs (#14588)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,10 +49,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
-- Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
-- Fix integer comparison on JSON responses. {pull}13348[13348]
-- Fix storage of HTTP bodies to work when JSON/Regex body checks are enabled. {pull}14223[14223]
 - Fix recording of SSL cert metadata for Expired/Unvalidated x509 certs. {pull}13687[13687]
 
 *Journalbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,11 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
+- Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
+- Fix integer comparison on JSON responses. {pull}13348[13348]
+- Fix storage of HTTP bodies to work when JSON/Regex body checks are enabled. {pull}14223[14223]
+- Fix recording of SSL cert metadata for Expired/Unvalidated x509 certs. {pull}13687[13687]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/dialchain/tls_test.go
+++ b/heartbeat/monitors/active/dialchain/tls_test.go
@@ -44,6 +44,19 @@ func Test_addCertMetdata(t *testing.T) {
 		BasicConstraintsValid: true,
 	}
 
+	expiredNotAfter := time.Now().Add(-time.Hour)
+	expiredCert := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             goodNotBefore,
+		NotAfter:              expiredNotAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
 	missingNotBeforeCert := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
@@ -76,27 +89,35 @@ func Test_addCertMetdata(t *testing.T) {
 	}
 	tests := []struct {
 		name     string
-		chains   [][]*x509.Certificate
+		certs    []*x509.Certificate
 		expected expected
 	}{
 		{
 			"Valid cert",
-			[][]*x509.Certificate{{&goodCert}},
+			[]*x509.Certificate{&goodCert},
 			expected{
 				notBefore: goodNotBefore,
 				notAfter:  &goodNotAfter,
 			},
 		},
 		{
+			"Expired cert",
+			[]*x509.Certificate{&expiredCert},
+			expected{
+				notBefore: goodNotBefore,
+				notAfter:  &expiredNotAfter,
+			},
+		},
+		{
 			"Missing not before",
-			[][]*x509.Certificate{{&missingNotBeforeCert}},
+			[]*x509.Certificate{&missingNotBeforeCert},
 			expected{
 				notAfter: &goodNotAfter,
 			},
 		},
 		{
 			"Missing not after",
-			[][]*x509.Certificate{{&missingNotAfterCert}},
+			[]*x509.Certificate{&missingNotAfterCert},
 			expected{
 				notBefore: goodNotBefore,
 			},
@@ -105,7 +126,7 @@ func Test_addCertMetdata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			event := common.MapStr{}
-			addCertMetdata(event, tt.chains)
+			addCertMetdata(event, tt.certs)
 			v, err := event.GetValue("tls.certificate_not_valid_before")
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected.notBefore, v)


### PR DESCRIPTION
This patch fixes https://github.com/elastic/beats/issues/13687 .

Previously heartbeat would only traverse valid x509 cert chains, with
this PR it now traverses all certs provided by the server.

(cherry picked from commit eff54c3069a63fe5c91b78c4edf15a6505c56759)