### PR TITLE
remove Python 2 compatibility shims and casts

### DIFF
--- a/auditbeat/tests/system/auditbeat.py
+++ b/auditbeat/tests/system/auditbeat.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 import os
 import shutil
 import sys
@@ -47,7 +45,7 @@ class BaseTest(MetricbeatTest):
         return p
 
 
-class PathCleanup(object):
+class PathCleanup:
     def __init__(self, paths):
         self.paths = paths
 

--- a/auditbeat/tests/system/test_show_command.py
+++ b/auditbeat/tests/system/test_show_command.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from builtins import range
 import os
 import platform
 import sys

--- a/dev-tools/aggregate_coverage.py
+++ b/dev-tools/aggregate_coverage.py
@@ -42,7 +42,7 @@ def main(arguments):
                             assert prev_stmt == stmt
                         lines[position] = (position, stmt, prev_count + count)
 
-    for line in sorted(["%s %d %d\n" % lines[key] for key in list(lines.keys())]):
+    for line in sorted(["%s %d %d\n" % lines[key] for key in lines.keys()]):
         args.outfile.write(line)
 
 

--- a/dev-tools/cmd/dashboards/export_5x_dashboards.py
+++ b/dev-tools/cmd/dashboards/export_5x_dashboards.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from elasticsearch import Elasticsearch
 import argparse
 import os

--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import glob
 import os
 import datetime
@@ -9,8 +7,6 @@ import csv
 import re
 import pdb
 import copy
-
-from builtins import bytes
 
 
 def read_file(filename):
@@ -411,7 +407,7 @@ if __name__ == "__main__":
     dependencies = create_notice(notice, args.beat, args.copyright, vendor_dirs, args.csvfile, overrides=overrides)
 
     # check that all licenses are accepted
-    for _, deps in list(dependencies.items()):
+    for _, deps in dependencies.items():
         for dep in deps:
             if dep["license_summary"] not in ACCEPTED_LICENSES:
                 raise Exception("Dependency {} has invalid license {}"

--- a/filebeat/tests/load/load.py
+++ b/filebeat/tests/load/load.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 import logging
 import logging.handlers
 import datetime

--- a/filebeat/tests/open-file-handlers/log_file.py
+++ b/filebeat/tests/open-file-handlers/log_file.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 import time
 import sys
 import logging

--- a/filebeat/tests/open-file-handlers/log_stdout.py
+++ b/filebeat/tests/open-file-handlers/log_stdout.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from builtins import str
-from builtins import range
 from past.utils import old_div
 import time
 import sys

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -1,6 +1,3 @@
-from builtins import oct
-from builtins import filter
-from builtins import object
 import json
 import os
 import stat
@@ -75,7 +72,7 @@ class BaseTest(TestCase):
         return oct(stat.S_IMODE(os.lstat(full_path).st_mode))
 
 
-class InputLogs(object):
+class InputLogs:
     """ InputLogs is used to write and append to files which are read by filebeat. """
 
     def __init__(self, home):
@@ -103,7 +100,7 @@ class InputLogs(object):
         return os.path.join(self.home, name)
 
 
-class Registry(object):
+class Registry:
     """ Registry provides access to the registry used by filebeat to store its progress """
 
     def __init__(self, home, name=None):
@@ -119,7 +116,7 @@ class Registry(object):
             entries = json.load(f)
 
         if filter:
-            entries = [x for x in entries if list(filter(x))]
+            entries = [x for x in entries if filter(x)]
         return entries
 
     def count(self, filter=None):
@@ -128,7 +125,7 @@ class Registry(object):
         return len(self.load(filter=filter))
 
 
-class LogState(object):
+class LogState:
     def __init__(self, path):
         self.path = path
         self.off = 0
@@ -141,7 +138,7 @@ class LogState(object):
             def filter(x): return True
         with open(self.path, "r") as f:
             f.seek(self.off)
-            return [l for l in f if list(filter(l))]
+            return [l for l in f if filter(l)]
 
     def contains(self, msg, ignore_case=False, count=1):
         if ignore_case:

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 
 import codecs

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from filebeat import BaseTest
 import os
 import socket

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import os
 import codecs

--- a/filebeat/tests/system/test_input.py
+++ b/filebeat/tests/system/test_input.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import os
 import time

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import os
 import six

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from builtins import str
-from builtins import range
 from past.utils import old_div
 from filebeat import BaseTest
 import os

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from filebeat import BaseTest
 from beat.beat import INTEGRATION_TESTS
 import os

--- a/filebeat/tests/system/test_multiline.py
+++ b/filebeat/tests/system/test_multiline.py
@@ -1,4 +1,3 @@
-from builtins import range
 from filebeat import BaseTest
 import os
 import time

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from filebeat import BaseTest
 from beat.beat import INTEGRATION_TESTS
 import os

--- a/filebeat/tests/system/test_processors.py
+++ b/filebeat/tests/system/test_processors.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from builtins import range
 from filebeat import BaseTest
 import io
 import os

--- a/filebeat/tests/system/test_publisher.py
+++ b/filebeat/tests/system/test_publisher.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 
 import os

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 """Test the registrar"""
-from __future__ import print_function
-
-from builtins import str
-from builtins import range
 import os
 import platform
 import re

--- a/filebeat/tests/system/test_reload_modules.py
+++ b/filebeat/tests/system/test_reload_modules.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 import unittest
 import os
@@ -92,7 +91,7 @@ class Test(BaseTest):
 
         # Check pipeline is present
         self.wait_until(lambda: any(re.match("filebeat-.*-test-test-default", key)
-                                    for key in list(self.es.transport.perform_request("GET", "/_ingest/pipeline/").keys())))
+                                    for key in self.es.transport.perform_request("GET", "/_ingest/pipeline/").keys()))
         proc.check_kill_and_wait()
 
     def test_no_es_connection(self):

