### PR TITLE
Cherry-pick #14825 to 7.5: [Metricbeat]Fix docker network metrics on multi iface

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
+- Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/network/data.go
+++ b/metricbeat/module/docker/network/data.go
@@ -23,8 +23,8 @@ import (
 )
 
 func eventsMapping(r mb.ReporterV2, netsStatsList []NetStats) {
-	for _, netsStats := range netsStatsList {
-		eventMapping(r, &netsStats)
+	for i := range netsStatsList {
+		eventMapping(r, &netsStatsList[i])
 	}
 }
 

--- a/metricbeat/module/docker/network/helper.go
+++ b/metricbeat/module/docker/network/helper.go
@@ -71,22 +71,22 @@ func (n *NetService) getNetworkStatsPerContainer(rawStats []docker.Stat, dedot b
 	formattedStats := []NetStats{}
 	for _, myStats := range rawStats {
 		for nameInterface, rawnNetStats := range myStats.Stats.Networks {
-			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, &rawnNetStats, &myStats, dedot))
+			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, rawnNetStats, myStats, dedot))
 		}
 	}
 
 	return formattedStats
 }
 
-func (n *NetService) getNetworkStats(nameInterface string, rawNetStats *types.NetworkStats, myRawstats *docker.Stat, dedot bool) NetStats {
-	newNetworkStats := createNetRaw(myRawstats.Stats.Read, rawNetStats)
+func (n *NetService) getNetworkStats(nameInterface string, rawNetStats types.NetworkStats, myRawstats docker.Stat, dedot bool) NetStats {
+	newNetworkStats := createNetRaw(myRawstats.Stats.Read, &rawNetStats)
 	oldNetworkStat, exist := n.NetworkStatPerContainer[myRawstats.Container.ID][nameInterface]
 
 	netStats := NetStats{
 		Container:     docker.NewContainer(myRawstats.Container, dedot),
 		Time:          myRawstats.Stats.Read,
 		NameInterface: nameInterface,
-		Total:         rawNetStats,
+		Total:         &rawNetStats,
 	}
 
 	if exist {


### PR DESCRIPTION
Cherry-pick of PR #14825 to 7.5 branch. Original message: 

Metricbeat docker metrics fails when multiple interfaces are configured at a container.
It looks like base code is using loop variable as a reference across iterations

Issue: https://github.com/elastic/beats/issues/14586

