### PR TITLE
[Docker Log Driver] Add pipereader tests and fix copyBuffer bug

### DIFF
--- a/x-pack/dockerlogbeat/pipereader/reader.go
+++ b/x-pack/dockerlogbeat/pipereader/reader.go
@@ -7,7 +7,6 @@ package pipereader
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"syscall"
@@ -103,7 +102,6 @@ func (reader *PipeReader) getValidLengthFrame() (int, error) {
 		if _, err := io.ReadFull(reader.fifoPipe, reader.lenFrameBuf); err != nil {
 			return 0, err
 		}
-		fmt.Printf("Got length frame of %#v\n", reader.lenFrameBuf)
 		bodyLen := int(reader.byteOrder.Uint32(reader.lenFrameBuf))
 		if bodyLen > 0 {
 			return bodyLen, nil

--- a/x-pack/dockerlogbeat/pipereader/reader_test.go
+++ b/x-pack/dockerlogbeat/pipereader/reader_test.go
@@ -1,0 +1,46 @@
+package pipereader
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/docker/docker/api/types/plugins/logdriver"
+)
+
+func TestPipeReader(t *testing.T) {
+
+	//setup
+	exampleStruct := &logdriver.LogEntry{
+		Source:   "Test",
+		TimeNano: 0,
+		Line:     []byte("This is a log line"),
+		Partial:  false,
+		PartialLogMetadata: &logdriver.PartialLogEntryMetadata{
+			Last:    false,
+			Id:      "",
+			Ordinal: 0,
+		},
+	}
+	rawBytes, err := proto.Marshal(exampleStruct)
+	assert.NoError(t, err)
+
+	sizeBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(sizeBytes, uint32(len(rawBytes)))
+	rawBytes = append(sizeBytes, rawBytes...)
+
+	// actual test
+	pipeRead, err := NewReaderFromReadCloser(ioutil.NopCloser(bytes.NewReader(rawBytes)))
+	assert.NoError(t, err)
+	var outLog logdriver.LogEntry
+	err = pipeRead.ReadMessage(&outLog)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "This is a log line", string(outLog.Line))
+
+}

--- a/x-pack/dockerlogbeat/pipereader/reader_test.go
+++ b/x-pack/dockerlogbeat/pipereader/reader_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package pipereader
 
 import (


### PR DESCRIPTION
We finally have tests for the log driver! Well, some. It would be nice to add more.

This also fixes a bug with how we handle buffers. It turns out that `CopyBuffer` won't actually check to see if it has a nil dst. 