### PR TITLE
[Docker Log driver] Expand testing, add mocking tooling

### DIFF
--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -18,16 +18,17 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	client, teardown := setupTestClient(t)
+	logString := "This is a log line"
+	client, teardown := setupTestClient(t, logString)
 	defer teardown()
 
 	event := testReturn(t, client)
-	assert.Equal(t, event.Fields["message"], "This is a log line")
+	assert.Equal(t, event.Fields["message"], logString)
 }
 
-func setupTestClient(t *testing.T) (*pipelinemock.MockPipelineConnector, func()) {
+func setupTestClient(t *testing.T, logString string) (*pipelinemock.MockPipelineConnector, func()) {
 	mockConnector := &pipelinemock.MockPipelineConnector{}
-	client := createNewClient(t, mockConnector)
+	client := createNewClient(t, logString, mockConnector)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -42,7 +43,7 @@ func setupTestClient(t *testing.T) (*pipelinemock.MockPipelineConnector, func())
 	}
 }
 
-func createNewClient(t *testing.T, mockConnector *pipelinemock.MockPipelineConnector) *ClientLogger {
+func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector) *ClientLogger {
 	// an example container metadata struct
 	cfgObject := logger.Info{
 		Config:             map[string]string{"output.elasticsearch": "localhost:9200"},
@@ -53,7 +54,7 @@ func createNewClient(t *testing.T, mockConnector *pipelinemock.MockPipelineConne
 	}
 
 	// create a new pipeline reader for use with the libbeat client
-	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInput(t))
+	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInputFromLine(t, logString))
 	require.NoError(t, err)
 
 	client, err := newClientFromPipeline(mockConnector, reader, "aaa", cfgObject)

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/daemon/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/x-pack/dockerlogbeat/pipelinemock"
@@ -53,10 +54,10 @@ func createNewClient(t *testing.T, mockConnector *pipelinemock.MockPipelineConne
 
 	// create a new pipeline reader for use with the libbeat client
 	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInput(t))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	client, err := newClientFromPipeline(mockConnector, reader, "aaa", cfgObject)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return client
 }

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -1,0 +1,55 @@
+package pipelinemanager
+
+import (
+	"testing"
+
+	"github.com/docker/docker/daemon/logger"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/x-pack/dockerlogbeat/pipelinemock"
+	"github.com/elastic/beats/x-pack/dockerlogbeat/pipereader"
+)
+
+func TestNewClient(t *testing.T) {
+	mockConnector := &pipelinemock.MockPipelineConnector{}
+	client := createNewClient(t, mockConnector)
+	// ConsumePipelineAndSent is what does the actual reading and sending.
+	// After we spawn this goroutine, we wait until we get something back
+	go client.ConsumePipelineAndSend()
+	event := testReturnAndClose(t, mockConnector, client)
+	assert.Equal(t, event.Fields["message"], "This is a log line")
+
+}
+
+func createNewClient(t *testing.T, mockConnector *pipelinemock.MockPipelineConnector) *ClientLogger {
+	// an example container metadata struct
+	cfgObject := logger.Info{
+		Config:             map[string]string{"output.elasticsearch": "localhost:9200"},
+		ContainerLabels:    map[string]string{"test.label": "test"},
+		ContainerID:        "3acc92989a97c415905eba090277b8a8834d087e58a95bed55450338ce0758dd",
+		ContainerName:      "testContainer",
+		ContainerImageName: "TestImage",
+	}
+
+	// create a new pipeline reader for use with the libbeat client
+	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInput(t))
+	assert.NoError(t, err)
+
+	client, err := newClientFromPipeline(mockConnector, reader, "aaa", cfgObject)
+	assert.NoError(t, err)
+
+	return client
+}
+
+func testReturnAndClose(t *testing.T, conn *pipelinemock.MockPipelineConnector, client *ClientLogger) beat.Event {
+	defer client.Close()
+	for {
+		// wait until we get our example event back
+		if events := conn.GetAllEvents(); len(events) > 0 {
+			assert.NotEmpty(t, events)
+			return events[0]
+		}
+	}
+
+}

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -19,14 +19,15 @@ import (
 
 func TestNewClient(t *testing.T) {
 	logString := "This is a log line"
-	client, teardown := setupTestClient(t, logString)
+	client, teardown := setupTestReader(t, logString)
 	defer teardown()
 
 	event := testReturn(t, client)
 	assert.Equal(t, event.Fields["message"], logString)
 }
 
-func setupTestClient(t *testing.T, logString string) (*pipelinemock.MockPipelineConnector, func()) {
+// setupTestReader sets up the "read side" of the pipeline, spawing a goroutine to read and event and send it back to the test.
+func setupTestReader(t *testing.T, logString string) (*pipelinemock.MockPipelineConnector, func()) {
 	mockConnector := &pipelinemock.MockPipelineConnector{}
 	client := createNewClient(t, logString, mockConnector)
 
@@ -43,6 +44,7 @@ func setupTestClient(t *testing.T, logString string) (*pipelinemock.MockPipeline
 	}
 }
 
+// createNewClient sets up the "write side" of the pipeline, creating a log event to write and send back into the test.
 func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector) *ClientLogger {
 	// an example container metadata struct
 	cfgObject := logger.Info{
@@ -63,6 +65,7 @@ func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock
 	return client
 }
 
+// testReturn waits in a loop until we get back an event
 func testReturn(t *testing.T, conn *pipelinemock.MockPipelineConnector) beat.Event {
 	for {
 		// wait until we get our example event back

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package pipelinemanager
 
 import (

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/elastic/beats/x-pack/dockerlogbeat/pipereader"
+
 	"github.com/docker/docker/daemon/logger"
 	"github.com/pkg/errors"
 
@@ -80,8 +82,13 @@ func (pm *PipelineManager) CreateClientWithConfig(containerConfig logger.Info, f
 		return nil, errors.Wrap(err, "error getting pipeline")
 	}
 
+	pipeRead, err := pipereader.NewReaderFromPath(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
 	//actually get to crafting the new client.
-	cl, err := newClientFromPipeline(pipeline.pipeline, file, hashstring, containerConfig)
+	cl, err := newClientFromPipeline(pipeline.pipeline, pipeRead, hashstring, containerConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating client")
 	}

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -82,13 +82,13 @@ func (pm *PipelineManager) CreateClientWithConfig(containerConfig logger.Info, f
 		return nil, errors.Wrap(err, "error getting pipeline")
 	}
 
-	pipeRead, err := pipereader.NewReaderFromPath(file)
+	reader, err := pipereader.NewReaderFromPath(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "")
 	}
 
 	//actually get to crafting the new client.
-	cl, err := newClientFromPipeline(pipeline.pipeline, pipeRead, hashstring, containerConfig)
+	cl, err := newClientFromPipeline(pipeline.pipeline, reader, hashstring, containerConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating client")
 	}

--- a/x-pack/dockerlogbeat/pipelinemock/pipelines.go
+++ b/x-pack/dockerlogbeat/pipelinemock/pipelines.go
@@ -61,7 +61,7 @@ type MockPipelineConnector struct {
 
 // GetAllEvents returns all events associated with a pipeline
 func (pc *MockPipelineConnector) GetAllEvents() []beat.Event {
-	evList := []beat.Event{}
+	var evList []beat.Event
 	for _, clientEvents := range pc.clients {
 		evList = append(evList, clientEvents.GetEvents()...)
 	}

--- a/x-pack/dockerlogbeat/pipelinemock/pipelines.go
+++ b/x-pack/dockerlogbeat/pipelinemock/pipelines.go
@@ -36,9 +36,8 @@ func (c *MockBeatClient) PublishAll(events []beat.Event) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	for _, e := range events {
-		c.publishes = append(c.publishes, e)
-	}
+	c.publishes = append(c.publishes, events...)
+
 }
 
 // Close mocks the Client Close method
@@ -62,7 +61,6 @@ type MockPipelineConnector struct {
 
 // GetAllEvents returns all events associated with a pipeline
 func (pc *MockPipelineConnector) GetAllEvents() []beat.Event {
-
 	evList := []beat.Event{}
 	for _, clientEvents := range pc.clients {
 		evList = append(evList, clientEvents.GetEvents()...)

--- a/x-pack/dockerlogbeat/pipelinemock/pipelines.go
+++ b/x-pack/dockerlogbeat/pipelinemock/pipelines.go
@@ -1,0 +1,89 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipelinemock
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+// MockBeatClient mocks the Client interface
+type MockBeatClient struct {
+	publishes []beat.Event
+	closed    bool
+	mtx       sync.Mutex
+}
+
+// GetEvents returns the published events
+func (c *MockBeatClient) GetEvents() []beat.Event {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	return c.publishes
+}
+
+// Publish mocks the Client Publish method
+func (c *MockBeatClient) Publish(e beat.Event) {
+	c.PublishAll([]beat.Event{e})
+}
+
+// PublishAll mocks the Client PublishAll method
+func (c *MockBeatClient) PublishAll(events []beat.Event) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for _, e := range events {
+		c.publishes = append(c.publishes, e)
+	}
+}
+
+// Close mocks the Client Close method
+func (c *MockBeatClient) Close() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.closed {
+		return fmt.Errorf("mock client already closed")
+	}
+
+	c.closed = true
+	return nil
+}
+
+// MockPipelineConnector mocks the PipelineConnector interface
+type MockPipelineConnector struct {
+	clients []*MockBeatClient
+	mtx     sync.Mutex
+}
+
+// GetAllEvents returns all events associated with a pipeline
+func (pc *MockPipelineConnector) GetAllEvents() []beat.Event {
+
+	evList := []beat.Event{}
+	for _, clientEvents := range pc.clients {
+		evList = append(evList, clientEvents.GetEvents()...)
+	}
+
+	return evList
+}
+
+// Connect mocks the PipelineConnector Connect method
+func (pc *MockPipelineConnector) Connect() (beat.Client, error) {
+	return pc.ConnectWith(beat.ClientConfig{})
+}
+
+// ConnectWith mocks the PipelineConnector ConnectWith method
+func (pc *MockPipelineConnector) ConnectWith(beat.ClientConfig) (beat.Client, error) {
+	pc.mtx.Lock()
+	defer pc.mtx.Unlock()
+
+	c := &MockBeatClient{}
+
+	pc.clients = append(pc.clients, c)
+
+	return c, nil
+}

--- a/x-pack/dockerlogbeat/pipelinemock/reader.go
+++ b/x-pack/dockerlogbeat/pipelinemock/reader.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipelinemock
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/docker/api/types/plugins/logdriver"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+// CreateTestInput creates a mocked ReadCloser for the pipelineReader
+func CreateTestInput(t *testing.T) io.ReadCloser {
+	//setup
+	exampleStruct := &logdriver.LogEntry{
+		Source:   "Test",
+		TimeNano: 0,
+		Line:     []byte("This is a log line"),
+		Partial:  false,
+		PartialLogMetadata: &logdriver.PartialLogEntryMetadata{
+			Last:    false,
+			Id:      "",
+			Ordinal: 0,
+		},
+	}
+
+	rawBytes, err := proto.Marshal(exampleStruct)
+	assert.NoError(t, err)
+
+	sizeBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(sizeBytes, uint32(len(rawBytes)))
+	rawBytes = append(sizeBytes, rawBytes...)
+	rc := ioutil.NopCloser(bytes.NewReader(rawBytes))
+	return rc
+}

--- a/x-pack/dockerlogbeat/pipelinemock/reader.go
+++ b/x-pack/dockerlogbeat/pipelinemock/reader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types/plugins/logdriver"
 	"github.com/gogo/protobuf/proto"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // CreateTestInputFromLine returns a ReadCloser based on an input string
@@ -38,13 +38,13 @@ func CreateTestInputFromLine(t *testing.T, line string) io.ReadCloser {
 
 func encodeLog(t *testing.T, out io.Writer, entry *logdriver.LogEntry) {
 	rawBytes, err := proto.Marshal(entry)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sizeBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(sizeBytes, uint32(len(rawBytes)))
 
 	_, err = out.Write(sizeBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = out.Write(rawBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/x-pack/dockerlogbeat/pipereader/reader.go
+++ b/x-pack/dockerlogbeat/pipereader/reader.go
@@ -7,7 +7,6 @@ package pipereader
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"syscall"
@@ -103,7 +102,6 @@ func (reader *PipeReader) getValidLengthFrame() (int, error) {
 		if _, err := io.ReadFull(reader.fifoPipe, reader.lenFrameBuf); err != nil {
 			return 0, err
 		}
-		fmt.Printf("Got length frame of %#v\n", reader.lenFrameBuf)
 		bodyLen := int(reader.byteOrder.Uint32(reader.lenFrameBuf))
 		if bodyLen > 0 {
 			return bodyLen, nil

--- a/x-pack/dockerlogbeat/pipereader/reader.go
+++ b/x-pack/dockerlogbeat/pipereader/reader.go
@@ -7,6 +7,7 @@ package pipereader
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"syscall"
@@ -102,6 +103,7 @@ func (reader *PipeReader) getValidLengthFrame() (int, error) {
 		if _, err := io.ReadFull(reader.fifoPipe, reader.lenFrameBuf); err != nil {
 			return 0, err
 		}
+		fmt.Printf("Got length frame of %#v\n", reader.lenFrameBuf)
 		bodyLen := int(reader.byteOrder.Uint32(reader.lenFrameBuf))
 		if bodyLen > 0 {
 			return bodyLen, nil

--- a/x-pack/dockerlogbeat/pipereader/reader_test.go
+++ b/x-pack/dockerlogbeat/pipereader/reader_test.go
@@ -5,41 +5,19 @@
 package pipereader
 
 import (
-	"bytes"
-	"encoding/binary"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/gogo/protobuf/proto"
 
 	"github.com/docker/docker/api/types/plugins/logdriver"
 )
 
 func TestPipeReader(t *testing.T) {
 
-	//setup
-	exampleStruct := &logdriver.LogEntry{
-		Source:   "Test",
-		TimeNano: 0,
-		Line:     []byte("This is a log line"),
-		Partial:  false,
-		PartialLogMetadata: &logdriver.PartialLogEntryMetadata{
-			Last:    false,
-			Id:      "",
-			Ordinal: 0,
-		},
-	}
-	rawBytes, err := proto.Marshal(exampleStruct)
-	assert.NoError(t, err)
-
-	sizeBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(sizeBytes, uint32(len(rawBytes)))
-	rawBytes = append(sizeBytes, rawBytes...)
+	rawBytes := pipeineMock.CreateTestInput(t)
 
 	// actual test
-	pipeRead, err := NewReaderFromReadCloser(ioutil.NopCloser(bytes.NewReader(rawBytes)))
+	pipeRead, err := NewReaderFromReadCloser(rawBytes)
 	assert.NoError(t, err)
 	var outLog logdriver.LogEntry
 	err = pipeRead.ReadMessage(&outLog)

--- a/x-pack/dockerlogbeat/pipereader/reader_test.go
+++ b/x-pack/dockerlogbeat/pipereader/reader_test.go
@@ -7,22 +7,23 @@ package pipereader
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/docker/docker/api/types/plugins/logdriver"
+	"github.com/elastic/beats/x-pack/dockerlogbeat/pipelinemock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPipeReader(t *testing.T) {
 
-	rawBytes := pipeineMock.CreateTestInput(t)
+	TestLine := "This is a log line"
+	reader := pipelinemock.CreateTestInputFromLine(t, TestLine)
 
 	// actual test
-	pipeRead, err := NewReaderFromReadCloser(rawBytes)
+	pipeRead, err := NewReaderFromReadCloser(reader)
 	assert.NoError(t, err)
 	var outLog logdriver.LogEntry
 	err = pipeRead.ReadMessage(&outLog)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "This is a log line", string(outLog.Line))
+	assert.Equal(t, TestLine, string(outLog.Line))
 
 }


### PR DESCRIPTION
This adds a 'main' integration test for the client handler and log reader, as well as a set of tools for mocking the publisher pipeline. A few things have shifted around in the client/pipeline managers in order to make testing easier. 