### PR TITLE
Pass TESTING_FILEBEAT_MODULES to integration tests

### DIFF
--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -208,6 +208,9 @@ func PythonUnitTest() error {
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).
+// Use GENERATE=true to generate expected log files.
+// Use TESTING_FILEBEAT_MODULES=module[,module] to limit what modules to test.
+// Use TESTING_FILEBEAT_FILESETS=fileset[,fileset] to limit what fileset to test.
 func PythonIntegTest(ctx context.Context) error {
 	if !devtools.IsInIntegTestEnv() {
 		mg.Deps(Fields)
@@ -217,5 +220,5 @@ func PythonIntegTest(ctx context.Context) error {
 		args := devtools.DefaultPythonTestIntegrationArgs()
 		args.Env["MODULES_PATH"] = devtools.CWD("module")
 		return devtools.PythonNoseTest(args)
-	}, "GENERATE")
+	}, "GENERATE", "TESTING_FILEBEAT_MODULES", "TESTING_FILEBEAT_FILESETS")
 }

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -174,6 +174,9 @@ func PythonUnitTest() error {
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).
+// Use GENERATE=true to generate expected log files.
+// Use TESTING_FILEBEAT_MODULES=module[,module] to limit what modules to test.
+// Use TESTING_FILEBEAT_FILESETS=fileset[,fileset] to limit what fileset to test.
 func PythonIntegTest(ctx context.Context) error {
 	if !devtools.IsInIntegTestEnv() {
 		mg.Deps(Fields)
@@ -183,5 +186,5 @@ func PythonIntegTest(ctx context.Context) error {
 		args := devtools.DefaultPythonTestIntegrationArgs()
 		args.Env["MODULES_PATH"] = devtools.CWD("module")
 		return devtools.PythonNoseTest(args)
-	}, "GENERATE")
+	}, "GENERATE", "TESTING_FILEBEAT_MODULES", "TESTING_FILEBEAT_FILESETS")
 }


### PR DESCRIPTION
Pass through TESTING_FILEBEAT_MODULES and TESTING_FILEBEAT_FILESETS
from the environment to the integration tests. This allows you to limit what module/fileset tests
are executed.

For example, this tests the zeek connection and zeek http filesets.

`TESTING_FILEBEAT_MODULES=zeek TESTING_FILEBEAT_FILESETS=connection,http mage -v pythonIntegTest`