### PR TITLE
Rerun test_modules.py with 7.6.0 Snapshots

### DIFF
--- a/filebeat/module/nginx/access/test/test-with-host.log-expected.json
+++ b/filebeat/module/nginx/access/test/test-with-host.log-expected.json
@@ -29,7 +29,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2017-05-29T19:02:48.000Z",
@@ -56,7 +56,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {
@@ -85,8 +87,8 @@
         "source.geo.city_name": "Berlin",
         "source.geo.continent_name": "Europe",
         "source.geo.country_iso_code": "DE",
-        "source.geo.location.lat": 52.4908,
-        "source.geo.location.lon": 13.3275,
+        "source.geo.location.lat": 52.4473,
+        "source.geo.location.lon": 13.4531,
         "source.geo.region_iso_code": "DE-BE",
         "source.geo.region_name": "Land Berlin",
         "source.ip": "85.181.35.98",
@@ -98,7 +100,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0"
+        "user_agent.version": "49.0."
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",
@@ -125,8 +127,8 @@
         "source.geo.city_name": "Berlin",
         "source.geo.continent_name": "Europe",
         "source.geo.country_iso_code": "DE",
-        "source.geo.location.lat": 52.4908,
-        "source.geo.location.lon": 13.3275,
+        "source.geo.location.lat": 52.4473,
+        "source.geo.location.lon": 13.4531,
         "source.geo.region_iso_code": "DE-BE",
         "source.geo.region_name": "Land Berlin",
         "source.ip": "85.181.35.98",
@@ -138,7 +140,7 @@
         "user_agent.os.full": "Mac OS X 10.14.0",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14.0",
-        "user_agent.version": "70.0.3538"
+        "user_agent.version": "70.0.3538.102"
     },
     {
         "@timestamp": "2016-01-22T13:18:29.000Z",
@@ -168,8 +170,8 @@
         "source.geo.city_name": "Springfield",
         "source.geo.continent_name": "North America",
         "source.geo.country_iso_code": "US",
-        "source.geo.location.lat": 39.772,
-        "source.geo.location.lon": -89.6859,
+        "source.geo.location.lat": 39.7647,
+        "source.geo.location.lon": -89.7379,
         "source.geo.region_iso_code": "US-IL",
         "source.geo.region_name": "Illinois",
         "source.ip": "199.96.1.1",
@@ -200,8 +202,6 @@
         ],
         "service.type": "nginx",
         "source.address": "2a03:0000:10ff:f00f:0000:0000:0:8000",
-        "source.as.number": 204094,
-        "source.as.organization.name": "Ricardo Rodrigues Charneca",
         "source.geo.continent_name": "Europe",
         "source.geo.country_iso_code": "PT",
         "source.geo.location.lat": 39.5,
@@ -282,7 +282,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     },
     {
@@ -310,7 +312,9 @@
         "user_agent.device.name": "Other",
         "user_agent.name": "Firefox Alpha",
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "user_agent.os.name": "Windows 7",
+        "user_agent.os.full": "Windows 7",
+        "user_agent.os.name": "Windows",
+        "user_agent.os.version": "7",
         "user_agent.version": "15.0.a2"
     }
 ]


### PR DESCRIPTION
This PR is to fix https://github.com/elastic/beats/pull/14761 by running test_modules.py with new snapshot.