### PR TITLE
[7.x][DOCS] Backport: add `systemctl enable heartbeat-elastic` to HB doc (#14218)

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -120,6 +120,13 @@ sudo apt-get update && sudo apt-get install {beatname_pkg}
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
+sudo systemctl enable {beatname_pkg}
+--------------------------------------------------
+
+If your system does not use `systemd` then run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
 sudo update-rc.d {beatname_pkg} defaults 95 10
 --------------------------------------------------
 
@@ -212,6 +219,13 @@ sudo yum install {beatname_pkg}
 --------------------------------------------------
 
 . To configure {beatname_uc} to start automatically during boot, run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo systemctl enable {beatname_pkg}
+--------------------------------------------------
+
+If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------


### PR DESCRIPTION
Backports community contribution #14218 to 7.x.