### PR TITLE
[filebeat] Revert accidental checkin of a local debug config file

### DIFF
--- a/filebeat/kafka.yml
+++ b/filebeat/kafka.yml
@@ -1,8 +1,0 @@
-version: '2.3'
-services:
-  kafka:
-    build: ${ES_BEATS}/testing/environments/docker/kafka
-    expose:
-      - 9092
-    environment:
-      - ADVERTISED_HOST=kafka


### PR DESCRIPTION
A local YML file (`kafka.yml`) was accidentally included in the commits for #14010