### PR TITLE
Use complete versions in deprecation warnings

### DIFF
--- a/libbeat/common/cfgtype/byte_size.go
+++ b/libbeat/common/cfgtype/byte_size.go
@@ -33,7 +33,7 @@ type ByteSize int64
 func (s *ByteSize) Unpack(v string) error {
 	sz, err := humanize.ParseBytes(v)
 	if isRawBytes(v) {
-		cfgwarn.Deprecate("7.0", "size now requires a unit (KiB, MiB, etc...), current value: %s.", v)
+		cfgwarn.Deprecate("7.0.0", "size now requires a unit (KiB, MiB, etc...), current value: %s.", v)
 	}
 	if err != nil {
 		return err

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -92,7 +92,7 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
 		return nil, nil, errMonitoringBothConfigEnabled
 	case beatCfg.XPackMonitoring.Enabled():
-		cfgwarn.Deprecate("8.0", warnMonitoringDeprecatedConfig)
+		cfgwarn.Deprecate("8.0.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
 		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
 	case beatCfg.Monitoring.Enabled():

--- a/metricbeat/module/system/core/config.go
+++ b/metricbeat/module/system/core/config.go
@@ -40,7 +40,7 @@ type Config struct {
 // Validate validates the core config.
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the core.metrics list.")
+		cfgwarn.Deprecate("6.1.0", "cpu_ticks is deprecated. Add 'ticks' to the core.metrics list.")
 	}
 
 	if len(c.Metrics) == 0 {

--- a/metricbeat/module/system/cpu/config.go
+++ b/metricbeat/module/system/cpu/config.go
@@ -41,7 +41,7 @@ type Config struct {
 // Validate validates the cpu config.
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the cpu.metrics list.")
+		cfgwarn.Deprecate("6.1.0", "cpu_ticks is deprecated. Add 'ticks' to the cpu.metrics list.")
 	}
 
 	if len(c.Metrics) == 0 {

--- a/metricbeat/module/system/process/config.go
+++ b/metricbeat/module/system/process/config.go
@@ -37,7 +37,7 @@ type Config struct {
 // Validate checks for depricated config options
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Use process.include_cpu_ticks instead")
+		cfgwarn.Deprecate("6.1.0", "cpu_ticks is deprecated. Use process.include_cpu_ticks instead")
 	}
 	return nil
 }

--- a/x-pack/functionbeat/provider/aws/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/aws/config.go
@@ -110,7 +110,7 @@ type MemSizeFactor64 int
 func (m *MemSizeFactor64) Unpack(v string) error {
 	sz, err := humanize.ParseBytes(v)
 	if isRawBytes(v) {
-		cfgwarn.Deprecate("7.0", "size now requires a unit (KiB, MiB, etc...), current value: %s.", v)
+		cfgwarn.Deprecate("7.0.0", "size now requires a unit (KiB, MiB, etc...), current value: %s.", v)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently we are inconsistent in how we display version numbers in our deprecation warnings. Sometimes we use just `major.minor` and sometimes we use the complete `major.minor.patch`. This PR simply makes all the version numbers in deprecation warnings consistent by using the latter format always.