### PR TITLE
Backport 14569 7.5

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Heartbeat*
 
 - Fix recording of SSL cert metadata for Expired/Unvalidated x509 certs. {pull}13687[13687]
+- Fix job scheduling issues with new scheduler implementation. {pull}14569[14569]
 
 *Journalbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/heartbeat/hbregistry"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/heartbeat/config"
@@ -63,7 +65,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	scheduler := scheduler.NewWithLocation(limit, location)
+	scheduler := scheduler.NewWithLocation(limit, hbregistry.SchedulerRegistry, location)
 
 	bt := &Heartbeat{
 		done:      make(chan struct{}),

--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 // Scheduler defines the syntax of a heartbeat.yml scheduler block.
 type Scheduler struct {
-	Limit    uint   `config:"limit"  validate:"min=0"`
+	Limit    int64  `config:"limit"  validate:"min=0"`
 	Location string `config:"location"`
 }
 

--- a/heartbeat/hbregistry/hbregistry.go
+++ b/heartbeat/hbregistry/hbregistry.go
@@ -15,43 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cron
+package hbregistry
 
-import (
-	"time"
+import "github.com/elastic/beats/libbeat/monitoring"
 
-	"github.com/gorhill/cronexpr"
-)
+// StatsRegistry contains a singleton instance of the heartbeat stats registry
+var StatsRegistry = monitoring.Default.NewRegistry("heartbeat")
 
-type Schedule cronexpr.Expression
+// SchedulerRegistry holds scheduler stats
+var SchedulerRegistry = StatsRegistry.NewRegistry("scheduler")
 
-func MustParse(in string) *Schedule {
-	s, err := Parse(in)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-func Parse(in string) (*Schedule, error) {
-	expr, err := cronexpr.Parse(in)
-	return (*Schedule)(expr), err
-}
-
-func (s *Schedule) Next(t time.Time) time.Time {
-	expr := (*cronexpr.Expression)(s)
-	return expr.Next(t)
-}
-
-func (s *Schedule) Unpack(str string) error {
-	tmp, err := Parse(str)
-	if err == nil {
-		*s = *tmp
-	}
-	return err
-}
-
-// RunOnInit returns false for interval schedulers.
-func (s *Schedule) RunOnInit() bool {
-	return false
-}
+// TelemetryRegistry contains a singleton instance of the heartbeat telemetry registry
+var TelemetryRegistry = monitoring.GetNamespace("state").GetRegistry().NewRegistry("heartbeat")

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/libbeat/monitoring"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,7 +36,7 @@ func TestMonitor(t *testing.T) {
 	reg := mockPluginsReg()
 	pipelineConnector := &MockPipelineConnector{}
 
-	sched := scheduler.New(1)
+	sched := scheduler.New(1, monitoring.NewRegistry())
 	err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -82,7 +84,7 @@ func TestDuplicateMonitorIDs(t *testing.T) {
 	reg := mockPluginsReg()
 	pipelineConnector := &MockPipelineConnector{}
 
-	sched := scheduler.New(1)
+	sched := scheduler.New(1, monitoring.NewRegistry())
 	err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -111,7 +113,7 @@ func TestCheckInvalidConfig(t *testing.T) {
 	reg := mockPluginsReg()
 	pipelineConnector := &MockPipelineConnector{}
 
-	sched := scheduler.New(1)
+	sched := scheduler.New(1, monitoring.NewRegistry())
 	err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()

--- a/heartbeat/monitors/plugin.go
+++ b/heartbeat/monitors/plugin.go
@@ -23,9 +23,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/elastic/beats/heartbeat/hbregistry"
 	"github.com/elastic/beats/heartbeat/monitors/jobs"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/plugin"
 )
 
@@ -38,19 +38,16 @@ type pluginBuilder struct {
 
 var pluginKey = "heartbeat.monitor"
 
-var statsRegistry = monitoring.Default.NewRegistry("heartbeat")
-var stateRegistry = monitoring.GetNamespace("state").GetRegistry().NewRegistry("heartbeat")
-
 // stateGlobalRecorder records statistics across all plugin types
-var stateGlobalRecorder = newRootGaugeRecorder(stateRegistry)
+var stateGlobalRecorder = newRootGaugeRecorder(hbregistry.TelemetryRegistry)
 
 func statsForPlugin(pluginName string) registryRecorder {
 	return multiRegistryRecorder{
 		recorders: []registryRecorder{
 			// state (telemetry)
-			newPluginGaugeRecorder(pluginName, stateRegistry),
+			newPluginGaugeRecorder(pluginName, hbregistry.TelemetryRegistry),
 			// Record global monitors / endpoints count
-			newPluginCountersRecorder(pluginName, statsRegistry),
+			newPluginCountersRecorder(pluginName, hbregistry.StatsRegistry),
 			// When stats for this plugin are updated, update the global stats as well
 			stateGlobalRecorder,
 		},

--- a/heartbeat/monitors/task_test.go
+++ b/heartbeat/monitors/task_test.go
@@ -18,6 +18,7 @@
 package monitors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/elastic/go-lookslike/validator"
@@ -102,7 +103,7 @@ func Test_runPublishJob(t *testing.T) {
 				}
 				tf := queue[0]
 				queue = queue[1:]
-				conts := tf()
+				conts := tf(context.Background())
 				for _, cont := range conts {
 					queue = append(queue, cont)
 				}

--- a/heartbeat/scheduler/doc.go
+++ b/heartbeat/scheduler/doc.go
@@ -15,32 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/*
+Package scheduler lets you run multi-stage tasks on a regular interval. These tasks are single functions that may spawn
+an arbitrary number of continuations.
+*/
 package scheduler
-
-import "sort"
-
-type timeOrd []*job
-
-func sortEntries(es []*job) {
-	sort.Sort(timeOrd(es))
-}
-
-func (b timeOrd) Len() int {
-	return len(b)
-}
-
-func (b timeOrd) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
-}
-
-// Less reports `earliest` time i should sort before j.
-// zero time is not `earliest` time.
-func (b timeOrd) Less(i, j int) bool {
-	if b[i].next.IsZero() {
-		return false
-	}
-	if b[j].next.IsZero() {
-		return true
-	}
-	return b[i].next.Before(b[j].next)
-}

--- a/heartbeat/scheduler/schedule/schedule.go
+++ b/heartbeat/scheduler/schedule/schedule.go
@@ -33,6 +33,11 @@ type intervalScheduler struct {
 	interval time.Duration
 }
 
+// RunOnInit returns true for interval schedulers.
+func (s intervalScheduler) RunOnInit() bool {
+	return true
+}
+
 func Parse(in string) (*Schedule, error) {
 	every := "@every"
 

--- a/heartbeat/scheduler/schedule/schedule.go
+++ b/heartbeat/scheduler/schedule/schedule.go
@@ -35,7 +35,7 @@ type intervalScheduler struct {
 
 // RunOnInit returns true for interval schedulers.
 func (s intervalScheduler) RunOnInit() bool {
-	return true
+	return false
 }
 
 func Parse(in string) (*Schedule, error) {

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -18,118 +18,154 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
-	"runtime/debug"
+	"fmt"
+	"math"
 	"sync"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
+	"github.com/elastic/beats/heartbeat/scheduler/timerqueue"
 	"github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 const (
 	statePreRunning int = iota + 1
 	stateRunning
-	stateDone
+	stateStopped
 )
-
-type Scheduler struct {
-	limit uint
-	state atomic.Int
-
-	location *time.Location
-
-	jobs   []*job
-	active uint // number of active entries
-
-	addCh, rmCh chan *job
-	finished    chan taskOverSignal
-
-	// list of active tasks waiting to be executed
-	tasks []task
-
-	done chan struct{}
-	wg   sync.WaitGroup
-}
-
-type Canceller func() error
-
-// A job is a re-schedulable entry point in a set of tasks. Each task can return
-// a new set of tasks being executed (subject to active task limits). Only after
-// all tasks of a job have been finished, the job is marked as done and subject
-// to be re-scheduled.
-type job struct {
-	id       string
-	next     time.Time
-	schedule Schedule
-	fn       TaskFunc
-
-	registered bool
-	running    uint32 // count number of active task for job
-}
-
-// A single task in an active job.
-type task struct {
-	job *job
-	fn  TaskFunc
-}
-
-// Single task in an active job. Optionally returns continuation of tasks to
-// be executed within current job.
-type TaskFunc func() []TaskFunc
-
-type taskOverSignal struct {
-	entry *job
-	cont  []task // continuation tasks to be executed by concurrently for job at hand
-}
-
-type Schedule interface {
-	Next(now time.Time) (next time.Time)
-}
 
 var debugf = logp.MakeDebug("scheduler")
 
-func New(limit uint) *Scheduler {
-	return NewWithLocation(limit, time.Local)
+// ErrInvalidTransition is returned from start/stop when making an invalid state transition, say from preRunning to stopped
+var ErrInvalidTransition = fmt.Errorf("invalid state transition")
+
+// Scheduler represents our async timer based scheduler.
+type Scheduler struct {
+	limit      int64
+	limitSem   *semaphore.Weighted
+	state      atomic.Int
+	location   *time.Location
+	timerQueue *timerqueue.TimerQueue
+	ctx        context.Context
+	cancelCtx  context.CancelFunc
+	stats      schedulerStats
 }
 
-func NewWithLocation(limit uint, location *time.Location) *Scheduler {
-	stateInitial := statePreRunning
-	return &Scheduler{
-		limit:    limit,
-		location: location,
+type schedulerStats struct {
+	activeJobs         *monitoring.Uint // gauge showing number of active jobs
+	activeTasks        *monitoring.Uint // gauge showing number of active tasks
+	waitingTasks       *monitoring.Uint // number of tasks waiting to run, but constrained by scheduler limit
+	jobsPerSecond      *monitoring.Uint // rate of job processing computed over the past hour
+	jobsMissedDeadline *monitoring.Uint // counter for number of jobs that missed start deadline
+}
 
-		state:  atomic.MakeInt(stateInitial),
-		jobs:   nil,
-		active: 0,
+// TaskFunc represents a single task in a job. Optionally returns continuation of tasks to
+// be executed within current job.
+type TaskFunc func(ctx context.Context) []TaskFunc
 
-		addCh:    make(chan *job),
-		rmCh:     make(chan *job),
-		finished: make(chan taskOverSignal),
+// Schedule defines an interface for getting the next scheduled runtime for a job
+type Schedule interface {
+	// Next returns the next runAt a scheduled event occurs after the given runAt
+	Next(now time.Time) (next time.Time)
+	// Returns true if this schedule type should run once immediately before checking Next.
+	// Cron tasks run at exact times so should set this to false.
+	RunOnInit() bool
+}
 
-		done: make(chan struct{}),
-		wg:   sync.WaitGroup{},
+// New creates a new Scheduler
+func New(limit int64, registry *monitoring.Registry) *Scheduler {
+	return NewWithLocation(limit, registry, time.Local)
+}
+
+// NewWithLocation creates a new Scheduler using the given runAt zone.
+func NewWithLocation(limit int64, registry *monitoring.Registry, location *time.Location) *Scheduler {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	if limit < 1 {
+		limit = math.MaxInt64
 	}
+
+	jobsMissedDeadlineCounter := monitoring.NewUint(registry, "jobs.missed_deadline")
+	activeJobsGauge := monitoring.NewUint(registry, "jobs.active")
+	activeTasksGauge := monitoring.NewUint(registry, "tasks.active")
+	waitingTasksGauge := monitoring.NewUint(registry, "tasks.waiting")
+
+	sched := &Scheduler{
+		limit:     limit,
+		location:  location,
+		state:     atomic.MakeInt(statePreRunning),
+		ctx:       ctx,
+		cancelCtx: cancelCtx,
+		limitSem:  semaphore.NewWeighted(limit),
+
+		timerQueue: timerqueue.NewTimerQueue(ctx),
+
+		stats: schedulerStats{
+			activeJobs:         activeJobsGauge,
+			activeTasks:        activeTasksGauge,
+			waitingTasks:       waitingTasksGauge,
+			jobsMissedDeadline: jobsMissedDeadlineCounter,
+		},
+	}
+
+	return sched
 }
 
+// Start the scheduler. Starting a stopped scheduler returns an error.
 func (s *Scheduler) Start() error {
-	if !s.transitionRunning() {
-		return errors.New("scheduler can only be stopped from a running state")
+	if s.state.Load() == stateStopped {
+		return ErrInvalidTransition
+	}
+	if !s.state.CAS(statePreRunning, stateRunning) {
+		return nil // we already running, just exit
 	}
 
-	go s.run()
+	s.timerQueue.Start()
+
+	// Missed deadline reporter
+	go s.missedDeadlineReporter()
+
 	return nil
 }
 
+func (s *Scheduler) missedDeadlineReporter() {
+	interval := time.Second * 15
+
+	t := time.NewTicker(interval)
+
+	// Counter used to check if we're missing more checks now than before
+	missedAtLastCheck := uint64(0)
+	for {
+		select {
+		case <-s.ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+			missingNow := s.stats.jobsMissedDeadline.Get()
+			missedDelta := missingNow - missedAtLastCheck
+			if missedDelta > 0 {
+				logp.Warn("%d tasks have missed their schedule deadlines in the last %s.", missedDelta, interval)
+			}
+			missedAtLastCheck = missingNow
+		}
+	}
+}
+
+// Stop all executing tasks in the scheduler. Cannot be restarted after Stop.
 func (s *Scheduler) Stop() error {
-	if !s.isRunning() {
-		return errors.New("scheduler can only be started from an initialized state")
+	if s.state.CAS(stateRunning, stateStopped) {
+		s.cancelCtx()
+		return nil
+	} else if s.state.Load() == stateStopped {
+		return nil
 	}
 
-	close(s.done)
-	s.wg.Wait()
-	s.transitionStopped()
-	return nil
+	return ErrInvalidTransition
 }
 
 // ErrAlreadyStopped is returned when an Add operation is attempted after the scheduler
@@ -138,282 +174,103 @@ var ErrAlreadyStopped = errors.New("attempted to add job to already stopped sche
 
 // Add adds the given TaskFunc to the current scheduler. Will return an error if the scheduler
 // is done.
-func (s *Scheduler) Add(sched Schedule, id string, entrypoint TaskFunc) (removeFn func() error, err error) {
-	debugf("Add scheduler job '%v'.", id)
-
-	j := &job{
-		id:         id,
-		fn:         entrypoint,
-		schedule:   sched,
-		registered: false,
-		running:    0,
-	}
-	if s.isPreRunning() {
-		s.addSync(j)
-	} else if s.isRunning() {
-		s.addCh <- j
-	} else {
+func (s *Scheduler) Add(sched Schedule, id string, entrypoint TaskFunc) (removeFn context.CancelFunc, err error) {
+	if s.state.Load() == stateStopped {
 		return nil, ErrAlreadyStopped
 	}
 
-	return func() error { return s.remove(j) }, nil
-}
+	jobCtx, jobCtxCancel := context.WithCancel(s.ctx)
 
-func (s *Scheduler) remove(j *job) error {
-	debugf("Remove scheduler job '%v'", j.id)
+	// lastRanAt stores the last runAt the task was invoked
+	// The initial value is runAt.Now() because we use it to get the next runAt a job is scheduled to run
+	lastRanAt := time.Now().In(s.location)
 
-	if s.isPreRunning() {
-		s.doRemove(j)
-	} else if s.isRunning() {
-		s.rmCh <- j
+	var taskFn timerqueue.TimerTaskFn
+
+	taskFn = func(_ time.Time) {
+		s.stats.activeJobs.Inc()
+		lastRanAt = s.runRecursiveJob(jobCtx, entrypoint)
+		s.stats.activeJobs.Dec()
+		s.runOnce(sched.Next(lastRanAt), taskFn)
+		debugf("Job '%v' returned at %v", id, time.Now())
 	}
-	// There is no need to handle the isDone case
-	// because removing the job accomplishes nothing if
-	// the scheduler is stopped
 
-	return nil
+	// We skip using the scheduler to execute the initial tasks for jobs that have RunOnInit returning true.
+	// You might think it'd be simpler to just invoke runOnce in either case with 0 as a lastRanAt value,
+	// however, that would caused the missed deadline stats to be incremented. Given that, it's easier
+	// and slightly more efficient to simply run these tasks immediately in a goroutine.
+	if sched.RunOnInit() {
+		go taskFn(time.Now())
+	} else {
+		s.runOnce(sched.Next(lastRanAt), taskFn)
+	}
+
+	return func() {
+		debugf("Remove scheduler job '%v'", id)
+		jobCtxCancel()
+	}, nil
 }
 
-func (s *Scheduler) run() {
-	defer func() {
-		// drain finished queue for active jobs to not leak
-		// go-routines on exit
-		for i := uint(0); i < s.active; i++ {
-			<-s.finished
-		}
-	}()
-
-	debugf("Start scheduler.")
-	defer debugf("Scheduler stopped.")
-
+func (s *Scheduler) runOnce(runAt time.Time, taskFn timerqueue.TimerTaskFn) {
 	now := time.Now().In(s.location)
-	for _, j := range s.jobs {
-		j.next = j.schedule.Next(now)
+	if runAt.Before(now) {
+		// Our last invocation went long!
+		s.stats.jobsMissedDeadline.Inc()
 	}
 
-	resched := true
-
-	var timer *time.Timer
-	for {
-		if resched {
-			sortEntries(s.jobs)
-		}
-		resched = true
-
-		unlimited := s.limit == 0
-		if (unlimited || s.active < s.limit) && len(s.jobs) > 0 {
-			next := s.jobs[0].next
-			debugf("Next wakeup time: %v", next)
-
-			if timer != nil {
-				timer.Stop()
-			}
-
-			// Calculate the amount of time between now and the next execution
-			// since the timers operation on durations, not exact amounts of time
-			nextExecIn := next.Sub(time.Now().In(s.location))
-			timer = time.NewTimer(nextExecIn)
-		}
-
-		var timeSignal <-chan time.Time
-		if timer != nil {
-			timeSignal = timer.C
-		}
-
-		select {
-		case now = <-timeSignal:
-			for _, j := range s.jobs {
-				if now.Before(j.next) {
-					break
-				}
-
-				if j.running > 0 {
-					debugf("Scheduled job '%v' still active.", j.id)
-					reschedActive(j, now)
-					continue
-				}
-
-				if s.limit > 0 && s.active == s.limit {
-					logp.Info("Scheduled job '%v' waiting.", j.id)
-					timer = nil
-					continue
-				}
-
-				s.startJob(j)
-			}
-
-		case sig := <-s.finished:
-			s.active--
-			j := sig.entry
-			debugf("Job '%v' returned at %v (cont=%v).", j.id, time.Now(), len(sig.cont))
-
-			// add number of job continuation tasks returned to current job task
-			// counter and remove count for task just being finished
-			j.running += uint32(len(sig.cont)) - 1
-
-			count := 0 // number of rescheduled waiting jobs
-
-			// try to start waiting jobs
-			for _, waiting := range s.jobs {
-				if now.Before(waiting.next) {
-					break
-				}
-
-				if waiting.running > 0 {
-					count++
-					reschedActive(waiting, now)
-					continue
-				}
-
-				debugf("Start waiting job: %v", waiting.id)
-				s.startJob(waiting)
-				break
-			}
-
-			// Try to start waiting tasks of already running jobs.
-			// The s.tasks waiting list will only have any entries if `s.limit > 0`.
-			if s.limit > 0 && (s.active < s.limit) {
-				if T := uint(len(s.tasks)); T > 0 {
-					N := s.limit - s.active
-					debugf("start up to %v waiting tasks (%v)", N, T)
-					if N > T {
-						N = T
-					}
-
-					tasks := s.tasks[:N]
-					s.tasks = s.tasks[N:]
-					for _, t := range tasks {
-						s.runTask(t)
-					}
-				}
-			}
-
-			// try to start returned tasks for current job and put left-over tasks into
-			// waiting list.
-			if N := len(sig.cont); N > 0 {
-				if s.limit > 0 {
-					limit := int(s.limit - s.active)
-					if N > limit {
-						N = limit
-					}
-				}
-
-				if N > 0 {
-					debugf("start returned tasks")
-					tasks := sig.cont[:N]
-					sig.cont = sig.cont[N:]
-					for _, t := range tasks {
-						s.runTask(t)
-					}
-				}
-			}
-			if len(sig.cont) > 0 {
-				s.tasks = append(s.tasks, sig.cont...)
-			}
-
-			// reschedule (sort) list of tasks, if any task to be run next is
-			// still active.
-			resched = count > 0
-
-		case j := <-s.addCh:
-			j.next = j.schedule.Next(time.Now().In(s.location))
-			s.addSync(j)
-
-		case j := <-s.rmCh:
-			s.doRemove(j)
-
-		case <-s.done:
-			debugf("done")
-			return
-
-		}
-	}
+	// Schedule task to run sometime in the future. Wrap the task in a go-routine so it doesn't
+	// block the timer thread.
+	asyncTask := func(now time.Time) { go taskFn(now) }
+	s.timerQueue.Push(runAt, asyncTask)
 }
 
-func reschedActive(j *job, now time.Time) {
-	logp.Info("Scheduled job '%v' already active.", j.id)
-	if !now.Before(j.next) {
-		j.next = j.schedule.Next(j.next)
-	}
+// runRecursiveJob runs the entry point for a job, blocking until all subtasks are completed.
+// Subtasks are run in separate goroutines.
+// returns the time execution began on its first task
+func (s *Scheduler) runRecursiveJob(jobCtx context.Context, task TaskFunc) (startedAt time.Time) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	startedAt = s.runRecursiveTask(jobCtx, task, wg)
+	wg.Wait()
+	return startedAt
 }
 
-func (s *Scheduler) startJob(j *job) {
-	j.running++
-	j.next = j.schedule.Next(j.next)
-	debugf("Start job '%v' at %v.", j.id, time.Now())
+// runRecursiveTask runs an individual task and its continuations until none are left with as much parallelism as possible.
+// Since task funcs can emit continuations recursively we need a function to execute
+// recursively.
+// The wait group passed into this function expects to already have its count incremented by one.
+func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *sync.WaitGroup) (startedAt time.Time) {
+	defer wg.Done()
 
-	s.runTask(task{j, j.fn})
-}
+	// The accounting for waiting/active tasks is done using atomics.
+	// Absolute accuracy is not critical here so the gap between modifying waitingTasks and activeJobs is acceptable.
+	s.stats.waitingTasks.Inc()
 
-func (s *Scheduler) runTask(t task) {
-	j := t.job
-	s.active++
+	// Acquire an execution slot in keeping with heartbeat.scheduler.limit
+	s.limitSem.Acquire(s.ctx, 1)
+	defer s.limitSem.Release(1)
 
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				logp.Err("Panic in job '%v'. Recovering, but please report this: %s.",
-					j.id, r)
-				logp.Err("Stacktrace: %s", debug.Stack())
-				s.signalFinished(j, nil)
-			}
-		}()
+	// Record the time this task started now that we have a resource to execute with
+	startedAt = time.Now()
 
-		cont := t.fn()
-		s.signalFinished(j, cont)
-	}()
-}
+	// Check if the scheduler has been shut down. If so, exit early
+	select {
+	case <-jobCtx.Done():
+		return startedAt
+	default:
+		s.stats.activeTasks.Inc()
+		s.stats.waitingTasks.Dec()
 
-func (s *Scheduler) addSync(j *job) {
-	j.registered = true
-	s.jobs = append(s.jobs, j)
-}
+		continuations := task(jobCtx)
+		s.stats.activeTasks.Dec()
 
-func (s *Scheduler) doRemove(j *job) {
-	// find entry
-	idx := -1
-	for i, other := range s.jobs {
-		if j == other {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		return
-	}
-
-	// delete entry, not preserving order
-	s.jobs[idx] = s.jobs[len(s.jobs)-1]
-	s.jobs = s.jobs[:len(s.jobs)-1]
-
-	// mark entry as unregistered
-	j.registered = false
-}
-
-func (s *Scheduler) signalFinished(j *job, cont []TaskFunc) {
-	var tasks []task
-	if len(cont) > 0 {
-		tasks = make([]task, len(cont))
-		for i, f := range cont {
-			tasks[i] = task{j, f}
+		wg.Add(len(continuations))
+		for _, cont := range continuations {
+			// Run continuations in parallel, note that these each will acquire their own slots
+			// We can discard the started at times for continuations as those are irrelevant
+			go s.runRecursiveTask(jobCtx, cont, wg)
 		}
 	}
 
-	s.finished <- taskOverSignal{j, tasks}
-}
-
-func (s *Scheduler) transitionRunning() bool {
-	return s.state.CAS(statePreRunning, stateRunning)
-}
-
-func (s *Scheduler) transitionStopped() bool {
-	return s.state.CAS(stateRunning, stateDone)
-}
-
-func (s *Scheduler) isPreRunning() bool {
-	return s.state.Load() == statePreRunning
-}
-
-func (s *Scheduler) isRunning() bool {
-	return s.state.Load() == stateRunning
+	return startedAt
 }

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -18,121 +18,185 @@
 package scheduler
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// The time in the island of tarawa 🏝. Good test TZ because it's pretty rare for a local box
+// The runAt in the island of tarawa 🏝. Good test TZ because it's pretty rare for a local box
 // to be state in this TZ, and it has a weird offset +0125+17300.
 func tarawaTime() *time.Location {
 	loc, err := time.LoadLocation("Pacific/Tarawa")
 	if err != nil {
-		panic("this computer doesn't know about tarawa time " + err.Error())
+		panic("this computer doesn't know about tarawa runAt " + err.Error())
 	}
 
 	return loc
 }
 
 func TestNew(t *testing.T) {
-	scheduler := New(123)
-	assert.Equal(t, uint(123), scheduler.limit)
+	scheduler := New(123, monitoring.NewRegistry())
+	assert.Equal(t, int64(123), scheduler.limit)
 	assert.Equal(t, time.Local, scheduler.location)
 }
 
 func TestNewWithLocation(t *testing.T) {
-	scheduler := NewWithLocation(123, tarawaTime())
-	assert.Equal(t, uint(123), scheduler.limit)
+	scheduler := NewWithLocation(123, monitoring.NewRegistry(), tarawaTime())
+	assert.Equal(t, int64(123), scheduler.limit)
 	assert.Equal(t, tarawaTime(), scheduler.location)
 }
 
 // Runs tasks as fast as possible. Good for keeping tests snappy.
-type instantSchedule struct{}
+type testSchedule struct {
+	delay time.Duration
+}
 
-func (instantSchedule) Next(now time.Time) time.Time {
-	return now
+func (testSchedule) RunOnInit() bool {
+	return true
+}
+
+func (t testSchedule) Next(now time.Time) time.Time {
+	return now.Add(t.delay)
 }
 
 // Test task that will only actually invoke the fn the given number of times
 // this lets us test around timing / scheduling weirdness more accurately, since
 // we can in tests expect an exact number of invocations
-func testTaskTimes(limit uint32, fn func()) func() []TaskFunc {
+func testTaskTimes(limit uint32, fn TaskFunc) TaskFunc {
 	invoked := new(uint32)
-	return func() []TaskFunc {
+	return func(ctx context.Context) (conts []TaskFunc) {
 		if atomic.LoadUint32(invoked) < limit {
-			fn()
+			conts = fn(ctx)
 		}
 		atomic.AddUint32(invoked, 1)
-		return nil
+		return conts
 	}
 }
 
 func TestScheduler_Start(t *testing.T) {
-	// We use tarawa time because it could expose some weird time math if by accident some code
+	// We use tarawa runAt because it could expose some weird runAt math if by accident some code
 	// relied on the local TZ.
-	s := NewWithLocation(10, tarawaTime())
+	s := NewWithLocation(10, monitoring.NewRegistry(), tarawaTime())
 	defer s.Stop()
 
 	executed := make(chan string)
 
 	preAddEvents := uint32(10)
-	s.Add(instantSchedule{}, "preAdd", testTaskTimes(preAddEvents, func() {
+	s.Add(testSchedule{0}, "preAdd", testTaskTimes(preAddEvents, func(_ context.Context) []TaskFunc {
 		executed <- "preAdd"
+		cont := func(_ context.Context) []TaskFunc {
+			executed <- "preAddCont"
+			return nil
+		}
+		return []TaskFunc{cont}
 	}))
 
 	removedEvents := uint32(1)
 	// This function will be removed after being invoked once
-	var remove func() error
-	// Attempt to execute this twice to see if remove() had any effect
-	remove, err := s.Add(instantSchedule{}, "removed", testTaskTimes(removedEvents+1, func() {
+	removeMtx := sync.Mutex{}
+	var remove context.CancelFunc
+	var testFn TaskFunc = func(_ context.Context) []TaskFunc {
 		executed <- "removed"
+		removeMtx.Lock()
 		remove()
-	}))
+		removeMtx.Unlock()
+		return nil
+	}
+	// Attempt to execute this twice to see if remove() had any effect
+	removeMtx.Lock()
+	remove, err := s.Add(testSchedule{}, "removed", testTaskTimes(removedEvents+1, testFn))
 	require.NoError(t, err)
+	require.NotNil(t, remove)
+	removeMtx.Unlock()
 
 	s.Start()
 
 	postAddEvents := uint32(10)
-	s.Add(instantSchedule{}, "postAdd", testTaskTimes(postAddEvents, func() {
+	s.Add(testSchedule{}, "postAdd", testTaskTimes(postAddEvents, func(_ context.Context) []TaskFunc {
 		executed <- "postAdd"
+		cont := func(_ context.Context) []TaskFunc {
+			executed <- "postAddCont"
+			return nil
+		}
+		return []TaskFunc{cont}
 	}))
 
 	received := make([]string, 0)
 	// We test for a good number of events in this loop because we want to ensure that the remove() took effect
 	// Otherwise, we might only do 1 preAdd and 1 postAdd event
-	for uint32(len(received)) < preAddEvents+removedEvents+postAddEvents {
+	// We double the number of pre/post add events to account for their continuations
+	totalExpected := preAddEvents*2 + removedEvents + postAddEvents*2
+	for uint32(len(received)) < totalExpected {
 		select {
 		case got := <-executed:
 			received = append(received, got)
-		case <-time.After(10 * time.Second):
-			require.Fail(t, "Timed out waiting for schedule job to execute")
+		case <-time.After(5 * time.Second):
+			require.Fail(t, fmt.Sprintf("Timed out waitingTasks for schedule job to execute, got %d of %d: %v",
+				len(received), totalExpected, received))
 		}
 	}
 
 	// The removed callback should only have been executed once
-	counts := map[string]uint32{"preAdd": 0, "postAdd": 0, "removed": 0}
+	counts := map[string]uint32{"preAdd": 0, "postAdd": 0, "preAddCont": 0, "postAddcont": 0, "removed": 0}
 	for _, s := range received {
 		counts[s]++
 	}
-	assert.Equal(t, preAddEvents, counts["preAdd"])
-	assert.Equal(t, postAddEvents, counts["postAdd"])
-	assert.Equal(t, removedEvents, counts["removed"])
+
+	// convert with int() because the printed output is nicer than hex
+	assert.Equal(t, int(preAddEvents), int(counts["preAdd"]))
+	assert.Equal(t, int(preAddEvents), int(counts["preAddCont"]))
+	assert.Equal(t, int(postAddEvents), int(counts["postAdd"]))
+	assert.Equal(t, int(postAddEvents), int(counts["postAddCont"]))
+	assert.Equal(t, int(removedEvents), int(counts["removed"]))
 }
 
 func TestScheduler_Stop(t *testing.T) {
-	s := NewWithLocation(10, tarawaTime())
+	s := NewWithLocation(10, monitoring.NewRegistry(), tarawaTime())
 
 	executed := make(chan struct{})
 
-	s.Start()
-	s.Stop()
+	require.NoError(t, s.Start())
+	require.NoError(t, s.Stop())
 
-	_, err := s.Add(instantSchedule{}, "testPostStop", testTaskTimes(1, func() {
+	_, err := s.Add(testSchedule{}, "testPostStop", testTaskTimes(1, func(_ context.Context) []TaskFunc {
 		executed <- struct{}{}
+		return nil
 	}))
 
 	assert.Equal(t, ErrAlreadyStopped, err)
+}
+
+func BenchmarkScheduler(b *testing.B) {
+	s := NewWithLocation(0, monitoring.NewRegistry(), tarawaTime())
+
+	sched := testSchedule{0}
+
+	executed := make(chan struct{})
+	for i := 0; i < 1024; i++ {
+		_, err := s.Add(sched, "testPostStop", func(_ context.Context) []TaskFunc {
+			executed <- struct{}{}
+			return nil
+		})
+		assert.NoError(b, err)
+	}
+
+	err := s.Start()
+	defer s.Stop()
+	assert.NoError(b, err)
+
+	count := 0
+	for count < b.N {
+		select {
+		case <-executed:
+			count++
+		}
+	}
 }

--- a/heartbeat/scheduler/timerqueue/doc.go
+++ b/heartbeat/scheduler/timerqueue/doc.go
@@ -15,43 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cron
+/*
+Package timerqueue implements lets you defer execution of functions to a later time using an efficient implementation
+based upon a priority queue and a single timer. The priority queue is implemented with the container/heap package.
 
-import (
-	"time"
-
-	"github.com/gorhill/cronexpr"
-)
-
-type Schedule cronexpr.Expression
-
-func MustParse(in string) *Schedule {
-	s, err := Parse(in)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-func Parse(in string) (*Schedule, error) {
-	expr, err := cronexpr.Parse(in)
-	return (*Schedule)(expr), err
-}
-
-func (s *Schedule) Next(t time.Time) time.Time {
-	expr := (*cronexpr.Expression)(s)
-	return expr.Next(t)
-}
-
-func (s *Schedule) Unpack(str string) error {
-	tmp, err := Parse(str)
-	if err == nil {
-		*s = *tmp
-	}
-	return err
-}
-
-// RunOnInit returns false for interval schedulers.
-func (s *Schedule) RunOnInit() bool {
-	return false
-}
+Internally timerqueue uses a single blocking thread to execute all tasks. If your tasks perform anything other than
+trivial operations it is recommended that you spawn goroutines from each task.
+*/
+package timerqueue

--- a/heartbeat/scheduler/timerqueue/heap.go
+++ b/heartbeat/scheduler/timerqueue/heap.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package timerqueue
+
+// timerHeap is the internal type that implements container/heap
+// pointers are faster to swap than bare structs here.
+type timerHeap []*timerTask
+
+// Less computes the order of the heap. We want the earliest time to Pop().
+func (th timerHeap) Less(i, j int) bool {
+	// We want pop to give us the earliest (lowest) time so use before
+	return th[i].runAt.Before(th[j].runAt)
+}
+
+// Swap switches two elements.
+func (th timerHeap) Swap(i, j int) {
+	th[i], th[j] = th[j], th[i]
+}
+
+// Push adds a new timerTask to the heap
+func (th *timerHeap) Push(tt interface{}) {
+	*th = append(*th, tt.(*timerTask))
+}
+
+// Pop returns the timerTask scheduled soonest.
+func (th *timerHeap) Pop() interface{} {
+	old := *th
+	n := len(old)
+	tt := old[n-1]
+	*th = old[0 : n-1]
+	return tt
+}
+
+// Len returns the length.
+func (th timerHeap) Len() int {
+	return len(th)
+}

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package timerqueue
+
+import (
+	"container/heap"
+	"context"
+	"time"
+)
+
+// timerTask represents a task run by the TimerQueue.
+type timerTask struct {
+	fn    TimerTaskFn
+	runAt time.Time
+}
+
+// TimerTaskFn is the function invoked by a timerTask.
+type TimerTaskFn func(now time.Time)
+
+// TimerQueue represents a priority queue of timers.
+type TimerQueue struct {
+	th        timerHeap
+	ctx       context.Context
+	nextRunAt *time.Time
+	pushCh    chan *timerTask
+	timer     *time.Timer
+}
+
+// NewTimerQueue creates a new instance.
+func NewTimerQueue(ctx context.Context) *TimerQueue {
+	tq := &TimerQueue{
+		th:     timerHeap{},
+		ctx:    ctx,
+		pushCh: make(chan *timerTask, 4096),
+		timer:  time.NewTimer(time.Hour * 86400),
+	}
+	heap.Init(&tq.th)
+
+	return tq
+}
+
+// Push adds a task to the queue. Returns true if successful
+// false if failed (due to cancelled context)
+func (tq *TimerQueue) Push(runAt time.Time, fn TimerTaskFn) bool {
+	// Block until push succeeds or shutdown
+	select {
+	case tq.pushCh <- &timerTask{runAt: runAt, fn: fn}:
+		return true
+	case <-tq.ctx.Done():
+		return false
+	}
+}
+
+// Start runs a goroutine within the given context that processes items in the queue, spawning a new goroutine
+// for each.
+func (tq *TimerQueue) Start() {
+	go func() {
+		for {
+			select {
+			case <-tq.ctx.Done():
+				// Stop the timerqueue
+				return
+			case now := <-tq.timer.C:
+				tasks := tq.popRunnable(now)
+
+				// Run the tasks in a separate goroutine so we can unblock the thread here for pushes etc.
+				go func() {
+					for _, tt := range tasks {
+						tt.fn(now)
+					}
+				}()
+
+				if tq.th.Len() > 0 {
+					nr := tq.th[0].runAt
+					tq.nextRunAt = &nr
+					tq.timer.Reset(nr.Sub(time.Now()))
+				} else {
+					tq.timer.Stop()
+					tq.nextRunAt = nil
+				}
+			case tt := <-tq.pushCh:
+				tq.pushInternal(tt)
+			}
+		}
+	}()
+}
+
+func (tq *TimerQueue) pushInternal(tt *timerTask) {
+	heap.Push(&tq.th, tt)
+
+	if tq.nextRunAt == nil || tq.nextRunAt.After(tt.runAt) {
+		// Stop and drain the timer prior to reset per https://golang.org/pkg/time/#Timer.Reset
+		// Only drain if nextRunAt is set, otherwise the timer channel has already been stopped the
+		// channel is empty (and thus would block)
+		if tq.nextRunAt != nil && !tq.timer.Stop() {
+			<-tq.timer.C
+		}
+		tq.timer.Reset(tt.runAt.Sub(time.Now()))
+
+		tq.nextRunAt = &tt.runAt
+	}
+}
+
+func (tq *TimerQueue) popRunnable(now time.Time) (res []*timerTask) {
+	for i := 0; tq.th.Len() > 0; i++ {
+		// the zeroth element of the heap is the same as a peek
+		peeked := tq.th[0]
+		if peeked.runAt.Before(now) {
+			popped := heap.Pop(&tq.th).(*timerTask)
+			res = append(res, popped)
+		} else {
+			break
+		}
+	}
+
+	return res
+}

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -1,0 +1,107 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package timerqueue
+
+import (
+	"context"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueRunsInOrder(t *testing.T) {
+	// Bugs can show up only occasionally
+	for i := 0; i < 100; i++ {
+		testQueueRunsInOrderOnce(t)
+	}
+}
+
+func testQueueRunsInOrderOnce(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+	tq := NewTimerQueue(ctx)
+
+	// Number of items to test with
+	numItems := 10
+
+	// Make a buffered queue for taskResCh so we can easily write to it within this thread.
+	taskResCh := make(chan int, numItems)
+
+	// Make a bunch of tasks past their deadline
+	var tasks []*timerTask
+	// Start from 1 so we can use the zero value when closing the channel
+	for i := 1; i <= numItems; i++ {
+		func(i int) {
+			schedFor := time.Unix(0, 0).Add(time.Duration(i))
+			tasks = append(tasks, &timerTask{runAt: schedFor, fn: func(now time.Time) {
+				taskResCh <- i
+				if i == numItems {
+					close(taskResCh)
+				}
+			}})
+		}(i)
+	}
+	// shuffle them so they're out of order
+	rand.Shuffle(len(tasks), func(i, j int) { tasks[i], tasks[j] = tasks[j], tasks[i] })
+
+	// insert the randomly ordered events into the queue
+	// we use the internal push because pushing and running are in the same threads, so
+	// using Push() may result in tasks being executed before all are inserted.
+	// This private method is not threadsafe, so is kept private.
+	for _, tt := range tasks {
+		tq.pushInternal(tt)
+	}
+
+	tq.Start()
+
+	var taskResults []int
+Reader:
+	for {
+		select {
+		case res := <-taskResCh:
+			if res == 0 { // chan closed
+				break Reader
+			}
+			taskResults = append(taskResults, res)
+		}
+	}
+
+	require.Len(t, taskResults, numItems)
+	require.True(t, sort.IntsAreSorted(taskResults), "Results not in order! %v", taskResults)
+}
+
+func TestQueueRunsTasksAddedAfterStart(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+	tq := NewTimerQueue(ctx)
+
+	tq.Start()
+
+	resCh := make(chan int)
+	tq.Push(time.Now(), func(now time.Time) {
+		resCh <- 1
+	})
+
+	select {
+	case r := <-resCh:
+		require.Equal(t, 1, r)
+	}
+}


### PR DESCRIPTION
@urso this is a backport of #14569 to 7.5. Given that the re-implementation fixes some significant bugs I think the backport is warranted here vs. waiting till 7.6. I did remove the one breaking change of the new `runOnInit` feature. I did this by setting it to `false` in the interval scheduler.