### PR TITLE
[DOCS] Added older release notice.

### DIFF
--- a/auditbeat/docs/page_header.html
+++ b/auditbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/docs/devguide/page_header.html
+++ b/docs/devguide/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/filebeat/docs/page_header.html
+++ b/filebeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/heartbeat/docs/page_header.html
+++ b/heartbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/journalbeat/docs/page_header.html
+++ b/journalbeat/docs/page_header.html
@@ -1,4 +1,11 @@
-This functionality is experimental and may be changed or removed completely in a
-future release. Elastic will take a best effort approach to fix any issues, but
-experimental features are not subject to the support SLA of official GA
-features.
+<p>
+  This functionality is experimental and may be changed or removed completely in a
+  future release. Elastic will take a best effort approach to fix any issues, but
+  experimental features are not subject to the support SLA of official GA
+  features.
+</p>
+<p>  
+<strong>NOTE</strong>: This  You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/libbeat/docs/page_header.html
+++ b/libbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/metricbeat/docs/page_header.html
+++ b/metricbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/packetbeat/docs/page_header.html
+++ b/packetbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/winlogbeat/docs/page_header.html
+++ b/winlogbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 

--- a/x-pack/functionbeat/docs/page_header.html
+++ b/x-pack/functionbeat/docs/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p> 


### PR DESCRIPTION
Explicitly set page_header.html for 6.8 so that the default notice can be updated for OOM versions.

Prerequisite for: elastic/docs#1528