### PR TITLE
Cherry-pick #14532 to 7.x: Add deprecation warning to setup --machine-learning

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -49,6 +49,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/cloudid"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/common/seccomp"
@@ -536,6 +537,8 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 		}
 
 		if setup.MachineLearning && b.SetupMLCallback != nil {
+			cfgwarn.Deprecate("8.0.0", "Setting up ML using %v is going to be removed. Please use the ML app to setup jobs.", strings.Title(b.Info.Beat))
+			fmt.Println("Setting up ML using setup --machine-learning is going to be removed in 8.0.0. Please use the ML app instead.\nSee more: https://www.elastic.co/guide/en/elastic-stack-overview/current/xpack-ml.html")
 			err = b.SetupMLCallback(&b.Beat, b.Config.Kibana)
 			if err != nil {
 				return err


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14532 to 7.x branch. Original message: 

The flag `--machine-learning` is going to be removed in 8.0, as ML jobs have to be configured using the ML app in Kibana.

The following warning is emitted when running `./filebeat setup --machine-learning`:
```
$ ./filebeat setup --machine-learning
Setting up ML using setup --machine-learning is going to be removed in 8.0. Please use the ML app instead.
See more: https://www.elastic.co/guide/en/elastic-stack-overview/current/xpack-ml.html
Loaded machine learning job configurations
```

When the flag `-e` is passed a warning shows up in the logs:
```
2019-11-15T10:54:12.420+0100    WARN    [cfgwarn]       instance/beat.go:558    DEPRECATED: Setting up ML using Filebeat is going to be removed. Please use the
 ML app to setup jobs. Will be removed in version: 8.0
```

Has to be backported to 7.x.

Closes elastic/beats#11349