### PR TITLE
[DOCS] Remove asciidoctor flag because it's the default now

### DIFF
--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -38,5 +38,5 @@ do
     params="$params --resource=${resource_dir}"
   fi
 
-  $docs_dir/build_docs --asciidoctor --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
+  $docs_dir/build_docs --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
 done


### PR DESCRIPTION
The doc build now uses asciidoctor by default because all books have been migrated....yay! Removing the asciidoctor switch because it gives us a cleaner log.