### PR TITLE
Cherry-pick #14625 to 7.x: [Winlogbeat] Set host.name to computername

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -271,6 +271,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Winlogbeat*
 
 - Fix data race affecting config validation at startup. {issue}13005[13005]
+- Set host.name to computername in Windows event logs & sysmon.  Requires {pull}14407[14407] in libbeat to work  {issue}13706[13706]
 
 *Functionbeat*
 

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -134,6 +134,7 @@ func (e Record) ToEvent() beat.Event {
 	m.Put("event.code", e.EventIdentifier.ID)
 	m.Put("event.provider", e.Provider.Name)
 	addOptional(m, "event.action", e.Task)
+	addOptional(m, "host.name", e.Computer)
 
 	m.Put("event.created", time.Now())
 

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -11,6 +11,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -83,6 +86,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -154,6 +160,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -230,6 +239,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -301,6 +313,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -374,6 +389,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -445,6 +463,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -518,6 +539,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -589,6 +613,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -665,6 +692,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -736,6 +766,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -812,6 +845,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -883,6 +919,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -956,6 +995,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1027,6 +1069,9 @@
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1100,6 +1145,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1172,6 +1220,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_success"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1243,6 +1294,9 @@
       "outcome": "failure",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "authentication_failure"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -57,6 +60,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -80,6 +83,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -61,6 +64,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -62,6 +65,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -61,6 +64,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -61,6 +64,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -62,6 +65,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -81,6 +84,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
@@ -8,6 +8,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
     },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
+    },
     "log": {
       "level": "information"
     },
@@ -59,6 +62,9 @@
       "kind": "event",
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "WIN-41OB2LO92CR"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
@@ -10,6 +10,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "process_start"
     },
+    "host": {
+      "name": "vagrant"
+    },
     "log": {
       "level": "information"
     },

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
@@ -10,6 +10,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "process_end"
     },
+    "host": {
+      "name": "vagrant"
+    },
     "log": {
       "level": "information"
     },
@@ -63,6 +66,9 @@
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "process_end"
     },
+    "host": {
+      "name": "vagrant"
+    },
     "log": {
       "level": "information"
     },
@@ -115,6 +121,9 @@
       "module": "security",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": "process_end"
+    },
+    "host": {
+      "name": "vagrant"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -30,6 +30,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -97,6 +100,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -166,6 +172,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -240,6 +249,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -307,6 +319,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -383,6 +398,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -446,6 +464,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -520,6 +541,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -579,6 +603,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -655,6 +682,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -764,6 +794,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -827,6 +860,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -895,6 +931,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -969,6 +1008,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1028,6 +1070,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -1103,6 +1148,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1171,6 +1219,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1238,6 +1289,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -1334,6 +1388,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1408,6 +1465,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -1529,6 +1589,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1636,6 +1699,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -1750,6 +1816,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -1827,6 +1896,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -1942,6 +2014,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -2061,6 +2136,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2124,6 +2202,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -2234,6 +2315,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2301,6 +2385,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -2411,6 +2498,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2475,6 +2565,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2538,6 +2631,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -2642,6 +2738,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2734,6 +2833,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -2797,6 +2899,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -2896,6 +3001,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3010,6 +3118,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3126,6 +3237,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -3189,6 +3303,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3304,6 +3421,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -3412,6 +3532,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -3476,6 +3599,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -3535,6 +3661,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3612,6 +3741,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3716,6 +3848,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -3825,6 +3960,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -3896,6 +4034,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -4012,6 +4153,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4084,6 +4228,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -4178,6 +4325,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4246,6 +4396,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4310,6 +4463,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4361,6 +4517,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4411,6 +4570,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -4521,6 +4683,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4594,6 +4759,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4657,6 +4825,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -4767,6 +4938,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -4839,6 +5013,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -4949,6 +5126,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5012,6 +5192,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -5092,6 +5275,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5171,6 +5357,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5235,6 +5424,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -5344,6 +5536,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -5460,6 +5655,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5575,6 +5773,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5684,6 +5885,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5756,6 +5960,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -5836,6 +6043,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -5899,6 +6109,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -6008,6 +6221,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -6128,6 +6344,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -6236,6 +6455,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -6303,6 +6525,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -6418,6 +6643,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -6485,6 +6713,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -6600,6 +6831,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -6709,6 +6943,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -6795,6 +7032,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -6911,6 +7151,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7000,6 +7243,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7059,6 +7305,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -7169,6 +7418,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7248,6 +7500,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7307,6 +7562,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -7416,6 +7674,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -7527,6 +7788,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7615,6 +7879,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -7725,6 +7992,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7823,6 +8093,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -7920,6 +8193,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -8040,6 +8316,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8150,6 +8429,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8252,6 +8534,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -8362,6 +8647,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8471,6 +8759,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8538,6 +8829,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -8646,6 +8940,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8713,6 +9010,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -8793,6 +9093,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8861,6 +9164,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -8931,6 +9237,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -8998,6 +9307,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9068,6 +9380,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9131,6 +9446,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9205,6 +9523,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9272,6 +9593,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9345,6 +9669,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9412,6 +9739,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9481,6 +9811,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9548,6 +9881,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9664,6 +10000,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9743,6 +10082,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9812,6 +10154,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -9923,6 +10268,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -9982,6 +10330,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10050,6 +10401,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10165,6 +10519,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -10228,6 +10585,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10296,6 +10656,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10408,6 +10771,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10527,6 +10893,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -10594,6 +10963,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10708,6 +11080,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -10824,6 +11199,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -10934,6 +11312,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -11038,6 +11419,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -11153,6 +11537,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -11478,6 +11865,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -11607,6 +11997,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -11670,6 +12063,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -11743,6 +12139,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -11793,6 +12192,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -11861,6 +12263,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -11977,6 +12382,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12092,6 +12500,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12159,6 +12570,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -12269,6 +12683,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12378,6 +12795,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12486,6 +12906,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12583,6 +13006,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12651,6 +13077,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12718,6 +13147,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -12828,6 +13260,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -12907,6 +13342,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -13023,6 +13461,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13086,6 +13527,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -13155,6 +13599,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13219,6 +13666,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13270,6 +13720,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13320,6 +13773,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13369,6 +13825,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -13442,6 +13901,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2016"
+    },
     "log": {
       "level": "information"
     },
