### PR TITLE
[Elastic logging driver] Trim slashes from container names and fix beat name

### DIFF
--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader.go
@@ -103,7 +103,7 @@ func (cl *ClientLogger) publishLoop(reader chan logdriver.LogEntry) {
 				"container": common.MapStr{
 					"labels": cl.containerMeta.ContainerLabels,
 					"id":     cl.containerMeta.ContainerID,
-					"name":   cl.containerMeta.ContainerName,
+					"name":   strings.Trim(cl.containerMeta.ContainerName, "/"),
 					"image": common.MapStr{
 						"name": cl.containerMeta.ContainerImageName,
 					},

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -13,23 +13,32 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/x-pack/dockerlogbeat/pipelinemock"
 	"github.com/elastic/beats/x-pack/dockerlogbeat/pipereader"
 )
 
 func TestNewClient(t *testing.T) {
 	logString := "This is a log line"
-	client, teardown := setupTestReader(t, logString)
+	cfgObject := logger.Info{
+		Config:             map[string]string{"output.elasticsearch": "localhost:9200"},
+		ContainerLabels:    map[string]string{"test.label": "test"},
+		ContainerID:        "3acc92989a97c415905eba090277b8a8834d087e58a95bed55450338ce0758dd",
+		ContainerName:      "/testContainer",
+		ContainerImageName: "TestImage",
+	}
+	client, teardown := setupTestReader(t, logString, cfgObject)
 	defer teardown()
 
 	event := testReturn(t, client)
 	assert.Equal(t, event.Fields["message"], logString)
+	assert.Equal(t, event.Fields["container"].(common.MapStr)["name"], "testContainer")
 }
 
 // setupTestReader sets up the "read side" of the pipeline, spawing a goroutine to read and event and send it back to the test.
-func setupTestReader(t *testing.T, logString string) (*pipelinemock.MockPipelineConnector, func()) {
+func setupTestReader(t *testing.T, logString string, containerConfig logger.Info) (*pipelinemock.MockPipelineConnector, func()) {
 	mockConnector := &pipelinemock.MockPipelineConnector{}
-	client := createNewClient(t, logString, mockConnector)
+	client := createNewClient(t, logString, mockConnector, containerConfig)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -45,7 +54,7 @@ func setupTestReader(t *testing.T, logString string) (*pipelinemock.MockPipeline
 }
 
 // createNewClient sets up the "write side" of the pipeline, creating a log event to write and send back into the test.
-func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector) *ClientLogger {
+func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector, containerConfig logger.Info) *ClientLogger {
 	// an example container metadata struct
 	cfgObject := logger.Info{
 		Config:             map[string]string{"output.elasticsearch": "localhost:9200"},

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -51,7 +51,7 @@ func loadNewPipeline(logOptsConfig map[string]string, name string, log *logp.Log
 	}
 
 	info := beat.Info{
-		Beat:     "elastic-log-plugin",
+		Beat:     "elastic-logging-plugin",
 		Version:  "0",
 		Name:     name,
 		Hostname: hostname,


### PR DESCRIPTION
Some more last-minute cleanup before we merge this to master.