### PR TITLE
Handle changes to license fields

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -123,7 +123,8 @@ type License struct {
 	IssueDateInMillis  int        `json:"issue_date_in_millis"`
 	ExpiryDate         *time.Time `json:"expiry_date,omitempty"`
 	ExpiryDateInMillis int        `json:"expiry_date_in_millis,omitempty"`
-	MaxNodes           int        `json:"max_nodes"`
+	MaxNodes           int        `json:"max_nodes,omitempty"`
+	MaxResourceUnits   int        `json:"max_resource_units,omitempty"`
 	IssuedTo           string     `json:"issued_to"`
 	Issuer             string     `json:"issuer"`
 	StartDateInMillis  int        `json:"start_date_in_millis"`
@@ -492,7 +493,6 @@ func (l *License) ToMapStr() common.MapStr {
 		"issue_date":           l.IssueDate,
 		"issue_date_in_millis": l.IssueDateInMillis,
 		"expiry_date":          l.ExpiryDate,
-		"max_nodes":            l.MaxNodes,
 		"issued_to":            l.IssuedTo,
 		"issuer":               l.Issuer,
 		"start_date_in_millis": l.StartDateInMillis,
@@ -502,6 +502,16 @@ func (l *License) ToMapStr() common.MapStr {
 		// We don't want to record a 0 expiry date as this means the license has expired
 		// in the Stack Monitoring UI
 		m["expiry_date_in_millis"] = l.ExpiryDateInMillis
+	}
+
+	// Enterprise licenses have max_resource_units. All other licenses have
+	// max_nodes.
+	if l.MaxNodes != 0 {
+		m["max_nodes"] = l.MaxNodes
+	}
+
+	if l.MaxResourceUnits != 0 {
+		m["max_resource_units"] = l.MaxResourceUnits
 	}
 
 	return m

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -153,6 +153,7 @@ class Test(metricbeat.BaseTest):
             self.assertIsNot(type(issue_date), float)
 
             self.assertNotIn("expiry_date_in_millis", license)
+            self.assertNotIn("max_resource_units", license)
 
     def create_ml_job(self):
         # Check if an ml job already exists


### PR DESCRIPTION
Resolves #15148.

This PR teaches the `elasticsearch` Metricbeat module, particularly the `cluster_stats` metricset, to handle either `max_nodes` or `max_resource_units` in the monitored ES cluster's license. It will report either or both fields to Stack Monitoring, depending on which ones are set.