### PR TITLE
Fixed indentation of 'slowlog.enabled' in 'logstash.yml'.

### DIFF
--- a/filebeat/modules.d/logstash.yml.disabled
+++ b/filebeat/modules.d/logstash.yml.disabled
@@ -12,7 +12,7 @@
 
   # Slow logs
   slowlog:
-   enabled: true
+    enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:


### PR DESCRIPTION
The following error occurred and fixed it.

`ERROR	instance/beat.go:667	Exiting: 1 error: error loading config file: invalid config: yaml: line 15: did not find expected key`