### PR TITLE
Allow console output to make local debugging easier

### DIFF
--- a/x-pack/functionbeat/function/beater/functionbeat.go
+++ b/x-pack/functionbeat/function/beater/functionbeat.go
@@ -29,6 +29,7 @@ var (
 	supportedOutputs = []string{
 		"elasticsearch",
 		"logstash",
+		"console", // for local debugging
 	}
 )
 


### PR DESCRIPTION
Normally it doesn't make much sense to have the `console` output enabled for Functionbeat. However, when using a tool such as [`sam`](https://aws.amazon.com/serverless/sam/) (with the AWS provider) for testing local changes or debugging locally, it's very convenient to enable the `console` output.

For this reason, this PR adds support for the `console` output in Functionbeat.

It is worth noting that we do not document the `console` output in our [online docs](https://www.elastic.co/guide/en/beats/functionbeat/current/configuring-output.html), so supporting it should not become a source of confusion for end users of Functionbeat. For the same reason, I am not including a CHANGELOG entry in this PR either.