### PR TITLE
[6.8][DOCS] Backport: Switch doc build to use direct_html flag (#15159)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2019 Elasticsearch BV
+Copyright 2014-2020 Elasticsearch BV
 
 This product includes software developed by The Apache Software 
 Foundation (http://www.apache.org/).

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -37,5 +37,5 @@ do
     params="$params --resource=${resource_dir}"
   fi
 
-  $docs_dir/build_docs --asciidoctor --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
+  $docs_dir/build_docs --direct_html --respect_edit_url_overrides $params --doc "$index" --out "$dest_dir"
 done


### PR DESCRIPTION
Backports #15159 to 6.8 branch.