### PR TITLE
Cherry-pick #14738 to 7.x: Refactor kubernetes autodiscover to enable different resource based discovery

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -346,6 +346,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for API keys in Elasticsearch outputs. {pull}14324[14324]
 - Ensure that init containers are no longer tailed after they stop {pull}14394[14394]
 - Add consumer_lag in Kafka consumergroup metricset {pull}14822[14822]
+- Refactor kubernetes autodiscover to enable different resource based discovery {pull}14738[14738]
 
 *Auditbeat*
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -23,7 +23,7 @@ data:
     #filebeat.autodiscover:
     #  providers:
     #    - type: kubernetes
-    #      host: ${NODE_NAME}
+    #      node: ${NODE_NAME}
     #      hints.enabled: true
     #      hints.default_config:
     #        type: container

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -23,7 +23,7 @@ data:
     #filebeat.autodiscover:
     #  providers:
     #    - type: kubernetes
-    #      host: ${NODE_NAME}
+    #      node: ${NODE_NAME}
     #      hints.enabled: true
     #      hints.default_config:
     #        type: container

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -18,7 +18,7 @@ data:
     #metricbeat.autodiscover:
     #  providers:
     #    - type: kubernetes
-    #      host: ${NODE_NAME}
+    #      node: ${NODE_NAME}
     #      hints.enabled: true
 
     processors:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -18,7 +18,7 @@ data:
     #metricbeat.autodiscover:
     #  providers:
     #    - type: kubernetes
-    #      host: ${NODE_NAME}
+    #      node: ${NODE_NAME}
     #      hints.enabled: true
 
     processors:

