### PR TITLE
[7.5][DOCS] Backport: Remove asciidoctor flag because it's the default now (#14774)

### DIFF
--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -38,5 +38,5 @@ do
     params="$params --resource=${resource_dir}"
   fi
 
-  $docs_dir/build_docs --asciidoctor --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
+  $docs_dir/build_docs --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
 done


### PR DESCRIPTION
Backports #14774 to 7.5 branch.