### PR TITLE
Cherry-pick #14857 to 7.x: Fix cluster-wide Kafka client bug

### DIFF
--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -116,6 +116,13 @@ func (b *Broker) Connect() error {
 		return errors.Wrap(err, "broker.Open failed")
 	}
 
+	c, err := getClusterWideClient(b.Addr(), b.cfg)
+	if err != nil {
+		closeBroker(b.broker)
+		return fmt.Errorf("Could not get cluster client for advertised broker with address %v", b.Addr())
+	}
+	b.client = c
+
 	if b.id != noID || !b.matchID {
 		return nil
 	}
@@ -138,12 +145,6 @@ func (b *Broker) Connect() error {
 	b.id = other.ID()
 	b.advertisedAddr = other.Addr()
 
-	c, err := getClusterWideClient(b.Addr(), b.cfg)
-	if err != nil {
-		closeBroker(b.broker)
-		return fmt.Errorf("Could not get cluster client for advertised broker with address %v", b.Addr())
-	}
-	b.client = c
 	return nil
 }
 

--- a/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
@@ -81,7 +81,7 @@ func TestFetch(t *testing.T) {
 	for retries := 0; retries < 3; retries++ {
 		data, errors = mbtest.ReportingFetchV2Error(f)
 		if len(data) > 0 {
-			break
+			continue
 		}
 		time.Sleep(500 * time.Millisecond)
 	}


### PR DESCRIPTION
Cherry-pick of PR #14857 to 7.x branch. Original message: 

This PR fixes a bug introduced on https://github.com/elastic/beats/pull/14822.

The cluster-wide client was never re-opened after the first call to `Fetch` method because all the other times the `Connect` method to broker was returning before the cluster-wide client initialisation, due to https://github.com/elastic/beats/blob/4f0b4f96a0b97db5b61690feca1adf3b6db347ee/metricbeat/module/kafka/broker.go#L126.

cc: @jsoriano @mtojek 