### PR TITLE
Enable script processor for Metricbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -504,6 +504,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add metrics to envoyproxy server metricset and support for envoy proxy 1.12. {pull}14416[14416] {issue}13642[13642]
 - Release kubernetes modules `controllermanager`, `scheduler`, `proxy`, `state_cronjob` and `state_resourcequota` as GA. {pull}14584[14584]
 - Add module for ActiveMQ. {pull}14580[14580]
+- Enable script processor. {pull}14711[14711]
 
 *Packetbeat*
 

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -26,9 +26,13 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/metricbeat/beater"
 	"github.com/elastic/beats/metricbeat/cmd/test"
+
 	// import modules
 	_ "github.com/elastic/beats/metricbeat/include"
 	_ "github.com/elastic/beats/metricbeat/include/fields"
+
+	// Import processors.
+	_ "github.com/elastic/beats/libbeat/processors/script"
 )
 
 // Name of this beat

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -28,7 +28,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :win_os:
 :no_decode_cef_processor:
 :no_decode_csv_fields_processor:
-:no_script_processor:
 :no_timestamp_processor:
 
 include::{libbeat-dir}/shared-beats-attributes.asciidoc[]


### PR DESCRIPTION
This PR enables the `script` processor in Metricbeat. We can use it for some data conversion in events coming from Lightweight modules.