### PR TITLE
Pass PYTHON_EXE when integration tests are executed from mage

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -147,6 +147,7 @@ func RunIntegTest(mageTarget string, test func() error, passThroughEnvVars ...st
 	env := []string{
 		"TEST_COVERAGE",
 		"RACE_DETECTOR",
+		"PYTHON_EXE",
 	}
 	env = append(env, passThroughEnvVars...)
 	return runInIntegTestEnv(mageTarget, test, env...)


### PR DESCRIPTION
Integration tests executed on docker through mage in #14798 
were still being executed with Python 2, pass through
`PYTHON_EXE` so they are executed with Python 3.