### PR TITLE
mapping host user to docker user when running docker-compose

### DIFF
--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     pid: host
     cap_add:
       - AUDIT_CONTROL
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       # We launch docker containers to test docker autodiscover:
       - /var/run/docker.sock:/var/run/docker.sock
     command: make
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     # We launch docker containers to test docker autodiscover:
     - /var/run/docker.sock:/var/run/docker.sock
     command: make
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     working_dir: /go/src/github.com/elastic/beats/libbeat
     command: make
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -72,7 +72,7 @@ TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
 DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${BEAT_VERSION//-}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
-DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
+DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} USER_ID="$(shell id -u):$(shell id -g)" docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 PYTHON_ENV?=${BUILD_DIR}/python-env

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     network_mode: host
     command: make
+    user: ${USER_ID}
 
   # Modules
   aerospike:

--- a/x-pack/auditbeat/docker-compose.yml
+++ b/x-pack/auditbeat/docker-compose.yml
@@ -12,3 +12,4 @@ services:
     cap_add:
       - AUDIT_CONTROL
       - NET_ADMIN
+    user: ${USER_ID}

--- a/x-pack/filebeat/docker-compose.yml
+++ b/x-pack/filebeat/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ${PWD}/../..:/go/src/github.com/elastic/beats/
       - /var/run/docker.sock:/var/run/docker.sock
     command: make
+    user: ${USER_ID}
 
   googlepubsub:
     build: input/googlepubsub/_meta
@@ -32,4 +33,3 @@ services:
     extends:
       file: ${ES_BEATS}/testing/environments/${STACK_ENVIRONMENT}.yml
       service: elasticsearch
-

--- a/x-pack/functionbeat/docker-compose.yml
+++ b/x-pack/functionbeat/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       # We launch docker containers to test docker autodiscover:
       - /var/run/docker.sock:/var/run/docker.sock
     command: make
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       # We launch docker containers to test docker autodiscover:
       - /var/run/docker.sock:/var/run/docker.sock
     command: make
+    user: ${USER_ID}
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     network_mode: host
     command: make
+    user: ${USER_ID}
 
   # Modules
   activemq:


### PR DESCRIPTION
Caused by https://github.com/elastic/apm-server/pull/2972

When using docker-compose the user from the host can be passed to the docker container therefore when mounting the volumes from the workspace there won't be any conflict with the user/group.