--- a/filebeat/tests/system/test_setup.py
+++ b/filebeat/tests/system/test_setup.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import os
 import yaml

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 import gzip
 import os
 import time

--- a/filebeat/tests/system/test_stdin.py
+++ b/filebeat/tests/system/test_stdin.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from builtins import range
 from filebeat import BaseTest
 import os
 

--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -1,4 +1,3 @@
-from builtins import range
 from filebeat import BaseTest
 import socket
 

--- a/filebeat/tests/system/test_tcp.py
+++ b/filebeat/tests/system/test_tcp.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import socket
 

--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import socket
 import ssl

--- a/filebeat/tests/system/test_udp.py
+++ b/filebeat/tests/system/test_udp.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import range
 from filebeat import BaseTest
 import socket
 

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 import os
 import sys
 import http.server

--- a/heartbeat/tests/system/test_telemetry.py
+++ b/heartbeat/tests/system/test_telemetry.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 from heartbeat import BaseTest
 import urllib.request
 import urllib.error

--- a/libbeat/scripts/create_packer.py
+++ b/libbeat/scripts/create_packer.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import argparse
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 from collections import OrderedDict
 import os

--- a/libbeat/scripts/generate_makefile_doc.py
+++ b/libbeat/scripts/generate_makefile_doc.py
@@ -7,8 +7,6 @@ Example usage:
 
    python generate_makefile_doc.py Makefile1 Makefile2 ...
 """
-from __future__ import print_function
-
 import argparse
 import re
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from builtins import range
-from builtins import object
 import subprocess
 
 import jinja2
@@ -514,7 +511,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         given list of expected fields.
         """
         for o in objs:
-            for key in list(o.keys()):
+            for key in o.keys():
                 known = key in dict_fields or key in expected_fields
                 ismeta = key.startswith('@metadata.')
                 if not(known or ismeta):
@@ -602,7 +599,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
 
     def flatten_object(self, obj, dict_fields, prefix=""):
         result = {}
