### PR TITLE
Cherry-pick #12973 to 7.x: [libbeat] Enable TLS 1.3

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -358,6 +358,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Make use of consumer_lag in Kafka dashboard {pull}14863[14863]
 - Refactor kubernetes autodiscover to enable different resource based discovery {pull}14738[14738]
 - Add `add_id` processor. {pull}14524[14524]
+- Enable TLS 1.3 in all beats. {pull}12973[12973]
 
 *Auditbeat*
 

--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -161,7 +161,13 @@ class Test(BaseTest):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tls = ssl.wrap_socket(sock, cert_reqs=ssl.CERT_REQUIRED,
                               ca_certs=CERTIFICATE1, do_handshake_on_connect=True)
+
         tls.connect((config.get('host'), config.get('port')))
+        # In TLS 1.3 authentication failures are not detected by the initial
+        # connection and handshake. For the client to detect that authentication
+        # has failed (at least in python) it must wait for a server response
+        # so that the failure can be reported as an exception when it arrives.
+        tls.recv(1)
 
     def test_tcp_over_tls_mutual_auth_succeed(self):
         """

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -132,7 +132,7 @@ func TestApplyEmptyConfig(t *testing.T) {
 
 	cfg := tmp.BuildModuleConfig("")
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
 	assert.Len(t, cfg.Certificates, 0)
 	assert.Nil(t, cfg.RootCAs)
 	assert.Equal(t, false, cfg.InsecureSkipVerify)
@@ -164,7 +164,7 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
 	assert.Len(t, cfg.CurvePreferences, 1)
 	assert.Equal(t, tls.RenegotiateOnceAsClient, cfg.Renegotiation)
 }
@@ -189,7 +189,7 @@ func TestServerConfigDefaults(t *testing.T) {
 		// values set by default
 		assert.Equal(t, false, cfg.InsecureSkipVerify)
 		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
 		assert.Equal(t, tls.NoClientCert, cfg.ClientAuth)
 	})
 	t.Run("when CA is explicitly set", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestServerConfigDefaults(t *testing.T) {
 		// values set by default
 		assert.Equal(t, false, cfg.InsecureSkipVerify)
 		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
 		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
 	})
 }
@@ -227,7 +227,7 @@ func TestApplyWithServerConfig(t *testing.T) {
     certificate_authorities: [ca_test.pem]
     verification_mode: none
     client_authentication: optional
-    supported_protocols: [TLSv1.1, TLSv1.2]
+    supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
     cipher_suites:
       - "ECDHE-ECDSA-AES-256-CBC-SHA"
       - "ECDHE-ECDSA-AES-256-GCM-SHA384"
@@ -255,7 +255,7 @@ func TestApplyWithServerConfig(t *testing.T) {
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
 	assert.Len(t, cfg.CurvePreferences, 1)
 	assert.Equal(t, tls.VerifyClientCertIfGiven, cfg.ClientAuth)
 }

--- a/libbeat/common/transport/tlscommon/types.go
+++ b/libbeat/common/transport/tlscommon/types.go
@@ -108,12 +108,14 @@ const (
 	TLSVersion10    TLSVersion = tls.VersionTLS10
 	TLSVersion11    TLSVersion = tls.VersionTLS11
 	TLSVersion12    TLSVersion = tls.VersionTLS12
+	TLSVersion13    TLSVersion = tls.VersionTLS13
 )
 
 // TLSDefaultVersions list of versions of TLS we should support.
 var TLSDefaultVersions = []TLSVersion{
 	TLSVersion11,
 	TLSVersion12,
+	TLSVersion13,
 }
 
 type tlsClientAuth int
@@ -137,6 +139,7 @@ var tlsProtocolVersions = map[string]TLSVersion{
 	"TLSv1.0": TLSVersion10,
 	"TLSv1.1": TLSVersion11,
 	"TLSv1.2": TLSVersion12,
+	"TLSv1.3": TLSVersion13,
 }
 
 var tlsProtocolVersionsInverse = map[TLSVersion]string{
@@ -144,6 +147,7 @@ var tlsProtocolVersionsInverse = map[TLSVersion]string{
 	TLSVersion10:    "TLSv1.0",
 	TLSVersion11:    "TLSv1.1",
 	TLSVersion12:    "TLSv1.2",
+	TLSVersion13:    "TLSv1.3",
 }
 
 // TLSVerificationMode represents the type of verification to do on the remote host,

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -129,9 +129,10 @@ The passphrase used to decrypt an encrypted key stored in the configured `key` f
 List of allowed SSL/TLS versions. If SSL/TLS server decides for protocol versions
 not configured, the connection will be dropped during or after the handshake. The
 setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`.
+`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and
+`TLSv1.3`.
 
-The default value is `[TLSv1.1, TLSv1.2]`.
+The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
 
 [float]
 ==== `verification_mode`
@@ -149,7 +150,8 @@ The default is `full`.
 
 The list of cipher suites to use. The first entry has the highest priority.
 If this option is omitted, the Go crypto library's default
-suites are used (recommended).
+suites are used (recommended). Note that TLS 1.3 cipher suites are not
+individually configurable in Go, so they are not included in this list.
 
 The following cipher suites are available:
 


### PR DESCRIPTION
Cherry-pick of PR #12973 to 7.x branch. Original message: 

Closes elastic/beats#10226

Add TLS 1.3 support in libbeat SSL configurations.