### PR TITLE
Cherry-pick #15055 to 7.x: Update Kubernetes Autodiscover docs with the new resources

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -116,20 +116,38 @@ endif::[]
 [float]
 ===== Kubernetes
 
-The Kubernetes autodiscover provider watches for Kubernetes pods to start, update, and stop.
+The Kubernetes autodiscover provider watches for Kubernetes nodes, pods, services to start, update, and stop.
 
 These are the available fields during within config templating. The `kubernetes.*` fields will be available on each emitted event.
 
+[float]
+====== Generic fields:
   * host
   * port (if exposed)
+  * kubernetes.labels
+  * kubernetes.annotations
+
+[float]
+====== Pod specific:
   * kubernetes.container.id
   * kubernetes.container.image
   * kubernetes.container.name
-  * kubernetes.labels
   * kubernetes.namespace
   * kubernetes.node.name
   * kubernetes.pod.name
   * kubernetes.pod.uid
+
+[float]
+====== Node specific:
+  * kubernetes.node.name
+  * kubernetes.node.uid
+
+[float]
+====== Service specific:
+  * kubernetes.namespace
+  * kubernetes.service.name
+  * kubernetes.service.uid
+  * kubernetes.annotations
 
 If the `include_annotations` config is added to the provider config, then the list of annotations present in the config
 are added to the event.


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#15055 to 7.x branch. Original message: 

This PR updates documentation now that kubernetes autodiscover provides different resource based discovery.

Codebase changed at elastic/beats#14738


closes https://github.com/elastic/beats/issues/14975

cc: @exekias @odacremolbap @vjsamuel 