--- a/libbeat/autodiscover/providers/kubernetes/config_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/config_test.go
@@ -53,6 +53,22 @@ func TestConfigWithCustomBuilders(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestConfigWithIncorrectScope(t *testing.T) {
+	cfg := common.MapStr{
+		"scope":         "node",
+		"resource":      "service",
+		"hints.enabled": true,
+	}
+
+	config := common.MustNewConfigFrom(&cfg)
+	c := defaultConfig()
+	err := config.Unpack(&c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "service", c.Resource)
+	assert.Equal(t, "cluster", c.Scope)
+}
+
 type mockBuilder struct {
 }
 

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -1,0 +1,219 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"k8s.io/api/core/v1"
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type node struct {
+	uuid    uuid.UUID
+	config  *Config
+	metagen kubernetes.MetaGenerator
+	logger  *logp.Logger
+	publish func(bus.Event)
+	watcher kubernetes.Watcher
+}
+
+// NewNodeEventer creates an eventer that can discover and process node objects
+func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+	metagen, err := kubernetes.NewMetaGenerator(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logp.NewLogger("autodiscover.node")
+
+	config := defaultConfig()
+	err = cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that node is set correctly whenever the scope is set to "node". Make sure that node is empty
+	// when cluster scope is enforced.
+	if config.Scope == "node" {
+		config.Node = kubernetes.DiscoverKubernetesNode(config.Node, kubernetes.IsInCluster(config.KubeConfig), client)
+	} else {
+		config.Node = ""
+	}
+
+	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
+
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
+		SyncTimeout: config.SyncPeriod,
+		Node:        config.Node,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)
+	}
+
+	p := &node{
+		config:  config,
+		uuid:    uuid,
+		publish: publish,
+		metagen: metagen,
+		logger:  logger,
+		watcher: watcher,
+	}
+
+	watcher.AddEventHandler(p)
+	return p, nil
+}
+
+// OnAdd ensures processing of node objects that are newly created
+func (n *node) OnAdd(obj interface{}) {
+	n.logger.Debugf("Watcher Node add: %+v", obj)
+	n.emit(obj.(*kubernetes.Node), "start")
+}
+
+// OnUpdate ensures processing of node objects that are updated
+func (n *node) OnUpdate(obj interface{}) {
+	node := obj.(*kubernetes.Node)
+	if node.GetObjectMeta().GetDeletionTimestamp() != nil {
+		n.logger.Debugf("Watcher Node update (terminating): %+v", obj)
+		// Node is terminating, don't reload its configuration and ignore the event as long as node is Ready.
+		if isNodeReady(node) {
+			return
+		}
+		time.AfterFunc(n.config.CleanupTimeout, func() { n.emit(node, "stop") })
+	} else {
+		n.logger.Debugf("Watcher Node update: %+v", obj)
+		// TODO: figure out how to avoid stop starting when node status is periodically being updated by kubelet
+		n.emit(node, "stop")
+		n.emit(node, "start")
+	}
+}
+
+// OnDelete ensures processing of node objects that are deleted
+func (n *node) OnDelete(obj interface{}) {
+	n.logger.Debugf("Watcher Node delete: %+v", obj)
+	time.AfterFunc(n.config.CleanupTimeout, func() { n.emit(obj.(*kubernetes.Node), "stop") })
+}
+
+// GenerateHints creates hints needed for hints builder
+func (n *node) GenerateHints(event bus.Event) bus.Event {
+	// Try to build a config with enabled builders. Send a provider agnostic payload.
+	// Builders are Beat specific.
+	e := bus.Event{}
+	var annotations common.MapStr
+	var kubeMeta common.MapStr
+	rawMeta, ok := event["kubernetes"]
+	if ok {
+		kubeMeta = rawMeta.(common.MapStr)
+		// The builder base config can configure any of the field values of kubernetes if need be.
+		e["kubernetes"] = kubeMeta
+		if rawAnn, ok := kubeMeta["annotations"]; ok {
+			annotations = rawAnn.(common.MapStr)
+		}
+	}
+	if host, ok := event["host"]; ok {
+		e["host"] = host
+	}
+	if port, ok := event["port"]; ok {
+		e["port"] = port
+	}
+
+	hints := builder.GenerateHints(annotations, "", n.config.Prefix)
+	n.logger.Debugf("Generated hints %+v", hints)
+	if len(hints) != 0 {
+		e["hints"] = hints
+	}
+
+	n.logger.Debugf("Generated builder event %+v", e)
+
+	return e
+}
+
+// Start starts the eventer
+func (n *node) Start() error {
+	return n.watcher.Start()
+}
+
+// Stop stops the eventer
+func (n *node) Stop() {
+	n.watcher.Stop()
+}
+
+func (n *node) emit(node *kubernetes.Node, flag string) {
+	host := getAddress(node)
+
+	// If a node doesn't have an IP then dont monitor it
+	if host == "" && flag != "stop" {
+		return
+	}
+
+	eventID := fmt.Sprint(node.GetObjectMeta().GetUID())
+	meta := n.metagen.ResourceMetadata(node)
+
+	// TODO: Refactor metagen to make sure that this is seamless
+	meta.Put("node.name", node.Name)
+	meta.Put("node.uid", string(node.GetObjectMeta().GetUID()))
+
+	kubemeta := meta.Clone()
+	// Pass annotations to all events so that it can be used in templating and by annotation builders.
+	annotations := common.MapStr{}
+	for k, v := range node.GetObjectMeta().GetAnnotations() {
+		safemapstr.Put(annotations, k, v)
+	}
+	kubemeta["annotations"] = annotations
+	event := bus.Event{
+		"provider":   n.uuid,
+		"id":         eventID,
+		flag:         true,
+		"host":       host,
+		"kubernetes": kubemeta,
+		"meta": common.MapStr{
+			"kubernetes": meta,
+		},
+	}
+	n.publish(event)
+
+}
+
+func getAddress(node *kubernetes.Node) string {
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeExternalIP && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	return ""
+}
+
+func isNodeReady(node *kubernetes.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/libbeat/autodiscover/providers/kubernetes/node_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/node_test.go
@@ -1,0 +1,275 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/beats/libbeat/autodiscover/template"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func TestGenerateHints_Node(t *testing.T) {
+	tests := []struct {
+		event  bus.Event
+		result bus.Event
+	}{
+		// Empty events should return empty hints
+		{
+			event:  bus.Event{},
+			result: bus.Event{},
+		},
+		// Only kubernetes payload must return only kubernetes as part of the hint
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"node": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"node": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+		},
+		// Scenarios being tested:
+		// metrics/module must be found in hints.metrics
+		// not.to.include must not be part of hints
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+						"not.to.include":            "true",
+					}),
+					"node": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"not.to.include":            "true",
+						"co.elastic.metrics/period": "10s",
+					}),
+					"node": common.MapStr{
+						"name": "foobar",
+					},
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "10s",
+					},
+				},
+			},
+		},
+	}
+
+	cfg := defaultConfig()
+
+	s := service{
+		config: cfg,
+		logger: logp.NewLogger("kubernetes.service"),
+	}
+	for _, test := range tests {
+		assert.Equal(t, s.GenerateHints(test.event), test.result)
+	}
+}
+
+func TestEmitEvent_Node(t *testing.T) {
+	name := "metricbeat"
+	nodeIP := "192.168.0.1"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	UUID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		Message  string
+		Flag     string
+		Node     *kubernetes.Node
+		Expected bus.Event
+	}{
+		{
+			Message: "Test node start",
+			Flag:    "start",
+			Node: &kubernetes.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeExternalIP,
+							Address: nodeIP,
+						},
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "1.2.3.4",
+						},
+					},
+				},
+			},
+			Expected: bus.Event{
+				"start":    true,
+				"host":     "192.168.0.1",
+				"id":       uid,
+				"provider": UUID,
+				"kubernetes": common.MapStr{
+					"node": common.MapStr{
+						"name": "metricbeat",
+						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+					},
+					"annotations": common.MapStr{},
+				},
+				"meta": common.MapStr{
+					"kubernetes": common.MapStr{
+						"node": common.MapStr{
+							"name": "metricbeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+					},
+				},
+				"config": []*common.Config{},
+			},
+		},
+		{
+			Message: "Test service without host",
+			Flag:    "start",
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Status: v1.NodeStatus{},
+			},
+			Expected: nil,
+		},
+		{
+			Message: "Test stop node without host",
+			Flag:    "stop",
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{},
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionFalse,
+						},
+					},
+				},
+			},
+			Expected: bus.Event{
+				"stop":     true,
+				"host":     "",
+				"id":       uid,
+				"provider": UUID,
+				"kubernetes": common.MapStr{
+					"node": common.MapStr{
+						"name": "metricbeat",
+						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+					},
+					"annotations": common.MapStr{},
+				},
+				"meta": common.MapStr{
+					"kubernetes": common.MapStr{
+						"node": common.MapStr{
+							"name": "metricbeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+					},
+				},
+				"config": []*common.Config{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Message, func(t *testing.T) {
+			mapper, err := template.NewConfigMapper(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			metaGen, err := kubernetes.NewMetaGenerator(common.NewConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p := &Provider{
+				config:    defaultConfig(),
+				bus:       bus.New("test"),
+				templates: mapper,
+				logger:    logp.NewLogger("kubernetes"),
+			}
+
+			no := &node{
+				metagen: metaGen,
+				config:  defaultConfig(),
+				publish: p.publish,
+				uuid:    UUID,
+				logger:  logp.NewLogger("kubernetes.no"),
+			}
+
+			p.eventer = no
+
+			listener := p.bus.Subscribe()
+
+			no.emit(test.Node, test.Flag)
+
+			select {
+			case event := <-listener.Events():
+				assert.Equal(t, test.Expected, event, test.Message)
+			case <-time.After(2 * time.Second):
+				if test.Expected != nil {
+					t.Fatal("Timeout while waiting for event")
+				}
+			}
+		})
+	}
+}

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -1,0 +1,277 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gofrs/uuid"
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type pod struct {
+	uuid    uuid.UUID
+	config  *Config
+	metagen kubernetes.MetaGenerator
+	logger  *logp.Logger
+	publish func(bus.Event)
+	watcher kubernetes.Watcher
+}
+
+// NewPodEventer creates an eventer that can discover and process pod objects
+func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+	metagen, err := kubernetes.NewMetaGenerator(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logp.NewLogger("autodiscover.pod")
+
+	config := defaultConfig()
+	err = cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that node is set correctly whenever the scope is set to "node". Make sure that node is empty
+	// when cluster scope is enforced.
+	if config.Scope == "node" {
+		config.Node = kubernetes.DiscoverKubernetesNode(config.Node, kubernetes.IsInCluster(config.KubeConfig), client)
+	} else {
+		config.Node = ""
+	}
+
+	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
+
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
+		SyncTimeout: config.SyncPeriod,
+		Node:        config.Node,
+		Namespace:   config.Namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Pod{}, err)
+	}
+
+	p := &pod{
+		config:  config,
+		uuid:    uuid,
+		publish: publish,
+		metagen: metagen,
+		logger:  logger,
+		watcher: watcher,
+	}
+
+	watcher.AddEventHandler(p)
+	return p, nil
+}
+
+// OnAdd ensures processing of service objects that are newly added
+func (p *pod) OnAdd(obj interface{}) {
+	p.logger.Debugf("Watcher Node add: %+v", obj)
+	p.emit(obj.(*kubernetes.Pod), "start")
+}
+
+// OnUpdate emits events for a given pod depending on the state of the pod,
+// if it is terminating, a stop event is scheduled, if not, a stop and a start
+// events are sent sequentially to recreate the resources assotiated to the pod.
+func (p *pod) OnUpdate(obj interface{}) {
+	pod := obj.(*kubernetes.Pod)
+	if pod.GetObjectMeta().GetDeletionTimestamp() != nil {
+		p.logger.Debugf("Watcher Node update (terminating): %+v", obj)
+		// Node is terminating, don't reload its configuration and ignore the event
+		// if some pod is still running, we will receive more events when containers
+		// terminate.
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.State.Running != nil {
+				return
+			}
+		}
+		time.AfterFunc(p.config.CleanupTimeout, func() { p.emit(pod, "stop") })
+	} else {
+		p.logger.Debugf("Watcher Node update: %+v", obj)
+		p.emit(pod, "stop")
+		p.emit(pod, "start")
+	}
+}
+
+// GenerateHints creates hints needed for hints builder
+func (p *pod) OnDelete(obj interface{}) {
+	p.logger.Debugf("Watcher Node delete: %+v", obj)
+	time.AfterFunc(p.config.CleanupTimeout, func() { p.emit(obj.(*kubernetes.Pod), "stop") })
+}
+
+func (p *pod) GenerateHints(event bus.Event) bus.Event {
+	// Try to build a config with enabled builders. Send a provider agnostic payload.
+	// Builders are Beat specific.
+	e := bus.Event{}
+	var annotations common.MapStr
+	var kubeMeta, container common.MapStr
+	rawMeta, ok := event["kubernetes"]
+	if ok {
+		kubeMeta = rawMeta.(common.MapStr)
+		// The builder base config can configure any of the field values of kubernetes if need be.
+		e["kubernetes"] = kubeMeta
+		if rawAnn, ok := kubeMeta["annotations"]; ok {
+			annotations = rawAnn.(common.MapStr)
+		}
+	}
+	if host, ok := event["host"]; ok {
+		e["host"] = host
+	}
+	if port, ok := event["port"]; ok {
+		e["port"] = port
+	}
+
+	if rawCont, ok := kubeMeta["container"]; ok {
+		container = rawCont.(common.MapStr)
+		// This would end up adding a runtime entry into the event. This would make sure
+		// that there is not an attempt to spin up a docker input for a rkt container and when a
+		// rkt input exists it would be natively supported.
+		e["container"] = container
+	}
+
+	cname := builder.GetContainerName(container)
+	hints := builder.GenerateHints(annotations, cname, p.config.Prefix)
+	p.logger.Debugf("Generated hints %+v", hints)
+	if len(hints) != 0 {
+		e["hints"] = hints
+	}
+
+	p.logger.Debugf("Generated builder event %+v", e)
+
+	return e
+}
+
+// Start starts the eventer
+func (p *pod) Start() error {
+	return p.watcher.Start()
+}
+
+// Stop stops the eventer
+func (p *pod) Stop() {
+	p.watcher.Stop()
+}
+
+func (p *pod) emit(pod *kubernetes.Pod, flag string) {
+	// Emit events for all containers
+	p.emitEvents(pod, flag, pod.Spec.Containers, pod.Status.ContainerStatuses)
+
+	// Emit events for all initContainers
+	p.emitEvents(pod, flag, pod.Spec.InitContainers, pod.Status.InitContainerStatuses)
+}
+
+func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernetes.Container,
+	containerstatuses []kubernetes.PodContainerStatus) {
+	host := pod.Status.PodIP
+
+	// If the container doesn't exist in the runtime or its network
+	// is not configured, it won't have an IP. Skip it as we cannot
+	// generate configs without host, and an update will arrive when
+	// the container is ready.
+	// If stopping, emit the event in any case to ensure cleanup.
+	if host == "" && flag != "stop" {
+		return
+	}
+
+	// Collect all runtimes from status information.
+	containerIDs := map[string]string{}
+	runtimes := map[string]string{}
+	for _, c := range containerstatuses {
+		// If the container is not being stopped then add the container only if it is in running state.
+		// This makes sure that we dont keep tailing init container logs after they have stopped.
+		// Emit the event in case that the pod is being stopped.
+		if flag == "stop" || c.State.Running != nil {
+			cid, runtime := kubernetes.ContainerIDWithRuntime(c)
+			containerIDs[c.Name] = cid
+			runtimes[c.Name] = runtime
+		}
+	}
+
+	// Emit container and port information
+	for _, c := range containers {
+		// If it doesn't have an ID, container doesn't exist in
+		// the runtime, emit only an event if we are stopping, so
+		// we are sure of cleaning up configurations.
+		cid := containerIDs[c.Name]
+		if cid == "" && flag != "stop" {
+			continue
+		}
+
+		// This must be an id that doesn't depend on the state of the container
+		// so it works also on `stop` if containers have been already deleted.
+		eventID := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), c.Name)
+
+		cmeta := common.MapStr{
+			"id":      cid,
+			"name":    c.Name,
+			"image":   c.Image,
+			"runtime": runtimes[c.Name],
+		}
+		meta := p.metagen.ContainerMetadata(pod, c.Name, c.Image)
+
+		// Information that can be used in discovering a workload
+		kubemeta := meta.Clone()
+		kubemeta["container"] = cmeta
+
+		// Pass annotations to all events so that it can be used in templating and by annotation builders.
+		annotations := common.MapStr{}
+		for k, v := range pod.GetObjectMeta().GetAnnotations() {
+			safemapstr.Put(annotations, k, v)
+		}
+		kubemeta["annotations"] = annotations
+
+		// Without this check there would be overlapping configurations with and without ports.
+		if len(c.Ports) == 0 {
+			event := bus.Event{
+				"provider":   p.uuid,
+				"id":         eventID,
+				flag:         true,
+				"host":       host,
+				"kubernetes": kubemeta,
+				"meta": common.MapStr{
+					"kubernetes": meta,
+				},
+			}
+			p.publish(event)
+		}
+
+		for _, port := range c.Ports {
+			event := bus.Event{
+				"provider":   p.uuid,
+				"id":         eventID,
+				flag:         true,
+				"host":       host,
+				"port":       port.ContainerPort,
+				"kubernetes": kubemeta,
+				"meta": common.MapStr{
+					"kubernetes": meta,
+				},
+			}
+			p.publish(event)
+		}
+	}
+}

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -1,0 +1,187 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gofrs/uuid"
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type service struct {
+	uuid    uuid.UUID
+	config  *Config
+	metagen kubernetes.MetaGenerator
+	logger  *logp.Logger
+	publish func(bus.Event)
+	watcher kubernetes.Watcher
+}
+
+// NewServiceEventer creates an eventer that can discover and process service objects
+func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+	metagen, err := kubernetes.NewMetaGenerator(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logp.NewLogger("autodiscover.service")
+
+	config := defaultConfig()
+	err = cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
+		SyncTimeout: config.SyncPeriod,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Service{}, err)
+	}
+
+	p := &service{
+		config:  config,
+		uuid:    uuid,
+		publish: publish,
+		metagen: metagen,
+		logger:  logger,
+		watcher: watcher,
+	}
+
+	watcher.AddEventHandler(p)
+	return p, nil
+}
+
+// OnAdd ensures processing of service objects that are newly created
+func (s *service) OnAdd(obj interface{}) {
+	s.logger.Debugf("Watcher Node add: %+v", obj)
+	s.emit(obj.(*kubernetes.Service), "start")
+}
+
+// OnUpdate ensures processing of service objects that are updated
+func (s *service) OnUpdate(obj interface{}) {
+	svc := obj.(*kubernetes.Service)
+	// Once service is in terminated state, mark it for deletion
+	if svc.GetObjectMeta().GetDeletionTimestamp() != nil {
+		time.AfterFunc(s.config.CleanupTimeout, func() { s.emit(svc, "stop") })
+	} else {
+		s.logger.Debugf("Watcher Node update: %+v", obj)
+		s.emit(svc, "stop")
+		s.emit(svc, "start")
+	}
+}
+
+// OnDelete ensures processing of service objects that are deleted
+func (s *service) OnDelete(obj interface{}) {
+	s.logger.Debugf("Watcher Node delete: %+v", obj)
+	time.AfterFunc(s.config.CleanupTimeout, func() { s.emit(obj.(*kubernetes.Service), "stop") })
+}
+
+// GenerateHints creates hints needed for hints builder
+func (s *service) GenerateHints(event bus.Event) bus.Event {
+	// Try to build a config with enabled builders. Send a provider agnostic payload.
+	// Builders are Beat specific.
+	e := bus.Event{}
+	var annotations common.MapStr
+	var kubeMeta common.MapStr
+	rawMeta, ok := event["kubernetes"]
+	if ok {
+		kubeMeta = rawMeta.(common.MapStr)
+		// The builder base config can configure any of the field values of kubernetes if need be.
+		e["kubernetes"] = kubeMeta
+		if rawAnn, ok := kubeMeta["annotations"]; ok {
+			annotations = rawAnn.(common.MapStr)
+		}
+	}
+	if host, ok := event["host"]; ok {
+		e["host"] = host
+	}
+	if port, ok := event["port"]; ok {
+		e["port"] = port
+	}
+
+	hints := builder.GenerateHints(annotations, "", s.config.Prefix)
+	s.logger.Debugf("Generated hints %+v", hints)
+	if len(hints) != 0 {
+		e["hints"] = hints
+	}
+
+	s.logger.Debugf("Generated builder event %+v", e)
+
+	return e
+}
+
+// Start starts the eventer
+func (s *service) Start() error {
+	return s.watcher.Start()
+}
+
+// Stop stops the eventer
+func (s *service) Stop() {
+	s.watcher.Stop()
+}
+
+func (s *service) emit(svc *kubernetes.Service, flag string) {
+	host := svc.Spec.ClusterIP
+
+	// If a service doesn't have an IP then dont monitor it
+	if host == "" && flag != "stop" {
+		return
+	}
+
+	eventID := fmt.Sprint(svc.GetObjectMeta().GetUID())
+	meta := s.metagen.ResourceMetadata(svc)
+
+	// TODO: Refactor metagen to make sure that this is seamless
+	meta.Put("service.name", svc.Name)
+	meta.Put("service.uid", string(svc.GetObjectMeta().GetUID()))
+
+	kubemeta := meta.Clone()
+	// Pass annotations to all events so that it can be used in templating and by annotation builders.
+	annotations := common.MapStr{}
+	for k, v := range svc.GetObjectMeta().GetAnnotations() {
+		safemapstr.Put(annotations, k, v)
+	}
+	kubemeta["annotations"] = annotations
+
+	for _, port := range svc.Spec.Ports {
+		event := bus.Event{
+			"provider":   s.uuid,
+			"id":         eventID,
+			flag:         true,
+			"host":       host,
+			"port":       int(port.Port),
+			"kubernetes": kubemeta,
+			"meta": common.MapStr{
+				"kubernetes": meta,
+			},
+		}
+		s.publish(event)
+	}
+
+}

