### PR TITLE
Cherry-pick #14928 to 7.x: Add missing UBI images for heartbeat, journalbeat, packetbeat

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -411,3 +411,11 @@ specs:
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries


### PR DESCRIPTION
Cherry-pick of PR #14928 to 7.x branch. Original message: 

This adds these missing images:

```
docker.elastic.co/beats/heartbeat-ubi7
docker.elastic.co/beats/journalbeat-ubi7
docker.elastic.co/beats/packetbeat-ubi7
```