-        for key, value in list(obj.items()):
+        for key, value in obj.items():
             if isinstance(value, dict) and prefix + key not in dict_fields:
                 new_prefix = prefix + key + "."
                 result.update(self.flatten_object(value, dict_fields,
@@ -684,7 +681,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     return True
             return False
 
-        for key in list(flat.keys()):
+        for key in flat.keys():
             metaKey = key.startswith('@metadata.')
             if not(is_documented(key, expected_fields) or metaKey):
                 raise Exception("Key '{}' found in event is not documented!".format(key))

--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-
-from builtins import object
 import os
 import sys
 import tarfile
@@ -204,7 +198,7 @@ class ComposeMixin(object):
         def positivehash(x):
             return hash(x) % ((sys.maxsize+1) * 2)
 
-        return "%s_%X" % (basename, positivehash(frozenset(list(cls.COMPOSE_ENV.items()))))
+        return "%s_%X" % (basename, positivehash(frozenset(cls.COMPOSE_ENV.items())))
 
     @classmethod
     def compose_project(cls):

--- a/libbeat/tests/system/idxmgmt.py
+++ b/libbeat/tests/system/idxmgmt.py
@@ -1,4 +1,3 @@
-from builtins import object
 from elasticsearch import NotFoundError
 from nose.tools import raises
 import datetime
@@ -20,7 +19,7 @@ class IdxMgmt(object):
         for i in indices:
             self.delete_index_and_alias(i)
             self.delete_template(template=i)
-        for i in list([x for x in policies if x != '']):
+        for i in [x for x in policies if x != '']:
             self.delete_policy(i)
 
     def delete_index_and_alias(self, index=""):
@@ -44,7 +43,7 @@ class IdxMgmt(object):
     def delete_policy(self, policy):
         # Delete any existing policy starting with given policy
         policies = self._client.transport.perform_request('GET', "/_ilm/policy")
-        for p, _ in list(policies.items()):
+        for p, _ in policies.items():
             if not p.startswith(policy):
                 continue
             try:
@@ -73,7 +72,7 @@ class IdxMgmt(object):
 
     def assert_alias_not_created(self, alias):
         resp = self._client.transport.perform_request('GET', '/_alias')
-        for name, entry in list(resp.items()):
+        for name, entry in resp.items():
             if alias not in name:
                 continue
             assert entry["aliases"] == {}, entry["aliases"]

--- a/libbeat/tests/system/test_cmd_version.py
+++ b/libbeat/tests/system/test_cmd_version.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from base import BaseTest
 from elasticsearch import Elasticsearch, TransportError
 

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -1,4 +1,3 @@
-from builtins import str
 from base import BaseTest
 import os
 import os.path

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -1,4 +1,3 @@
-from builtins import oct
 from base import BaseTest
 
 import os

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -1,4 +1,3 @@
-from builtins import range
 from base import BaseTest
 import os
 from elasticsearch import Elasticsearch

--- a/libbeat/tests/system/test_seccomp.py
+++ b/libbeat/tests/system/test_seccomp.py
@@ -1,5 +1,3 @@
-from builtins import map
-from builtins import range
 import platform
 import unittest
 from base import BaseTest

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from base import BaseTest
 from idxmgmt import IdxMgmt
 import os

--- a/metricbeat/module/apache/test_apache.py
+++ b/metricbeat/module/apache/test_apache.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 import os
 import unittest
 from nose.plugins.attrib import attr
@@ -78,16 +76,16 @@ class ApacheStatusTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def verify_fields(self, evt):
-        self.assertItemsEqual(self.de_dot(APACHE_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(APACHE_FIELDS), evt.keys())
         apache_status = evt["apache"]["status"]
         if self.old_apache_version():
             self.assertItemsEqual(
-                self.de_dot(APACHE_OLD_STATUS_FIELDS), list(apache_status.keys()))
+                self.de_dot(APACHE_OLD_STATUS_FIELDS), apache_status.keys())
         else:
             self.assertItemsEqual(
-                self.de_dot(APACHE_STATUS_FIELDS), list(apache_status.keys()))
+                self.de_dot(APACHE_STATUS_FIELDS), apache_status.keys())
             self.assertItemsEqual(
-                self.de_dot(CPU_FIELDS), list(apache_status["cpu"].keys()))
+                self.de_dot(CPU_FIELDS), apache_status["cpu"].keys())
             # There are more fields that could be checked.
 
     def old_apache_version(self):

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 import re
 import sys
 import os

--- a/metricbeat/module/mysql/test_mysql.py
+++ b/metricbeat/module/mysql/test_mysql.py
@@ -38,7 +38,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), evt.keys(), evt)
 
         status = evt["mysql"]["status"]
         assert status["connections"] > 0

--- a/metricbeat/scripts/create_metricset.py
+++ b/metricbeat/scripts/create_metricset.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from builtins import input
 import os
 import argparse
 

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 import sys
 import os
@@ -105,7 +104,7 @@ class BaseTest(TestCase):
 
         fields = COMMON_FIELDS + fields
         print(fields)
-        self.assertItemsEqual(self.de_dot(fields), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(fields), evt.keys())
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_autodiscover_jolokia.py
+++ b/metricbeat/tests/system/test_autodiscover_jolokia.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_cmd.py
+++ b/metricbeat/tests/system/test_cmd.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import shutil
 import metricbeat

