### PR TITLE
Add the Tokenizer field

### DIFF
--- a/libbeat/processors/dissect/docs/dissect.asciidoc
+++ b/libbeat/processors/dissect/docs/dissect.asciidoc
@@ -14,6 +14,8 @@ processors:
 
 The `dissect` processor has the following configuration settings:
 
+`tokenizer`:: The field used to define the *dissection* pattern.
+
 `field`:: (Optional) The event field to tokenize. Default is `message`.
 
 `target_prefix`:: (Optional) The name of the field where the values will be extracted. When an empty


### PR DESCRIPTION
Missing the `tokenizer` field in the dissect processor documentation.

Fix: #14994