### PR TITLE
[Elastic Log Plugin] Turn on Jenkins and Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ jobs:
 
     # Docker Log Driver
     - os: linux
-      env: TARGETS="-C x-pack/dockerlogbeat unit-tests"
+      env: TARGETS="-C x-pack/dockerlogbeat testsuite"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,12 @@ jobs:
       go: $TRAVIS_GO_VERSION
       stage: test
 
+    # Docker Log Driver
+    - os: linux
+      env: TARGETS="-C x-pack/dockerlogbeat unit-tests"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+
     # Journalbeat
     - os: linux
       env: TARGETS="-C journalbeat testsuite"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,7 +339,7 @@ pipeline {
             stage('Dockerlogbeat'){
               steps {
                 withBeatsEnv(){
-                  makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogbeat unit-tests")
+                  makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogbeat testsuite")
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -325,6 +325,25 @@ pipeline {
             }
           }
         }
+        stage('dockerlogbeat'){
+          agent { label 'ubuntu && immutable' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_DOCKERLOGBEAT != "false"
+            }
+          }
+          stages {
+            stage('Dockerlogbeat'){
+              steps {
+                withBeatsEnv(){
+                  makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogdriver unit-tests")
+                }
+              }
+            }
+          }
+        }
         stage('Winlogbeat'){
           agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
           env.BUILD_METRICBEAT = isChanged(["^metricbeat/.*"])
           env.BUILD_PACKETBEAT = isChanged(["^packetbeat/.*"])
           env.BUILD_WINLOGBEAT = isChanged(["^winlogbeat/.*"])
+          env.BUILD_DOCKERLOGBEAT = isChanged(["^x-pack/dockerlogbeat/.*"])
           env.BUILD_FUNCTIONBEAT = isChanged(["^x-pack/functionbeat/.*"])
           env.BUILD_JOURNALBEAT = isChanged(["^journalbeat/.*"])
           env.BUILD_GENERATOR = isChanged(["^generator/.*"])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
             stage('Dockerlogbeat'){
               steps {
                 withBeatsEnv(){
-                  makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogdriver unit-tests")
+                  makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogbeat unit-tests")
                 }
               }
             }

--- a/x-pack/dockerlogbeat/Makefile
+++ b/x-pack/dockerlogbeat/Makefile
@@ -1,0 +1,17 @@
+# Name can be overwritten, as Metricbeat is also a library
+BEAT_NAME?="Elastic logging plugin"
+BEAT_TITLE?=dockerlogdriver
+SYSTEM_TESTS?=false
+TEST_ENVIRONMENT?=true
+ES_BEATS?=../../
+
+# Metricbeat can only be cross-compiled on platforms not requiring CGO.
+GOX_OS=linux
+GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
+
+include $(ES_BEATS)/dev-tools/make/xpack.mk
+
+
+.PHONY: unit-tests
+unit-tests:
+	mage unitTest

--- a/x-pack/dockerlogbeat/Makefile
+++ b/x-pack/dockerlogbeat/Makefile
@@ -13,5 +13,5 @@ include $(ES_BEATS)/dev-tools/make/xpack.mk
 
 
 .PHONY: unit-tests
-unit-tests:
+unit-tests: mage
 	mage unitTest

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -172,11 +172,12 @@ docker plugin enable %s
 	return nil
 }
 
-// IntegTest is currently a dummy test
+// IntegTest is currently a dummy test for the `testsuite` target
 func IntegTest() {
 	fmt.Printf("There are no Integration tests for The Elastic Log Plugin\n")
 }
 
+// Update is currently a dummy test for the `testsuite` target
 func Update() {
 	fmt.Printf("There is no Update for The Elastic Log Plugin\n")
 }

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -25,6 +25,8 @@ import (
 	_ "github.com/elastic/beats/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/test"
 )
 
 var hubID = "elastic"
@@ -168,4 +170,13 @@ docker plugin enable %s
 		filepath.Join(packageStagingDir, "install.sh"))
 
 	return nil
+}
+
+// IntegTest is currently a dummy test
+func IntegTest() {
+	fmt.Printf("There are no Integration tests for The Elastic Log Plugin\n")
+}
+
+func Update() {
+	fmt.Printf("There is no Update for The Elastic Log Plugin\n")
 }

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -23,6 +23,8 @@ import (
 
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
 )
 
 var hubID = "elastic"

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -23,7 +23,7 @@ func TestNewClient(t *testing.T) {
 	defer teardown()
 
 	event := testReturn(t, client)
-	assert.Equal(t, event.Fields["message"], "fail")
+	assert.Equal(t, event.Fields["message"], logString)
 }
 
 // setupTestReader sets up the "read side" of the pipeline, spawing a goroutine to read and event and send it back to the test.

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -23,7 +23,7 @@ func TestNewClient(t *testing.T) {
 	defer teardown()
 
 	event := testReturn(t, client)
-	assert.Equal(t, event.Fields["message"], logString)
+	assert.Equal(t, event.Fields["message"], "fail")
 }
 
 // setupTestReader sets up the "read side" of the pipeline, spawing a goroutine to read and event and send it back to the test.


### PR DESCRIPTION


This PR just enables our current unit tests to run under CI, which is probably one of the last things we'll need before we merge this to master.