### PR TITLE
Cherry-pick #14936 to 7.x: Add missing files override for docker ubi images

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -419,3 +419,6 @@ specs:
         <<: *docker_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}


### PR DESCRIPTION
Cherry-pick of PR #14936 to 7.x branch. Original message: 

