### PR TITLE
The MapVisitor didn't handle correctly Uint and Uin64

### DIFF
--- a/x-pack/agent/pkg/agent/transpiler/ast.go
+++ b/x-pack/agent/pkg/agent/transpiler/ast.go
@@ -397,7 +397,9 @@ func load(val reflect.Value) (Node, error) {
 		return &StrVal{value: val.Interface().(string)}, nil
 	case reflect.Int, reflect.Int64:
 		return &IntVal{value: val.Interface().(int)}, nil
-	case reflect.Uint, reflect.Uint64:
+	case reflect.Uint:
+		return &UIntVal{value: uint64(val.Interface().(uint))}, nil
+	case reflect.Uint64:
 		return &UIntVal{value: val.Interface().(uint64)}, nil
 	case reflect.Float64:
 		return &FloatVal{value: val.Interface().(float64)}, nil
@@ -441,6 +443,8 @@ func (a *AST) dispatch(n Node, visitor Visitor) {
 		visitor.OnStr(t.value)
 	case *IntVal:
 		visitor.OnInt(t.value)
+	case *UIntVal:
+		visitor.OnUInt(t.value)
 	case *BoolVal:
 		visitor.OnBool(t.value)
 	case *FloatVal:

--- a/x-pack/agent/pkg/agent/transpiler/ast_test.go
+++ b/x-pack/agent/pkg/agent/transpiler/ast_test.go
@@ -113,6 +113,29 @@ func TestAST(t *testing.T) {
 				},
 			},
 		},
+		"support unsigned integers": {
+			hashmap: map[string]interface{}{
+				"timeout": 12,
+				"range":   []uint64{20, 30, 40},
+			},
+			ast: &AST{
+				root: &Dict{
+					value: []Node{
+						&Key{
+							name: "range",
+							value: &List{
+								[]Node{
+									&UIntVal{value: uint64(20)},
+									&UIntVal{value: uint64(30)},
+									&UIntVal{value: uint64(40)},
+								},
+							},
+						},
+						&Key{name: "timeout", value: &IntVal{value: 12}},
+					},
+				},
+			},
+		},
 		"support floats": {
 			hashmap: map[string]interface{}{
 				"ratio":   0.5,

--- a/x-pack/agent/pkg/agent/transpiler/map_visitor.go
+++ b/x-pack/agent/pkg/agent/transpiler/map_visitor.go
@@ -20,6 +20,11 @@ func (m *MapVisitor) OnInt(v int) {
 	m.Content = v
 }
 
+// OnUInt is called when we visit a UintVal.
+func (m *MapVisitor) OnUInt(v uint64) {
+	m.Content = v
+}
+
 // OnFloat is called when we visit a FloatVal.
 func (m *MapVisitor) OnFloat(v float64) {
 	m.Content = v

--- a/x-pack/agent/pkg/agent/transpiler/visitor.go
+++ b/x-pack/agent/pkg/agent/transpiler/visitor.go
@@ -10,6 +10,7 @@ type Visitor interface {
 	OnList() VisitorList
 	OnStr(string)
 	OnInt(int)
+	OnUInt(uint64)
 	OnFloat(float64)
 	OnBool(bool)
 }


### PR DESCRIPTION
This PR add support for these types to make sure the convertion is
correctly done. The problem was the generated map had NIL values instead
of having the unsigned int values.

Fix: #15182