@@ -13505,6 +13967,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
@@ -13603,6 +14068,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2016"
     },
     "log": {
       "level": "information"

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -7,6 +7,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -40,6 +43,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -84,6 +90,9 @@
     },
     "hash": {
       "sha1": "ac93c3b38e57a2715572933dbcb2a1c2892dbc5e"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -157,6 +166,9 @@
     "hash": {
       "sha1": "6df8163a6320b80b60733f9d62e2f39b4b16b678"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -229,6 +241,9 @@
       "provider": "Microsoft-Windows-Sysmon",
       "type": "process_end"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -270,6 +285,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
       "type": "process_end"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -315,6 +333,9 @@
     },
     "hash": {
       "sha1": "5a4c0e82ff95c9fb762d46a696ef9f1b68001c21"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -390,6 +411,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -448,6 +472,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -509,6 +536,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -569,6 +599,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -628,6 +661,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -693,6 +729,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -755,6 +794,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -815,6 +857,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -873,6 +918,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -936,6 +984,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -998,6 +1049,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1057,6 +1111,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1115,6 +1172,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1179,6 +1239,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1241,6 +1304,9 @@
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1305,6 +1371,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1366,6 +1435,9 @@
       "provider": "Microsoft-Windows-Sysmon",
       "type": "process_end"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1407,6 +1479,9 @@
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
       "type": "process_end"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1450,6 +1525,9 @@
     },
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\fe823684-c940-49f2-a940-14b02cbafba9.tmp"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1498,6 +1576,9 @@
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\162d4140-cfab-4d05-9c92-bca60515a622.tmp"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1544,6 +1625,9 @@
     },
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\1450fedf-ac4c-4e35-b371-ed5d3bbe4776.tmp"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1592,6 +1676,9 @@
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\37ed32e9-3c5f-4663-8457-c70743e9456d.tmp"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1638,6 +1725,9 @@
       "provider": "Microsoft-Windows-Sysmon",
       "type": "process_end"
     },
+    "host": {
+      "name": "vagrant-2012-r2"
+    },
     "log": {
       "level": "information"
     },
@@ -1680,6 +1770,9 @@
     },
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\nmmhkkegccagdldgiimedpiccmgmieda\\def\\ecb9c915-c4c2-4600-a920-f2bc302990a8.tmp"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"
@@ -1727,6 +1820,9 @@
     },
     "file": {
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\gfdkimpbcpahaombhbimeihdjnejgicl\\def\\ee4a6e45-bffd-49f4-98ae-32aebcc890b5.tmp"
+    },
+    "host": {
+      "name": "vagrant-2012-r2"
     },
     "log": {
       "level": "information"


### PR DESCRIPTION
Cherry-pick of PR #14625 to 7.x branch. Original message: 

 - set host.name to computer name for windows events and sysmon

Fixes #13706