### PR TITLE
Add temporary file needed by conf.yaml to refactor output docs

### DIFF
--- a/libbeat/outputs/codec/docs/placeholder.asciidoc
+++ b/libbeat/outputs/codec/docs/placeholder.asciidoc
@@ -1,0 +1,2 @@
+Placeholder file to support adding a new resource to the conf.yaml in the docs
+repo.


### PR DESCRIPTION
Adds temporary place holder file in preparation for moving output docs to live under code modules. (Required before updating the conf.yaml in the docs repo)