### PR TITLE
Cherry-pick #15074 to 7.x: Add missing CHANGELOG entry

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -277,6 +277,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Closing handler after verifying the registry key in diskio metricset. {issue}14683[14683] {pull}14759[14759]
 - Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]
 - Fix ListMetrics pagination in aws module. {issue}14926[14926] {pull}14942[14942]
+- Fix mixed modules loading standard and light metricsets {pull}15011[15011]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #15074 to 7.x branch. Original message: 

This PR adds missing CHANGELOG entry for the PR https://github.com/elastic/beats/pull/15011