--- a/libbeat/autodiscover/providers/kubernetes/service_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/service_test.go
@@ -1,0 +1,305 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/beats/libbeat/autodiscover/template"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func TestGenerateHints_Service(t *testing.T) {
+	tests := []struct {
+		event  bus.Event
+		result bus.Event
+	}{
+		// Empty events should return empty hints
+		{
+			event:  bus.Event{},
+			result: bus.Event{},
+		},
+		// Only kubernetes payload must return only kubernetes as part of the hint
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+		},
+		// Scenarios being tested:
+		// metrics/module must be found in hints.metrics
+		// not.to.include must not be part of hints
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+						"not.to.include":            "true",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"not.to.include":            "true",
+						"co.elastic.metrics/period": "10s",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "10s",
+					},
+				},
+			},
+		},
+	}
+
+	cfg := defaultConfig()
+
+	s := service{
+		config: cfg,
+		logger: logp.NewLogger("kubernetes.service"),
+	}
+	for _, test := range tests {
+		assert.Equal(t, s.GenerateHints(test.event), test.result)
+	}
+}
+
+func TestEmitEvent_Service(t *testing.T) {
+	name := "metricbeat"
+	namespace := "default"
+	clusterIP := "192.168.0.1"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	UUID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		Message  string
+		Flag     string
+		Service  *kubernetes.Service
+		Expected bus.Event
+	}{
+		{
+			Message: "Test service start",
+			Flag:    "start",
+			Service: &kubernetes.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name: "http",
+							Port: 8080,
+						},
+					},
+					ClusterIP: clusterIP,
+				},
+			},
+			Expected: bus.Event{
+				"start":    true,
+				"host":     "192.168.0.1",
+				"id":       uid,
+				"provider": UUID,
+				"port":     8080,
+				"kubernetes": common.MapStr{
+					"service": common.MapStr{
+						"name": "metricbeat",
+						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+					},
+					"namespace":   "default",
+					"annotations": common.MapStr{},
+				},
+				"meta": common.MapStr{
+					"kubernetes": common.MapStr{
+						"namespace": "default",
+						"service": common.MapStr{
+							"name": "metricbeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+					},
+				},
+				"config": []*common.Config{},
+			},
+		},
+		{
+			Message: "Test service without host",
+			Flag:    "start",
+			Service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name: "http",
+							Port: 8080,
+						},
+					},
+				},
+			},
+			Expected: nil,
+		},
+		{
+			Message: "Test service without port",
+			Flag:    "start",
+			Service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: clusterIP,
+				},
+			},
+			Expected: nil,
+		},
+		{
+			Message: "Test stop service without host",
+			Flag:    "stop",
+			Service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name: "http",
+							Port: 8080,
+						},
+					},
+				},
+			},
+			Expected: bus.Event{
+				"stop":     true,
+				"host":     "",
+				"id":       uid,
+				"port":     8080,
+				"provider": UUID,
+				"kubernetes": common.MapStr{
+					"service": common.MapStr{
+						"name": "metricbeat",
+						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+					},
+					"namespace":   "default",
+					"annotations": common.MapStr{},
+				},
+				"meta": common.MapStr{
+					"kubernetes": common.MapStr{
+						"namespace": "default",
+						"service": common.MapStr{
+							"name": "metricbeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+					},
+				},
+				"config": []*common.Config{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Message, func(t *testing.T) {
+			mapper, err := template.NewConfigMapper(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			metaGen, err := kubernetes.NewMetaGenerator(common.NewConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p := &Provider{
+				config:    defaultConfig(),
+				bus:       bus.New("test"),
+				templates: mapper,
+				logger:    logp.NewLogger("kubernetes"),
+			}
+
+			service := &service{
+				metagen: metaGen,
+				config:  defaultConfig(),
+				publish: p.publish,
+				uuid:    UUID,
+				logger:  logp.NewLogger("kubernetes.service"),
+			}
+
+			p.eventer = service
+
+			listener := p.bus.Subscribe()
+
+			service.emit(test.Service, test.Flag)
+
+			select {
+			case event := <-listener.Events():
+				assert.Equal(t, test.Expected, event, test.Message)
+			case <-time.After(2 * time.Second):
+				if test.Expected != nil {
+					t.Fatal("Timeout while waiting for event")
+				}
+			}
+		})
+	}
+}

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -67,6 +67,9 @@ type ReplicaSet = extv1.ReplicaSet
 // StatefulSet data
 type StatefulSet = appsv1.StatefulSet
 
+// Service data
+type Service = v1.Service
+
 // Time extracts time from k8s.Time type
 func Time(t *metav1.Time) time.Time {
 	return t.Time

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -83,9 +83,15 @@ type watcher struct {
 	logger   *logp.Logger
 }
 
-func tweakOptions(options *metav1.ListOptions, opt WatchOptions) {
+func nodeSelector(options *metav1.ListOptions, opt WatchOptions) {
 	if opt.Node != "" {
 		options.FieldSelector = "spec.nodeName=" + opt.Node
+	}
+}
+
+func nameSelector(options *metav1.ListOptions, opt WatchOptions) {
+	if opt.Node != "" {
+		options.FieldSelector = "metadata.name=" + opt.Node
 	}
 }
 
@@ -103,11 +109,11 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 		p := client.CoreV1().Pods(opts.Namespace)
 		listwatch = &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				tweakOptions(&options, opts)
+				nodeSelector(&options, opts)
 				return p.List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				tweakOptions(&options, opts)
+				nodeSelector(&options, opts)
 				return p.Watch(options)
 			},
 		}
@@ -129,9 +135,11 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 		n := client.CoreV1().Nodes()
 		listwatch = &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				nameSelector(&options, opts)
 				return n.List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				nameSelector(&options, opts)
 				return n.Watch(options)
 			},
 		}
@@ -173,6 +181,18 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 		}
 
 		objType = "statefulset"
