### PR TITLE
Update ecslog to fix an infinite loop

### DIFF
--- a/vendor/github.com/urso/ecslog/backend/layout/structured.go
+++ b/vendor/github.com/urso/ecslog/backend/layout/structured.go
@@ -74,7 +74,7 @@ func Structured(
 ) Factory {
 	return func(out io.Writer) (Layout, error) {
 		logCtx := ctxtree.New(nil, nil)
-		logCtx.AddFields(fields)
+		logCtx.AddFields(fields...)
 
 		l := &structLayout{
 			out:         out,
@@ -115,7 +115,7 @@ func (l *structLayout) Log(msg backend.Message) {
 		ecs.Log.FileLine(msg.Caller.Line()),
 
 		ecs.Message(msg.Message),
-	})
+	}...)
 	if msg.Name != "" {
 		ctx.AddField(ecs.Log.Name(msg.Name))
 	}

--- a/vendor/github.com/urso/ecslog/ctxtree/ctxtree.go
+++ b/vendor/github.com/urso/ecslog/ctxtree/ctxtree.go
@@ -78,7 +78,13 @@ func (c *Ctx) AddAll(args ...interface{}) {
 		arg := args[i]
 		switch v := arg.(type) {
 		case string:
-			c.AddField(fld.Any(v, args[i+1]))
+			switch val := args[i+1].(type) {
+			case fld.Value:
+				c.Add(v, val)
+			default:
+				c.AddField(fld.Any(v, args[i+1]))
+			}
+
 			i += 2
 		case fld.Field:
 			c.AddField(v)
@@ -100,7 +106,7 @@ func (c *Ctx) AddField(f fld.Field) {
 	}
 }
 
-func (c *Ctx) AddFields(fs []fld.Field) {
+func (c *Ctx) AddFields(fs ...fld.Field) {
 	c.fields = append(c.fields, fs...)
 	for i := range fs {
 		if fs[i].Standardized {

--- a/vendor/github.com/urso/ecslog/fld/fldfmt.go
+++ b/vendor/github.com/urso/ecslog/fld/fldfmt.go
@@ -1303,27 +1303,27 @@ func parseField(st *state, msg string, start, end int) (i int, err error) {
 	return i + 1, nil
 }
 
-func parseFlag(st *state, msg string, pos int) (i int, isflag bool) {
+func parseFlag(st *state, msg string, pos int) (int, bool) {
 	switch msg[pos] {
 	case '#':
 		st.flags.sharp = true
-		return i + 1, true
+		return pos + 1, true
 	case '+':
 		st.flags.plus = true
-		return i + 1, true
+		return pos + 1, true
 	case '-':
 		st.flags.minus = true
 		st.flags.zero = false
-		return i + 1, true
+		return pos + 1, true
 	case '0':
 		st.flags.zero = !st.flags.minus
-		return i + 1, true
+		return pos + 1, true
 	case ' ':
 		st.flags.space = true
-		return i + 1, true
+		return pos + 1, true
 	}
 
-	return i, false
+	return 0, false
 }
 
 func parseNum(msg string, start, end int) (num int, isnum bool, i int) {

--- a/vendor/github.com/urso/ecslog/go.mod
+++ b/vendor/github.com/urso/ecslog/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/elastic/go-structform v0.0.6
 	github.com/mitchellh/go-wordwrap v1.0.0
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/vendor/github.com/urso/ecslog/log.go
+++ b/vendor/github.com/urso/ecslog/log.go
@@ -58,7 +58,7 @@ func (l *Logger) WithFields(fields ...fld.Field) *Logger {
 		ctx:     ctxtree.Make(&l.ctx, nil),
 		backend: l.backend,
 	}
-	nl.ctx.AddFields(fields)
+	nl.ctx.AddFields(fields...)
 	return nl
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2945,52 +2945,52 @@
 			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
-			"checksumSHA1": "e4eoz21ILO9N53HapuQ4J9sCEY0=",
+			"checksumSHA1": "8eKL/I9cf6zLySi5NarRyYyF8os=",
 			"path": "github.com/urso/ecslog",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
 			"checksumSHA1": "rP0Ft8ZrRrGSMSbdx7JwdgMz770=",
 			"path": "github.com/urso/ecslog/backend",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
 			"checksumSHA1": "3L4vNSXK+lqMQHF/nyDGwwr1bnc=",
 			"path": "github.com/urso/ecslog/backend/appender",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
-			"checksumSHA1": "w/MhNG7lA0nAFpC9S/BDP+6gbcQ=",
+			"checksumSHA1": "c5/5Qu8SMddh+VW2DqnBR3nEwMw=",
 			"path": "github.com/urso/ecslog/backend/layout",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
-			"checksumSHA1": "3yEjEr1xKH5yyivpdFciPCM9gWE=",
+			"checksumSHA1": "DIM/Q3FG0w7Vzz+4I+Zgy3jhzYc=",
 			"path": "github.com/urso/ecslog/ctxtree",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
 			"checksumSHA1": "ceTMq4ANPxCFc7fOrKw9wK7SVY0=",
 			"path": "github.com/urso/ecslog/errx",
-			"revision": "49c373406d2818bae924627549de92a4faff247c",
-			"revisionTime": "2019-08-06T17:23:24Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
-			"checksumSHA1": "1hWMfBSQa1+fS0Zls5Mbi1v8s9s=",
+			"checksumSHA1": "2uz1b+A13xbrb9zKz5VW9YOST/Y=",
 			"path": "github.com/urso/ecslog/fld",
-			"revision": "12ff8e866d497e0479943e68f9ed6c59c0cd8acb",
-			"revisionTime": "2019-08-04T13:09:23Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
 			"checksumSHA1": "VmPq1COo1UGII2Tl+NhGR/GfFRE=",
 			"path": "github.com/urso/ecslog/fld/ecs",
-			"revision": "49c373406d2818bae924627549de92a4faff247c",
-			"revisionTime": "2019-08-06T17:23:24Z"
+			"revision": "cb6164201e76e9e9450a36a2f9d30865da7d72ef",
+			"revisionTime": "2019-12-16T18:45:53Z"
 		},
 		{
 			"checksumSHA1": "H7tCgNt2ajKK4FBJIDNlevu9MAc=",


### PR DESCRIPTION
This PR add the fix from https://github.com/urso/ecslog/pull/17
Which fix the infinite loop when using parsing flags, the bug was making
the library consume all the available memory until the OS killed the
process.