### PR TITLE
Rename TEST-empty.xml to .out

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -40,6 +40,7 @@ if (Test-Path "$env:beat\magefile.go") {
     echo "$env:beat\magefile.go does not exist"
     New-Item -ItemType directory -Path build | Out-Null
     New-Item -Name build\TEST-empty.xml -ItemType File | Out-Null
+    Remove-Item -Path build\TEST-empty.xml -Force | Out-Null
     exit
 }
 

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -39,8 +39,7 @@ if (Test-Path "$env:beat\magefile.go") {
 } else {
     echo "$env:beat\magefile.go does not exist"
     New-Item -ItemType directory -Path build | Out-Null
-    New-Item -Name build\TEST-empty.xml -ItemType File | Out-Null
-    Remove-Item -Path build\TEST-empty.xml -Force | Out-Null
+    New-Item -Name build\TEST-empty.out -ItemType File | Out-Null
     exit
 }
 

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -8,7 +8,7 @@ set -euox pipefail
 if [ ! -d "$beat" ]; then
   echo "$beat does not exist"
   mkdir -p build
-  touch build/TEST-empty.xml && rm build/TEST-empty.xml
+  touch build/TEST-empty.out
   exit
 fi
 

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -8,7 +8,7 @@ set -euox pipefail
 if [ ! -d "$beat" ]; then
   echo "$beat does not exist"
   mkdir -p build
-  touch build/TEST-empty.xml
+  touch build/TEST-empty.xml && rm build/TEST-empty.xml
   exit
 fi
 
@@ -27,7 +27,7 @@ cleanup() {
     ids=$(docker ps -q)
     if [ -n "$ids" ]; then
       docker kill $ids
-    fi  
+    fi
     echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
     docker system prune -f || true
   fi


### PR DESCRIPTION
~~_Please leave it as an experimental._~~

~~Trying to understand what will happen if TEST-empty.xml is deleted.~~

~~This PR removes file TEST-empty.xml, which left as empty one apparently fails Jenkins builds. I assumed that the file is here to verify RW permissions, so once it's successfully created it's removed.~~

~~If somebody can confirm that it's no required anymore, I can remove `touch` at all.~~

~~FTR Jenkins build job is green now.~~

I think I found a corresponding fix in the Git history. It has been applied to 7.x branches: https://github.com/elastic/beats/pull/12247