### PR TITLE
Add max_processing_time in Kafka input configuration options

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -102,6 +102,10 @@ How long to wait before retrying a failed read. Default is 2s.
 How long to wait for the minimum number of input bytes while reading. Default
 is 250ms.
 
+===== `max_processing_time`
+
+How long to wait for a message to be processed. Default is 20s.
+
 ===== `wait_close`
 
 When shutting down, how long to wait for in-flight messages to be delivered

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -114,7 +114,7 @@ func defaultConfig() kafkaInputConfig {
 		ConsumeBackoff:    2 * time.Second,
 		WaitClose:         2 * time.Second,
 		MaxWaitTime:       250 * time.Millisecond,
-		MaxProcessingTime: 20 * time.Microsecond,
+		MaxProcessingTime: 20 * time.Second,
 		IsolationLevel:    isolationLevelReadUncommitted,
 		Fetch: kafkaFetch{
 			Min:     1,

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -44,6 +44,7 @@ type kafkaInputConfig struct {
 	ConsumeBackoff           time.Duration     `config:"consume_backoff" validate:"min=0"`
 	WaitClose                time.Duration     `config:"wait_close" validate:"min=0"`
 	MaxWaitTime              time.Duration     `config:"max_wait_time"`
+	MaxProcessingTime        time.Duration     `config:"max_processing_time"`
 	IsolationLevel           isolationLevel    `config:"isolation_level"`
 	Fetch                    kafkaFetch        `config:"fetch"`
 	Rebalance                kafkaRebalance    `config:"rebalance"`
@@ -106,14 +107,15 @@ var (
 // were chosen to match sarama's defaults.
 func defaultConfig() kafkaInputConfig {
 	return kafkaInputConfig{
-		Version:        kafka.Version("1.0.0"),
-		InitialOffset:  initialOffsetOldest,
-		ClientID:       "filebeat",
-		ConnectBackoff: 30 * time.Second,
-		ConsumeBackoff: 2 * time.Second,
-		WaitClose:      2 * time.Second,
-		MaxWaitTime:    250 * time.Millisecond,
-		IsolationLevel: isolationLevelReadUncommitted,
+		Version:           kafka.Version("1.0.0"),
+		InitialOffset:     initialOffsetOldest,
+		ClientID:          "filebeat",
+		ConnectBackoff:    30 * time.Second,
+		ConsumeBackoff:    2 * time.Second,
+		WaitClose:         2 * time.Second,
+		MaxWaitTime:       250 * time.Millisecond,
+		MaxProcessingTime: 20 * time.Microsecond,
+		IsolationLevel:    isolationLevelReadUncommitted,
 		Fetch: kafkaFetch{
 			Min:     1,
 			Default: (1 << 20), // 1 MB
@@ -157,6 +159,7 @@ func newSaramaConfig(config kafkaInputConfig) (*sarama.Config, error) {
 	k.Consumer.Offsets.Initial = config.InitialOffset.asSaramaOffset()
 	k.Consumer.Retry.Backoff = config.ConsumeBackoff
 	k.Consumer.MaxWaitTime = config.MaxWaitTime
+	k.Consumer.MaxProcessingTime = config.MaxProcessingTime
 	k.Consumer.IsolationLevel = config.IsolationLevel.asSaramaIsolationLevel()
 
 	k.Consumer.Fetch.Min = config.Fetch.Min


### PR DESCRIPTION
This PR adds `MaxProcessingTime` in the configuration of sarama client https://github.com/Shopify/sarama/blob/72a629d7d1ac130c1f1221e66396e0b54dfeef3f/config.go#L327.

This was brought up by https://discuss.elastic.co/t/input-plugin-kafka-error-abandoned-subscription-to-k8s-pod-logs-kafka-topic-0-because-consuming-was-taking-too-long/211259.

cc: @urso 