### PR TITLE
Enable Docker build output while integration testing

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -327,14 +327,9 @@ func dockerComposeBuildImages() error {
 		args = append(args, "--no-cache")
 	}
 
-	out := ioutil.Discard
-	if mg.Verbose() {
-		out = os.Stderr
-	}
-
 	_, err = sh.Exec(
 		composeEnv,
-		out,
+		os.Stdout,
 		os.Stderr,
 		"docker-compose", args...,
 	)


### PR DESCRIPTION
Give more verbosity while Building Docker images to avoid having timeouts and providing a better testing output.  