### PR TITLE
[Metricbeat]Fix docker network metrics on multi iface

### DIFF
--- a/metricbeat/module/docker/network/data.go
+++ b/metricbeat/module/docker/network/data.go
@@ -23,8 +23,8 @@ import (
 )
 
 func eventsMapping(r mb.ReporterV2, netsStatsList []NetStats) {
-	for _, netsStats := range netsStatsList {
-		eventMapping(r, &netsStats)
+	for i := range netsStatsList {
+		eventMapping(r, &netsStatsList[i])
 	}
 }
 

--- a/metricbeat/module/docker/network/helper.go
+++ b/metricbeat/module/docker/network/helper.go
@@ -71,22 +71,22 @@ func (n *NetService) getNetworkStatsPerContainer(rawStats []docker.Stat, dedot b
 	formattedStats := []NetStats{}
 	for _, myStats := range rawStats {
 		for nameInterface, rawnNetStats := range myStats.Stats.Networks {
-			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, &rawnNetStats, &myStats, dedot))
+			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, rawnNetStats, myStats, dedot))
 		}
 	}
 
 	return formattedStats
 }
 
-func (n *NetService) getNetworkStats(nameInterface string, rawNetStats *types.NetworkStats, myRawstats *docker.Stat, dedot bool) NetStats {
-	newNetworkStats := createNetRaw(myRawstats.Stats.Read, rawNetStats)
+func (n *NetService) getNetworkStats(nameInterface string, rawNetStats types.NetworkStats, myRawstats docker.Stat, dedot bool) NetStats {
+	newNetworkStats := createNetRaw(myRawstats.Stats.Read, &rawNetStats)
 	oldNetworkStat, exist := n.NetworkStatPerContainer[myRawstats.Container.ID][nameInterface]
 
 	netStats := NetStats{
 		Container:     docker.NewContainer(myRawstats.Container, dedot),
 		Time:          myRawstats.Stats.Read,
 		NameInterface: nameInterface,
-		Total:         rawNetStats,
+		Total:         &rawNetStats,
 	}
 
 	if exist {


### PR DESCRIPTION
Metricbeat docker metrics fails when multiple interfaces are configured at a container.
It looks like base code is using loop variable as a reference across iterations

Issue: https://github.com/elastic/beats/issues/14586

