### PR TITLE
Skip flaky STAN integration test

### DIFF
--- a/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
@@ -23,6 +23,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	t.Skip("Skip flaky test")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
@@ -23,6 +23,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	// see: https://github.com/elastic/beats/issues/15180
 	t.Skip("Skip flaky test")
 	service := compose.EnsureUp(t, "stan")
 


### PR DESCRIPTION
Temporarily disable flaky test. Issue: https://github.com/elastic/beats/issues/15180