### PR TITLE
Docker image build isolation

### DIFF
--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -72,7 +72,13 @@ func Package() error {
 					"PackageType": pkgType.String(),
 					"BinaryExt":   binaryExtension(target.GOOS()),
 				}
-				spec.packageDir = packageStagingDir + "/" + pkgType.AddFileExtension(spec.Name+"-"+target.GOOS()+"-"+target.Arch())
+
+				spec.packageDir, err = pkgType.PackagingDir(packageStagingDir, target, spec)
+				if err != nil {
+					log.Printf("Skipping arch %v for package type %v: %v", target.Arch(), pkgType, err)
+					continue
+				}
+
 				spec = spec.Evaluate()
 
 				tasks = append(tasks, packageBuilder{target, spec, pkgType}.Build)

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -253,6 +253,22 @@ func (typ PackageType) AddFileExtension(file string) string {
 	return file
 }
 
+// PackagingDir returns the path that should be used for building and packaging.
+// The path returned guarantees that packaging operations can run in isolation.
+func (typ PackageType) PackagingDir(home string, target BuildPlatform, spec PackageSpec) (string, error) {
+	root := home
+	if typ == Docker {
+		imageName, err := spec.ImageName()
+		if err != nil {
+			return "", err
+		}
+		root = filepath.Join(root, imageName)
+	}
+
+	targetPath := typ.AddFileExtension(spec.Name + "-" + target.GOOS() + "-" + target.Arch())
+	return filepath.Join(root, targetPath), nil
+}
+
 // Build builds a package based on the provided spec.
 func (typ PackageType) Build(spec PackageSpec) error {
 	switch typ {
@@ -434,6 +450,19 @@ func (s PackageSpec) Evaluate(args ...map[string]interface{}) PackageSpec {
 	}
 
 	return s
+}
+
+// ImageName computes the image name from the spec. A template for the image
+// name can be configured by adding image_name to extra_vars.
+func (s PackageSpec) ImageName() (string, error) {
+	if name, _ := s.ExtraVars["image_name"]; name != "" {
+		imageName, err := s.Expand(name)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to expand image_name")
+		}
+		return imageName, nil
+	}
+	return s.Name, nil
 }
 
 func copyInstallScript(spec PackageSpec, script string, local *string) error {

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -179,7 +179,7 @@ func checkZip(t *testing.T, file string) {
 func checkDocker(t *testing.T, file string) {
 	p, info, err := readDocker(file)
 	if err != nil {
-		t.Error(err)
+		t.Errorf("error reading file %v: %v", file, err)
 		return
 	}
 


### PR DESCRIPTION
Fix isolation of docker image builds, such that all images are build
within a separate packaging directory.
Use the image name if present when saving the final image to the
distribution directory.

- Add ImageName helper to PackageSpec
- add PackageType.PackagingDir