### PR TITLE
Skip git directories when recursively finding files in mage targets

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -544,12 +544,17 @@ func FindFiles(globs ...string) ([]string, error) {
 
 // FindFilesRecursive recursively traverses from the CWD and invokes the given
 // match function on each regular file to determine if the given path should be
-// returned as a match.
+// returned as a match. It ignores files in .git directories.
 func FindFilesRecursive(match func(path string, info os.FileInfo) bool) ([]string, error) {
 	var matches []string
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		// Don't look for files in git directories
+		if info.Mode().IsDir() && filepath.Base(path) == ".git" {
+			return filepath.SkipDir
 		}
 
 		if !info.Mode().IsRegular() {


### PR DESCRIPTION
Some mage targets look for files recursively, in some cases we have seen
in CI that this search fails with some git object files, but we are not
interested in files in git directories when making these searches. Skip
these directories when finding files recursively.

Failure in CI seen in some PRs, in generator tests (whose mage targets
are run from directories containing a `.git` directory) in OSX, e.g. [here](https://travis-ci.org/elastic/beats/jobs/614908210):
```
>> check: Checking source code for common problems
Error: failed to find dashboards: lstat .git/objects/fd/87de2127926b03b6a6e38153de9cf0757a9f92: no such file or directory
failed search for YAML files: lstat .git/objects/fd/c5a85b9c0fdeb3aa9573ba6aa83747e2642704: no such file or directory
make[1]: *** [check] Error 1
make: *** [test] Error 1
```

Not sure why this happens but in any case we are not interested in
files inside `.git` directories when running mage targets.