### PR TITLE
Change the Authentication mechanism for fleet.

### DIFF
--- a/x-pack/agent/pkg/fleetapi/client.go
+++ b/x-pack/agent/pkg/fleetapi/client.go
@@ -59,17 +59,17 @@ func init() {
 
 // NewAuthWithConfig returns a Kibana client that will:
 //
-// - Send the AccessToken on every HTTP request.
+// - Send the API Key on every HTTP request.
 // - Ensure a minimun version of Kibana is required.
 // - Send the Fleet User Agent on every HTTP request.
-func NewAuthWithConfig(log *logger.Logger, config *config.Config, accessToken string) (*kibana.Client, error) {
+func NewAuthWithConfig(log *logger.Logger, config *config.Config, apiKey string) (*kibana.Client, error) {
 	return kibana.NewWithRawConfig(log, config, func(rt http.RoundTripper) (http.RoundTripper, error) {
 		rt, err := baseRoundTrippers(rt)
 		if err != nil {
 			return nil, err
 		}
 
-		rt, err = NewFleetAccessTokenRoundTripper(rt, accessToken)
+		rt, err = NewFleetAuthRoundTripper(rt, apiKey)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/agent/pkg/fleetapi/round_trippers.go
+++ b/x-pack/agent/pkg/fleetapi/round_trippers.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ErrInvalidAPIKey is returned when authentication fail to fleet.
-var ErrInvalidAPIKey = errors.New("invalid credentials to connect to fleet")
+var ErrInvalidAPIKey = errors.New("invalid api key to authenticate with fleet")
 
 // FleetUserAgentRoundTripper adds the Fleet user agent.
 type FleetUserAgentRoundTripper struct {

--- a/x-pack/agent/pkg/fleetapi/round_trippers.go
+++ b/x-pack/agent/pkg/fleetapi/round_trippers.go
@@ -11,7 +11,8 @@ import (
 	"github.com/elastic/beats/agent/kibana"
 )
 
-var InvalidCredentialsErr = errors.New("invalid credentials to connect to fleet")
+// ErrInvalidAPIKey is returned when authentication fail to fleet.
+var ErrInvalidAPIKey = errors.New("invalid credentials to connect to fleet")
 
 // FleetUserAgentRoundTripper adds the Fleet user agent.
 type FleetUserAgentRoundTripper struct {
@@ -50,7 +51,7 @@ func (r *FleetAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		defer resp.Body.Close()
-		return resp, InvalidCredentialsErr
+		return resp, ErrInvalidAPIKey
 	}
 	return resp, err
 }

--- a/x-pack/agent/pkg/fleetapi/round_trippers.go
+++ b/x-pack/agent/pkg/fleetapi/round_trippers.go
@@ -11,6 +11,8 @@ import (
 	"github.com/elastic/beats/agent/kibana"
 )
 
+var InvalidCredentialsErr = errors.New("invalid credentials to connect to fleet")
+
 // FleetUserAgentRoundTripper adds the Fleet user agent.
 type FleetUserAgentRoundTripper struct {
 	rt      http.RoundTripper
@@ -31,27 +33,35 @@ func NewFleetUserAgentRoundTripper(wrapped http.RoundTripper, version string) ht
 	}
 }
 
-// FleetAccessTokenRoundTripper allow all calls to be authenticated using the accessToken.
+// FleetAuthRoundTripper allow all calls to be authenticated using the api key.
 // The token is added as a header key.
-type FleetAccessTokenRoundTripper struct {
-	rt          http.RoundTripper
-	accessToken string
+type FleetAuthRoundTripper struct {
+	rt     http.RoundTripper
+	apiKey string
 }
 
 // RoundTrip makes all the calls to the service authenticated.
-func (r *FleetAccessTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	const key = "kbn-fleet-access-token"
-	req.Header.Set(key, r.accessToken)
-	return r.rt.RoundTrip(req)
+func (r *FleetAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	const key = "Authorization"
+	const prefix = "ApiKey "
+
+	req.Header.Set(key, prefix+r.apiKey)
+	resp, err := r.rt.RoundTrip(req)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		defer resp.Body.Close()
+		return resp, InvalidCredentialsErr
+	}
+	return resp, err
 }
 
-// NewFleetAccessTokenRoundTripper wrap an existing http.RoundTripper and adds the accessToken in the header.
-func NewFleetAccessTokenRoundTripper(
+// NewFleetAuthRoundTripper wrap an existing http.RoundTripper and adds the API in the header.
+func NewFleetAuthRoundTripper(
 	wrapped http.RoundTripper,
-	accessToken string,
+	apiKey string,
 ) (http.RoundTripper, error) {
-	if len(accessToken) == 0 {
-		return nil, errors.New("empty access token received")
+	if len(apiKey) == 0 {
+		return nil, errors.New("empty api key received")
 	}
-	return &FleetAccessTokenRoundTripper{rt: wrapped, accessToken: accessToken}, nil
+	return &FleetAuthRoundTripper{rt: wrapped, apiKey: apiKey}, nil
 }


### PR DESCRIPTION
Fleet changed how we should authenticate with them instead of using an
api key and a special header fields we now use the normal "Authorization" key and with this format:

```
Authorization: ApiKey {accessApiKey}
```

See https://github.com/elastic/kibana/pull/49639 for details