### PR TITLE
Cherry-pick #14800 to 7.5:Metricbeat perfmon - fix issues with retrieving counter paths/adding counters to query when OS language is not ENG

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix marshaling of ms-since-epoch values in `elasticsearch/cluster_stats` metricset. {pull}14378[14378]
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
+- Fix perfmon expanding counter path/adding counter to query when OS language is not english. {issue}14684[14684] {pull}14800[14800]
 - Add extra check on `ignore_non_existent_counters` flag if the PdhExpandWildCardPathW returns no errors but does not expand the counter path successfully in windows/perfmon metricset. {pull}14797[14797]
 - Fix rds metricset from reporting same values for different instances. {pull}14702[14702]
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]

--- a/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
@@ -83,6 +83,7 @@ func TestCounterWithNoInstanceName(t *testing.T) {
 				"instance_label":    "processor.name",
 				"measurement_label": "processor.time.total.pct",
 				"query":             `\UDPv4\Datagrams Sent/sec`,
+				//"query":             `\UDPv4\Verzonden datagrammen per seconde`,
 			},
 		},
 	}
@@ -112,7 +113,11 @@ func TestQuery(t *testing.T) {
 	}
 	defer q.Close()
 	counter := CounterConfig{Format: "float", InstanceName: "TestInstanceName"}
