### PR TITLE
[7.x] make additional credentials available for tests (#14990)

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -36,7 +36,21 @@ GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "*/vendor/*" 2
 GOFILES_ALL = $(GOFILES) $(shell find $(ES_BEATS) -type f -name '*.go' 2>/dev/null)
 GOPACKAGES_STRESSTESTS=$(shell find . -name '*.go' 2>/dev/null | xargs awk 'FNR>1 {nextfile} /\+build.*stresstest/ {print FILENAME; nextfile}' | xargs dirname | uniq)
 SHELL=bash
-ES_HOST?="elasticsearch"
+ES_HOST?=elasticsearch
+ES_PORT?=9200
+ES_USER?=beats
+ES_PASS?=testing
+KIBANA_HOST?=kibana
+KIBANA_PORT?=5601
+# Kibana's Elaticsearch user
+KIBANA_ES_USER?=beats
+KIBANA_ES_PASS?=testing
+# The beat's Kibana user
+BEAT_KIBANA_USER?=${KIBANA_ES_USER}
+BEAT_KIBANA_PASS?=${KIBANA_ES_PASS}
+# Define a superuser, e.g. for initial setup
+ES_SUPERUSER_USER?=admin
+ES_SUPERUSER_PASS?=changeme
 PWD=$(shell pwd)
 BUILD_DIR?=$(shell pwd)/build
 PKG_BUILD_DIR?=$(BUILD_DIR)/package${PKG_SUFFIX}
@@ -380,10 +394,21 @@ stop-environment:
 write-environment:
 	mkdir -p ${BUILD_DIR}
 	echo "BEAT_STRICT_PERMS=false" > ${BUILD_DIR}/test.env
+	# set ENV variables for beat
 	echo "ES_HOST=${ES_HOST}" >> ${BUILD_DIR}/test.env
-	echo "ES_PORT=9200" >> ${BUILD_DIR}/test.env
-	echo "ES_USER=beats" >> ${BUILD_DIR}/test.env
-	echo "ES_PASS=testing" >> ${BUILD_DIR}/test.env
+	echo "ES_PORT=${ES_PORT}" >> ${BUILD_DIR}/test.env
+	echo "ES_USER=${ES_USER}" >> ${BUILD_DIR}/test.env
+	echo "ES_PASS=${ES_PASS}" >> ${BUILD_DIR}/test.env
+	echo "ES_SUPERUSER_USER=${ES_SUPERUSER_USER}" >> ${BUILD_DIR}/test.env
+	echo "ES_SUPERUSER_PASS=${ES_SUPERUSER_PASS}" >> ${BUILD_DIR}/test.env
+	echo "KIBANA_HOST=${KIBANA_HOST}" >> ${BUILD_DIR}/test.env
+	echo "KIBANA_PORT=${KIBANA_PORT}" >> ${BUILD_DIR}/test.env
+	echo "KIBANA_USER=${BEAT_KIBANA_USER}" >> ${BUILD_DIR}/test.env
+	echo "KIBANA_PASS=${BEAT_KIBANA_PASS}" >> ${BUILD_DIR}/test.env
+	# set Kibana ENV variables
+	echo "ELASTICSEARCH_URL=${ES_HOST}:${ES_PORT}" > ${BUILD_DIR}/kibana.test.env
+	echo "ELASTICSEARCH_USERNAME=${KIBANA_ES_USER}" >> ${BUILD_DIR}/kibana.test.env
+	echo "ELASTICSEARCH_PASSWORD=${KIBANA_ES_PASS}" >> ${BUILD_DIR}/kibana.test.env
 
 # Tails the environment logs
 .PHONY: env-logs


### PR DESCRIPTION
Backports the following commits to 7.x:
 - make additional credentials available for tests (#14990)