### PR TITLE
add a BuildTar target

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -131,8 +131,8 @@ func Package() {
 	mg.SerialDeps(Build, Install)
 }
 
-// BuildTar builds a "release" tarball that can be used later with `docker pugin create`
-func BuildTar() error {
+// Release builds a "release" tarball that can be used later with `docker pugin create`
+func Release() error {
 	mg.Deps(Build)
 	name, err := getPluginName()
 	if err != nil {

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -131,7 +131,7 @@ func Package() {
 	mg.SerialDeps(Build, Install)
 }
 
-// Release builds a "release" tarball that can be used later with `docker pugin create`
+// Release builds a "release" tarball that can be used later with `docker plugin create`
 func Release() error {
 	mg.Deps(Build)
 	name, err := getPluginName()

--- a/x-pack/dockerlogbeat/readme.md
+++ b/x-pack/dockerlogbeat/readme.md
@@ -4,7 +4,7 @@
 This code is a working MVP for a [docker logging plugin](https://docs.docker.com/engine/extend/plugins_logging/). With the proper config, it can send logs to elasticsearch.
 ## Build and install
 
-To build and install, just run `mage Package`. The build process happens entire within docker. The only external dependency is [mage](https://github.com/magefile/mage#installation)
+To build and install, just run `mage Package`. The build process happens entire within docker. The only external dependencies are [mage](https://github.com/magefile/mage#installation) and golang.
 
 
 ## Running


### PR DESCRIPTION
This cleans up the magefile and adds a `BuildTar` target. This new target is partly a hack so people can test the plugin without building from source, and party a preview of how releases will work in the future, as we'll need a separate artifact to send to the release manager.

Still cleaning this up, I just wanted to have a PR in before I finished up for the day.