-	err = q.AddCounter(processorTimeCounter, counter, false)
+	path, err := q.GetCounterPaths(processorTimeCounter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = q.AddCounter(path[0], counter, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,9 +136,9 @@ func TestQuery(t *testing.T) {
 
 	assert.Len(t, values, 1)
 
-	value, found := values[processorTimeCounter]
+	value, found := values[path[0]]
 	if !found {
-		t.Fatal(processorTimeCounter, "not found")
+		t.Fatal(path[0], "not found")
 	}
 
 	assert.NoError(t, value[0].Err)
@@ -233,7 +238,12 @@ func TestLongOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 	counter := CounterConfig{Format: "long"}
-	err = query.AddCounter(processorTimeCounter, counter, false)
+	path, err := query.GetCounterPaths(processorTimeCounter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotZero(t, len(path))
+	err = query.AddCounter(path[0], counter, false)
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -255,7 +265,7 @@ func TestLongOutputFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, okLong := values[processorTimeCounter][0].Measurement.(int32)
+	_, okLong := values[path[0]][0].Measurement.(int32)
 
 	assert.True(t, okLong)
 }
@@ -268,7 +278,12 @@ func TestFloatOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 	counter := CounterConfig{Format: "float"}
-	err = query.AddCounter(processorTimeCounter, counter, false)
+	path, err := query.GetCounterPaths(processorTimeCounter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotZero(t, len(path))
+	err = query.AddCounter(path[0], counter, false)
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -290,7 +305,7 @@ func TestFloatOutputFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, okFloat := values[processorTimeCounter][0].Measurement.(float64)
+	_, okFloat := values[path[0]][0].Measurement.(float64)
 
 	assert.True(t, okFloat)
 }
@@ -318,7 +333,7 @@ func TestWildcardQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	assert.NotZero(t, len(values))
 	pctKey, err := values[0].MetricSetFields.HasKey("processor.time.pct")
 	if err != nil {
 		t.Fatal(err)
@@ -355,7 +370,7 @@ func TestWildcardQueryNoInstanceName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	assert.NotZero(t, len(values))
 	pctKey, err := values[0].MetricSetFields.HasKey("process.private.bytes")
 	if err != nil {
 		t.Fatal(err)

--- a/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
@@ -34,13 +34,15 @@ func TestOpenSuccessful(t *testing.T) {
 // TestAddCounterInvalidArgWhenQueryClosed will check if addcounter func fails when query is closed.
 func TestAddCounterInvalidArgWhenQueryClosed(t *testing.T) {
 	var q Query
-	counter := CounterConfig{Format: "float", InstanceName: "TestInstanceName"}
-	queryPath, err := q.ExpandWildCardPath(validQuery)
-	if err != nil {
-		t.Fatal(err)
+	queryPath, err := q.GetCounterPaths(validQuery)
+	// if windows os language is ENG then err will be nil, else the GetCounterPaths will execute the AddCounter
+	if assert.NoError(t, err) {
+		counter := CounterConfig{Format: "float", InstanceName: "TestInstanceName"}
+		err = q.AddCounter(queryPath[0], counter, false)
+		assert.Error(t, err, PDH_INVALID_HANDLE)
+	} else {
+		assert.Error(t, err, PDH_INVALID_ARGUMENT)
 	}
-	err = q.AddCounter(queryPath[0], counter, false)
-	assert.EqualValues(t, err, PDH_INVALID_ARGUMENT)
 }
 
 // func TestGetFormattedCounterValuesEmptyCounterList will check if getting the counter values will fail when no counter handles are added.
@@ -68,7 +70,7 @@ func TestSuccessfulQuery(t *testing.T) {
 	}
 	defer q.Close()
 	counter := CounterConfig{Format: "float", InstanceName: "TestInstanceName"}
-	queryPath, err := q.ExpandWildCardPath(validQuery)
+	queryPath, err := q.GetCounterPaths(validQuery)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/windows/perfmon/pdh_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_windows.go
@@ -23,13 +23,15 @@ import (
 	"strconv"
 	"syscall"
 	"unicode/utf16"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 // Windows API calls
 //sys _PdhOpenQuery(dataSource *uint16, userData uintptr, query *PdhQueryHandle) (errcode error) [failretval!=0] = pdh.PdhOpenQueryW
-//sys _PdhAddCounter(query PdhQueryHandle, counterPath string, userData uintptr, counter *PdhCounterHandle) (errcode error) [failretval!=0] = pdh.PdhAddEnglishCounterW
+//sys _PdhAddEnglishCounter(query PdhQueryHandle, counterPath string, userData uintptr, counter *PdhCounterHandle) (errcode error) [failretval!=0] = pdh.PdhAddEnglishCounterW
+//sys _PdhAddCounter(query PdhQueryHandle, counterPath string, userData uintptr, counter *PdhCounterHandle) (errcode error) [failretval!=0] = pdh.PdhAddCounterW
 //sys _PdhRemoveCounter(counter PdhCounterHandle) (errcode error) [failretval!=0] = pdh.PdhRemoveCounter
 //sys _PdhCollectQueryData(query PdhQueryHandle) (errcode error) [failretval!=0] = pdh.PdhCollectQueryData
 //sys _PdhGetFormattedCounterValueDouble(counter PdhCounterHandle, format PdhCounterFormat, counterType *uint32, value *PdhCounterValueDouble) (errcode error) [failretval!=0] = pdh.PdhGetFormattedCounterValue
@@ -38,6 +40,7 @@ import (
 //sys _PdhCloseQuery(query PdhQueryHandle) (errcode error) [failretval!=0] = pdh.PdhCloseQuery
 //sys _PdhExpandWildCardPath(dataSource *uint16, wildcardPath *uint16, expandedPathList *uint16, pathListLength *uint32) (errcode error) [failretval!=0] = pdh.PdhExpandWildCardPathW
 //sys _PdhExpandCounterPath(wildcardPath *uint16, expandedPathList *uint16, pathListLength *uint32) (errcode error) [failretval!=0] = pdh.PdhExpandCounterPathW
+//sys _PdhGetCounterInfo(counter PdhCounterHandle, text uint16, size *uint32, lpBuffer *byte) (errcode error) [failretval!=0] = pdh.PdhGetCounterInfoW
 
 type PdhQueryHandle uintptr
 
@@ -46,6 +49,28 @@ var InvalidQueryHandle = ^PdhQueryHandle(0)
 type PdhCounterHandle uintptr
 
 var InvalidCounterHandle = ^PdhCounterHandle(0)
+
+// PdhCounterInfo struct contains the performance counter details
+type PdhCounterInfo struct {
+	DwLength         uint32
+	DwType           uint32
+	CVersion         uint32
+	CStatus          uint32
+	LScale           int32
+	LDefaultScale    int32
+	DwUserData       *uint32
+	DwQueryUserData  *uint32
+	SzFullPath       *uint16 // pointer to a string
+	SzMachineName    *uint16 // pointer to a string
+	SzObjectName     *uint16 // pointer to a string
+	SzInstanceName   *uint16 // pointer to a string
+	SzParentInstance *uint16 // pointer to a string
+	DwInstanceIndex  uint32  // pointer to a string
+	SzCounterName    *uint16 // pointer to a string
+	Padding          [4]byte
+	SzExplainText    *uint16   // pointer to a string
+	DataBuffer       [1]uint32 // pointer to an extra space
+}
 
 // PdhCounterValueDouble  for double values
 type PdhCounterValueDouble struct {
@@ -86,6 +111,16 @@ func PdhOpenQuery(dataSource string, userData uintptr) (PdhQueryHandle, error) {
 	if err := _PdhOpenQuery(dataSourcePtr, userData, &handle); err != nil {
 		return InvalidQueryHandle, PdhErrno(err.(syscall.Errno))
 	}
+	return handle, nil
+}
+
+// PdhAddEnglishCounter adds the specified counter to the query.
+func PdhAddEnglishCounter(query PdhQueryHandle, counterPath string, userData uintptr) (PdhCounterHandle, error) {
+	var handle PdhCounterHandle
+	if err := _PdhAddEnglishCounter(query, counterPath, userData, &handle); err != nil {
+		return InvalidCounterHandle, PdhErrno(err.(syscall.Errno))
+	}
+
 	return handle, nil
 }
 
@@ -178,6 +213,27 @@ func PdhExpandCounterPath(utfPath *uint16) ([]uint16, error) {
 			return nil, PdhErrno(err.(syscall.Errno))
 		}
 		return expandPaths, nil
+	}
+	return nil, nil
+}
+
+// PdhGetCounterInfo returns the counter information for given handle
+func PdhGetCounterInfo(handle PdhCounterHandle) (*PdhCounterInfo, error) {
+	var bufSize uint32
+	var buff []byte
+	if err := _PdhGetCounterInfo(handle, 0, &bufSize, nil); err != nil {
+		if PdhErrno(err.(syscall.Errno)) != PDH_MORE_DATA {
+			return nil, PdhErrno(err.(syscall.Errno))
+		}
+		buff = make([]byte, bufSize)
+		bufSize = uint32(len(buff))
+
+		if err = _PdhGetCounterInfo(handle, 0, &bufSize, &buff[0]); err == nil {
+			counterInfo := (*PdhCounterInfo)(unsafe.Pointer(&buff[0]))
+			if counterInfo != nil {
+				return counterInfo, nil
+			}
+		}
 	}
 	return nil, nil
 }

--- a/metricbeat/module/windows/perfmon/pdh_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_windows_test.go
@@ -44,7 +44,7 @@ func TestPdhOpenQueryInvalidQuery(t *testing.T) {
 func TestPdhAddCounterInvalidCounter(t *testing.T) {
 	handle, err := PdhAddCounter(InvalidQueryHandle, validQuery, 0)
 	assert.EqualValues(t, handle, InvalidCounterHandle)
-	assert.EqualValues(t, err, PDH_INVALID_ARGUMENT)
+	assert.EqualValues(t, err, PDH_INVALID_HANDLE)
 }
 
 // TestPdhGetFormattedCounterValueInvalidCounter will test for invalid counters.
@@ -88,8 +88,20 @@ func TestPdhSuccessfulCounterRetrieval(t *testing.T) {
 		t.Fatal(err)
 	}
 	queryList, err := PdhExpandWildCardPath(utfPath)
-	if err != nil {
-		t.Fatal(err)
+	if err == PDH_CSTATUS_NO_OBJECT || err == PDH_CSTATUS_NO_COUNTER {
+		handle, err := PdhAddEnglishCounter(queryHandle, validQuery, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer PdhRemoveCounter(handle)
+		info, err := PdhGetCounterInfo(handle)
+		if err != nil {
+			t.Fatal(err)
+		}
+		queryList, err = PdhExpandWildCardPath(info.SzFullPath)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	queries := UTF16ToStringArray(queryList)
 	var counters []PdhCounterHandle

--- a/metricbeat/module/windows/perfmon/reader.go
+++ b/metricbeat/module/windows/perfmon/reader.go
@@ -59,7 +59,7 @@ func NewReader(config Config) (*Reader, error) {
 		config:        config,
 	}
 	for _, counter := range config.CounterConfig {
-		childQueries, err := query.ExpandWildCardPath(counter.Query)
+		childQueries, err := query.GetCounterPaths(counter.Query)
 		if err != nil {
 			if config.IgnoreNECounters {
 				switch err {
@@ -100,7 +100,7 @@ func NewReader(config Config) (*Reader, error) {
 func (r *Reader) RefreshCounterPaths() error {
 	var newCounters []string
 	for _, counter := range r.config.CounterConfig {
-		childQueries, err := r.query.ExpandWildCardPath(counter.Query)
+		childQueries, err := r.query.GetCounterPaths(counter.Query)
 		if err != nil {
 			if r.config.IgnoreNECounters {
 				switch err {

--- a/metricbeat/module/windows/perfmon/zpdh_windows.go
+++ b/metricbeat/module/windows/perfmon/zpdh_windows.go
@@ -58,16 +58,35 @@ var (
 
 	procPdhOpenQueryW               = modpdh.NewProc("PdhOpenQueryW")
 	procPdhAddEnglishCounterW       = modpdh.NewProc("PdhAddEnglishCounterW")
+	procPdhAddCounterW              = modpdh.NewProc("PdhAddCounterW")
 	procPdhRemoveCounter            = modpdh.NewProc("PdhRemoveCounter")
 	procPdhCollectQueryData         = modpdh.NewProc("PdhCollectQueryData")
 	procPdhGetFormattedCounterValue = modpdh.NewProc("PdhGetFormattedCounterValue")
 	procPdhCloseQuery               = modpdh.NewProc("PdhCloseQuery")
 	procPdhExpandWildCardPathW      = modpdh.NewProc("PdhExpandWildCardPathW")
 	procPdhExpandCounterPathW       = modpdh.NewProc("PdhExpandCounterPathW")
+	procPdhGetCounterInfoW          = modpdh.NewProc("PdhGetCounterInfoW")
 )
 
 func _PdhOpenQuery(dataSource *uint16, userData uintptr, query *PdhQueryHandle) (errcode error) {
 	r0, _, _ := syscall.Syscall(procPdhOpenQueryW.Addr(), 3, uintptr(unsafe.Pointer(dataSource)), uintptr(userData), uintptr(unsafe.Pointer(query)))
+	if r0 != 0 {
+		errcode = syscall.Errno(r0)
+	}
+	return
+}
+
+func _PdhAddEnglishCounter(query PdhQueryHandle, counterPath string, userData uintptr, counter *PdhCounterHandle) (errcode error) {
+	var _p0 *uint16
+	_p0, errcode = syscall.UTF16PtrFromString(counterPath)
+	if errcode != nil {
+		return
+	}
+	return __PdhAddEnglishCounter(query, _p0, userData, counter)
+}
+
+func __PdhAddEnglishCounter(query PdhQueryHandle, counterPath *uint16, userData uintptr, counter *PdhCounterHandle) (errcode error) {
+	r0, _, _ := syscall.Syscall6(procPdhAddEnglishCounterW.Addr(), 4, uintptr(query), uintptr(unsafe.Pointer(counterPath)), uintptr(userData), uintptr(unsafe.Pointer(counter)), 0, 0)
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)
 	}
@@ -84,7 +103,7 @@ func _PdhAddCounter(query PdhQueryHandle, counterPath string, userData uintptr, 
 }
 
 func __PdhAddCounter(query PdhQueryHandle, counterPath *uint16, userData uintptr, counter *PdhCounterHandle) (errcode error) {
-	r0, _, _ := syscall.Syscall6(procPdhAddEnglishCounterW.Addr(), 4, uintptr(query), uintptr(unsafe.Pointer(counterPath)), uintptr(userData), uintptr(unsafe.Pointer(counter)), 0, 0)
+	r0, _, _ := syscall.Syscall6(procPdhAddCounterW.Addr(), 4, uintptr(query), uintptr(unsafe.Pointer(counterPath)), uintptr(userData), uintptr(unsafe.Pointer(counter)), 0, 0)
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)
 	}
@@ -149,6 +168,14 @@ func _PdhExpandWildCardPath(dataSource *uint16, wildcardPath *uint16, expandedPa
 
 func _PdhExpandCounterPath(wildcardPath *uint16, expandedPathList *uint16, pathListLength *uint32) (errcode error) {
 	r0, _, _ := syscall.Syscall(procPdhExpandCounterPathW.Addr(), 3, uintptr(unsafe.Pointer(wildcardPath)), uintptr(unsafe.Pointer(expandedPathList)), uintptr(unsafe.Pointer(pathListLength)))
+	if r0 != 0 {
+		errcode = syscall.Errno(r0)
+	}
+	return
+}
+
+func _PdhGetCounterInfo(counter PdhCounterHandle, text uint16, size *uint32, lpBuffer *byte) (errcode error) {
+	r0, _, _ := syscall.Syscall6(procPdhGetCounterInfoW.Addr(), 4, uintptr(counter), uintptr(text), uintptr(unsafe.Pointer(size)), uintptr(unsafe.Pointer(lpBuffer)), 0, 0)
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)
 	}


### PR DESCRIPTION
Cherry-pick of PR #14800 to 7.5 branch. Original message:

Metricbeat perfmon - fix issues with retrieving counter paths/adding counters to query when OS language is is not ENG.

Should fix https://github.com/elastic/beats/issues/14684

Workaround follows also the NOTE steps in https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera#remarks


LEFT TO DO
- [x]  Test performance
- [x] Test fix on Windows Server 2012

Reproduce steps:
- Set system language to other than ENG
- test the counter list will contain performance counter paths in the different language `TypePerf.exe –q > counters.txt`
- use both the English path and the counter path in the different lang when configuring windows.yml
- both options should work