### PR TITLE
Metricbeat diskio metricset - closing the handle after checking the registry key

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -267,6 +267,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix regular expression to detect instance name in perfmon metricset. {issue}14273[14273] {pull}14666[14666]
 - Vshpere module splits `virtualmachine.host` into `virtualmachine.host.id` and `virtualmachine.host.hostname`. {issue}7187[7187] {pull}7213[7213]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
+- Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/diskio/diskstat_windows_helper.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_helper.go
@@ -138,6 +138,16 @@ func ioCounter(path string, diskPerformance *diskPerformance) error {
 // enablePerformanceCounters will enable performance counters by adding the EnableCounterForIoctl registry key
 func enablePerformanceCounters() error {
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Services\\partmgr", registry.READ|registry.WRITE)
+	// closing handler for the registry key. If the key is not one of the predefined registry keys (which is the case here), a call the RegCloseKey function shoulc be executed after using the handle.
+	defer func() {
+		if key != 0 {
+			clErr := key.Close()
+			if clErr != nil {
+				logp.L().Named("diskio").Errorf("cannot close handler for HKLM:SYSTEM\\CurrentControlSet\\Services\\Partmgr\\EnableCounterForIoctl key in the registry: %s", clErr)
+			}
+		}
+	}()
+
 	if err != nil {
 		return errors.Errorf("cannot open new key in the registry in order to enable the performance counters: %s", err)
 	}
@@ -148,6 +158,7 @@ func enablePerformanceCounters() error {
 		}
 		logp.L().Named("diskio").Info("The registry key EnableCounterForIoctl at HKLM:SYSTEM\\CurrentControlSet\\Services\\Partmgr has been created in order to enable the performance counters")
 	}
+
 	return nil
 }
 

--- a/metricbeat/module/system/diskio/diskstat_windows_helper.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_helper.go
@@ -138,7 +138,7 @@ func ioCounter(path string, diskPerformance *diskPerformance) error {
 // enablePerformanceCounters will enable performance counters by adding the EnableCounterForIoctl registry key
 func enablePerformanceCounters() error {
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Services\\partmgr", registry.READ|registry.WRITE)
-	// closing handler for the registry key. If the key is not one of the predefined registry keys (which is the case here), a call the RegCloseKey function shoulc be executed after using the handle.
+	// closing handler for the registry key. If the key is not one of the predefined registry keys (which is the case here), a call the RegCloseKey function should be executed after using the handle.
 	defer func() {
 		if key != 0 {
 			clErr := key.Close()


### PR DESCRIPTION
To check if the registry key exists we are using the RegOpenKeyExW function.
This returns a  pointer to a variable that receives a handle to the opened key. If the key is not one of the predefined registry keys which is the case call to the RegCloseKey function needs to be executed.
Should fix https://github.com/elastic/beats/issues/14683