### PR TITLE
[DOCS] Fixes security links

### DIFF
--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -31,7 +31,7 @@ values in the <<keystore,secrets keystore>>.
 specify credentials for {kib}, {beatname_uc} uses the `username` and `password`
 specified for the {es} output.
 <3> To use the pre-built Kibana dashboards, this user must have the
-`kibana_user` {xpack-ref}/built-in-roles.html[built-in role] or equivalent
+`kibana_user` {ref}/built-in-roles.html[built-in role] or equivalent
 privileges.
 +
 For more information, see <<securing-{beatname_lc}>>.


### PR DESCRIPTION
Related to elastic/elasticsearch#46880

This PR fixes links to content that has moved from the Stack Overview to the Elasticsearch Reference.

In particular, it fixes these broken links in https://github.com/elastic/stack-docs/pull/700

> 12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/master/securing-beats.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/elasticsearch-security.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/auditbeat/master/auditbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/filebeat/master/filebeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/filebeat/master/filebeat-modules-quickstart.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/functionbeat/master/functionbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/heartbeat/master/heartbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/journalbeat/master/journalbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/metricbeat/master/metricbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/packetbeat/master/packetbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
12:23:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/winlogbeat/master/winlogbeat-configuration.html:
12:23:19 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html