### PR TITLE
Cherry-pick: Fixes #14906 - Kafka output dropping messages due to size, but doesn’t increment the “failed” counter. (#14930)

### DIFF
--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -242,11 +242,13 @@ func (r *msgRef) fail(msg *message, err error) {
 	switch err {
 	case sarama.ErrInvalidMessage:
 		logp.Err("Kafka (topic=%v): dropping invalid message", msg.topic)
+		r.client.observer.Dropped(1)
 
 	case sarama.ErrMessageSizeTooLarge, sarama.ErrInvalidMessageSize:
 		logp.Err("Kafka (topic=%v): dropping too large message of size %v.",
 			msg.topic,
 			len(msg.key)+len(msg.value))
+		r.client.observer.Dropped(1)
 
 	default:
 		r.failed = append(r.failed, msg.data)


### PR DESCRIPTION
@faec Hi :) Can you please review?