### PR TITLE
Cherry-pick #14368 to 7.x: Fix docker client in tests so it performs API version negotiation.

### DIFF
--- a/libbeat/common/docker/client_test.go
+++ b/libbeat/common/docker/client_test.go
@@ -26,38 +26,37 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestNewClient(t *testing.T) {
-	host := "unix:///var/run/docker.sock"
-
-	client, err := NewClient(host, nil, nil)
+	c, err := NewClient(client.DefaultDockerHost, nil, nil)
 	assert.NoError(t, err)
-	assert.NotNil(t, client)
+	assert.NotNil(t, c)
 
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
+	_, err = c.ContainerList(context.Background(), types.ContainerListOptions{})
 	assert.NoError(t, err)
 
 	// This test only works on newer Docker versions (any supported one really)
-	switch client.ClientVersion() {
+	switch c.ClientVersion() {
 	case "1.22":
 		t.Skip("Docker version is too old for this test")
 	case api.DefaultVersion:
 		t.Logf("Using default API version: %s", api.DefaultVersion)
 	default:
-		t.Logf("Negotiated version: %s", client.ClientVersion())
+		t.Logf("Negotiated version: %s", c.ClientVersion())
 	}
 
 	// Test we can hardcode version
 	os.Setenv("DOCKER_API_VERSION", "1.22")
 
-	client, err = NewClient(host, nil, nil)
+	c, err = NewClient(client.DefaultDockerHost, nil, nil)
 	assert.NoError(t, err)
-	assert.NotNil(t, client)
-	assert.Equal(t, "1.22", client.ClientVersion())
+	assert.NotNil(t, c)
+	assert.Equal(t, "1.22", c.ClientVersion())
 
-	_, err = client.ContainerList(context.Background(), types.ContainerListOptions{})
+	_, err = c.ContainerList(context.Background(), types.ContainerListOptions{})
 	assert.NoError(t, err)
 }

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -36,6 +36,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 const (
@@ -53,7 +55,7 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	c, err := client.NewEnvClient()
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -23,6 +23,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 // Client for Docker
@@ -32,7 +34,7 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	c, err := client.NewEnvClient()
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	return Client{cli: c}, err
 }
 

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/elastic/beats/auditbeat/core"
+	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
@@ -69,20 +70,20 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	client, err := client.NewEnvClient()
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Close()
+	defer c.Close()
 
-	reader, err := client.ImagePull(context.Background(), "busybox", types.ImagePullOptions{})
+	reader, err := c.ImagePull(context.Background(), "busybox", types.ImagePullOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	io.Copy(os.Stdout, reader)
 	reader.Close()
 
-	resp, err := client.ContainerCreate(context.Background(), &container.Config{
+	resp, err := c.ContainerCreate(context.Background(), &container.Config{
 		Image: "busybox",
 		Cmd:   []string{"echo", "foo"},
 	}, nil, nil, "")
@@ -90,7 +91,7 @@ func createEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{})
+	c.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{})
 }
 
 func getConfig() map[string]interface{} {


### PR DESCRIPTION
Cherry-pick of PR #14368 to 7.x branch. Original message: 

Running the unit tests locally I was running into an issue where docker usage inside of the tests was not negotiating API version with my version of docker.

`Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.38`

This fixes the issue and is the same way the docker module works in libbeat/common/docker.