### PR TITLE
Journalbeat: add index option to input

### DIFF
--- a/filebeat/channel/connector.go
+++ b/filebeat/channel/connector.go
@@ -18,12 +18,11 @@
 package channel
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/add_formatted_index"
 )
 
 // ConnectorFunc is an adapter for using ordinary functions as Connector.
@@ -32,14 +31,6 @@ type ConnectorFunc func(*common.Config, beat.ClientConfig) (Outleter, error)
 type pipelineConnector struct {
 	parent   *OutletFactory
 	pipeline beat.Pipeline
-}
-
-// addFormattedIndex is a Processor to set an event's "raw_index" metadata field
-// with a given TimestampFormatString. The elasticsearch output interprets
-// that field as specifying the (raw string) index the event should be sent to;
-// in other outputs it is just included in the metadata.
-type addFormattedIndex struct {
-	formatString *fmtstr.TimestampFormatString
 }
 
 // Connect passes the cfg and the zero value of beat.ClientConfig to the underlying function.
@@ -132,7 +123,7 @@ func processorsForConfig(
 		if err != nil {
 			return nil, err
 		}
-		indexProcessor := &addFormattedIndex{timestampFormat}
+		indexProcessor := &add_formatted_index.AddFormattedIndex{timestampFormat}
 		procs.List = append(procs.List, indexProcessor)
 	}
 
@@ -159,21 +150,4 @@ func processorsForConfig(
 	// higher level, but for now we need to respect the existing semantics.
 	procs.List = append(procs.List, userProcessors.List...)
 	return procs, nil
-}
-
-func (p *addFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
-	index, err := p.formatString.Run(event.Timestamp)
-	if err != nil {
-		return nil, err
-	}
-
-	if event.Meta == nil {
-		event.Meta = common.MapStr{}
-	}
-	event.Meta["raw_index"] = index
-	return event, nil
-}
-
-func (p *addFormattedIndex) String() string {
-	return fmt.Sprintf("add_index_pattern=%v", p.formatString)
 }

--- a/filebeat/channel/connector.go
+++ b/filebeat/channel/connector.go
@@ -123,7 +123,7 @@ func processorsForConfig(
 		if err != nil {
 			return nil, err
 		}
-		indexProcessor := &add_formatted_index.AddFormattedIndex{timestampFormat}
+		indexProcessor := add_formatted_index.New(timestampFormat)
 		procs.List = append(procs.List, indexProcessor)
 	}
 

--- a/filebeat/channel/connector.go
+++ b/filebeat/channel/connector.go
@@ -124,12 +124,12 @@ func processorsForConfig(
 			return nil, err
 		}
 		indexProcessor := add_formatted_index.New(timestampFormat)
-		procs.List = append(procs.List, indexProcessor)
+		procs.AddProcessor(indexProcessor)
 	}
 
 	// 2. ClientConfig processors
 	if lst := clientCfg.Processing.Processor; lst != nil {
-		procs.List = append(procs.List, lst)
+		procs.AddProcessor(lst)
 	}
 
 	// 3. User processors
@@ -137,17 +137,7 @@ func processorsForConfig(
 	if err != nil {
 		return nil, err
 	}
-	// Subtlety: it is important here that we append the individual elements of
-	// userProcessors, rather than userProcessors itself, even though
-	// userProcessors implements the processors.Processor interface. This is
-	// because the contents of what we return are later pulled out into a
-	// processing.group rather than a processors.Processors, and the two have
-	// different error semantics: processors.Processors aborts processing on
-	// any error, whereas processing.group only aborts on fatal errors. The
-	// latter is the most common behavior, and the one we are preserving here for
-	// backwards compatibility.
-	// We are unhappy about this and have plans to fix this inconsistency at a
-	// higher level, but for now we need to respect the existing semantics.
-	procs.List = append(procs.List, userProcessors.List...)
+	procs.AddProcessors(*userProcessors)
+
 	return procs, nil
 }

