### PR TITLE
[Docker Log Driver] Clean up logging

### DIFF
--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -41,7 +41,7 @@ type PipelineManager struct {
 // NewPipelineManager creates a new Pipeline map
 func NewPipelineManager(logCfg *common.Config) *PipelineManager {
 	return &PipelineManager{
-		Logger: logp.NewLogger("dockerlogbeat"),
+		Logger: logp.NewLogger("PipelineManager"),
 		//mu:        new(sync.Mutex),
 		pipelines: make(map[string]*Pipeline),
 		clients:   make(map[string]*ClientLogger),


### PR DESCRIPTION
Into the cleanup phase of the MVP now.

This refactors our hacked up logging, so we're using a proper log driver we get from libbeat, and not random `Printf` statements.