### PR TITLE
Fix mage package on generated beats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,11 +148,11 @@ jobs:
 
     # Generators
     - os: linux
-      env: TARGETS="-C generator/metricbeat test"
+      env: TARGETS="-C generator/metricbeat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C generator/beat test"
+      env: TARGETS="-C generator/beat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,15 +157,11 @@ jobs:
       stage: test
 
     - os: osx
-      env:
-        - TARGETS="-C generator/metricbeat test"
-        - PLATFORMS="darwin/amd64"
+      env: TARGETS="-C generator/metricbeat test"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env:
-        - TARGETS="-C generator/beat test"
-        - PLATFORMS="darwin/amd64"
+      env: TARGETS="-C generator/beat test"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,11 +157,15 @@ jobs:
       stage: test
 
     - os: osx
-      env: TARGETS="-C generator/metricbeat test"
+      env:
+        - TARGETS="-C generator/metricbeat test"
+        - PLATFORMS="darwin/amd64"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="-C generator/beat test"
+      env:
+        - TARGETS="-C generator/beat test"
+        - PLATFORMS="darwin/amd64"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -424,14 +424,14 @@ pipeline {
             stage('Generators Metricbeat Linux'){
               steps {
                 withBeatsEnv(){
-                  makeTarget("Generators Metricbeat Linux", "-C generator/metricbeat test")
+                  makeTarget("Generators Metricbeat Linux", "-C generator/metricbeat test test-package")
                 }
               }
             }
             stage('Generators Beat Linux'){
               steps {
                 withBeatsEnv(){
-                  makeTarget("Generators Beat Linux", "-C generator/beat test")
+                  makeTarget("Generators Beat Linux", "-C generator/beat test test-package")
                 }
               }
             }

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -89,3 +89,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -16,6 +16,12 @@ test: prepare-test
 	$(MAKE) || exit 1 ; \
 	$(MAKE) unit
 
+.PHONY: test-package
+test-package: test
+	cd ${BEAT_PATH} ; \
+	export PATH=$${GOPATH}/bin:$${PATH}; \
+	mage package
+
 .PHONY: prepare-test
 prepare-test:: ${GOPATH}/bin/mage
 	rm -fr ${BEAT_PATH}

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -14,8 +14,7 @@ test: prepare-test
 	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
-	$(MAKE) unit ; \
-	mage package
+	$(MAKE) unit
 
 .PHONY: prepare-test
 prepare-test:: ${GOPATH}/bin/mage

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -15,7 +15,7 @@ test: prepare-test
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
 	$(MAKE) unit
-	$(MAKE) package
+	mage package
 
 .PHONY: prepare-test
 prepare-test:: ${GOPATH}/bin/mage

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -14,7 +14,7 @@ test: prepare-test
 	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
-	$(MAKE) unit
+	$(MAKE) unit ; \
 	mage package
 
 .PHONY: prepare-test

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -15,6 +15,7 @@ test: prepare-test
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
 	$(MAKE) unit
+	$(MAKE) package
 
 .PHONY: prepare-test
 prepare-test:: ${GOPATH}/bin/mage

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -124,3 +124,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}


### PR DESCRIPTION
Mage package calls some targets by name (instead of by reference), and
then these targets need to be defined in the main magefile.

Add mage package to the test suite so we earlier detect these issues.

This is probably broken since https://github.com/elastic/beats/pull/14162

Fix https://github.com/elastic/beats/issues/15122