--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 import os
 from metricbeat import BaseTest
 import unittest

--- a/metricbeat/tests/system/test_consul.py
+++ b/metricbeat/tests/system/test_consul.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest
@@ -44,14 +43,14 @@ class ConsulAgentTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(CONSUL_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(CONSUL_FIELDS), evt.keys())
         consul_agent = evt["consul"]["agent"]
 
         consul_agent.pop("raft", None)
         consul_agent.pop("autopilot", None)
 
         print(consul_agent)
-        self.assertItemsEqual(self.de_dot(AGENT_FIELDS), list(consul_agent.keys()))
+        self.assertItemsEqual(self.de_dot(AGENT_FIELDS), consul_agent.keys())
 
         assert(consul_agent["runtime"]["heap_objects"] > 0)
 

--- a/metricbeat/tests/system/test_couchdb.py
+++ b/metricbeat/tests/system/test_couchdb.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_envoyproxy.py
+++ b/metricbeat/tests/system/test_envoyproxy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_golang.py
+++ b/metricbeat/tests/system/test_golang.py
@@ -27,7 +27,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(GOLANG_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(GOLANG_FIELDS), evt.keys(), evt)
         assert evt["golang"]["heap"]["allocations"]["total"] > 0
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest
@@ -21,7 +20,7 @@ class HaproxyTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS + ["process"]), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS + ["process"]), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -49,7 +48,7 @@ class HaproxyTest(metricbeat.BaseTest):
 
         for evt in output:
             print(evt)
-            self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS + ["process"]), list(evt.keys()), evt)
+            self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS + ["process"]), evt.keys(), evt)
             self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -1,4 +1,3 @@
-from builtins import str
 import os
 import metricbeat
 import unittest
@@ -38,7 +37,7 @@ class Test(metricbeat.BaseTest):
 
         del evt["http"]["test"]["hello"]
 
