### PR TITLE
Cherry-pick #14099 to 7.x: [Metricbeat] change server_status_path default setting for nginx module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -248,7 +248,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix performance counter values for windows/perfmon metricset. {issue}14036[14036] {pull}14039[14039]
 - Add FailOnRequired when applying schema and fix metric names in mongodb metrics metricset. {pull}14143[14143]
 - Change `server_status_path` default setting for nginx module {issue}13806[13806] {pull}14099[14099]
-- Convert increments of 100 nanoseconds/ticks to milliseconds for WriteTime and ReadTime in diskio metricset (Windows) for consistency. {issue}14233[14233]
 - Limit some of the error messages to the logs only {issue}14317[14317] {pull}14327[14327]
 - Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
 - Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -247,6 +247,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change kubernetes.event.message to text. {pull}13964[13964]
 - Fix performance counter values for windows/perfmon metricset. {issue}14036[14036] {pull}14039[14039]
 - Add FailOnRequired when applying schema and fix metric names in mongodb metrics metricset. {pull}14143[14143]
+- Change `server_status_path` default setting for nginx module {issue}13806[13806] {pull}14099[14099]
+- Convert increments of 100 nanoseconds/ticks to milliseconds for WriteTime and ReadTime in diskio metricset (Windows) for consistency. {issue}14233[14233]
 - Limit some of the error messages to the logs only {issue}14317[14317] {pull}14327[14327]
 - Convert indexed ms-since-epoch timestamp fields in `elasticsearch/ml_job` metricset to ints from float64s. {issue}14220[14220] {pull}14222[14222]
 - Fix ARN parsing function to work for ELB ARNs. {pull}14316[14316]

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -41,8 +41,8 @@ metricbeat.modules:
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  server_status_path: "nginx_status"
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -645,8 +645,8 @@ metricbeat.modules:
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  server_status_path: "nginx_status"
 
 #------------------------------- PHP_FPM Module -------------------------------
 - module: php_fpm

--- a/metricbeat/module/nginx/_meta/config.reference.yml
+++ b/metricbeat/module/nginx/_meta/config.reference.yml
@@ -6,5 +6,5 @@
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  server_status_path: "nginx_status"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -756,8 +756,8 @@ metricbeat.modules:
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  server_status_path: "nginx_status"
 
 #-------------------------------- Oracle Module --------------------------------
 - module: oracle


### PR DESCRIPTION
Cherry-pick of PR #14099 to 7.x branch. Original message: 

Changed default `server_status_path` to `nginx_status`

Fixes: elastic/beats#13806 