### PR TITLE
Print default output on go test when called from mage

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -101,7 +101,10 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 	fmt.Println(">> go test:", params.TestName, "Testing")
 
 	// Build args list to Go.
-	args := []string{"test", "-v"}
+	args := []string{"test"}
+	if mg.Verbose() {
+		args = append(args, "-v")
+	}
 	if params.Race {
 		args = append(args, "-race")
 	}
@@ -123,9 +126,6 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 	// Wire up the outputs.
 	bufferOutput := new(bytes.Buffer)
 	outputs := []io.Writer{bufferOutput}
-	if mg.Verbose() {
-		outputs = append(outputs, os.Stdout)
-	}
 	if params.OutputFile != "" {
 		fileOutput, err := os.Create(createDir(params.OutputFile))
 		if err != nil {
@@ -135,8 +135,8 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		outputs = append(outputs, fileOutput)
 	}
 	output := io.MultiWriter(outputs...)
-	goTest.Stdout = output
-	goTest.Stderr = output
+	goTest.Stdout = io.MultiWriter(output, os.Stdout)
+	goTest.Stderr = io.MultiWriter(output, os.Stderr)
 
 	// Execute 'go test' and measure duration.
 	start := time.Now()


### PR DESCRIPTION
Now we are not printing anything when go test is called
from mage. This is problematic with long builds in travis
because it timeouts when no output is received.
It is also counterintuitive not to receive any output during
a while when running tests locally.
Calling `mage -v` prints the verbose output of `go test`,
what can be too verbose.

Change this behaviour to change the default output
to print the default output of `go test`, and keep the
behaviour for `mage -v`.