### PR TITLE
[Elastic logging plugin] Fix some old naming issues

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -30,7 +30,7 @@ import (
 )
 
 var hubID = "elastic"
-var name = "docker-logging-plugin"
+var name = "elastic-logging-plugin"
 var containerName = name + "_container"
 var dockerPluginName = filepath.Join(hubID, name)
 var packageStagingDir = "build/package/"

--- a/x-pack/dockerlogbeat/readme.md
+++ b/x-pack/dockerlogbeat/readme.md
@@ -9,7 +9,7 @@ To build and install, just run `mage Package`. The build process happens entire 
 
 ## Running
 
-`docker run --log-driver=ossifrage/hellologdriver:0.0.1 --log-opt output.elasticsearch.hosts="172.18.0.2:9200" --log-opt output.elasticsearch.index="dockerbeat-test" -it debian:jessie /bin/bash`
+`docker run --log-driver=elastic-logging-plugin:8.0.0 --log-opt output.elasticsearch.hosts="172.18.0.2:9200" --log-opt output.elasticsearch.index="dockerbeat-test" -it debian:jessie /bin/bash`
 
 
 ## How it works


### PR DESCRIPTION
This should hopefully be the last change before we merge the feature branch for master. The plugin deadname was still floating around a few places.