### PR TITLE
Cherry-pick #14668 to 7.5:[Filebeat]Fix filebeat azure dashboards - event.category should be `Alert`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - cisco/asa fileset: Fix parsing of 302021 message code. {pull}14519[14519]
+- Fix filebeat azure dashboards, event category should be `Alert`. {pull}14668[14668]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-alerts-overview.json
+++ b/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-alerts-overview.json
@@ -328,7 +328,7 @@
             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
             "query": {
               "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alerts\" "
+              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alert\" "
             }
           }
         },
@@ -455,7 +455,7 @@
             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
             "query": {
               "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alerts\" "
+              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alert\" "
             }
           }
         },

--- a/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-overview.json
+++ b/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-overview.json
@@ -1134,7 +1134,7 @@
             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
             "query": {
               "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alerts\" "
+              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alert\" "
             }
           }
         },


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14668 to 7.5 branch. Original message:

Some of the dashboards were filtering the event.category against `Alerts`, should be `Alert`