### PR TITLE
Fix default value in rollover_alias docs

### DIFF
--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -51,7 +51,7 @@ required license; otherwise, {beatname_uc} creates daily indices.
 ==== `setup.ilm.rollover_alias`
 
 The index lifecycle write alias name. The default is
-+{beatname_lc}-%{{beat_version_key}}+. Setting this option changes the alias name.
++{beatname_lc}-%{[{beat_version_key}]}+. Setting this option changes the alias name.
 
 NOTE: If you modify this setting after loading the index template, you must
 overwrite the template to apply the changes.


### PR DESCRIPTION
In #12233 it has been reported that we are still missing the `[]` on the rollover_alias.