### PR TITLE
Cherry-pick #15049 to 7.x: Enable all metricsets for AWS module

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -1,11 +1,11 @@
 - module: aws
-  period: 300s
+  period: 1m
   metricsets:
-    - ec2
+    - usage
   regions:
     - us-east-1
 - module: aws
-  period: 300s
+  period: 5m
   metricsets:
     - cloudwatch
   metrics:
@@ -16,3 +16,29 @@
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
       statistic: ["Average", "Maximum"]
+  regions:
+    - us-east-1
+- module: aws
+  period: 5m
+  metricsets:
+    - ebs
+    - ec2
+    - elb
+    - sns
+    - sqs
+    - rds
+  regions:
+    - us-east-1
+- module: aws
+  period: 12h
+  metricsets:
+    - billing
+  regions:
+    - us-east-1
+- module: aws
+  period: 24h
+  metricsets:
+    - s3_daily_storage
+    - s3_request
+  regions:
+    - us-east-1

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -2,13 +2,13 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.x/metricbeat-module-aws.html
 
 - module: aws
-  period: 300s
+  period: 1m
   metricsets:
-    - ec2
+    - usage
   regions:
     - us-east-1
 - module: aws
-  period: 300s
+  period: 5m
   metricsets:
     - cloudwatch
   metrics:
@@ -19,3 +19,29 @@
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
       statistic: ["Average", "Maximum"]
+  regions:
+    - us-east-1
+- module: aws
+  period: 5m
+  metricsets:
+    - ebs
+    - ec2
+    - elb
+    - sns
+    - sqs
+    - rds
+  regions:
+    - us-east-1
+- module: aws
+  period: 12h
+  metricsets:
+    - billing
+  regions:
+    - us-east-1
+- module: aws
+  period: 24h
+  metricsets:
+    - s3_daily_storage
+    - s3_request
+  regions:
+    - us-east-1


### PR DESCRIPTION
Cherry-pick of PR #15049 to 7.x branch. Original message: 

This PR enables all metricsets defined in the AWS module.

Issue: https://github.com/elastic/beats/issues/14964 