### PR TITLE
Fix: use metrics_path instead of path in system tests

### DIFF
--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -37,8 +37,11 @@ metricbeat.modules:
   period: {{ m.period }}
   {% endif -%}
 
+  {% if m.metrics_path -%}
+  metrics_path: {{ m.metrics_path }}
+  {% endif -%}
+
   {% if m.path -%}
-  metrics_path: {{ m.path }}
   path: {{ m.path }}
   {% endif -%}
 

--- a/metricbeat/tests/system/test_dropwizard.py
+++ b/metricbeat/tests/system/test_dropwizard.py
@@ -17,7 +17,7 @@ class Test(metricbeat.BaseTest):
             "name": "dropwizard",
             "metricsets": ["collector"],
             "hosts": self.get_hosts(),
-            "path": "/test/metrics",
+            "metrics_path": "/test/metrics",
             "period": "1s",
             "namespace": "test",
         }])


### PR DESCRIPTION
Issue: https://github.com/elastic/beats/pull/14605

The file `test_dropwizard.py` should use metrics_path instead of path in system test. 

_To be verified with CI:
With this approach, there is no breaking changes in any prod config files (metrics_path and path stay as is)._

The other approach is to replace all `path` occurrences with `metrics_path`, but that requires breaking changes in config schemas.