### PR TITLE
Skipping Metricbeat couchbase system tests

### DIFF
--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -4,6 +4,7 @@ import unittest
 from parameterized import parameterized
 
 
+@unittest.skip("See https://github.com/elastic/beats/issues/14660")
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['couchbase']

--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -7,7 +7,10 @@ from parameterized import parameterized
 @unittest.skip("See https://github.com/elastic/beats/issues/14660")
 class Test(metricbeat.BaseTest):
 
-    COMPOSE_SERVICES = ['couchbase']
+    # Commented out as part of skipping test. See https://github.com/elastic/beats/issues/14660.
+    # Otherwise, the tests are skipped but Docker Compose still tries to bring up
+    # the Couchbase service container and fails.
+    # COMPOSE_SERVICES = ['couchbase']
     FIELDS = ['couchbase']
 
     @parameterized.expand([


### PR DESCRIPTION
This test has been failing consistently in Jenkins CI as shown below.

```
09:12:17 ======================================================================
09:12:17 ERROR: test suite for <class 'test_couchbase.Test'>
09:12:17 ----------------------------------------------------------------------
09:12:17 Traceback (most recent call last):
09:12:17   File "/go/src/github.com/elastic/beats/metricbeat/build/python-env/local/lib/python2.7/site-packages/nose/suite.py", line 209, in run
09:12:17     self.setUp()
09:12:17   File "/go/src/github.com/elastic/beats/metricbeat/build/python-env/local/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
09:12:17     self.setupContext(ancestor)
09:12:17   File "/go/src/github.com/elastic/beats/metricbeat/build/python-env/local/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
09:12:17     try_run(context, names)
09:12:17   File "/go/src/github.com/elastic/beats/metricbeat/build/python-env/local/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
09:12:17     return func()
09:12:17   File "/go/src/github.com/elastic/beats/metricbeat/tests/system/metricbeat.py", line 30, in setUpClass
09:12:17     super(BaseTest, self).setUpClass()
09:12:17   File "/go/src/github.com/elastic/beats/libbeat/tests/system/beat/beat.py", line 150, in setUpClass
09:12:17     self.compose_up()
09:12:17   File "/go/src/github.com/elastic/beats/libbeat/tests/system/beat/compose.py", line 79, in compose_up
09:12:17     container.name_without_project)
09:12:17 Exception: Container couchbase_1 unexpectedly finished on startup
09:12:17 -------------------- >> begin captured logging << --------------------
09:12:17 compose.config.config: DEBUG: Using configuration files: /go/src/github.com/elastic/beats/metricbeat/docker-compose.yml
09:12:17 docker.utils.config: DEBUG: Trying paths: ['/root/.docker/config.json', '/root/.dockercfg']
09:12:17 docker.utils.config: DEBUG: No config file found
09:12:17 docker.utils.config: DEBUG: Trying paths: ['/root/.docker/config.json', '/root/.dockercfg']
09:12:17 docker.utils.config: DEBUG: No config file found
09:12:17 compose.parallel: DEBUG: Pending: set([<Container: metricbeat_791afe0d4d8c_kibana_1 (02a4bb)>, <Container: metricbeat_791afe0d4d8c_elasticsearch_1 (6eb97f)>])
09:12:17 compose.parallel: DEBUG: Starting producer thread for <Container: metricbeat_791afe0d4d8c_kibana_1 (02a4bb)>
09:12:17 compose.parallel: DEBUG: Starting producer thread for <Container: metricbeat_791afe0d4d8c_elasticsearch_1 (6eb97f)>
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Finished processing: <Container: metricbeat_791afe0d4d8c_elasticsearch_1 (6eb97f)>
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Finished processing: <Container: metricbeat_791afe0d4d8c_kibana_1 (02a4bb)>
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.config.config: DEBUG: Using configuration files: /go/src/github.com/elastic/beats/metricbeat/docker-compose.yml
09:12:17 docker.utils.config: DEBUG: Trying paths: ['/root/.docker/config.json', '/root/.dockercfg']
09:12:17 docker.utils.config: DEBUG: No config file found
09:12:17 docker.utils.config: DEBUG: Trying paths: ['/root/.docker/config.json', '/root/.dockercfg']
09:12:17 docker.utils.config: DEBUG: No config file found
09:12:17 compose.service: INFO: Pulling couchbase (docker.elastic.co/observability-ci/beats-integration-couchbase:4.5.1-1)...
09:12:17 docker.auth: DEBUG: Looking for auth config
09:12:17 docker.auth: DEBUG: No auth config in memory - loading from filesystem
09:12:17 docker.utils.config: DEBUG: Trying paths: ['/root/.docker/config.json', '/root/.dockercfg']
09:12:17 docker.utils.config: DEBUG: No config file found
09:12:17 docker.auth: DEBUG: Looking for auth entry for u'docker.elastic.co'
09:12:17 docker.auth: DEBUG: No entry found
09:12:17 docker.auth: DEBUG: No auth config found
09:12:17 compose.service: ERROR: 404 Client Error: Not Found ("pull access denied for docker.elastic.co/observability-ci/beats-integration-couchbase, repository does not exist or may require 'docker login': denied: requested access to the resource is denied")
09:12:17 compose.parallel: DEBUG: Pending: set([<Service: couchbase>])
09:12:17 compose.parallel: DEBUG: Starting producer thread for <Service: couchbase>
09:12:17 compose.parallel: DEBUG: Pending: set([ServiceName(project='metricbeat_791afe0d4d8c', service='couchbase', number=1)])
09:12:17 compose.parallel: DEBUG: Starting producer thread for ServiceName(project='metricbeat_791afe0d4d8c', service='couchbase', number=1)
09:12:17 compose.service: DEBUG: Added config hash: 667381e221e46cf4b531e892ce0b71bfd9ab9056346715a68a4cb5800638234f
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Finished processing: ServiceName(project='metricbeat_791afe0d4d8c', service='couchbase', number=1)
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 compose.parallel: DEBUG: Finished processing: <Service: couchbase>
09:12:17 compose.parallel: DEBUG: Pending: set([])
09:12:17 --------------------- >> end captured logging << ---------------------
09:12:17 
09:12:17 ----------------------------------------------------------------------
```

This PR skips the test while we investigate the underlying cause and fix it. Issue to track re-enabling the test: https://github.com/elastic/beats/issues/14660.