-        self.assertItemsEqual(self.de_dot(HTTP_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(HTTP_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -71,7 +70,7 @@ class Test(metricbeat.BaseTest):
         # Delete dynamic namespace part for fields comparison
         del evt["http"]["server"]
 
-        self.assertItemsEqual(self.de_dot(HTTP_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(HTTP_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_jolokia.py
+++ b/metricbeat/tests/system/test_jolokia.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_kubernetes.py
+++ b/metricbeat/tests/system/test_kubernetes.py
@@ -71,7 +71,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), expected_events)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(KUBERNETES_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(KUBERNETES_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_memcached.py
+++ b/metricbeat/tests/system/test_memcached.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -31,6 +31,6 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MONGODB_FIELDS + ["process"]), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(MONGODB_FIELDS + ["process"]), evt.keys())
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/test_munin.py
+++ b/metricbeat/tests/system/test_munin.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import unittest

--- a/metricbeat/tests/system/test_nats.py
+++ b/metricbeat/tests/system/test_nats.py
@@ -30,7 +30,7 @@ class TestNats(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(NATS_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(NATS_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -55,7 +55,7 @@ class TestNats(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(NATS_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(NATS_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -80,7 +80,7 @@ class TestNats(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(NATS_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(NATS_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -105,7 +105,7 @@ class TestNats(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(NATS_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(NATS_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_phpfpm.py
+++ b/metricbeat/tests/system/test_phpfpm.py
@@ -29,6 +29,6 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(PHPFPM_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(PHPFPM_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/test_postgresql.py
+++ b/metricbeat/tests/system/test_postgresql.py
@@ -14,7 +14,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             top_level_fields = metricbeat.COMMON_FIELDS + ["postgresql"]
-            self.assertItemsEqual(self.de_dot(top_level_fields), list(evt.keys()))
+            self.assertItemsEqual(self.de_dot(top_level_fields), evt.keys())
 
             self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 import sys
 import metricbeat
@@ -37,13 +36,13 @@ class Test(metricbeat.BaseTest):
         self.assertItemsEqual(self.de_dot([
             'agent', '@timestamp', 'system', 'metricset.module',
             'metricset.rtt', 'metricset.name', 'host', 'service', 'ecs', 'event'
-        ]), list(evt.keys()))
+        ]), evt.keys())
         cpu = evt["system"]["cpu"]
         print(list(cpu.keys()))
         self.assertItemsEqual(self.de_dot([
             "system", "cores", "user", "softirq", "iowait",
             "idle", "irq", "steal", "nice", "total"
-        ]), list(cpu.keys()))
+        ]), cpu.keys())
 
     def test_dropfields_with_condition(self):
         """

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -28,6 +28,6 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(PROMETHEUS_FIELDS), list(evt.keys()), evt)
+        self.assertItemsEqual(self.de_dot(PROMETHEUS_FIELDS), evt.keys(), evt)
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import metricbeat
 import redis
@@ -46,11 +45,11 @@ class Test(metricbeat.BaseTest):
         evt = output[0]
 
         fields = REDIS_FIELDS + ["process", "os"]
-        self.assertItemsEqual(self.de_dot(fields), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(fields), evt.keys())
         redis_info = evt["redis"]["info"]
-        self.assertItemsEqual(self.de_dot(REDIS_INFO_FIELDS), list(redis_info.keys()))
-        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), list(redis_info["clients"].keys()))
-        self.assertItemsEqual(self.de_dot(CPU_FIELDS), list(redis_info["cpu"].keys()))
+        self.assertItemsEqual(self.de_dot(REDIS_INFO_FIELDS), redis_info.keys())
+        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), redis_info["clients"].keys())
+        self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -84,9 +83,9 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
         redis_info = evt["redis"]["keyspace"]
-        self.assertItemsEqual(self.de_dot(REDIS_KEYSPACE_FIELDS), list(redis_info.keys()))
+        self.assertItemsEqual(self.de_dot(REDIS_KEYSPACE_FIELDS), redis_info.keys())
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -124,7 +123,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -154,12 +153,12 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
         redis_info = evt["redis"]["info"]
         print(redis_info)
-        self.assertItemsEqual(fields, list(redis_info.keys()))
-        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), list(redis_info["clients"].keys()))
-        self.assertItemsEqual(self.de_dot(CPU_FIELDS), list(redis_info["cpu"].keys()))
+        self.assertItemsEqual(fields, redis_info.keys())
+        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), redis_info["clients"].keys())
+        self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
 
 
 class TestRedis4(Test):

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -74,7 +74,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         cpu = evt["system"]["cpu"]
-        self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS), list(cpu.keys()))
+        self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS), cpu.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_cpu_ticks_option(self):
@@ -100,7 +100,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             cpuStats = evt["system"]["cpu"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS_ALL), list(cpuStats.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS_ALL), cpuStats.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_core(self):
@@ -123,7 +123,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             core = evt["system"]["core"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS), list(core.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS), core.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_core_with_cpu_ticks(self):
@@ -149,7 +149,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             core = evt["system"]["core"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS_ALL), list(core.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS_ALL), core.keys())
 
     @unittest.skipUnless(re.match("(?i)linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_load(self):
@@ -172,7 +172,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         cpu = evt["system"]["load"]
-        self.assertItemsEqual(self.de_dot(SYSTEM_LOAD_FIELDS), list(cpu.keys()))
+        self.assertItemsEqual(self.de_dot(SYSTEM_LOAD_FIELDS), cpu.keys())
 
     @unittest.skipUnless(re.match("(?i)win|freebsd", sys.platform), "os")
     def test_diskio(self):
@@ -196,7 +196,7 @@ class Test(metricbeat.BaseTest):
             self.assert_fields_are_documented(evt)
             if 'error' not in evt:
                 diskio = evt["system"]["diskio"]
-                self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS), list(diskio.keys()))
+                self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS), diskio.keys())
 
     @unittest.skipUnless(re.match("(?i)linux", sys.platform), "os")
     def test_diskio_linux(self):
@@ -219,7 +219,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             diskio = evt["system"]["diskio"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS_LINUX), list(diskio.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS_LINUX), diskio.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_filesystem(self):
@@ -242,7 +242,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             filesystem = evt["system"]["filesystem"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_FILESYSTEM_FIELDS), list(filesystem.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_FILESYSTEM_FIELDS), filesystem.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_fsstat(self):
@@ -265,7 +265,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         fsstat = evt["system"]["fsstat"]
-        self.assertItemsEqual(SYSTEM_FSSTAT_FIELDS, list(fsstat.keys()))
+        self.assertItemsEqual(SYSTEM_FSSTAT_FIELDS, fsstat.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_memory(self):
@@ -291,7 +291,7 @@ class Test(metricbeat.BaseTest):
         if not re.match("(?i)linux", sys.platform) and not "hugepages" in memory:
             # Ensure presence of hugepages only in Linux
             memory["hugepages"] = None
-        self.assertItemsEqual(self.de_dot(SYSTEM_MEMORY_FIELDS), list(memory.keys()))
+        self.assertItemsEqual(self.de_dot(SYSTEM_MEMORY_FIELDS), memory.keys())
 
         # Check that percentages are calculated.
         mem = memory
@@ -325,7 +325,7 @@ class Test(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             network = evt["system"]["network"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_NETWORK_FIELDS), list(network.keys()))
+            self.assertItemsEqual(self.de_dot(SYSTEM_NETWORK_FIELDS), network.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd", sys.platform), "os")
     def test_process_summary(self):
@@ -411,7 +411,7 @@ class Test(metricbeat.BaseTest):
             if cwd is not None:
                 found_cwd = True
 
-            self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, list(process.keys()))
+            self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, process.keys())
 
         self.assertTrue(found_cmdline, "cmdline not found in any process events")
 

--- a/metricbeat/tests/system/test_uwsgi.py
+++ b/metricbeat/tests/system/test_uwsgi.py
@@ -20,7 +20,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             top_level_fields = metricbeat.COMMON_FIELDS + ["uwsgi"]
-            self.assertItemsEqual(self.de_dot(top_level_fields), list(evt.keys()))
+            self.assertItemsEqual(self.de_dot(top_level_fields), evt.keys())
 
             self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -37,7 +37,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(ZK_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(ZK_FIELDS), evt.keys())
         zk_mntr = evt["zookeeper"]["mntr"]
 
         zk_mntr.pop("pending_syncs", None)
@@ -46,7 +46,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         zk_mntr.pop("max_file_descriptor_count", None)
         zk_mntr.pop("followers", None)
 
-        self.assertItemsEqual(self.de_dot(MNTR_FIELDS), list(zk_mntr.keys()))
+        self.assertItemsEqual(self.de_dot(MNTR_FIELDS), zk_mntr.keys())
 
         self.assert_fields_are_documented(evt)
 
@@ -71,7 +71,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(ZK_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(ZK_FIELDS), evt.keys())
         zk_srvr = evt["zookeeper"]["server"]
 
         assert zk_srvr["connections"] >= 0
@@ -99,7 +99,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(ZK_FIELDS + ["client"]), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(ZK_FIELDS + ["client"]), evt.keys())
         zk_conns = evt["zookeeper"]["connection"]
 
         assert zk_conns["queued"] >= 0

--- a/packetbeat/scripts/create_tcp_protocol.py
+++ b/packetbeat/scripts/create_tcp_protocol.py
@@ -1,4 +1,3 @@
-from builtins import input
 import os
 import argparse
 

--- a/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/tcp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_delete.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/tcp_stats.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_stats.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/udp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/udp_delete.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/udp_multi_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_multi_store.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/gen/memcache/udp_single_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_single_store.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import mc
 
 

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import subprocess

--- a/packetbeat/tests/system/test_0006_wsgi.py
+++ b/packetbeat/tests/system/test_0006_wsgi.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 import six

--- a/packetbeat/tests/system/test_0017_mysql_long_result.py
+++ b/packetbeat/tests/system/test_0017_mysql_long_result.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0018_pgsql_long_result.py
+++ b/packetbeat/tests/system/test_0018_pgsql_long_result.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0019_hide_params.py
+++ b/packetbeat/tests/system/test_0019_hide_params.py
@@ -26,7 +26,7 @@ class Test(BaseTest):
         assert o["type"] == "http"
         assert o["url.query"] == "pass=xxxxx&user=monica"
         assert o["url.path"] == "/login"
-        for _, val in list(o.items()):
+        for _, val in o.items():
             if isinstance(val, six.string_types):
                 assert "secret" not in val
 
@@ -47,7 +47,7 @@ class Test(BaseTest):
         assert o["type"] == "http"
         assert o["url.query"] == "pass=xxxxx&user=monica"
         assert o["url.path"] == "/login"
-        for _, val in list(o.items()):
+        for _, val in o.items():
             if isinstance(val, six.string_types):
                 assert "secret" not in val
 

--- a/packetbeat/tests/system/test_0023_http_params.py
+++ b/packetbeat/tests/system/test_0023_http_params.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0025_mongodb_basic.py
+++ b/packetbeat/tests/system/test_0025_mongodb_basic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 from packetbeat import BaseTest
 
@@ -253,6 +252,6 @@ class Test(BaseTest):
             re.compile(r'Unknown operation code: (\d+)'), 1)
 
         assert len(unknown_counts) > 0
-        for k, v in list(unknown_counts.items()):
+        for k, v in unknown_counts.items():
             assert v == 1, "Unknown opcode reported more than once: opcode={0}, count={1}".format(
                 k, v)

--- a/packetbeat/tests/system/test_0026_test_config.py
+++ b/packetbeat/tests/system/test_0026_test_config.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 import os
 import unittest

--- a/packetbeat/tests/system/test_0029_http_gap.py
+++ b/packetbeat/tests/system/test_0029_http_gap.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0060_processors.py
+++ b/packetbeat/tests/system/test_0060_processors.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 

--- a/packetbeat/tests/system/test_0062_cassandra.py
+++ b/packetbeat/tests/system/test_0062_cassandra.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0062_http_headers.py
+++ b/packetbeat/tests/system/test_0062_http_headers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0063_http_body.py
+++ b/packetbeat/tests/system/test_0063_http_body.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import BaseTest
 
 """

--- a/packetbeat/tests/system/test_0065_unmatched_http.py
+++ b/packetbeat/tests/system/test_0065_unmatched_http.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from packetbeat import (BaseTest, TRANS_REQUIRED_FIELDS)
 
 

--- a/script/config_collector.py
+++ b/script/config_collector.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import argparse
 import yaml

--- a/script/generate.py
+++ b/script/generate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 if __name__ == "__main__":
     print("This script is deprecated. Please use `mage GenerateCustomBeat`")
     exit(1)

--- a/script/kibana-migration.py
+++ b/script/kibana-migration.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from past.builtins import basestring
 import yaml
 import glob

--- a/script/renamed_fields.py
+++ b/script/renamed_fields.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from past.builtins import basestring
 import yaml
 
@@ -39,7 +38,7 @@ def read_migration_fields(beat):
                         continue
                     migration_fields[k["from"]] = k["to"]
 
-    return sorted(list(migration_fields.items()), key=lambda x: x[0])
+    return sorted(migration_fields.items(), key=lambda x: x[0])
 
 
 if __name__ == "__main__":

--- a/script/update_golang_x.py
+++ b/script/update_golang_x.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import argparse
@@ -19,7 +17,7 @@ def update(pkg_name):
     packages = ['{pkg}{revision}'.format(pkg=pkg, revision=revision) for pkg in packages]
     cmd = ['govendor', 'fetch'] + packages
     if args.verbose:
-        print(' '.join(cmd)))
+        print(' '.join(cmd))
     subprocess.check_call(cmd)
 
 

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import subprocess
 import sys

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -2,7 +2,6 @@ import os
 import sys
 import time
 import unittest
-from builtins import str
 from winlogbeat import WriteReadTest
 
 if sys.platform.startswith("win"):

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -3,7 +3,6 @@ import sys
 import time
 import unittest
 from winlogbeat import WriteReadTest
-from builtins import str
 
 if sys.platform.startswith("win"):
     import win32evtlog

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import jinja2
 import os
 import sys

--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -1,7 +1,3 @@
-from builtins import map
-from builtins import str
-from builtins import range
-from builtins import object
 import json
 import operator
 import platform
@@ -204,7 +200,7 @@ def pretty_print_json(d):
     return json.dumps(d, indent=3, default=lambda o: o.to_json(), sort_keys=True)
 
 
-class TCP4TestCase(object):
+class TCP4TestCase:
     def __init__(self):
         pass
 
@@ -245,7 +241,7 @@ class TCP4TestCase(object):
         })
 
 
-class UDP4TestCase(object):
+class UDP4TestCase:
     def __init__(self):
         pass
 
@@ -284,7 +280,7 @@ class UDP4TestCase(object):
         })
 
 
-class ConnectedUDP4TestCase(object):
+class ConnectedUDP4TestCase:
     def __init__(self):
         pass
 
@@ -327,7 +323,7 @@ class ConnectedUDP4TestCase(object):
         })
 
 
-class ConnectedUDP6TestCase(object):
+class ConnectedUDP6TestCase:
     def __init__(self):
         pass
 
@@ -374,7 +370,7 @@ class ConnectedUDP6TestCase(object):
         })
 
 
-class UDP6TestCase(object):
+class UDP6TestCase:
     def __init__(self):
         pass
 
@@ -417,7 +413,7 @@ class UDP6TestCase(object):
         })
 
 
-class MultiUDP4TestCase(object):
+class MultiUDP4TestCase:
     def __init__(self):
         self.client_addr = None
         self.server_addr = [None] * 3
@@ -501,7 +497,7 @@ class MultiUDP4TestCase(object):
         ])
 
 
