### PR TITLE
Improve container healthcheck to check for number of channels

### DIFF
--- a/x-pack/metricbeat/module/stan/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/stan/_meta/Dockerfile
@@ -10,12 +10,17 @@ RUN cd src/github.com/nats-io/stan.go/examples/stan-bench && git checkout tags/v
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
 FROM alpine:latest
-RUN apk add --no-cache --upgrade bash
+RUN apk add --no-cache --upgrade bash curl jq
 COPY --from=0 nats-streaming-server /nats-streaming-server
 COPY --from=build-env /go/src/github.com/nats-io/stan.go/examples/stan-bench/stan-bench /stan-bench
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222
-HEALTHCHECK --interval=1s --retries=10 CMD nc -w 1 0.0.0.0 8222 </dev/null
+ADD healthcheck.sh /healthcheck.sh
+RUN ["chmod", "+x", "/healthcheck.sh"]
 ADD run.sh /run.sh
+
+# Healthcheck waits until channels have been created by the benchamrk that runs inside
+HEALTHCHECK --interval=1s --retries=100 CMD /healthcheck.sh
+
 # Run with default memory based store
 ENTRYPOINT ["/run.sh"]

--- a/x-pack/metricbeat/module/stan/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/stan/_meta/Dockerfile
@@ -19,7 +19,7 @@ ADD healthcheck.sh /healthcheck.sh
 RUN ["chmod", "+x", "/healthcheck.sh"]
 ADD run.sh /run.sh
 
-# Healthcheck waits until channels have been created by the benchamrk that runs inside
+# Healthcheck waits until channels have been created by the benchmark that runs inside
 HEALTHCHECK --interval=1s --retries=100 CMD /healthcheck.sh
 
 # Run with default memory based store

--- a/x-pack/metricbeat/module/stan/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/stan/_meta/Dockerfile
@@ -10,7 +10,7 @@ RUN cd src/github.com/nats-io/stan.go/examples/stan-bench && git checkout tags/v
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
 FROM alpine:latest
-RUN apk add --no-cache --upgrade bash curl jq
+RUN apk add --no-cache --upgrade bash
 COPY --from=0 nats-streaming-server /nats-streaming-server
 COPY --from=build-env /go/src/github.com/nats-io/stan.go/examples/stan-bench/stan-bench /stan-bench
 # Expose client, management, and cluster ports

--- a/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
+++ b/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-res=$(wget -q -O - http://0.0.0.0:8222/streaming/channelsz | egrep -e '"count": (\d)+,' | cut -d":" -f2 |cut -d"," -f1 | xargs)
+res=$(wget -q -O - http://0.0.0.0:8222/streaming/channelsz | sed -n 's/"count": \([[:digit:]]\+\),/\1/p')
 
 if [[ $res = 0 ]]; then
 	exit 1

--- a/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
+++ b/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+res=$(curl -s http://0.0.0.0:8222/streaming/channelsz | jq '.count')
+
+if [[ $res = 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
+++ b/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
@@ -2,8 +2,8 @@
 
 res=$(wget -q -O - http://0.0.0.0:8222/streaming/channelsz | sed -n 's/"count": \([[:digit:]]\+\),/\1/p')
 
-if [[ $res = 0 ]]; then
-	exit 1
+if [[ $res -gt 0 ]]; then
+	exit 0
 fi
 
-exit 0
+exit 1

--- a/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
+++ b/x-pack/metricbeat/module/stan/_meta/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-res=$(curl -s http://0.0.0.0:8222/streaming/channelsz | jq '.count')
+res=$(wget -q -O - http://0.0.0.0:8222/streaming/channelsz | egrep -e '"count": (\d)+,' | cut -d":" -f2 |cut -d"," -f1 | xargs)
 
 if [[ $res = 0 ]]; then
 	exit 1


### PR DESCRIPTION
This PR aims to solve flakiness found in STAN integration tests. Reported in https://github.com/elastic/beats/issues/15180

It is possible that tests will start before channels have been populated in https://github.com/elastic/beats/blob/master/x-pack/metricbeat/module/stan/_meta/run.sh#L5.

We need to make sure that tests will start only if there are channels so as the monitoring endpoints to be able to return valuable data for the module.

This will happen by improving the container health-check to wait until at least one streaming channel is available. 