### PR TITLE
[DOCS] Adds security fixes to release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,10 @@ https://github.com/elastic/beats/compare/v7.4.1...v7.5.0[View commits]
 
 *Filebeat*
 
+- Fix a denial of service flaw when parsing malformed DSA public keys in Go.
+If {filebeat} is configured to accept incoming TLS connections with client
+authentication enabled, a remote attacker could cause the Beat to stop
+processing events. (CVE-2019-17596) See https://www.elastic.co/community/security/
 - Fix timezone parsing of rabbitmq module ingest pipelines. {pull}13879[13879]
 - Fix conditions and error checking of date processors in ingest pipelines that use `event.timezone` to parse dates. {pull}13883[13883]
 - Fix timezone parsing of Cisco module ingest pipelines. {pull}13893[13893]
@@ -57,6 +61,10 @@ https://github.com/elastic/beats/compare/v7.4.1...v7.5.0[View commits]
 
 *Metricbeat*
 
+- Fix a denial of service flaw when parsing malformed DSA public keys in Go.
+If {metricbeat} is configured to accept incoming TLS connections with client
+authentication enabled, a remote attacker could cause the Beat to stop
+processing events. (CVE-2019-17596) See https://www.elastic.co/community/security/
 - PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function. {issue}12590[12590] {pull}12622[12622]
 - Fix `docker.cpu.system.pct` calculation by using the reported number online cpus instead of the number of metrics per cpu. {pull}13691[13691]
 - Change kubernetes.event.message to text {pull}13964[13964]


### PR DESCRIPTION
This PR augments the 7.5.0 release notes with information about the security fixes (and links to them on https://www.elastic.co/community/security/).

Preview: http://beats_14888.docs-preview.app.elstc.co/guide/en/beats/libbeat/7.5/release-notes-7.5.0.html