### PR TITLE
[7.5] Skipping Metricbeat couchbase system tests (#14661)

### DIFF
--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -4,9 +4,13 @@ import unittest
 from parameterized import parameterized
 
 
+@unittest.skip("See https://github.com/elastic/beats/issues/14660")
 class Test(metricbeat.BaseTest):
 
-    COMPOSE_SERVICES = ['couchbase']
+    # Commented out as part of skipping test. See https://github.com/elastic/beats/issues/14660.
+    # Otherwise, the tests are skipped but Docker Compose still tries to bring up
+    # the Couchbase service container and fails.
+    # COMPOSE_SERVICES = ['couchbase']
     FIELDS = ['couchbase']
 
     @parameterized.expand([


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Skipping Metricbeat couchbase system tests  (#14661)