### PR TITLE
[DOCS] Remove incorrect information about monitoring data routing

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -16,17 +16,16 @@
 <titleabbrev>Internal collection</titleabbrev>
 ++++
 
-The following method involves sending the metrics to the production cluster, 
-which ultimately routes them to the monitoring cluster.
+The following method involves sending the metrics directly to the monitoring
+cluster.
 ifndef::serverless[]
 For an alternative method, see <<monitoring-metricbeat-collection>>.
 endif::[]
 
-To learn about monitoring in general, see 
-{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
-
-//TODO: Not sure if these docs need to be updated to be parallel with other
-//stack components since this is the old way of configuring monitoring. 
+//Commenting out this link temporarily until the general monitoring docs can be
+//updated. 
+//To learn about monitoring in general, see 
+//{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
 
 . Create an API key or user that has appropriate authority to send system-level monitoring
 data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -7,8 +7,7 @@
 ++++
 
 In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc} 
-and ship it to the monitoring cluster, rather than routing it through the 
-production cluster as described in <<monitoring-internal-collection>>.
+and ship it to the monitoring cluster.
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 Because you'll be using {metricbeat} to _monitor_ {beatname_uc}, you'll need to
@@ -174,7 +173,7 @@ it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
 If the Elastic {security-features} are enabled, you must also provide a user 
 ID and password so that {metricbeat} can collect metrics successfully: 
 
-.. Create a user on the production cluster that has the 
+.. Create a user on the {es} cluster that has the 
 `remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
 Alternatively, if it's available in your environment, use the
 `remote_monitoring_user` {ref}/built-in-users.html[built-in user].


### PR DESCRIPTION
Fixes incorrect description of how data is routed when using internal collection (monitoring.* settings).

Also comments out links because the linked material is likely to confuse rather than help users.