### PR TITLE
[libbeat] move Docker helpers to libbeat, add some godocs

### DIFF
--- a/libbeat/common/docker/helpers.go
+++ b/libbeat/common/docker/helpers.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package docker
+
+import (
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
+)
+
+// ExtractContainerName strips the `/` characters that frequently appear in container names
+func ExtractContainerName(names []string) string {
+	output := names[0]
+
+	if len(names) > 1 {
+		for _, name := range names {
+			if strings.Count(output, "/") > strings.Count(name, "/") {
+				output = name
+			}
+		}
+	}
+	return strings.Trim(output, "/")
+}
+
+// DeDotLabels returns a new common.MapStr containing a copy of the labels
+// where the dots have been converted into nested structure, avoiding
+// possible mapping errors
+func DeDotLabels(labels map[string]string, dedot bool) common.MapStr {
+	outputLabels := common.MapStr{}
+	for k, v := range labels {
+		if dedot {
+			// This is necessary so that ES does not interpret '.' fields as new
+			// nested JSON objects, and also makes this compatible with ES 2.x.
+			label := common.DeDot(k)
+			outputLabels.Put(label, v)
+		} else {
+			// If we don't dedot we ensure there are no mapping errors with safemapstr
+			safemapstr.Put(outputLabels, k, v)
+		}
+	}
+
+	return outputLabels
+}

--- a/metricbeat/module/docker/config.go
+++ b/metricbeat/module/docker/config.go
@@ -17,6 +17,7 @@
 
 package docker
 
+// Config contains the config needed for the docker module
 type Config struct {
 	TLS   *TLSConfig `config:"ssl"`
 	DeDot bool       `config:"labels.dedot"`
@@ -29,6 +30,7 @@ func DefaultConfig() Config {
 	}
 }
 
+// TLSConfig contains TLS config
 type TLSConfig struct {
 	Enabled     *bool  `config:"enabled"`
 	CA          string `config:"certificate_authority"`
@@ -36,6 +38,7 @@ type TLSConfig struct {
 	Key         string `config:"key"`
 }
 
+// IsEnabled return true if TLS is enabled
 func (c *TLSConfig) IsEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
 }

--- a/metricbeat/module/docker/config.go
+++ b/metricbeat/module/docker/config.go
@@ -17,7 +17,7 @@
 
 package docker
 
-// Config contains the config needed for the docker module
+// Config contains the config needed for the docker
 type Config struct {
 	TLS   *TLSConfig `config:"ssl"`
 	DeDot bool       `config:"labels.dedot"`
@@ -30,7 +30,7 @@ func DefaultConfig() Config {
 	}
 }
 
-// TLSConfig contains TLS config
+// TLSConfig contains TLS settings required to connect to the docker daemon via TCP
 type TLSConfig struct {
 	Enabled     *bool  `config:"enabled"`
 	CA          string `config:"certificate_authority"`

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -23,8 +23,8 @@ import (
 	"github.com/docker/docker/api/types"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
 func eventsMapping(r mb.ReporterV2, containersList []types.Container, dedot bool) {

--- a/metricbeat/module/docker/docker.go
+++ b/metricbeat/module/docker/docker.go
@@ -38,6 +38,7 @@ import (
 // Select Docker API version
 const dockerAPIVersion = "1.22"
 
+// HostParser is a TCP host parser function for docker tcp host addresses
 var HostParser = parse.URLHostParserBuilder{DefaultScheme: "tcp"}.Build()
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 	}
 }
 
+// NewModule creates a new module after performing validation.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
 	// Validate that at least one host has been specified.
 	config := struct {
@@ -59,6 +61,7 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	return &base, nil
 }
 
+// Stat contains container and statistics information
 type Stat struct {
 	Container *types.Container
 	Stats     types.StatsJSON

--- a/metricbeat/module/docker/helper_test.go
+++ b/metricbeat/module/docker/helper_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/stretchr/testify/assert"
+
+	helpers "github.com/elastic/beats/libbeat/common/docker"
 )
 
 func TestDeDotLabels(t *testing.T) {
@@ -33,7 +35,7 @@ func TestDeDotLabels(t *testing.T) {
 	}
 
 	t.Run("dedot enabled", func(t *testing.T) {
-		result := DeDotLabels(labels, true)
+		result := helpers.DeDotLabels(labels, true)
 		assert.Equal(t, common.MapStr{
 			"com_docker_swarm_task":      "",
 			"com_docker_swarm_task_id":   "1",
@@ -42,7 +44,7 @@ func TestDeDotLabels(t *testing.T) {
 	})
 
 	t.Run("dedot disabled", func(t *testing.T) {
-		result := DeDotLabels(labels, false)
+		result := helpers.DeDotLabels(labels, false)
 		assert.Equal(t, common.MapStr{
 			"com": common.MapStr{
 				"docker": common.MapStr{

--- a/metricbeat/module/docker/image/data.go
+++ b/metricbeat/module/docker/image/data.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/api/types"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/metricbeat/module/docker"
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 func eventsMapping(imagesList []types.ImageSummary, dedot bool) []common.MapStr {


### PR DESCRIPTION
This is needed for #13990, since that plugin needs to do dedot/name stripping stuff as well.

I'm not sure if we should move the rest of `helper.go` to libbeat. I was thinking no, since the logic of the `Container` type seems specific to what metricbeat is doing?


Also added some missing godocs while I was at it.