### PR TITLE
[Filebeat] Add example to CoreDNS filebeat module docs

### DIFF
--- a/filebeat/docs/modules/coredns.asciidoc
+++ b/filebeat/docs/modules/coredns.asciidoc
@@ -8,10 +8,10 @@ This file is generated! See scripts/docs_collector.py
 :modulename: coredns
 :has-dashboards: true
 
-== Coredns Module
+== CoreDNS module
 
-This is a filebeat module for coredns. It supports both standalone coredns deployment and 
-coredns deployment in Kubernetes. 
+This is a filebeat module for CoreDNS. It supports both standalone CoreDNS deployment and
+CoreDNS deployment in Kubernetes.
 
 [float]
 === Compatibility
@@ -26,6 +26,18 @@ This module comes with a sample dashboard.
 
 [role="screenshot"]
 image::./images/kibana-coredns.jpg[]
+
+[float]
+==== `log` fileset settings
+
+Example config:
+
+[source,yaml]
+----
+- module: corends
+  log:
+    enabled: true
+----
 
 
 [float]

--- a/filebeat/docs/modules/coredns.asciidoc
+++ b/filebeat/docs/modules/coredns.asciidoc
@@ -34,10 +34,18 @@ Example config:
 
 [source,yaml]
 ----
-- module: corends
+- module: coredns
   log:
     enabled: true
+    var.paths: ["/var/log/coredns.log"]
+    var.tags: ["coredns", "staging"]
 ----
+
+include::../include/var-paths.asciidoc[]
+
+*`var.tags`*::
+
+An array of tags describing the monitored CoreDNS setup.
 
 
 [float]

--- a/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
@@ -3,10 +3,10 @@
 :modulename: coredns
 :has-dashboards: true
 
-== Coredns Module
+== CoreDNS module
 
-This is a filebeat module for coredns. It supports both standalone coredns deployment and 
-coredns deployment in Kubernetes. 
+This is a filebeat module for CoreDNS. It supports both standalone CoreDNS deployment and
+CoreDNS deployment in Kubernetes.
 
 [float]
 === Compatibility
@@ -21,3 +21,15 @@ This module comes with a sample dashboard.
 
 [role="screenshot"]
 image::./images/kibana-coredns.jpg[]
+
+[float]
+==== `log` fileset settings
+
+Example config:
+
+[source,yaml]
+----
+- module: corends
+  log:
+    enabled: true
+----

--- a/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
@@ -29,7 +29,15 @@ Example config:
 
 [source,yaml]
 ----
-- module: corends
+- module: coredns
   log:
     enabled: true
+    var.paths: ["/var/log/coredns.log"]
+    var.tags: ["coredns", "staging"]
 ----
+
+include::../include/var-paths.asciidoc[]
+
+*`var.tags`*::
+
+An array of tags describing the monitored CoreDNS setup.


### PR DESCRIPTION
The PR adds an example to CoreDNS filebeat docs presenting how to enable the module.

Issue: https://github.com/elastic/beats/issues/14874