### PR TITLE
Update Kubernetes Autodiscover docs with the new resources

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -126,7 +126,7 @@ These are the available fields during within config templating. The `kubernetes.
   * kubernetes.labels
   * kubernetes.annotations
 
-====== Pod spesific:
+====== Pod specific:
   * kubernetes.container.id
   * kubernetes.container.image
   * kubernetes.container.name
@@ -135,11 +135,11 @@ These are the available fields during within config templating. The `kubernetes.
   * kubernetes.pod.name
   * kubernetes.pod.uid
 
-====== Node spesific:
+====== Node specific:
   * kubernetes.node.name
   * kubernetes.node.uid
 
-====== Service spesific:
+====== Service specific:
   * kubernetes.namespace
   * kubernetes.service.name
   * kubernetes.service.uid

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -120,12 +120,14 @@ The Kubernetes autodiscover provider watches for Kubernetes nodes, pods, service
 
 These are the available fields during within config templating. The `kubernetes.*` fields will be available on each emitted event.
 
+[float]
 ====== Generic fields:
   * host
   * port (if exposed)
   * kubernetes.labels
   * kubernetes.annotations
 
+[float]
 ====== Pod specific:
   * kubernetes.container.id
   * kubernetes.container.image
@@ -135,10 +137,12 @@ These are the available fields during within config templating. The `kubernetes.
   * kubernetes.pod.name
   * kubernetes.pod.uid
 
+[float]
 ====== Node specific:
   * kubernetes.node.name
   * kubernetes.node.uid
 
+[float]
 ====== Service specific:
   * kubernetes.namespace
   * kubernetes.service.name

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -116,20 +116,34 @@ endif::[]
 [float]
 ===== Kubernetes
 
-The Kubernetes autodiscover provider watches for Kubernetes pods to start, update, and stop.
+The Kubernetes autodiscover provider watches for Kubernetes nodes, pods, services to start, update, and stop.
 
 These are the available fields during within config templating. The `kubernetes.*` fields will be available on each emitted event.
 
+====== Generic fields:
   * host
   * port (if exposed)
+  * kubernetes.labels
+  * kubernetes.annotations
+
+====== Pod spesific:
   * kubernetes.container.id
   * kubernetes.container.image
   * kubernetes.container.name
-  * kubernetes.labels
   * kubernetes.namespace
   * kubernetes.node.name
   * kubernetes.pod.name
   * kubernetes.pod.uid
+
+====== Node spesific:
+  * kubernetes.node.name
+  * kubernetes.node.uid
+
+====== Service spesific:
+  * kubernetes.namespace
+  * kubernetes.service.name
+  * kubernetes.service.uid
+  * kubernetes.annotations
 
 If the `include_annotations` config is added to the provider config, then the list of annotations present in the config
 are added to the event.


### PR DESCRIPTION
This PR updates documentation now that kubernetes autodiscover provides different resource based discovery.

Codebase changed at #14738


closes https://github.com/elastic/beats/issues/14975

cc: @exekias @odacremolbap @vjsamuel 