### PR TITLE
[metricbeat] Fallback to different CPU calculation if we have no online_cpu count

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -290,6 +290,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
 - Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]
 - Fix ListMetrics pagination in aws module. {issue}14926[14926] {pull}14942[14942]
+- Fix CPU count in docker/cpu in cases where no `online_cpus` are reported {pull}15070[15070]
 
 *Packetbeat*
 


### PR DESCRIPTION
So, apparently CentOS VMs on Azure will use an odd (but apparently supported) version of docker that does not give you an `online_cpu` field with the container `/stats` request. This breaks the `cpu.*.pct` fields, which use cpu count in their calculations. Previous versions used a length count:

```go
func (u *cpuUsage) CPUs() int {
	if u.cpus == 0 {
		u.cpus = len(u.Stats.CPUStats.CPUUsage.PercpuUsage)
	}
	return u.cpus
}
```

However, we can't just fall back to this, for reasons outlined in #13674. It seems we're not the first people to run into that issue, see https://github.com/coreos/bugs/issues/2088 .


So, we're instead looping through `PercpuUsage` and using non-zero fields. This is assuming that per-cpu usage is never zero. This is kinda ugly, but hopefully this is an edge case we won't hit too often.
