### PR TITLE
[DOCS] Fixes security link

### DIFF
--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -43,7 +43,7 @@ you plan to monitor {beatname_uc} in {kib} and have not yet set up the
 password, set it up now.
 
 For more information about {security}, see
-{xpack-ref}/xpack-security.html[Securing the {stack}].
+{ref}/elasticsearch-security.html[Security overview].
 
 [[feature-roles]]
 === {beatname_uc} features that require authorization


### PR DESCRIPTION
This PR fixes a link to https://www.elastic.co/guide/en/elasticsearch/reference/6.8/elasticsearch-security.html, which used to be "xpack-security.html".  The Beats pages that contained this link were being redirected via a deleted page, but this PR avoids the need the redirection.

Related to https://github.com/elastic/docs/pull/1490