-class SocketFactory(object):
+class SocketFactory:
 
     def __init__(self, network, transport):
         self.network = network
@@ -548,7 +544,7 @@ def transaction_udp_oneway(client, client_addr, server, server_addr, req, resp):
     msg, _ = server.recvfrom(len(req))
 
 
-class DNSTestCase(object):
+class DNSTestCase:
 
     def __init__(self, enabled=True, delay_seconds=0, network="ipv4", transport="tcp", bidirectional=True):
         self.dns_enabled = enabled
@@ -675,7 +671,7 @@ class DNSTestCase(object):
         ]
         if not self.dns_enabled:
             for ev in expected_events:
-                for k in [x for x in list(ev.keys()) if x.endswith('.domain')]:
+                for k in [x for x in ev.keys() if x.endswith('.domain')]:
                     ev[k] = None
 
         return HasEvent(expected_events)
@@ -719,7 +715,7 @@ def random_address_ipv6():
     return 'fdee:' + ':'.join(['{:x}'.format(random.randint(1, 65535)) for _ in range(7)])
 
 
-class HasEvent(object):
+class HasEvent:
     def __init__(self, expected):
         if isinstance(expected, dict):
             self.expected = [expected]
@@ -739,7 +735,7 @@ class HasEvent(object):
         for (iexp, exp) in enumerate(expected):
             for (idoc, doc) in enumerate(documents):
                 if all((k in doc and (doc[k] == v or callable(v) and v(doc[k]))) or (v is None and k not in doc)
-                       for k, v in list(exp.items())):
+                       for k, v in exp.items()):
                     break
             else:
                 return False
