### PR TITLE
Remove container_name from Metricbeat autodiscover eventID

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -217,7 +217,10 @@ func (p *Provider) emitEvents(pod *kubernetes.Pod, flag string, containers []kub
 
 		// This must be an id that doesn't depend on the state of the container
 		// so it works also on `stop` if containers have been already deleted.
-		eventID := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), c.Name)
+		eventID := fmt.Sprintf("%s", pod.GetObjectMeta().GetUID())
+		if p.bus.GetName() != "metricbeat" {
+			eventID = fmt.Sprintf("%s.%s", eventID, c.Name)
+		}
 
 		cmeta := common.MapStr{
 			"id":      cid,

--- a/libbeat/common/bus/bus.go
+++ b/libbeat/common/bus/bus.go
@@ -29,6 +29,9 @@ type Event common.MapStr
 
 // Bus provides a common channel to emit and listen for Events
 type Bus interface {
+	// New initializes a new bus with the given name and returns it
+	GetName() string
+
 	// Publish an event to the bus
 	Publish(Event)
 
@@ -74,6 +77,11 @@ func NewBusWithStore(name string, size int) Bus {
 		listeners: make([]*listener, 0),
 		store:     make(chan Event, size),
 	}
+}
+
+// GetName returns the name of the bus
+func (b *bus) GetName() string {
+	return b.name
 }
 
 func (b *bus) Publish(e Event) {


### PR DESCRIPTION
In Metricbeat we don't want to have different eventIDs for
containers within the same Pod, since these containers
share the same IP and handling them seperately can lead in
launching hint based modules for all of the containers.

Signed-off-by: chrismark <chrismarkou92@gmail.com>

### What this PR solves
This PR tackles the problem of having a module to be launched twice in case we have 2 containers in the Pod with annotations. See #12011 .

This patch will make https://github.com/elastic/beats/blob/d8cd8c437fe7891addb56f3cd7a048aed422b644/libbeat/autodiscover/autodiscover.go#L211
work as expected, in cases like:
```console
2019-11-26T09:48:44.093Z	DEBUG	[autodiscover]	autodiscover/autodiscover.go:210	eventID: 878f170c-c892-4735-8b4f-60bf707fd01d:266e2380-d3b6-423b-a257-0cb428235fc6.prometheus-container
2019-11-26T09:48:44.093Z	DEBUG	[autodiscover]	autodiscover/autodiscover.go:211	hash: 2490033313956307158

2019-11-26T09:48:44.107Z	DEBUG	[autodiscover]	autodiscover/autodiscover.go:210	eventID: 878f170c-c892-4735-8b4f-60bf707fd01d:266e2380-d3b6-423b-a257-0cb428235fc6.redis-container
2019-11-26T09:48:44.107Z	DEBUG	[autodiscover]	autodiscover/autodiscover.go:211	hash: 2490033313956307158
```

closes: #12011