### PR TITLE
Update docker info metricset to use V2 reporter

### DIFF
--- a/metricbeat/module/docker/info/_meta/data.json
+++ b/metricbeat/module/docker/info/_meta/data.json
@@ -1,25 +1,28 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "docker": {
         "info": {
             "containers": {
                 "paused": 0,
-                "running": 29,
-                "stopped": 19,
-                "total": 48
+                "running": 2,
+                "stopped": 12,
+                "total": 14
             },
-            "id": "V727:GUJU:KXA5:Y5YS:RYFT:6IYQ:GQN7:IGGT:O4YO:NRU3:ZIRV:MHEJ",
-            "images": 168
+            "id": "VF5E:SKD6:YFIG:VDGO:JU3M:ZT2N:4E6B:7IOL:5QOS:M3HT:EM7E:VL22",
+            "images": 425
         }
     },
+    "event": {
+        "dataset": "docker.info",
+        "duration": 115000,
+        "module": "docker"
+    },
     "metricset": {
-        "host": "/var/run/docker.sock",
-        "module": "docker",
         "name": "info",
-        "rtt": 115
+        "period": 10000
+    },
+    "service": {
+        "address": "/var/run/docker.sock",
+        "type": "docker"
     }
 }

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/docker/docker/client"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
@@ -59,17 +58,18 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch creates a new event for info.
 // See: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-system-wide-information
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	info, err := m.dockerClient.Info(context.TODO())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return eventMapping(&info), nil
+	r.Event(mb.Event{MetricSetFields: eventMapping(&info)})
+
+	return nil
 }
 
-//Close stops the metricset
+// Close stops the metricset
 func (m *MetricSet) Close() error {
-
 	return m.dockerClient.Close()
 }

--- a/metricbeat/module/docker/info/info_integration_test.go
+++ b/metricbeat/module/docker/info/info_integration_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewEventFetcher(t, getConfig())
-	err := mbtest.WriteEvent(f, t)
-	if err != nil {
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+
+	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)
 	}
 }


### PR DESCRIPTION
This was the last module using the old `EventFetcher` interface. Once this get's in we can clean them up (https://github.com/elastic/beats/pull/11762)