### PR TITLE
Cherry-pick #14942 to 7.5: [Metricbeat] Add pagination to ListMetrics AWS API call

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -76,6 +76,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix rds metricset from reporting same values for different instances. {pull}14702[14702]
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
 - Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]
+- Fix ListMetrics pagination in aws module. {issue}14926[14926] {pull}14942[14942]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -6,6 +6,7 @@ package aws
 
 import (
 	"context"
+	"math"
 	"strings"
 	"time"
 
@@ -32,20 +33,28 @@ func GetStartTimeEndTime(period time.Duration) (time.Time, time.Time) {
 // ListMetrics Cloudwatch API is used to list the specified metrics. The returned metrics can be used with GetMetricData
 // to obtain statistical data.
 func GetListMetricsOutput(namespace string, regionName string, svcCloudwatch cloudwatchiface.ClientAPI) ([]cloudwatch.Metric, error) {
-	listMetricsInput := &cloudwatch.ListMetricsInput{Namespace: &namespace}
-	reqListMetrics := svcCloudwatch.ListMetricsRequest(listMetricsInput)
+	var metricsTotal []cloudwatch.Metric
+	init := true
+	var nextToken *string
 
-	// List metrics of a given namespace for each region
-	listMetricsOutput, err := reqListMetrics.Send(context.TODO())
-	if err != nil {
-		return nil, errors.Wrap(err, "ListMetricsRequest failed, skipping region "+regionName)
+	for init || nextToken != nil {
+		init = false
+		listMetricsInput := &cloudwatch.ListMetricsInput{
+			NextToken: nextToken,
+			Namespace: &namespace,
+		}
+		reqListMetrics := svcCloudwatch.ListMetricsRequest(listMetricsInput)
+
+		// List metrics of a given namespace for each region
+		listMetricsOutput, err := reqListMetrics.Send(context.TODO())
+		if err != nil {
+			return nil, errors.Wrap(err, "ListMetricsRequest failed, skipping region "+regionName)
+		}
+		metricsTotal = append(metricsTotal, listMetricsOutput.Metrics...)
+		nextToken = listMetricsOutput.NextToken
 	}
 
-	if listMetricsOutput.Metrics == nil || len(listMetricsOutput.Metrics) == 0 {
-		// No metrics in this region
-		return nil, nil
-	}
-	return listMetricsOutput.Metrics, nil
+	return metricsTotal, nil
 }
 
 func getMetricDataPerRegion(metricDataQueries []cloudwatch.MetricDataQuery, nextToken *string, svc cloudwatchiface.ClientAPI, startTime time.Time, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
@@ -67,18 +76,15 @@ func getMetricDataPerRegion(metricDataQueries []cloudwatch.MetricDataQuery, next
 // GetMetricDataResults function uses MetricDataQueries to get metric data output.
 func GetMetricDataResults(metricDataQueries []cloudwatch.MetricDataQuery, svc cloudwatchiface.ClientAPI, startTime time.Time, endTime time.Time) ([]cloudwatch.MetricDataResult, error) {
 	init := true
+	maxQuerySize := 100
 	getMetricDataOutput := &cloudwatch.GetMetricDataOutput{NextToken: nil}
 	for init || getMetricDataOutput.NextToken != nil {
 		init = false
 		// Split metricDataQueries into smaller slices that length no longer than 100.
+		// 100 is defined in maxQuerySize.
 		// To avoid ValidationError: The collection MetricDataQueries must not have a size greater than 100.
-		iter := len(metricDataQueries) / 100
-		for i := 0; i <= iter; i++ {
-			metricDataQueriesPartial := metricDataQueries[iter*100:]
-			if i != iter {
-				metricDataQueriesPartial = metricDataQueries[i*100 : (i+1)*100-1]
-			}
-
+		for i := 0; i < len(metricDataQueries); i += maxQuerySize {
+			metricDataQueriesPartial := metricDataQueries[i:int(math.Min(float64(i+maxQuerySize), float64(len(metricDataQueries))))]
 			if len(metricDataQueriesPartial) == 0 {
 				return getMetricDataOutput.MetricDataResults, nil
 			}


### PR DESCRIPTION
Cherry-pick of PR #14942 to 7.5 branch. Original message: 

I finally was able to reproduce this problem with creating 165 EC2 instances in the same region but different availability zones.

## What's the bug
When there is a large amount of AWS EC2 instances in same region, ec2 metricset starts to lose data from some of the instances. After one data collection, you can see only some of the instances have metrics in Elasticsearch. For example, with 165 EC2 instances in us-east-1, I was only able to collect metrics from 159 EC2 instances.

Only seeing metrics from 159 instances:
<img width="1279" alt="Screen Shot 2019-12-04 at 3 02 40 PM" src="https://user-images.githubusercontent.com/14081635/70185569-45864b80-16a7-11ea-87d2-64cf31da3a66.png">

## How to fix it
The problem turned out to be in two places:
1. When splitting a large array into smaller size arrays, there is 1 data point missing for every split caused by the wrong right index in for loop.
2. Pagination is missing for ListMetrics AWS API call. This is the main problem causing the data loss.

With this fix, I'm able to see metrics from all 165 EC2 instances:
<img width="1315" alt="Screen Shot 2019-12-04 at 3 03 15 PM" src="https://user-images.githubusercontent.com/14081635/70185630-66e73780-16a7-11ea-8c1a-641fe272569f.png">

## How to test this
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  credential_profile_name: elastic-beats
  regions:
    - us-east-1
```
Not sure if there is a better way to do it. I had to create a large amount of EC2 instances in AWS in order to reproduce this problem. Create 165 EC2 instances in the same region and then run aws module with the config above. Make sure in Kibana, you can see metrics from all 165 instances after several collection period. Note: if you check Kibana right away after the first collection period, you might only see a small portion of instances showed up. That's because instances are still creating and it takes time to get to running state and also send data to Cloudwatch.

closes https://github.com/elastic/beats/issues/14926