### PR TITLE
[Metricbeat] Enable all AWS regions by default

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -2,8 +2,6 @@
   period: 1m
   metricsets:
     - usage
-  regions:
-    - us-east-1
 - module: aws
   period: 5m
   metricsets:
@@ -16,8 +14,6 @@
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
       statistic: ["Average", "Maximum"]
-  regions:
-    - us-east-1
 - module: aws
   period: 5m
   metricsets:
@@ -27,8 +23,6 @@
     - sns
     - sqs
     - rds
-  regions:
-    - us-east-1
 - module: aws
   period: 12h
   metricsets:
@@ -40,5 +34,3 @@
   metricsets:
     - s3_daily_storage
     - s3_request
-  regions:
-    - us-east-1

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -5,8 +5,6 @@
   period: 1m
   metricsets:
     - usage
-  regions:
-    - us-east-1
 - module: aws
   period: 5m
   metricsets:
@@ -19,8 +17,6 @@
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
       statistic: ["Average", "Maximum"]
-  regions:
-    - us-east-1
 - module: aws
   period: 5m
   metricsets:
@@ -30,8 +26,6 @@
     - sns
     - sqs
     - rds
-  regions:
-    - us-east-1
 - module: aws
   period: 12h
   metricsets:
@@ -43,5 +37,3 @@
   metricsets:
     - s3_daily_storage
     - s3_request
-  regions:
-    - us-east-1


### PR DESCRIPTION
This PR enables all AWS regions by default.

Issue: https://github.com/elastic/beats/issues/14964

/cc @kaiyan-sheng