### PR TITLE
[6.8] Fix #7998: ignore event fields that contains a nil interface of type encoding.TextMarshaler (#7999)

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -158,6 +158,9 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 
 	switch value.(type) {
 	case encoding.TextMarshaler:
+		if reflect.ValueOf(value).Kind() == reflect.Ptr && reflect.ValueOf(value).IsNil() {
+			return nil, nil
+		}
 		text, err := value.(encoding.TextMarshaler).MarshalText()
 		if err != nil {
 			return nil, []error{errors.Wrapf(err, "key=%v: error converting %T to string", joinKeys(keys...), value)}

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -198,7 +199,9 @@ func TestNormalizeValue(t *testing.T) {
 	logp.TestingSetup()
 
 	var nilStringPtr *string
+	var nilTimePtr *time.Time
 	someString := "foo"
+	uuidValue := uuid.NewV1()
 
 	type mybool bool
 	type myint int32
@@ -209,9 +212,11 @@ func TestNormalizeValue(t *testing.T) {
 		out interface{}
 	}{
 		{nil, nil},
-		{&someString, someString},   // Pointers are dereferenced.
-		{nilStringPtr, nil},         // Nil pointers are dropped.
-		{NetString("test"), "test"}, // It honors the TextMarshaler contract.
+		{&someString, someString},       // Pointers are dereferenced.
+		{nilStringPtr, nil},             // Nil pointers are dropped.
+		{nilTimePtr, nil},               // Nil pointers are dropped.
+		{uuidValue, uuidValue.String()}, // Struct that honors the TextMarshaler contract.
+		{NetString("test"), "test"},     // It honors the TextMarshaler contract.
 		{true, true},
 		{int8(8), int8(8)},
 		{uint8(8), uint8(8)},

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -201,7 +200,6 @@ func TestNormalizeValue(t *testing.T) {
 	var nilStringPtr *string
 	var nilTimePtr *time.Time
 	someString := "foo"
-	uuidValue := uuid.NewV1()
 
 	type mybool bool
 	type myint int32
@@ -212,11 +210,10 @@ func TestNormalizeValue(t *testing.T) {
 		out interface{}
 	}{
 		{nil, nil},
-		{&someString, someString},       // Pointers are dereferenced.
-		{nilStringPtr, nil},             // Nil pointers are dropped.
-		{nilTimePtr, nil},               // Nil pointers are dropped.
-		{uuidValue, uuidValue.String()}, // Struct that honors the TextMarshaler contract.
-		{NetString("test"), "test"},     // It honors the TextMarshaler contract.
+		{&someString, someString},   // Pointers are dereferenced.
+		{nilStringPtr, nil},         // Nil pointers are dropped.
+		{nilTimePtr, nil},           // Nil pointers are dropped.
+		{NetString("test"), "test"}, // It honors the TextMarshaler contract.
 		{true, true},
 		{int8(8), int8(8)},
 		{uint8(8), uint8(8)},


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Fix #7998: ignore event fields that contains a nil interface of type encoding.TextMarshaler (#7999) 