### PR TITLE
Assert Trial in the licenser integration test

### DIFF
--- a/x-pack/libbeat/licenser/elastic_fetcher_integration_test.go
+++ b/x-pack/libbeat/licenser/elastic_fetcher_integration_test.go
@@ -47,8 +47,8 @@ func TestElasticsearch(t *testing.T) {
 		return
 	}
 
-	assert.NotNil(t, license.Get())
-	assert.NotNil(t, license.Type)
+	assert.Equal(t, Trial, license.Get())
+	assert.Equal(t, Trial, license.Type)
 	assert.Equal(t, Active, license.Status)
 
 	assert.NotEmpty(t, license.UUID)


### PR DESCRIPTION
This is a start instead of asserting that the type and mode are not nil
we assert that we receive a trial mode when run in integration test.

The remaining of the types check are done via mocks / recorded response
from the server.