--- a/journalbeat/beater/journalbeat.go
+++ b/journalbeat/beater/journalbeat.go
@@ -67,7 +67,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 
 	var inputs []*input.Input
 	for _, c := range config.Inputs {
-		i, err := input.New(c, b.Publisher, done, cp.States())
+		i, err := input.New(c, b, done, cp.States())
 		if err != nil {
 			return nil, err
 		}

--- a/journalbeat/docs/config-options.asciidoc
+++ b/journalbeat/docs/config-options.asciidoc
@@ -215,3 +215,16 @@ available:
 `CONTAINER_NAME`::            `container.name`
 `CONTAINER_PARTIAL_MESSAGE`:: `container.partial`
 `CONTAINER_TAG`::             `container.image.tag`
+
+[float]
+[id="index"]
+==== `index`
+
+If present, this formatted string overrides the index for events from this input
+(for elasticsearch outputs), or sets the `raw_index` field of the event's
+metadata (for other outputs). This string can only refer to the agent name and
+version and the event timestamp; for access to dynamic fields, use
+`output.elasticsearch.index` or a processor.
+
+Example value: `"%{[agent.name]}-myindex-%{+yyyy.MM.dd}"` might
+expand to `"journalbeat-myindex-2019.12.13"`.

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/beats/journalbeat/config"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/processors"
 )
 
@@ -47,6 +48,8 @@ type Config struct {
 	common.EventMetadata `config:",inline"`
 	// Processors to run on events.
 	Processors processors.PluginConfig `config:"processors"`
+	// ES output index pattern
+	Index fmtstr.EventFormatString `config:"index"`
 }
 
 var (

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -221,7 +221,7 @@ func processorsForInput(beatInfo beat.Info, config Config) (*processors.Processo
 			return nil, err
 		}
 		indexProcessor := add_formatted_index.New(timestampFormat)
-		procs.List = append(procs.List, indexProcessor)
+		procs.AddProcessor(indexProcessor)
 	}
 
 	// 2. User processors
@@ -229,18 +229,7 @@ func processorsForInput(beatInfo beat.Info, config Config) (*processors.Processo
 	if err != nil {
 		return nil, err
 	}
-	// Subtlety: it is important here that we append the individual elements of
-	// userProcessors, rather than userProcessors itself, even though
-	// userProcessors implements the processors.Processor interface. This is
-	// because the contents of what we return are later pulled out into a
-	// processing.group rather than a processors.Processors, and the two have
-	// different error semantics: processors.Processors aborts processing on
-	// any error, whereas processing.group only aborts on fatal errors. The
-	// latter is the most common behavior, and the one we are preserving here for
-	// backwards compatibility.
-	// We are unhappy about this and have plans to fix this inconsistency at a
-	// higher level, but for now we need to respect the existing semantics.
-	procs.List = append(procs.List, userProcessors.List...)
+	procs.AddProcessors(*userProcessors)
 
 	return procs, nil
 }

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -102,7 +102,7 @@ func New(
 		readers = append(readers, r)
 	}
 
-	processors, err := processors.New(config.Processors)
+	inputProcessors, err := processors.New(config.Processors)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func New(
 		id:         id,
 		logger:     logger,
 		eventMeta:  config.EventMetadata,
-		processors: processors,
+		processors: inputProcessors,
 	}, nil
 }
 

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -102,7 +102,7 @@ func New(
 		readers = append(readers, r)
 	}
 
-	inputProcessors, err := processors.New(config.Processors)
+	inputProcessors, err := processorsForInput(config)
 	if err != nil {
 		return nil, err
 	}
