### PR TITLE
Fix typo in devguide, new filebeat module

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -456,7 +456,7 @@ make create-fields MODULE={module} FILESET={fileset}
 ----
 
 Please, always check the generated file and make sure the fields are correct.
-Documenatation of fields must be added manually.
+Documentation of fields must be added manually.
 
 If the fields are correct, it is time to generate documentation, configuration
 and Kibana index patterns.


### PR DESCRIPTION
This PR fixes a small typo in Beats documentation: Create new filebeat module
