### PR TITLE
[DOCS] Indicate that Journalbeat dashboard is broken

### DIFF
--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -196,9 +196,9 @@ in the _Beats Platform Reference_.
 [[view-kibana-dashboards]]
 === Step 6: Explore your data in {kib}
 
-To start exploring your data, go to the Discover application in {kib}. From
-there, you can submit search queries, filter the search results, and view
-document data.
+The {beatname_uc} dashboard is currently broken. To start exploring your data,
+go to the Discover application in {kib}. From there, you can submit search
+queries, filter the search results, and view document data.
 
 To learn how to build visualizations and dashboards to view your data, see the
 _{kibana-ref}/index.html[{kib} User Guide]_.


### PR DESCRIPTION
The Journalbeat dashboard has been broken for a long time. Until we can fix it (or remove it completely), we should mention that it's broken so users don't waste time loading it. 

The forum discussion that prompted this issue is here: https://discuss.elastic.co/t/journalbeat-dashboards-fail/211542

Related issue is here: https://github.com/elastic/beats/issues/11751

I know we don't typically mention broken features in the doc, but this seems like a special case since the feature is experimental and it's possible we might not fix the problem.