@@ -202,4 +202,8 @@ func (i *Input) Stop() {
 // Wait waits until all readers are done.
 func (i *Input) Wait() {
 	i.Stop()
+}
+
+func processorsForInput(config Config) (*processors.Processors, error) {
+	return processors.New(config.Processors)
 }

--- a/journalbeat/input/input_test.go
+++ b/journalbeat/input/input_test.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
+	_ "github.com/elastic/beats/libbeat/processors/actions"
+)
+
+func TestProcessorsForInput(t *testing.T) {
+	testCases := map[string]struct {
+		beatInfo       beat.Info
+		configStr      string
+		event          beat.Event
+		expectedFields map[string]string
+	}{
+		"Simple static index": {
+			configStr: "index: 'test'",
+			expectedFields: map[string]string{
+				"@metadata.raw_index": "test",
+			},
+		},
+		"Index with agent info + timestamp": {
+			beatInfo:  beat.Info{Beat: "TestBeat", Version: "3.9.27"},
+			configStr: "index: 'beat-%{[agent.name]}-%{[agent.version]}-%{+yyyy.MM.dd}'",
+			event:     beat.Event{Timestamp: time.Date(1999, time.December, 31, 23, 0, 0, 0, time.UTC)},
+			expectedFields: map[string]string{
+				"@metadata.raw_index": "beat-TestBeat-3.9.27-1999.12.31",
+			},
+		},
+		"Set field in input config": {
+			configStr: `processors: [add_fields: {fields: {testField: inputConfig}}]`,
+			expectedFields: map[string]string{
+				"fields.testField": "inputConfig",
+			},
+		},
+	}
+	for description, test := range testCases {
+		if test.event.Fields == nil {
+			test.event.Fields = common.MapStr{}
+		}
+		config, err := inputConfigFromString(test.configStr)
+		if err != nil {
+			t.Errorf("[%s] %v", description, err)
+			continue
+		}
+		processors, err := processorsForInput(test.beatInfo, config)
+		if err != nil {
+			t.Errorf("[%s] %v", description, err)
+			continue
+		}
+		processedEvent, err := processors.Run(&test.event)
+		// We don't check if err != nil, because we are testing the final outcome
+		// of running the processors, including when some of them fail.
+		if processedEvent == nil {
+			t.Errorf("[%s] Unexpected fatal error running processors: %v\n",
+				description, err)
+		}
+		for key, value := range test.expectedFields {
+			field, err := processedEvent.GetValue(key)
+			if err != nil {
+				t.Errorf("[%s] Couldn't get field %s from event: %v", description, key, err)
+				continue
+			}
+			assert.Equal(t, field, value)
+			fieldStr, ok := field.(string)
+			if !ok {
+				// Note that requiring a string here is just to simplify the test setup,
+				// not a requirement of the underlying api.
+				t.Errorf("[%s] Field [%s] should be a string", description, key)
+				continue
+			}
+			if fieldStr != value {
+				t.Errorf("[%s] Event field [%s]: expected [%s], got [%s]", description, key, value, fieldStr)
+			}
+		}
+	}
+}
+
+func TestProcessorsForInputIsFlat(t *testing.T) {
+	// This test is regrettable, and exists because of inconsistencies in
+	// processor handling between processors.Processors and processing.group
+	// (which implements beat.ProcessorList) -- see processorsForConfig for
+	// details. The upshot is that, for now, if the input configuration specifies
+	// processors, they must be returned as direct children of the resulting
+	// processors.Processors (rather than being collected in additional tree
+	// structure).
+	// This test should be removed once we have a more consistent mechanism for
+	// collecting and running processors.
+	configStr := `processors:
+- add_fields: {fields: {testField: value}}
+- add_fields: {fields: {testField2: stuff}}`
+	config, err := inputConfigFromString(configStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processors, err := processorsForInput(
+		beat.Info{}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(processors.List))
+}
+
+// setRawIndex is a bare-bones processor to set the raw_index field to a
+// constant string in the event metadata. It is used to test order of operations
+// for processorsForConfig.
+type setRawIndex struct {
+	indexStr string
+}
+
+func (p *setRawIndex) Run(event *beat.Event) (*beat.Event, error) {
+	if event.Meta == nil {
+		event.Meta = common.MapStr{}
+	}
+	event.Meta["raw_index"] = p.indexStr
+	return event, nil
+}
+
+func (p *setRawIndex) String() string {
+	return fmt.Sprintf("set_raw_index=%v", p.indexStr)
+}
+
+// Helper function to convert from YML input string to an unpacked
+// Config
+func inputConfigFromString(s string) (Config, error) {
+	config := Config{}
+	cfg, err := common.NewConfigFrom(s)
+	if err != nil {
+		return config, err
+	}
+	err = cfg.Unpack(&config)
+	return config, err
+}
+
+// makeProcessors wraps one or more bare Processor objects in Processors.
+func makeProcessors(procs ...processors.Processor) *processors.Processors {
+	procList := processors.NewList(nil)
+	procList.List = procs
+	return procList
+}

--- a/libbeat/processors/add_formatted_index/add_formatted_index.go
+++ b/libbeat/processors/add_formatted_index/add_formatted_index.go
@@ -25,19 +25,19 @@ import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
-// addFormattedIndex is a Processor to set an event's "raw_index" metadata field
+// AddFormattedIndex is a Processor to set an event's "raw_index" metadata field
 // with a given TimestampFormatString. The elasticsearch output interprets
 // that field as specifying the (raw string) index the event should be sent to;
 // in other outputs it is just included in the metadata.
-type addFormattedIndex struct {
+type AddFormattedIndex struct {
 	formatString *fmtstr.TimestampFormatString
 }
 
-func New(formatString *fmtstr.TimestampFormatString) *addFormattedIndex {
-	return &addFormattedIndex{formatString}
+func New(formatString *fmtstr.TimestampFormatString) *AddFormattedIndex {
+	return &AddFormattedIndex{formatString}
 }
 
-func (p *addFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
+func (p *AddFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
 	index, err := p.formatString.Run(event.Timestamp)
 	if err != nil {
 		return nil, err
@@ -50,6 +50,6 @@ func (p *addFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
 	return event, nil
 }
 
-func (p *addFormattedIndex) String() string {
+func (p *AddFormattedIndex) String() string {
 	return fmt.Sprintf("add_index_pattern=%v", p.formatString)
 }

--- a/libbeat/processors/add_formatted_index/add_formatted_index.go
+++ b/libbeat/processors/add_formatted_index/add_formatted_index.go
@@ -38,6 +38,7 @@ func New(formatString *fmtstr.TimestampFormatString) *AddFormattedIndex {
 	return &AddFormattedIndex{formatString}
 }
 
+// Run runs the processor.
 func (p *AddFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
 	index, err := p.formatString.Run(event.Timestamp)
 	if err != nil {

--- a/libbeat/processors/add_formatted_index/add_formatted_index.go
+++ b/libbeat/processors/add_formatted_index/add_formatted_index.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package add_formatted_index
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+)
+
+// AddFormattedIndex is a Processor to set an event's "raw_index" metadata field
+// with a given TimestampFormatString. The elasticsearch output interprets
+// that field as specifying the (raw string) index the event should be sent to;
+// in other outputs it is just included in the metadata.
+type AddFormattedIndex struct {
+	formatString *fmtstr.TimestampFormatString
+}
+
+func (p *AddFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
+	index, err := p.formatString.Run(event.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	if event.Meta == nil {
+		event.Meta = common.MapStr{}
+	}
+	event.Meta["raw_index"] = index
+	return event, nil
+}
+
+func (p *AddFormattedIndex) String() string {
+	return fmt.Sprintf("add_index_pattern=%v", p.formatString)
+}

--- a/libbeat/processors/add_formatted_index/add_formatted_index.go
+++ b/libbeat/processors/add_formatted_index/add_formatted_index.go
@@ -25,15 +25,19 @@ import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
-// AddFormattedIndex is a Processor to set an event's "raw_index" metadata field
+// addFormattedIndex is a Processor to set an event's "raw_index" metadata field
 // with a given TimestampFormatString. The elasticsearch output interprets
 // that field as specifying the (raw string) index the event should be sent to;
 // in other outputs it is just included in the metadata.
-type AddFormattedIndex struct {
+type addFormattedIndex struct {
 	formatString *fmtstr.TimestampFormatString
 }
 
-func (p *AddFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
+func New(formatString *fmtstr.TimestampFormatString) *addFormattedIndex {
+	return &addFormattedIndex{formatString}
+}
+
+func (p *addFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
 	index, err := p.formatString.Run(event.Timestamp)
 	if err != nil {
 		return nil, err
@@ -46,6 +50,6 @@ func (p *AddFormattedIndex) Run(event *beat.Event) (*beat.Event, error) {
 	return event, nil
 }
 
-func (p *AddFormattedIndex) String() string {
+func (p *addFormattedIndex) String() string {
 	return fmt.Sprintf("add_index_pattern=%v", p.formatString)
 }

--- a/libbeat/processors/add_formatted_index/add_formatted_index.go
+++ b/libbeat/processors/add_formatted_index/add_formatted_index.go
@@ -33,6 +33,7 @@ type AddFormattedIndex struct {
 	formatString *fmtstr.TimestampFormatString
 }
 
+// New returns a new AddFormattedIndex processor.
 func New(formatString *fmtstr.TimestampFormatString) *AddFormattedIndex {
 	return &AddFormattedIndex{formatString}
 }

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -103,10 +103,12 @@ func New(config PluginConfig) (*Processors, error) {
 	return procs, nil
 }
 
+// AddProcessor adds a single Processor to Processors
 func (procs *Processors) AddProcessor(p Processor) {
 	procs.List = append(procs.List, p)
 }
 
+// AddProcessors adds more Processors to Processors
 func (procs *Processors) AddProcessors(p Processors) {
 	// Subtlety: it is important here that we append the individual elements of
 	// p, rather than p itself, even though

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -60,7 +60,7 @@ func New(config PluginConfig) (*Processors, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to make if/then/else processor")
 			}
-			procs.add(p)
+			procs.AddProcessor(p)
 			continue
 		}
 
@@ -94,7 +94,7 @@ func New(config PluginConfig) (*Processors, error) {
 			return nil, err
 		}
 
-		procs.add(plugin)
+		procs.AddProcessor(plugin)
 	}
 
 	if len(procs.List) > 0 {
@@ -103,8 +103,23 @@ func New(config PluginConfig) (*Processors, error) {
 	return procs, nil
 }
 
-func (procs *Processors) add(p Processor) {
+func (procs *Processors) AddProcessor(p Processor) {
 	procs.List = append(procs.List, p)
+}
+
+func (procs *Processors) AddProcessors(p Processors) {
+	// Subtlety: it is important here that we append the individual elements of
+	// p, rather than p itself, even though
+	// p implements the processors.Processor interface. This is
+	// because the contents of what we return are later pulled out into a
+	// processing.group rather than a processors.Processors, and the two have
+	// different error semantics: processors.Processors aborts processing on
+	// any error, whereas processing.group only aborts on fatal errors. The
+	// latter is the most common behavior, and the one we are preserving here for
+	// backwards compatibility.
+	// We are unhappy about this and have plans to fix this inconsistency at a
+	// higher level, but for now we need to respect the existing semantics.
+	procs.List = append(procs.List, p.List...)
 }
 
 // RunBC (run backwards-compatible) applies the processors, by providing the


### PR DESCRIPTION
Resolves #15063.

This PR allows Journalbeat inputs to take a new option, `index`. The value of this option determines which Elasticsearch index should be used by the Elasticsearch output for indexing Journalbeat events. For other outputs, the index name is passed via the `@metadata["raw_index"]` field.

For example, with this `journalbeat.yml` configuration:

```
journalbeat.inputs:
  - paths: []
    index: foo

output.console:
  enabled: true
```

Running `journalbeat -e` will result in events like:

```
{"@timestamp":"2019-12-12T00:59:42.856Z","@metadata":{"beat":"journalbeat","type":"_doc","version":"8.0.0","raw_index":"foo"},...}
```
