### PR TITLE
Cherry-pick #14407 to 7.x: Libbeat: Do not overwrite agent.*, ecs.version, and host.name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow Metricbeat's beat module to read monitoring information over a named pipe or unix domain socket. {pull}14558[14558]
 - Remove version information from default ILM policy for improved upgrade experience on custom policies. {pull}14745[14745]
 - Running `setup` cmd respects `setup.ilm.overwrite` setting for improved support of custom policies. {pull}14741[14741]
+- Libbeat: Do not overwrite agent.*, ecs.version, and host.name. {pull}14407[14407]
 
 *Auditbeat*
 

--- a/libbeat/processors/actions/add_fields.go
+++ b/libbeat/processors/actions/add_fields.go
@@ -29,8 +29,9 @@ import (
 )
 
 type addFields struct {
-	fields common.MapStr
-	shared bool
+	fields    common.MapStr
+	shared    bool
+	overwrite bool
 }
 
 // FieldsKey is the default target key for the add_fields processor.
@@ -66,8 +67,8 @@ func CreateAddFields(c *common.Config) (processors.Processor, error) {
 // NewAddFields creates a new processor adding the given fields to events.
 // Set `shared` true if there is the chance of labels being changed/modified by
 // subsequent processors.
-func NewAddFields(fields common.MapStr, shared bool) processors.Processor {
-	return &addFields{fields: fields, shared: shared}
+func NewAddFields(fields common.MapStr, shared bool, overwrite bool) processors.Processor {
+	return &addFields{fields: fields, shared: shared, overwrite: overwrite}
 }
 
 func (af *addFields) Run(event *beat.Event) (*beat.Event, error) {
@@ -76,7 +77,12 @@ func (af *addFields) Run(event *beat.Event) (*beat.Event, error) {
 		fields = fields.Clone()
 	}
 
-	event.Fields.DeepUpdate(fields)
+	if af.overwrite {
+		event.Fields.DeepUpdate(fields)
+	} else {
+		event.Fields.DeepUpdateNoOverwrite(fields)
+	}
+
 	return event, nil
 }
 
@@ -99,5 +105,5 @@ func makeFieldsProcessor(target string, fields common.MapStr, shared bool) proce
 		}
 	}
 
-	return NewAddFields(fields, shared)
+	return NewAddFields(fields, shared, true)
 }

--- a/libbeat/processors/actions/add_labels.go
+++ b/libbeat/processors/actions/add_labels.go
@@ -56,5 +56,5 @@ func createAddLabels(c *common.Config) (processors.Processor, error) {
 func NewAddLabels(labels common.MapStr, shared bool) processors.Processor {
 	return NewAddFields(common.MapStr{
 		LabelsKey: labels.Flatten(),
-	}, shared)
+	}, shared, true)
 }

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -295,7 +295,7 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 		// With dynamic fields potentially changing at any time, we need to copy,
 		// so we do not change shared structures be accident.
 		fieldsNeedsCopy := needsCopy || cfg.DynamicFields != nil || hasKeyAnyOf(fields, builtin)
-		processors.add(actions.NewAddFields(fields, fieldsNeedsCopy))
+		processors.add(actions.NewAddFields(fields, fieldsNeedsCopy, true))
 	}
 
 	if cfg.DynamicFields != nil {
@@ -310,7 +310,7 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 
 	// setup 6: add beats and host metadata
 	if meta := builtin; len(meta) > 0 {
-		processors.add(actions.NewAddFields(meta, needsCopy))
+		processors.add(actions.NewAddFields(meta, needsCopy, false))
 	}
 
 	// setup 8: pipeline processors list

--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -165,7 +165,7 @@ func TestProcessorsConfigs(t *testing.T) {
 			local: beat.ProcessingConfig{
 				Processor: func() beat.ProcessorList {
 					g := newGroup("test", logp.L())
-					g.add(actions.NewAddFields(common.MapStr{"custom": "value"}, true))
+					g.add(actions.NewAddFields(common.MapStr{"custom": "value"}, true, true))
 					return g
 				}(),
 			},


### PR DESCRIPTION
Cherry-pick of PR #14407 to 7.x branch. Original message: 

Addresses part of https://github.com/elastic/beats/issues/13920#issuecomment-540022838.

Libbeat currently sets a few fields in every event, with no option to turn it off, or to at least not overwrite existing values.

This is a problem when receiving forwarded events (see  https://github.com/elastic/beats/issues/13920 for details). The field I'm most concerned about is `host.name` which is used by the Kibana SIEM app to identify hosts. This PR changes Libbeat to not overwrite `host.name` and a few other fields when they are already set (see list of fields below). This is technically a breaking change, though I think in almost all cases the current behavior is not what users would expect, and it is creating problems in the wild (eg https://github.com/elastic/beats/issues/13706, [discuss #1](https://discuss.elastic.co/t/hosts-tab-in-siem-and-wef/190162), [discuss #2](https://discuss.elastic.co/t/siem-not-detecting-asa-success-failure-logins/203754)) - so I would like to make it in 7.x.

A bit more detail on the implementation: Adds a new function `MapStr. DeepUpdateNoOverwrite` alongside the existing `MapStr.DeepUpdate` and an `overwrite` parameter to the `add_fields` processor (but does not expose it).

The affected fields that will no longer be overwritten if they already exist are:
1. agent.ephemeral_id
2. agent.hostname
3. agent.id
4. agent.type
5. agent.version
6. ecs.version
7. host.name

If we do not want to change the behavior for all these fields we could also refactor the code to only not overwrite `host.name` - but I think it makes sense to not overwrite any of these fields.