### PR TITLE
Cherry-pick #14797 to 7.5:Additional check on flag ignore_non_existent_counters if the PdhExpandWildCardPathW returns no errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
+- Add extra check on `ignore_non_existent_counters` flag if the PdhExpandWildCardPathW returns no errors but does not expand the counter path successfully in windows/perfmon metricset. {pull}14797[14797]
 - Fix rds metricset from reporting same values for different instances. {pull}14702[14702]
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
 - Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -89,6 +89,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches events and reports them upstream
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
+	// if the ignore_non_existent_counters flag is set and no valid counter paths are found the Read func will still execute, a check is done before
+	if len(m.reader.query.counters) == 0 {
+		return errors.New("no counters to read")
+	}
+
 	// refresh performance counter list
 	// Some counters, such as rate counters, require two counter values in order to compute a displayable value. In this case we must call PdhCollectQueryData twice before calling PdhGetFormattedCounterValue.
 	// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).

--- a/metricbeat/module/windows/perfmon/reader.go
+++ b/metricbeat/module/windows/perfmon/reader.go
@@ -76,6 +76,12 @@ func NewReader(config Config) (*Reader, error) {
 		}
 		// check if the pdhexpandcounterpath/pdhexpandwildcardpath functions have expanded the counter successfully.
 		if len(childQueries) == 0 || (len(childQueries) == 1 && strings.Contains(childQueries[0], "*")) {
+			// covering cases when PdhExpandWildCardPathW returns no counter paths or is unable to expand and the ignore_non_existent_counters flag is set
+			if config.IgnoreNECounters {
+				r.log.Infow("Ignoring non existent counter", "initial query", counter.Query,
+					logp.Namespace("perfmon"), "expanded query", childQueries)
+				continue
+			}
 			return nil, errors.Errorf(`failed to expand counter (query="%v")`, counter.Query)
 		}
 		for _, v := range childQueries {


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14797 to 7.5 branch. Original message:

Additional check on flag `ignore_non_existent_counters` if the `PdhExpandWildCardPathW` returns no errors.
The flag is checked only if the `PdhExpandWildCardPathW` returns an error. There could be cases where this func does not return an error but will not expand the counter path or return any counter paths.
An extra check is added in this cases.