### PR TITLE
Change from Enrollment token to use Elasticsearch API key

### DIFF
--- a/x-pack/agent/pkg/agent/application/application.go
+++ b/x-pack/agent/pkg/agent/application/application.go
@@ -101,13 +101,13 @@ func getKibanaClient(log *logger.Logger, c *ManagementConfig) (_ sender, err err
 		return nil, errors.New("fleet mode enabled but management.fleet.kibana not specified")
 	}
 
-	if c.Fleet.AccessToken != "" {
+	if c.Fleet.AccessAPIKey != "" {
 		rawConfig, err := config.NewConfigFrom(kibanaConfig)
 		if err != nil {
 			return nil, err
 		}
 
-		return fleetapi.NewAuthWithConfig(log, rawConfig, c.Fleet.AccessToken)
+		return fleetapi.NewAuthWithConfig(log, rawConfig, c.Fleet.AccessAPIKey)
 	}
 
 	return fleetapi.NewWithConfig(log, kibanaConfig)

--- a/x-pack/agent/pkg/agent/application/config_storage.go
+++ b/x-pack/agent/pkg/agent/application/config_storage.go
@@ -7,8 +7,8 @@ package application
 import "github.com/elastic/beats/agent/kibana"
 
 type fleetConfig struct {
-	AccessToken string         `config:"access_token"`
-	Kibana      *kibana.Config `config:"kibana"`
+	AccessAPIKey string         `config:"access_api_key"`
+	Kibana       *kibana.Config `config:"kibana"`
 }
 
 type store interface {

--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -31,7 +31,7 @@ type clienter interface {
 // EnrollCmd is an enroll subcommand that interacts between the Kibana API and the Agent.
 type EnrollCmd struct {
 	log                  *logger.Logger
-	enrollmentToken      string
+	enrollAPIKey         string
 	client               clienter
 	id                   string
 	userProvidedMetadata map[string]interface{}
@@ -45,7 +45,7 @@ func NewEnrollCmd(
 	log *logger.Logger,
 	url string,
 	CAs []string,
-	enrollmentToken string,
+	enrollAPIKey string,
 	id string,
 	userProvidedMetadata map[string]interface{},
 	configStore store,
@@ -70,7 +70,7 @@ func NewEnrollCmd(
 	return &EnrollCmd{
 		log:                  log,
 		client:               client,
-		enrollmentToken:      enrollmentToken,
+		enrollAPIKey:         enrollAPIKey,
 		id:                   id,
 		userProvidedMetadata: userProvidedMetadata,
 		kibanaConfig:         cfg,
@@ -83,9 +83,9 @@ func (c *EnrollCmd) Execute() error {
 	cmd := fleetapi.NewEnrollCmd(c.client)
 
 	r := &fleetapi.EnrollRequest{
-		EnrollmentToken: c.enrollmentToken,
-		SharedID:        c.id,
-		Type:            fleetapi.PermanentEnroll,
+		EnrollAPIKey: c.enrollAPIKey,
+		SharedID:     c.id,
+		Type:         fleetapi.PermanentEnroll,
 		Metadata: fleetapi.Metadata{
 			Local:        metadata(),
 			UserProvided: c.userProvidedMetadata,
@@ -98,8 +98,8 @@ func (c *EnrollCmd) Execute() error {
 	}
 
 	if err := c.configStore.Save(fleetConfig{
-		AccessToken: resp.Item.AccessToken,
-		Kibana:      c.kibanaConfig,
+		AccessAPIKey: resp.Item.AccessAPIKey,
+		Kibana:       c.kibanaConfig,
 	}); err != nil {
 		return errors.Wrap(err, "could not save credentials")
 	}
@@ -113,5 +113,3 @@ func metadata() map[string]interface{} {
 		"version":  release.Version(),
 	}
 }
-
-// info Enrollment token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXBlIjoiRU5ST0xNRU5UX1RPS0VOIiwicG9saWN5Ijp7ImlkIjoiNjlmM2Y1YTAtZWM1Mi0xMWU5LTkzYzQtZDcyYWI4YTY5MzkxIn0sImlhdCI6MTU3MDgxNzQzMn0.tVxm4JY9gAcd14YlQTmi_y-8AqbGtKyS_PXXI2gdLBY

--- a/x-pack/agent/pkg/agent/application/enroll_cmd_test.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd_test.go
@@ -62,7 +62,7 @@ func TestEnroll(t *testing.T) {
             "version": "8.0.0"
         },
         "actions": [],
-        "access_token": "my-access-token"
+        "access_api_key": "my-access-api-key"
     }
 }`))
 			})
@@ -78,7 +78,7 @@ func TestEnroll(t *testing.T) {
 				log,
 				url,
 				[]string{caFile},
-				"my-enrollment-token",
+				"my-enrollment-api-key",
 				"my-id",
 				map[string]interface{}{"custom": "customize"},
 				store,
@@ -89,7 +89,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			require.True(t, store.Called)
-			require.Equal(t, store.Config.AccessToken, "my-access-token")
+			require.Equal(t, store.Config.AccessAPIKey, "my-access-api-key")
 			require.Equal(t, store.Config.Kibana.Host, host)
 			require.Equal(t, store.Config.Kibana.Protocol, kibana.Protocol("https"))
 			require.Equal(t, store.Config.Kibana.Username, "")
@@ -120,7 +120,7 @@ func TestEnroll(t *testing.T) {
             "version": "8.0.0"
         },
         "actions": [],
-        "access_token": "my-access-token"
+        "access_api_key": "my-access-api-key"
     }
 }`))
 			})
@@ -132,7 +132,7 @@ func TestEnroll(t *testing.T) {
 				log,
 				url,
 				make([]string, 0),
-				"my-enrollment-token",
+				"my-enrollment-api-key",
 				"my-id",
 				map[string]interface{}{"custom": "customize"},
 				store,
@@ -143,7 +143,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			require.True(t, store.Called)
-			require.Equal(t, store.Config.AccessToken, "my-access-token")
+			require.Equal(t, store.Config.AccessAPIKey, "my-access-api-key")
 			require.Equal(t, store.Config.Kibana.Host, host)
 			require.Equal(t, store.Config.Kibana.Protocol, kibana.Protocol("http"))
 			require.Equal(t, store.Config.Kibana.Username, "")

--- a/x-pack/agent/pkg/fleetapi/enroll_cmd.go
+++ b/x-pack/agent/pkg/fleetapi/enroll_cmd.go
@@ -74,10 +74,10 @@ func (p EnrollType) MarshalJSON() ([]byte, error) {
 //   }
 // }
 type EnrollRequest struct {
-	EnrollmentToken string     `json:"-"`
-	Type            EnrollType `json:"type"`
-	SharedID        string     `json:"sharedId,omitempty"`
-	Metadata        Metadata   `json:"metadata"`
+	EnrollAPIKey string     `json:"-"`
+	Type         EnrollType `json:"type"`
+	SharedID     string     `json:"sharedId,omitempty"`
+	Metadata     Metadata   `json:"metadata"`
 }
 
 // Metadata is a all the metadata send or received from the agent.
@@ -90,8 +90,8 @@ type Metadata struct {
 func (e *EnrollRequest) Validate() error {
 	var err error
 
-	if len(e.EnrollmentToken) == 0 {
-		err = multierror.Append(err, errors.New("missing enrollment token"))
+	if len(e.EnrollAPIKey) == 0 {
+		err = multierror.Append(err, errors.New("missing enrollment api key"))
 	}
 
 	if len(e.Type) == 0 {
@@ -116,7 +116,7 @@ func (e *EnrollRequest) Validate() error {
 //     "user_provided_metadata": {},
 //     "local_metadata": {},
 //     "actions": [],
-//     "access_token": "ACCESS_TOKEN"
+//     "access_api_key": "API_KEY"
 //   }
 // }
 type EnrollResponse struct {
@@ -135,7 +135,7 @@ type EnrollItemResponse struct {
 	UserProvidedMetadata map[string]interface{} `json:"user_provided_metadata"`
 	LocalMetadata        map[string]interface{} `json:"local_metadata"`
 	Actions              []interface{}          `json:"actions"`
-	AccessToken          string                 `json:"access_token"`
+	AccessAPIKey         string                 `json:"access_api_key"`
 }
 
 // Validate validates the response send from the server.
@@ -150,8 +150,8 @@ func (e *EnrollResponse) Validate() error {
 		err = multierror.Append(err, errors.New("missing enrollment type"))
 	}
 
-	if len(e.Item.AccessToken) == 0 {
-		err = multierror.Append(err, errors.New("access token is missing"))
+	if len(e.Item.AccessAPIKey) == 0 {
+		err = multierror.Append(err, errors.New("access api key is missing"))
 	}
 
 	return err
@@ -165,14 +165,15 @@ type EnrollCmd struct {
 // Execute enroll the Agent in the Fleet.
 func (e *EnrollCmd) Execute(r *EnrollRequest) (*EnrollResponse, error) {
 	const p = "/api/fleet/agents/enroll"
-	const key = "kbn-fleet-enrollment-token"
+	const key = "Authorization"
+	const prefix = "ApiKey "
 
 	if err := r.Validate(); err != nil {
 		return nil, err
 	}
 
 	headers := map[string][]string{
-		key: []string{r.EnrollmentToken},
+		key: []string{prefix + r.EnrollAPIKey},
 	}
 
 	b, err := json.Marshal(r)

--- a/x-pack/agent/pkg/fleetapi/enroll_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/enroll_cmd_test.go
@@ -26,7 +26,7 @@ func TestEnroll(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 
 				// Assert Enrollment Token.
-				require.Equal(t, "my-enrollment-token", r.Header.Get("kbn-fleet-enrollment-token"))
+				require.Equal(t, "ApiKey my-enrollment-api-key", r.Header.Get("Authorization"))
 
 				decoder := json.NewDecoder(r.Body)
 				defer r.Body.Close()
@@ -53,7 +53,7 @@ func TestEnroll(t *testing.T) {
 						EnrolledAt:           time.Now(),
 						UserProvidedMetadata: make(map[string]interface{}),
 						LocalMetadata:        make(map[string]interface{}),
-						AccessToken:          "my-access-token",
+						AccessAPIKey:         "my-access-api-key",
 					},
 				}
 
@@ -72,9 +72,9 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			req := &EnrollRequest{
-				Type:            PermanentEnroll,
-				EnrollmentToken: "my-enrollment-token",
-				SharedID:        "im-a-beat",
+				Type:         PermanentEnroll,
+				EnrollAPIKey: "my-enrollment-api-key",
+				SharedID:     "im-a-beat",
 				Metadata: Metadata{
 					Local: map[string]interface{}{
 						"os": "linux",
@@ -87,7 +87,7 @@ func TestEnroll(t *testing.T) {
 			resp, err := cmd.Execute(req)
 			require.NoError(t, err)
 
-			require.Equal(t, "my-access-token", resp.Item.AccessToken)
+			require.Equal(t, "my-access-api-key", resp.Item.AccessAPIKey)
 			require.Equal(t, "created", resp.Action)
 			require.True(t, resp.Success)
 		},
@@ -111,9 +111,9 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			req := &EnrollRequest{
-				Type:            PermanentEnroll,
-				EnrollmentToken: "my-enrollment-token",
-				SharedID:        "im-a-beat",
+				Type:         PermanentEnroll,
+				EnrollAPIKey: "my-enrollment-api-key",
+				SharedID:     "im-a-beat",
 				Metadata: Metadata{
 					Local: map[string]interface{}{
 						"os": "linux",


### PR DESCRIPTION
This PR updates the enroll command to use an Elasticsearch token instead
of custom token for enrollment.

See https://github.com/elastic/kibana/pull/49639 for details