### PR TITLE
update typo

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -867,7 +867,7 @@ processors:
      separator: ,
      ignore_missing: false
      overwrite_keys: true
-     trim_leading_whitespace: false
+     trim_leading_space: false
      fail_on_error: true
 -----------------------------------------------------
 


### PR DESCRIPTION
`trim_leading_whitespace` should be `trim_leading_space`