@@ -747,7 +743,7 @@ class HasEvent(object):
         return True
 
 
-class Comparison(object):
+class Comparison:
     def __init__(self, op, value):
         self.op = op
         self.value = value

--- a/x-pack/libbeat/tests/system/test_management.py
+++ b/x-pack/libbeat/tests/system/test_management.py
@@ -1,4 +1,3 @@
-from builtins import range
 import sys
 import os
 import glob

--- a/x-pack/metricbeat/tests/system/test_activemq.py
+++ b/x-pack/metricbeat/tests/system/test_activemq.py
@@ -1,4 +1,3 @@
-from builtins import range
 import random
 import string
 import sys

--- a/x-pack/metricbeat/tests/system/test_coredns.py
+++ b/x-pack/metricbeat/tests/system/test_coredns.py
@@ -32,4 +32,4 @@ class Test(XPackTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
-            self.assertItemsEqual(self.de_dot(COREDNS_FIELDS), list(evt.keys()), evt)
+            self.assertItemsEqual(self.de_dot(COREDNS_FIELDS), evt.keys(), evt)

--- a/x-pack/metricbeat/tests/system/test_mssql.py
+++ b/x-pack/metricbeat/tests/system/test_mssql.py
@@ -39,7 +39,7 @@ class Test(XPackTest):
         self.assertEqual(len(output), 4)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MSSQL_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(MSSQL_FIELDS), evt.keys())
         self.assertTrue(evt["mssql"]["transaction_log"]["space_usage"]["used"]["pct"] > 0)
         self.assertTrue(evt["mssql"]["transaction_log"]["stats"]["active_size"]["bytes"] > 0)
 
@@ -68,7 +68,7 @@ class Test(XPackTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MSSQL_FIELDS), list(evt.keys()))
+        self.assertItemsEqual(self.de_dot(MSSQL_FIELDS), evt.keys())
         self.assertTrue(evt["mssql"]["performance"]["buffer"]["page_life_expectancy"]["sec"] > 0)
         self.assertTrue(evt["mssql"]["performance"]["user_connections"] > 0)
 


### PR DESCRIPTION
If we don't want to support both Python 2 and Python 3 at the same time, a lot of compatibility shims and casts from iterators to lists can be avoided.

This PR is mostly based on regexing through #14798 and removing unnecessary changes. I tried to avoid introducing new changes.

Disclaimer: I wasn't able to run the test suite yet to make sure this doesn't introduce more errors than the parent PR. Hence the draft status.