+	case *Service:
+		svc := client.CoreV1().Services(opts.Namespace)
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return svc.List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return svc.Watch(options)
+			},
+		}
+
+		objType = "service"
 	default:
 		return nil, fmt.Errorf("unsupported resource type for watching %T", resource)
 	}

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -179,15 +179,24 @@ contain variables from the autodiscover event. They can be accessed under data n
 
 The `kubernetes` autodiscover provider has the following configuration settings:
 
-`host`:: (Optional) Specify the node to scope {beatname_lc} to in case it
+`node`:: (Optional) Specify the node to scope {beatname_lc} to in case it
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
 `namespace`:: (Optional) Select the namespace from which to collect the
   metadata. If it is not set, the processor collects metadata from all
-  namespaces. It is unset by default.
+  namespaces. It is unset by default. The namespace configuration only applies to
+  kubernetes resources that are namespace scoped.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
   client. If kube_config is not set, KUBECONFIG environment variable will be
   checked and if not present it will fall back to InCluster.
+`resource`:: (Optional) Select the resource to do discovery on. Currently supported
+  Kubernetes resources are `pod`, `service` and `node`. If not configured `resource`
+  defaults to `pod`.
+`scope`:: (Optional) Specify at what level autodiscover needs to be done at. `scope` can
+  either take `node` or `cluster` as values. `node` scope allows discovery of resources in
+  the specified node. `cluster` scope allows cluster wide discovery. Only `pod` and `node` resources
+  can be discovered at node scope.
+
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14738 to 7.x branch. Original message: 

This PR tries to move around code in a way such that each resource has its own interface implementation and the autodiscover relies on a `resource` parameter to determine what the watcher to spin up and how to create hints. We also now add `scope` as a parameter to define if Beats is running either at a `node` level or at a `cluster` level.

```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      kube_config: ${HOME}/.kube/config
      resource: service
      hints.enabled: true

output.console.pretty: true
```

The above configuration would enable discovering service objects across the cluster. 

```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      kube_config: ${HOME}/.kube/config
      resource: pod
      scope: cluster
      hints.enabled: true
```

The above configuration would allow doing pod discovery across the cluster. 

closes elastic/beats#14044 and elastic/beats#10578