### PR TITLE
Cherry-pick #14637 to 7.x: Fix typo in metricbeat hints documentation

### DIFF
--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -41,7 +41,7 @@ Metrics retrieval timeout, default: 3s
 SSL parameters, as seen in <<configuration-ssl>>.
 
 [float]
-===== `co.elastic.logs/raw`
+===== `co.elastic.metrics/raw`
 When an entire module configuration needs to be completely set the `raw` hint can be used. You can provide a
 stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or
 a list of configurations.


### PR DESCRIPTION
Cherry-pick of PR #14637 to 7.x branch. Original message: 

