### PR TITLE
Make independent python virtualenvs in docker

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -5,8 +5,11 @@ RUN \
       && apt-get install -y --no-install-recommends \
          python-pip \
          virtualenv \
+         python3 \
          librpm-dev \
       && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -7,8 +7,11 @@ RUN \
          python-pip \
          rsync \
          virtualenv \
+         python3 \
          libpcap-dev \
       && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -4,8 +4,10 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-         netcat python-pip virtualenv && \
+         netcat python-pip virtualenv python3 && \
     apt-get clean
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -4,8 +4,10 @@ MAINTAINER Noémi Ványi <noemi.vanyi@elastic.co>
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      python-pip virtualenv libsystemd-dev libc6-dev-i386 gcc-arm-linux-gnueabi && \
+      python-pip virtualenv python3 libsystemd-dev libc6-dev-i386 gcc-arm-linux-gnueabi && \
     apt-get clean
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade setuptools
 

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-         netcat python-pip virtualenv libpcap-dev && \
+         netcat python-pip virtualenv python3 libpcap-dev && \
     apt-get clean
 
 ENV PYTHON_ENV=/tmp/python-env

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -208,7 +208,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} -e PYTHON_EXE=${PYTHON_EXE} beat make system-tests
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -20,6 +20,7 @@ nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==4.2b1
+Pillow==6.2.1
 redis==2.10.6
 requests==2.20.0
 six==1.11.0

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -20,7 +20,7 @@ nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==4.2b1
-Pillow==6.2.1
+Pillow==5.4.1
 redis==2.10.6
 requests==2.20.0
 six==1.11.0

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -6,7 +6,10 @@ RUN \
          netcat \
          python-pip \
          virtualenv \
+         python3 \
       && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -4,8 +4,10 @@ MAINTAINER Pier-Hugues Pellerin <ph@elastic.co>
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-         netcat python-pip rsync virtualenv && \
+         netcat python-pip rsync virtualenv python3 && \
     apt-get clean
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade setuptools
 

--- a/x-pack/libbeat/Dockerfile
+++ b/x-pack/libbeat/Dockerfile
@@ -3,8 +3,10 @@ FROM golang:1.13.4
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-         netcat python-pip rsync virtualenv && \
+         netcat python-pip rsync virtualenv python3 && \
     apt-get clean
+
+ENV PYTHON_ENV=/tmp/python-env
 
 RUN pip install --upgrade setuptools
 


### PR DESCRIPTION
System tests running in docker are using the same virtual environment as
the host. If version of python in the virtual environment is not available
in the guest, it will use the default in the system, that is so far
Python 2.

Also install Python 3 in the dockers, and Pillow, that was needed on my
system when running locally.