### PR TITLE
Update Module checklist after latests changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/module-checklist.md
+++ b/.github/ISSUE_TEMPLATE/module-checklist.md
@@ -21,8 +21,7 @@ For a metricset to go GA, the following criterias should be met:
 * [ ] Fields follow [ECS](https://github.com/elastic/ecs) and [naming conventions](https://www.elastic.co/guide/en/beats/devguide/master/event-conventions.html)
 * [ ] Dashboards exists (if applicable)
 * [ ] Kibana Home Tutorial (if applicable)
-  * [ ] Open issue in [EUI repo](https://github.com/elastic/eui) to add [icon for module](https://elastic.github.io/eui/#/display/icons) if not already exists.
-  * [ ] Open PR against Kibana repo with tutorial. Examples can be found [here](https://github.com/elastic/kibana/tree/master/src/legacy/core_plugins/kibana/server/tutorials).
+  * Open PR against Kibana repo with tutorial. Examples can be found [here](https://github.com/elastic/kibana/tree/master/src/legacy/core_plugins/kibana/server/tutorials).
 
 ## Filebeat module
 


### PR DESCRIPTION
We are no longer using EUI for integration icons. We need to put an SVG
file in the Kibana tutorials app now. This change updates the template
accordingly