### PR TITLE
[Testing] Allow loading fielddata on _id field

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -14,6 +14,7 @@ services:
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
     - "xpack.security.enabled=false"
+    - "indices.id_field_data.enabled=true"
 
   logstash:
     image: docker.elastic.co/logstash/logstash:8.0.0-SNAPSHOT


### PR DESCRIPTION
_Fixes issue reported in: https://github.com/elastic/beats/issues/14849_

This PR adjusts testing environment to recent changes introduced in Elasticsearch 8.0-SNAPSHOT: https://github.com/elastic/elasticsearch/pull/49166 .

Without this change filebeat integration tests fail:
```
"Caused by: java.lang.IllegalArgumentException: Fielddata access on the _id field is disallowed, you can re-enable it by updating the dynamic cluster setting: indices.id_field_data.enabled",
"at org.elasticsearch.index.mapper.IdFieldMapper$IdFieldType$1.build(IdFieldMapper.java:172) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]",
"at org.elasticsearch.index.fielddata.IndexFieldDataService.getForField(IndexFieldDataService.java:134) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]",
"at org.elasticsearch.index.query.QueryShardContext.getForField(QueryShardContext.java:194) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]",
```