### PR TITLE
Adding benchmarking of various fingerprinting methods

### DIFF
--- a/libbeat/processors/fingerprint/fingerprint_test.go
+++ b/libbeat/processors/fingerprint/fingerprint_test.go
@@ -400,6 +400,8 @@ func BenchmarkHashMethods(b *testing.B) {
 }
 
 func nRandomEvents(num int) []beat.Event {
+	prng := rand.New(rand.NewSource(12345))
+
 	const charset = "abcdefghijklmnopqrstuvwxyz" +
 		"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
 		"0123456789"
@@ -409,7 +411,7 @@ func nRandomEvents(num int) []beat.Event {
 	var events []beat.Event
 	for i := 0; i < num; i++ {
 		for j := range b {
-			b[j] = charset[rand.Intn(charsetLen)]
+			b[j] = charset[prng.Intn(charsetLen)]
 		}
 		events = append(events, beat.Event{
 			Fields: common.MapStr{


### PR DESCRIPTION
This PR adds benchmarking for various hash methods available in the fingerprint processor.

### Sample run

```
cd $GOPATH/src/github.com/elastic/beats/libbeat/processors/fingerprint
go test -bench=.
```

```
goos: darwin
goarch: amd64
pkg: github.com/elastic/beats/libbeat/processors/fingerprint
BenchmarkHashMethods/sha1-8             1000000000               0.0865 ns/op
BenchmarkHashMethods/sha256-8           1000000000               0.127 ns/op
BenchmarkHashMethods/sha384-8           1000000000               0.108 ns/op
BenchmarkHashMethods/sha512-8           1000000000               0.107 ns/op
BenchmarkHashMethods/xxhash-8           1000000000               0.0443 ns/op
BenchmarkHashMethods/md5-8              1000000000               0.0837 ns/op
PASS
ok      github.com/elastic/beats/libbeat/processors/fingerprint 7.093s
```