### PR TITLE
[Elastic Logging Plugin] Use LoadWithSettings and clean up pipeline code

### DIFF
--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -140,10 +140,11 @@ func (pm *PipelineManager) removePipelineIfNeeded(hash string) {
 		delete(pm.pipelines, hash)
 		//pipelines must be closed after clients
 		//Just do this here, since the caller doesn't know if we need to close the libbeat pipeline
-		go func() {
-			pm.Logger.Debugf("Pipeline closing from removePipelineIfNeeded")
-			pipeline.Close()
-		}()
+		pm.Logger.Debugf("Pipeline closing from removePipelineIfNeeded")
+		err := pipeline.Close()
+		if err != nil {
+			pm.Logger.Errorf("Error closing pipeline: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes an issue where we would stop sending logs once a container stopped, potentially missing events that are sent while a container is still shutting down.

Also removed a unneeded `go` statement, as clients/piplines are closed asynchronously.