### PR TITLE
[7.x] Allow users to set just monitoring.cluster_uuid (#14338)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -122,6 +122,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
 - Support usage of custom builders without hints and mappers {pull}13839[13839]
 - Fix kubernetes `metaGenerator.ResourceMetadata` when parent reference controller is nil {issue}14320[14320] {pull}14329[14329]
+- Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -411,30 +411,12 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	monitoringCfg, reporterSettings, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
+	r, err := b.setupMonitoring(settings)
 	if err != nil {
 		return err
 	}
-
-	if monitoringCfg.Enabled() {
-		settings := report.Settings{
-			DefaultUsername: settings.Monitoring.DefaultUsername,
-			Format:          reporterSettings.Format,
-			ClusterUUID:     reporterSettings.ClusterUUID,
-		}
-		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
-		if err != nil {
-			return err
-		}
-		defer reporter.Stop()
-
-		// Expose monitoring.cluster_uuid in state API
-		if reporterSettings.ClusterUUID != "" {
-			stateRegistry := monitoring.GetNamespace("state").GetRegistry()
-			monitoringRegistry := stateRegistry.NewRegistry("monitoring")
-			clusterUUIDRegVar := monitoring.NewString(monitoringRegistry, "cluster_uuid")
-			clusterUUIDRegVar.Set(reporterSettings.ClusterUUID)
-		}
+	if r != nil {
+		defer r.Stop()
 	}
 
 	if b.Config.MetricLogging == nil || b.Config.MetricLogging.Enabled() {
@@ -894,6 +876,41 @@ func (b *Beat) clusterUUIDFetchingCallback() (elasticsearch.ConnectCallback, err
 	}
 
 	return callback, nil
+}
+
+func (b *Beat) setupMonitoring(settings Settings) (report.Reporter, error) {
+	monitoringCfg, reporterSettings, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	monitoringClusterUUID, err := monitoring.GetClusterUUID(monitoringCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Expose monitoring.cluster_uuid in state API
+	if monitoringClusterUUID != "" {
+		stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+		monitoringRegistry := stateRegistry.NewRegistry("monitoring")
+		clusterUUIDRegVar := monitoring.NewString(monitoringRegistry, "cluster_uuid")
+		clusterUUIDRegVar.Set(monitoringClusterUUID)
+	}
+
+	if monitoring.IsEnabled(monitoringCfg) {
+		settings := report.Settings{
+			DefaultUsername: settings.Monitoring.DefaultUsername,
+			Format:          reporterSettings.Format,
+			ClusterUUID:     monitoringClusterUUID,
+		}
+		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
+		if err != nil {
+			return nil, err
+		}
+		return reporter, nil
+	}
+
+	return nil, nil
 }
 
 // handleError handles the given error by logging it and then returning the

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -97,14 +97,40 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-		var info struct {
-			ClusterUUID string `config:"cluster_uuid"`
-		}
-		if err := monitoringCfg.Unpack(&info); err != nil {
-			return nil, nil, err
-		}
-		return monitoringCfg, &report.Settings{Format: report.FormatBulk, ClusterUUID: info.ClusterUUID}, nil
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk}, nil
 	default:
 		return nil, nil, nil
 	}
+}
+
+// GetClusterUUID returns the value of the monitoring.cluster_uuid setting, if it is set.
+func GetClusterUUID(monitoringCfg *common.Config) (string, error) {
+	if monitoringCfg == nil {
+		return "", nil
+	}
+
+	var config struct {
+		ClusterUUID string `config:"cluster_uuid"`
+	}
+	if err := monitoringCfg.Unpack(&config); err != nil {
+		return "", err
+	}
+
+	return config.ClusterUUID, nil
+}
+
+// IsEnabled returns whether the monitoring reporter is enabled or not.
+func IsEnabled(monitoringCfg *common.Config) bool {
+	if monitoringCfg == nil {
+		return false
+	}
+
+	// If the only setting in the monitoring config is cluster_uuid, it is
+	// not enabled
+	fields := monitoringCfg.GetFields()
+	if len(fields) == 1 && fields[0] == "cluster_uuid" {
+		return false
+	}
+
+	return monitoringCfg.Enabled()
 }

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -116,10 +116,20 @@ xpack.monitoring.elasticsearch.state.period: 3s      # to speed up tests
 
 {% if monitoring -%}
 #================================ X-Pack Monitoring (direct) =====================================
-monitoring.elasticsearch.hosts: {{monitoring.elasticsearch.hosts}}
-monitoring.elasticsearch.metrics.period: 2s    # to speed up tests
-monitoring.elasticsearch.state.period: 3s      # to speed up tests
+monitoring:
+    {% if monitoring.elasticsearch -%}
+    elasticsearch.hosts: {{monitoring.elasticsearch.hosts}}
+    elasticsearch.metrics.period: 2s    # to speed up tests
+    elasticsearch.state.period: 3s      # to speed up tests
+    {% endif -%}
+
+    {% if monitoring.cluster_uuid -%}
+    cluster_uuid: {{monitoring.cluster_uuid}}
+    {% endif -%}
 {% endif -%}
 
 # vim: set ft=jinja:
 
+{% if http_enabled -%}
+http.enabled: {{http_enabled}}
+{% endif -%}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Allow users to set just monitoring.cluster_uuid  (#14338)