### PR TITLE
Cherry-pick #14950 to 7.5: Fix proxy_url option in Elasticsearch output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
+- Fix `proxy_url` option in Elasticsearch output. {pull}14950[14950]
 - Fix bug with potential concurrent reads and writes from event.Meta map by Kafka output. {issue}14542[14542] {pull}14568[14568]
 
 *Auditbeat*

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -20,11 +20,18 @@
 package elasticsearch
 
 import (
+	"context"
+	"io/ioutil"
 	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -40,6 +47,36 @@ func TestClientConnect(t *testing.T) {
 	client := getTestingElasticsearch(t)
 	err := client.Connect()
 	assert.NoError(t, err)
+}
+
+func TestClientConnectWithProxy(t *testing.T) {
+	wrongPort, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	go func() {
+		c, err := wrongPort.Accept()
+		if err == nil {
+			// Provoke an early-EOF error on client
+			c.Close()
+		}
+	}()
+	defer wrongPort.Close()
+
+	proxy := startTestProxy(t, internal.GetURL())
+	defer proxy.Close()
+
+	// Use connectTestEs instead of getTestingElasticsearch to make use of makeES
+	_, client := connectTestEs(t, map[string]interface{}{
+		"hosts":   "http://" + wrongPort.Addr().String(),
+		"timeout": 5, // seconds
+	})
+	assert.Error(t, client.Connect(), "it should fail without proxy")
+
+	_, client = connectTestEs(t, map[string]interface{}{
+		"hosts":     "http://" + wrongPort.Addr().String(),
+		"proxy_url": proxy.URL,
+		"timeout":   5, // seconds
+	})
+	assert.NoError(t, client.Connect())
 }
 
 func TestClientPublishEvent(t *testing.T) {
@@ -304,4 +341,33 @@ func randomClient(grp outputs.Group) outputs.NetworkClient {
 
 	client := grp.Clients[rand.Intn(L)]
 	return client.(outputs.NetworkClient)
+}
+
+// startTestProxy starts a proxy that redirects all connections to the specified URL
+func startTestProxy(t *testing.T, redirectURL string) *httptest.Server {
+	t.Helper()
+
+	realURL, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := r.Clone(context.Background())
+		req.RequestURI = ""
+		req.URL.Scheme = realURL.Scheme
+		req.URL.Host = realURL.Host
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		for _, header := range []string{"Content-Encoding", "Content-Type"} {
+			w.Header().Set(header, resp.Header.Get(header))
+		}
+		w.WriteHeader(resp.StatusCode)
+		w.Write(body)
+	}))
+	return proxy
 }

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -20,7 +20,6 @@
 package elasticsearch
 
 import (
-	"context"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -351,10 +350,11 @@ func startTestProxy(t *testing.T, redirectURL string) *httptest.Server {
 	require.NoError(t, err)
 
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		req := r.Clone(context.Background())
-		req.RequestURI = ""
+		req, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
+		require.NoError(t, err)
 		req.URL.Scheme = realURL.Scheme
 		req.URL.Host = realURL.Host
+		req.Header = r.Header
 
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -166,7 +166,7 @@ func makeES(
 
 	var proxyURL *url.URL
 	if !config.ProxyDisable {
-		proxyURL, err := parseProxyURL(config.ProxyURL)
+		proxyURL, err = parseProxyURL(config.ProxyURL)
 		if err != nil {
 			return outputs.Fail(err)
 		}
@@ -290,7 +290,7 @@ func NewElasticsearchClients(cfg *common.Config) ([]Client, error) {
 
 	var proxyURL *url.URL
 	if !config.ProxyDisable {
-		proxyURL, err := parseProxyURL(config.ProxyURL)
+		proxyURL, err = parseProxyURL(config.ProxyURL)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry-pick of PR #14950 to 7.5 branch. Original message: 

Proxy URL was only being set in the scope of
an if, not in the real settings.

Add a test to cover this setting.