### PR TITLE
[metricbeat]kubernetes: ksm service labels

### DIFF
--- a/metricbeat/module/kubernetes/state_service/_meta/data.json
+++ b/metricbeat/module/kubernetes/state_service/_meta/data.json
@@ -1,50 +1,47 @@
 {
-    "@timestamp": "2019-11-27T18:13:26.661Z",
+    "@timestamp": "2019-12-18T14:47:52.427Z",
     "@metadata": {
       "beat": "metricbeat",
       "type": "_doc",
       "version": "8.0.0"
     },
+    "event": {
+      "dataset": "kubernetes.service",
+      "module": "kubernetes",
+      "duration": 44555276
+    },
     "metricset": {
-      "period": 10000,
-      "name": "state_service"
+      "name": "state_service",
+      "period": 10000
     },
     "service": {
-      "address": "kube-state-metrics.kube-system:8080",
-      "type": "kubernetes"
+      "type": "kubernetes",
+      "address": "kube-state-metrics.kube-system:8080"
     },
     "kubernetes": {
-      "namespace": "istio-system",
       "service": {
-        "name": "prometheus",
-        "created": "2019-11-25T21:00:49.000Z",
-        "cluster_ip": "10.98.33.120",
         "type": "ClusterIP",
-        "labels": {
-          "label_release": "istio",
-          "label_app": "prometheus",
-          "label_operator_istio_io_component": "Prometheus",
-          "label_operator_istio_io_managed": "Reconcile",
-          "label_operator_istio_io_version": "1.4.0"
-        }
+        "name": "productpage",
+        "created": "2019-11-25T21:08:36.000Z",
+        "cluster_ip": "10.104.43.66"
+      },
+      "namespace": "default",
+      "labels": {
+        "app": "productpage"
       }
+    },
+    "agent": {
+      "type": "metricbeat",
+      "ephemeral_id": "c2655cd5-2091-4cd2-848d-6abba04bc26c",
+      "hostname": "minikube",
+      "id": "e9952df4-592e-4102-84a6-ad0b333b3b98",
+      "version": "8.0.0"
     },
     "ecs": {
       "version": "1.2.0"
     },
     "host": {
       "name": "minikube"
-    },
-    "agent": {
-      "ephemeral_id": "74d75916-9e2d-4d4c-8b5d-30dfdec1eb34",
-      "hostname": "minikube",
-      "id": "228b79ac-d00f-4272-89ea-867e9b07faa3",
-      "version": "8.0.0",
-      "type": "metricbeat"
-    },
-    "event": {
-      "dataset": "kubernetes.service",
-      "module": "kubernetes",
-      "duration": 45413119
     }
- }
+  }
+  

--- a/metricbeat/module/kubernetes/state_service/_meta/test/ksm-unit-1.8.expected
+++ b/metricbeat/module/kubernetes/state_service/_meta/test/ksm-unit-1.8.expected
@@ -2,90 +2,14 @@
 	{
 		"RootFields": {},
 		"ModuleFields": {
-			"namespace": "default"
-		},
-		"MetricSetFields": {
-			"created": "2017-07-14T02:40:00.000Z",
-			"external_ip": "1.2.3.10",
 			"labels": {
-				"label_app": "example6"
+				"app": "example2"
 			},
-			"name": "test-service6",
-			"type": "ClusterIP"
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.service",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {},
-		"ModuleFields": {
-			"namespace": "default"
-		},
-		"MetricSetFields": {
-			"created": "2017-07-14T02:40:00.000Z",
-			"ingress_hostname": "www.example.com",
-			"ingress_ip": "1.2.3.8",
-			"labels": {
-				"label_app": "example5"
-			},
-			"name": "test-service5",
-			"type": "LoadBalancer"
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.service",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {},
-		"ModuleFields": {
-			"namespace": "default"
-		},
-		"MetricSetFields": {
-			"cluster_ip": "1.2.3.4",
-			"created": "2017-07-14T02:40:00.000Z",
-			"labels": {
-				"label_app": "example1"
-			},
-			"name": "test-service1",
-			"type": "ClusterIP"
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.service",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {},
-		"ModuleFields": {
 			"namespace": "default"
 		},
 		"MetricSetFields": {
 			"cluster_ip": "1.2.3.5",
 			"created": "2017-07-14T02:40:00.000Z",
-			"labels": {
-				"label_app": "example2"
-			},
 			"name": "test-service2",
 			"type": "NodePort"
 		},
@@ -103,14 +27,66 @@
 	{
 		"RootFields": {},
 		"ModuleFields": {
+			"labels": {
+				"app": "example3"
+			},
+			"namespace": "default"
+		},
+		"MetricSetFields": {
+			"cluster_ip": "1.2.3.6",
+			"created": "2017-07-14T02:40:00.000Z",
+			"load_balancer_ip": "1.2.3.7",
+			"name": "test-service3",
+			"type": "LoadBalancer"
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.service",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {},
+		"ModuleFields": {
+			"labels": {
+				"app": "example5"
+			},
+			"namespace": "default"
+		},
+		"MetricSetFields": {
+			"created": "2017-07-14T02:40:00.000Z",
+			"ingress_hostname": "www.example.com",
+			"ingress_ip": "1.2.3.8",
+			"name": "test-service5",
+			"type": "LoadBalancer"
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.service",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {},
+		"ModuleFields": {
+			"labels": {
+				"app": "example4"
+			},
 			"namespace": "default"
 		},
 		"MetricSetFields": {
 			"created": "2017-07-14T02:40:00.000Z",
 			"external_name": "www.example.com",
-			"labels": {
-				"label_app": "example4"
-			},
 			"name": "test-service4",
 			"type": "ExternalName"
 		},
@@ -128,17 +104,41 @@
 	{
 		"RootFields": {},
 		"ModuleFields": {
+			"labels": {
+				"app": "example6"
+			},
 			"namespace": "default"
 		},
 		"MetricSetFields": {
-			"cluster_ip": "1.2.3.6",
 			"created": "2017-07-14T02:40:00.000Z",
+			"external_ip": "1.2.3.10",
+			"name": "test-service6",
+			"type": "ClusterIP"
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.service",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {},
+		"ModuleFields": {
 			"labels": {
-				"label_app": "example3"
+				"app": "example1"
 			},
-			"load_balancer_ip": "1.2.3.7",
-			"name": "test-service3",
-			"type": "LoadBalancer"
+			"namespace": "default"
+		},
+		"MetricSetFields": {
+			"cluster_ip": "1.2.3.4",
+			"created": "2017-07-14T02:40:00.000Z",
+			"name": "test-service1",
+			"type": "ClusterIP"
 		},
 		"Index": "",
 		"ID": "",

--- a/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.7.plain-expected.json
+++ b/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.7.plain-expected.json
@@ -6,14 +6,41 @@
             "module": "kubernetes"
         },
         "kubernetes": {
+            "labels": {
+                "k8s_app": "kube-state-metrics"
+            },
+            "namespace": "kube-system",
+            "service": {
+                "cluster_ip": "10.105.144.35",
+                "created": "2019-07-19T10:41:47.000Z",
+                "name": "kube-state-metrics",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "component": "apiserver",
+                "provider": "kubernetes"
+            },
             "namespace": "default",
             "service": {
                 "cluster_ip": "10.96.0.1",
                 "created": "2019-07-19T10:39:29.000Z",
-                "labels": {
-                    "label_component": "apiserver",
-                    "label_provider": "kubernetes"
-                },
                 "name": "kubernetes",
                 "type": "ClusterIP"
             }
@@ -34,43 +61,16 @@
             "module": "kubernetes"
         },
         "kubernetes": {
+            "labels": {
+                "k8s_app": "kube-dns",
+                "kubernetes_io_cluster_service": "true",
+                "kubernetes_io_name": "KubeDNS"
+            },
             "namespace": "kube-system",
             "service": {
                 "cluster_ip": "10.96.0.10",
                 "created": "2019-07-19T10:39:31.000Z",
-                "labels": {
-                    "label_k8s_app": "kube-dns",
-                    "label_kubernetes_io_cluster_service": "true",
-                    "label_kubernetes_io_name": "KubeDNS"
-                },
                 "name": "kube-dns",
-                "type": "ClusterIP"
-            }
-        },
-        "metricset": {
-            "name": "state_service",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "event": {
-            "dataset": "kubernetes.service",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "namespace": "kube-system",
-            "service": {
-                "cluster_ip": "10.105.144.35",
-                "created": "2019-07-19T10:41:47.000Z",
-                "labels": {
-                    "label_k8s_app": "kube-state-metrics"
-                },
-                "name": "kube-state-metrics",
                 "type": "ClusterIP"
             }
         },

--- a/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.8.plain
+++ b/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.8.plain
@@ -1,0 +1,1498 @@
+# HELP kube_certificatesigningrequest_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_certificatesigningrequest_labels gauge
+# HELP kube_certificatesigningrequest_created Unix creation timestamp
+# TYPE kube_certificatesigningrequest_created gauge
+# HELP kube_certificatesigningrequest_condition The number of each certificatesigningrequest condition
+# TYPE kube_certificatesigningrequest_condition gauge
+# HELP kube_certificatesigningrequest_cert_length Length of the issued cert
+# TYPE kube_certificatesigningrequest_cert_length gauge
+# HELP kube_configmap_info Information about configmap.
+# TYPE kube_configmap_info gauge
+kube_configmap_info{namespace="kube-system",configmap="extension-apiserver-authentication"} 1
+kube_configmap_info{namespace="kube-system",configmap="kube-proxy"} 1
+kube_configmap_info{namespace="kube-system",configmap="kubeadm-config"} 1
+kube_configmap_info{namespace="kube-system",configmap="kubelet-config-1.16"} 1
+kube_configmap_info{namespace="kube-public",configmap="cluster-info"} 1
+kube_configmap_info{namespace="kube-system",configmap="coredns"} 1
+# HELP kube_configmap_created Unix creation timestamp
+# TYPE kube_configmap_created gauge
+kube_configmap_created{namespace="kube-system",configmap="coredns"} 1.574715529e+09
+kube_configmap_created{namespace="kube-system",configmap="extension-apiserver-authentication"} 1.574715527e+09
+kube_configmap_created{namespace="kube-system",configmap="kube-proxy"} 1.574715529e+09
+kube_configmap_created{namespace="kube-system",configmap="kubeadm-config"} 1.574715528e+09
+kube_configmap_created{namespace="kube-system",configmap="kubelet-config-1.16"} 1.574715528e+09
+kube_configmap_created{namespace="kube-public",configmap="cluster-info"} 1.574715529e+09
+# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
+# TYPE kube_configmap_metadata_resource_version gauge
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="extension-apiserver-authentication",resource_version="43"} 1
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="kube-proxy",resource_version="184"} 1
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="kubeadm-config",resource_version="154"} 1
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="kubelet-config-1.16",resource_version="157"} 1
+kube_configmap_metadata_resource_version{namespace="kube-public",configmap="cluster-info",resource_version="107408"} 1
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="coredns",resource_version="404904"} 1
+# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_cronjob_labels gauge
+# HELP kube_cronjob_info Info about cronjob.
+# TYPE kube_cronjob_info gauge
+# HELP kube_cronjob_created Unix creation timestamp
+# TYPE kube_cronjob_created gauge
+# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+# TYPE kube_cronjob_status_active gauge
+# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+# TYPE kube_cronjob_status_last_schedule_time gauge
+# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
+# TYPE kube_cronjob_spec_suspend gauge
+# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
+# TYPE kube_cronjob_spec_starting_deadline_seconds gauge
+# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+# TYPE kube_cronjob_next_schedule_time gauge
+# HELP kube_daemonset_created Unix creation timestamp
+# TYPE kube_daemonset_created gauge
+kube_daemonset_created{namespace="kube-system",daemonset="kube-proxy"} 1.574715529e+09
+# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
+# TYPE kube_daemonset_status_current_number_scheduled gauge
+kube_daemonset_status_current_number_scheduled{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
+# TYPE kube_daemonset_status_desired_number_scheduled gauge
+kube_daemonset_status_desired_number_scheduled{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
+# TYPE kube_daemonset_status_number_available gauge
+kube_daemonset_status_number_available{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_status_number_misscheduled The number of nodes running a daemon pod but are not supposed to.
+# TYPE kube_daemonset_status_number_misscheduled gauge
+kube_daemonset_status_number_misscheduled{namespace="kube-system",daemonset="kube-proxy"} 0
+# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+# TYPE kube_daemonset_status_number_ready gauge
+kube_daemonset_status_number_ready{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
+# TYPE kube_daemonset_status_number_unavailable gauge
+kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="kube-proxy"} 0
+# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# TYPE kube_daemonset_updated_number_scheduled gauge
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_daemonset_metadata_generation gauge
+kube_daemonset_metadata_generation{namespace="kube-system",daemonset="kube-proxy"} 1
+# HELP kube_daemonset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_daemonset_labels gauge
+kube_daemonset_labels{namespace="kube-system",daemonset="kube-proxy",label_k8s_app="kube-proxy"} 1
+# HELP kube_deployment_created Unix creation timestamp
+# TYPE kube_deployment_created gauge
+kube_deployment_created{namespace="kube-system",deployment="coredns"} 1.574715529e+09
+kube_deployment_created{namespace="kube-system",deployment="kube-state-metrics"} 1.574871639e+09
+# HELP kube_deployment_status_replicas The number of replicas per deployment.
+# TYPE kube_deployment_status_replicas gauge
+kube_deployment_status_replicas{namespace="kube-system",deployment="coredns"} 2
+kube_deployment_status_replicas{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
+# TYPE kube_deployment_status_replicas_available gauge
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="coredns"} 2
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
+# TYPE kube_deployment_status_replicas_unavailable gauge
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="coredns"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="kube-state-metrics"} 0
+# HELP kube_deployment_status_replicas_updated The number of updated replicas per deployment.
+# TYPE kube_deployment_status_replicas_updated gauge
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="coredns"} 2
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
+# TYPE kube_deployment_status_observed_generation gauge
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="coredns"} 5
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
+# TYPE kube_deployment_spec_replicas gauge
+kube_deployment_spec_replicas{namespace="kube-system",deployment="coredns"} 2
+kube_deployment_spec_replicas{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
+# TYPE kube_deployment_spec_paused gauge
+kube_deployment_spec_paused{namespace="kube-system",deployment="coredns"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="kube-state-metrics"} 0
+# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="kube-state-metrics"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="coredns"} 1
+# HELP kube_deployment_spec_strategy_rollingupdate_max_surge Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="coredns"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_deployment_metadata_generation gauge
+kube_deployment_metadata_generation{namespace="kube-system",deployment="coredns"} 5
+kube_deployment_metadata_generation{namespace="kube-system",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_deployment_labels gauge
+kube_deployment_labels{namespace="kube-system",deployment="coredns",label_k8s_app="kube-dns"} 1
+kube_deployment_labels{namespace="kube-system",deployment="kube-state-metrics",label_k8s_app="kube-state-metrics"} 1
+# HELP kube_endpoint_info Information about endpoint.
+# TYPE kube_endpoint_info gauge
+kube_endpoint_info{namespace="default",endpoint="kubernetes"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-state-metrics"} 1
+kube_endpoint_info{namespace="default",endpoint="productpage"} 1
+kube_endpoint_info{namespace="default",endpoint="reviews"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-dns"} 1
+kube_endpoint_info{namespace="default",endpoint="details"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-controller-manager"} 1
+kube_endpoint_info{namespace="default",endpoint="ratings"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-scheduler"} 1
+# HELP kube_endpoint_created Unix creation timestamp
+# TYPE kube_endpoint_created gauge
+kube_endpoint_created{namespace="kube-system",endpoint="kube-controller-manager"} 1.57471553e+09
+kube_endpoint_created{namespace="default",endpoint="ratings"} 1.574716116e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-scheduler"} 1.574715528e+09
+kube_endpoint_created{namespace="default",endpoint="details"} 1.574716116e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-state-metrics"} 1.574871639e+09
+kube_endpoint_created{namespace="default",endpoint="productpage"} 1.574716116e+09
+kube_endpoint_created{namespace="default",endpoint="reviews"} 1.574716116e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-dns"} 1.574715538e+09
+kube_endpoint_created{namespace="default",endpoint="kubernetes"} 1.574715528e+09
+# HELP kube_endpoint_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_endpoint_labels gauge
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-scheduler"} 1
+kube_endpoint_labels{namespace="default",endpoint="details",label_app="details",label_service="details"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-controller-manager"} 1
+kube_endpoint_labels{namespace="default",endpoint="ratings",label_app="ratings",label_service="ratings"} 1
+kube_endpoint_labels{namespace="default",endpoint="reviews",label_app="reviews",label_service="reviews"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-dns",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS"} 1
+kube_endpoint_labels{namespace="default",endpoint="kubernetes"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-state-metrics",label_k8s_app="kube-state-metrics"} 1
+kube_endpoint_labels{namespace="default",endpoint="productpage",label_app="productpage",label_service="productpage"} 1
+# HELP kube_endpoint_address_available Number of addresses available in endpoint.
+# TYPE kube_endpoint_address_available gauge
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-controller-manager"} 0
+kube_endpoint_address_available{namespace="default",endpoint="ratings"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-scheduler"} 0
+kube_endpoint_address_available{namespace="default",endpoint="details"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-state-metrics"} 2
+kube_endpoint_address_available{namespace="default",endpoint="productpage"} 0
+kube_endpoint_address_available{namespace="default",endpoint="reviews"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-dns"} 6
+kube_endpoint_address_available{namespace="default",endpoint="kubernetes"} 1
+# HELP kube_endpoint_address_not_ready Number of addresses not ready in endpoint
+# TYPE kube_endpoint_address_not_ready gauge
+kube_endpoint_address_not_ready{namespace="default",endpoint="kubernetes"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-state-metrics"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="productpage"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="reviews"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-dns"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="details"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-controller-manager"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="ratings"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-scheduler"} 0
+# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
+# TYPE kube_hpa_metadata_generation gauge
+# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+# TYPE kube_hpa_spec_max_replicas gauge
+# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
+# TYPE kube_hpa_spec_min_replicas gauge
+# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
+# TYPE kube_hpa_status_current_replicas gauge
+# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+# TYPE kube_hpa_status_desired_replicas gauge
+# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_hpa_labels gauge
+# HELP kube_hpa_status_condition The condition of this autoscaler.
+# TYPE kube_hpa_status_condition gauge
+# HELP kube_ingress_info Information about ingress.
+# TYPE kube_ingress_info gauge
+# HELP kube_ingress_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_ingress_labels gauge
+# HELP kube_ingress_created Unix creation timestamp
+# TYPE kube_ingress_created gauge
+# HELP kube_ingress_metadata_resource_version Resource version representing a specific version of ingress.
+# TYPE kube_ingress_metadata_resource_version gauge
+# HELP kube_ingress_path Ingress host, paths and backend service information.
+# TYPE kube_ingress_path gauge
+# HELP kube_ingress_tls Ingress TLS host and secret information.
+# TYPE kube_ingress_tls gauge
+# HELP kube_job_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_job_labels gauge
+# HELP kube_job_info Information about job.
+# TYPE kube_job_info gauge
+# HELP kube_job_created Unix creation timestamp
+# TYPE kube_job_created gauge
+# HELP kube_job_spec_parallelism The maximum desired number of pods the job should run at any given time.
+# TYPE kube_job_spec_parallelism gauge
+# HELP kube_job_spec_completions The desired number of successfully finished pods the job should be run with.
+# TYPE kube_job_spec_completions gauge
+# HELP kube_job_spec_active_deadline_seconds The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
+# TYPE kube_job_spec_active_deadline_seconds gauge
+# HELP kube_job_status_succeeded The number of pods which reached Phase Succeeded.
+# TYPE kube_job_status_succeeded gauge
+# HELP kube_job_status_failed The number of pods which reached Phase Failed.
+# TYPE kube_job_status_failed gauge
+# HELP kube_job_status_active The number of actively running pods.
+# TYPE kube_job_status_active gauge
+# HELP kube_job_complete The job has completed its execution.
+# TYPE kube_job_complete gauge
+# HELP kube_job_failed The job has failed its execution.
+# TYPE kube_job_failed gauge
+# HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
+# TYPE kube_job_status_start_time gauge
+# HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
+# TYPE kube_job_status_completion_time gauge
+# HELP kube_job_owner Information about the Job's owner.
+# TYPE kube_job_owner gauge
+# HELP kube_limitrange Information about limit range.
+# TYPE kube_limitrange gauge
+# HELP kube_limitrange_created Unix creation timestamp
+# TYPE kube_limitrange_created gauge
+# HELP kube_namespace_created Unix creation timestamp
+# TYPE kube_namespace_created gauge
+kube_namespace_created{namespace="kube-system"} 1.574715526e+09
+kube_namespace_created{namespace="default"} 1.574715527e+09
+kube_namespace_created{namespace="kube-node-lease"} 1.574715526e+09
+kube_namespace_created{namespace="kube-public"} 1.574715526e+09
+# HELP kube_namespace_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_namespace_labels gauge
+kube_namespace_labels{namespace="kube-public"} 1
+kube_namespace_labels{namespace="kube-system"} 1
+kube_namespace_labels{namespace="default",label_istio_injection="enabled"} 1
+kube_namespace_labels{namespace="kube-node-lease"} 1
+# HELP kube_namespace_status_phase kubernetes namespace status phase.
+# TYPE kube_namespace_status_phase gauge
+kube_namespace_status_phase{namespace="kube-system",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-system",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="default",phase="Active"} 1
+kube_namespace_status_phase{namespace="default",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="kube-node-lease",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-node-lease",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="kube-public",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-public",phase="Terminating"} 0
+# HELP kube_node_info Information about a cluster node.
+# TYPE kube_node_info gauge
+kube_node_info{node="minikube",kernel_version="4.19.76",os_image="Buildroot 2019.02.6",container_runtime_version="docker://18.9.9",kubelet_version="v1.16.2",kubeproxy_version="v1.16.2",provider_id=""} 1
+# HELP kube_node_created Unix creation timestamp
+# TYPE kube_node_created gauge
+kube_node_created{node="minikube"} 1.574715526e+09
+# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_node_labels gauge
+kube_node_labels{node="minikube",label_beta_kubernetes_io_arch="amd64",label_beta_kubernetes_io_os="linux",label_kubernetes_io_arch="amd64",label_kubernetes_io_hostname="minikube",label_kubernetes_io_os="linux",label_node_role_kubernetes_io_master=""} 1
+# HELP kube_node_role The role of a cluster node.
+# TYPE kube_node_role gauge
+kube_node_role{node="minikube",role="master"} 1
+# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
+# TYPE kube_node_spec_unschedulable gauge
+kube_node_spec_unschedulable{node="minikube"} 0
+# HELP kube_node_spec_taint The taint of a cluster node.
+# TYPE kube_node_spec_taint gauge
+# HELP kube_node_status_condition The condition of a cluster node.
+# TYPE kube_node_status_condition gauge
+kube_node_status_condition{node="minikube",condition="MemoryPressure",status="true"} 0
+kube_node_status_condition{node="minikube",condition="MemoryPressure",status="false"} 1
+kube_node_status_condition{node="minikube",condition="MemoryPressure",status="unknown"} 0
+kube_node_status_condition{node="minikube",condition="DiskPressure",status="true"} 0
+kube_node_status_condition{node="minikube",condition="DiskPressure",status="false"} 1
+kube_node_status_condition{node="minikube",condition="DiskPressure",status="unknown"} 0
+kube_node_status_condition{node="minikube",condition="PIDPressure",status="true"} 0
+kube_node_status_condition{node="minikube",condition="PIDPressure",status="false"} 1
+kube_node_status_condition{node="minikube",condition="PIDPressure",status="unknown"} 0
+kube_node_status_condition{node="minikube",condition="Ready",status="true"} 1
+kube_node_status_condition{node="minikube",condition="Ready",status="false"} 0
+kube_node_status_condition{node="minikube",condition="Ready",status="unknown"} 0
+# HELP kube_node_status_phase The phase the node is currently in.
+# TYPE kube_node_status_phase gauge
+# HELP kube_node_status_capacity The capacity for different resources of a node.
+# TYPE kube_node_status_capacity gauge
+kube_node_status_capacity{node="minikube",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_capacity{node="minikube",resource="memory",unit="byte"} 1.6028741632e+10
+kube_node_status_capacity{node="minikube",resource="pods",unit="integer"} 110
+kube_node_status_capacity{node="minikube",resource="cpu",unit="core"} 4
+kube_node_status_capacity{node="minikube",resource="ephemeral_storage",unit="byte"} 1.736114176e+10
+# HELP kube_node_status_capacity_pods The total pod resources of the node.
+# TYPE kube_node_status_capacity_pods gauge
+kube_node_status_capacity_pods{node="minikube"} 110
+# HELP kube_node_status_capacity_cpu_cores The total CPU resources of the node.
+# TYPE kube_node_status_capacity_cpu_cores gauge
+kube_node_status_capacity_cpu_cores{node="minikube"} 4
+# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
+# TYPE kube_node_status_capacity_memory_bytes gauge
+kube_node_status_capacity_memory_bytes{node="minikube"} 1.6028741632e+10
+# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable gauge
+kube_node_status_allocatable{node="minikube",resource="cpu",unit="core"} 4
+kube_node_status_allocatable{node="minikube",resource="ephemeral_storage",unit="byte"} 1.736114176e+10
+kube_node_status_allocatable{node="minikube",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_allocatable{node="minikube",resource="memory",unit="byte"} 1.6028741632e+10
+kube_node_status_allocatable{node="minikube",resource="pods",unit="integer"} 110
+# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_pods gauge
+kube_node_status_allocatable_pods{node="minikube"} 110
+# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_cpu_cores gauge
+kube_node_status_allocatable_cpu_cores{node="minikube"} 4
+# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_memory_bytes gauge
+kube_node_status_allocatable_memory_bytes{node="minikube"} 1.6028741632e+10
+# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_persistentvolumeclaim_labels gauge
+kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="myclaim",label_blah="bluh"} 1
+kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="claim1",label_category="disposable",label_team="observability"} 1
+kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="claim2"} 1
+# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+# TYPE kube_persistentvolumeclaim_info gauge
+kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="myclaim",storageclass="standard",volumename="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab"} 1
+kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="claim1",storageclass="standard",volumename="pvc-8c0b2241-8952-498b-acc9-246f9654c705"} 1
+kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="claim2",storageclass="notexisting",volumename=""} 1
+# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
+# TYPE kube_persistentvolumeclaim_status_phase gauge
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim1",phase="Lost"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim1",phase="Bound"} 1
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim1",phase="Pending"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim2",phase="Lost"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim2",phase="Bound"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="claim2",phase="Pending"} 1
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="myclaim",phase="Lost"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="myclaim",phase="Bound"} 1
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="myclaim",phase="Pending"} 0
+# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="myclaim"} 1.073741824e+09
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="claim1"} 8.589934592e+10
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="claim2"} 8.589934592e+09
+# HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
+# TYPE kube_persistentvolumeclaim_access_mode gauge
+kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="myclaim",access_mode="ReadWriteOnce"} 1
+kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="claim1",access_mode="ReadWriteOnce"} 1
+kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="claim2",access_mode="ReadWriteOnce"} 1
+# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_persistentvolume_labels gauge
+kube_persistentvolume_labels{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab"} 1
+kube_persistentvolume_labels{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705"} 1
+kube_persistentvolume_labels{persistentvolume="pv0001"} 1
+# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
+# TYPE kube_persistentvolume_status_phase gauge
+kube_persistentvolume_status_phase{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",phase="Available"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",phase="Bound"} 1
+kube_persistentvolume_status_phase{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",phase="Failed"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",phase="Available"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",phase="Bound"} 1
+kube_persistentvolume_status_phase{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",phase="Failed"} 0
+kube_persistentvolume_status_phase{persistentvolume="pv0001",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="pv0001",phase="Available"} 1
+kube_persistentvolume_status_phase{persistentvolume="pv0001",phase="Bound"} 0
+kube_persistentvolume_status_phase{persistentvolume="pv0001",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="pv0001",phase="Failed"} 0
+# HELP kube_persistentvolume_info Information about persistentvolume.
+# TYPE kube_persistentvolume_info gauge
+kube_persistentvolume_info{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705",storageclass="standard"} 1
+kube_persistentvolume_info{persistentvolume="pv0001",storageclass=""} 1
+kube_persistentvolume_info{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab",storageclass="standard"} 1
+# HELP kube_persistentvolume_capacity_bytes Persistentvolume capacity in bytes.
+# TYPE kube_persistentvolume_capacity_bytes gauge
+kube_persistentvolume_capacity_bytes{persistentvolume="pv0001"} 1.073741824e+09
+kube_persistentvolume_capacity_bytes{persistentvolume="pvc-385c7f1d-1eb2-4439-be5d-5a68294338ab"} 1.073741824e+09
+kube_persistentvolume_capacity_bytes{persistentvolume="pvc-8c0b2241-8952-498b-acc9-246f9654c705"} 8.589934592e+10
+# HELP kube_poddisruptionbudget_created Unix creation timestamp
+# TYPE kube_poddisruptionbudget_created gauge
+# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
+# TYPE kube_poddisruptionbudget_status_current_healthy gauge
+# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
+# TYPE kube_poddisruptionbudget_status_desired_healthy gauge
+# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
+# TYPE kube_poddisruptionbudget_status_pod_disruptions_allowed gauge
+# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
+# TYPE kube_poddisruptionbudget_status_expected_pods gauge
+# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
+# TYPE kube_poddisruptionbudget_status_observed_generation gauge
+# HELP kube_pod_info Information about pod.
+# TYPE kube_pod_info gauge
+kube_pod_info{namespace="kube-system",pod="kube-apiserver-minikube",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="3909b628-aabf-4ef6-9ee6-7f5f63a036bc",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-proxy-np9tm",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="9a9ab9dd-d243-4e2f-83d7-1d2fce984551",node="minikube",created_by_kind="DaemonSet",created_by_name="kube-proxy",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",host_ip="192.168.39.59",pod_ip="172.17.0.18",uid="4ee0348a-922f-4760-abdc-976d434a728e",node="minikube",created_by_kind="ReplicaSet",created_by_name="coredns-5644d7b6d9",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",host_ip="192.168.39.59",pod_ip="172.17.0.13",uid="b920270d-ee8b-4e69-97d0-ec9de4462f77",node="minikube",created_by_kind="ReplicaSet",created_by_name="coredns-5644d7b6d9",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="etcd-minikube",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="295d948e-3c7f-413a-ac40-20ca3aa3a787",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="storage-provisioner",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="e9c0d671-9ec1-43be-97e2-84231659e799",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="kube-scheduler-minikube",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="a8016a33-c17d-4025-ba5a-ce77bcc600c2",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",host_ip="192.168.39.59",pod_ip="172.17.0.19",uid="7c34653e-e4af-4deb-a6bb-7c81b085c223",node="minikube",created_by_kind="ReplicaSet",created_by_name="kube-state-metrics-898d4db8d",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="kube-addon-manager-minikube",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="69c6b2dd-ae37-444b-bc9a-b7b1416b2f6b",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class=""} 1
+kube_pod_info{namespace="default",pod="playground",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="15e5cf9d-79fc-464e-96b5-7c766955e22b",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="kube-controller-manager-minikube",host_ip="192.168.39.59",pod_ip="192.168.39.59",uid="2f88fe06-a365-4600-b08b-88360927ad2c",node="minikube",created_by_kind="<none>",created_by_name="<none>",priority_class="system-cluster-critical"} 1
+# HELP kube_pod_start_time Start time in unix timestamp for a pod.
+# TYPE kube_pod_start_time gauge
+kube_pod_start_time{namespace="default",pod="playground"} 1.57487538e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-controller-manager-minikube"} 1.575047009e+09
+kube_pod_start_time{namespace="kube-system",pod="storage-provisioner"} 1.57471554e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-scheduler-minikube"} 1.575047009e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm"} 1.574871641e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-addon-manager-minikube"} 1.575047009e+09
+kube_pod_start_time{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4"} 1.574715537e+09
+kube_pod_start_time{namespace="kube-system",pod="etcd-minikube"} 1.575047009e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-apiserver-minikube"} 1.575047009e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-proxy-np9tm"} 1.574715537e+09
+kube_pod_start_time{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb"} 1.575044552e+09
+# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
+# TYPE kube_pod_completion_time gauge
+# HELP kube_pod_owner Information about the Pod's owner.
+# TYPE kube_pod_owner gauge
+kube_pod_owner{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",owner_kind="ReplicaSet",owner_name="kube-state-metrics-898d4db8d",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-addon-manager-minikube",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="default",pod="playground",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-controller-manager-minikube",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="storage-provisioner",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-scheduler-minikube",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",owner_kind="ReplicaSet",owner_name="coredns-5644d7b6d9",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",owner_kind="ReplicaSet",owner_name="coredns-5644d7b6d9",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="etcd-minikube",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-apiserver-minikube",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-proxy-np9tm",owner_kind="DaemonSet",owner_name="kube-proxy",owner_is_controller="true"} 1
+# HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_pod_labels gauge
+kube_pod_labels{namespace="default",pod="playground"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-controller-manager-minikube",label_component="kube-controller-manager",label_tier="control-plane"} 1
+kube_pod_labels{namespace="kube-system",pod="storage-provisioner",label_addonmanager_kubernetes_io_mode="Reconcile",label_integration_test="storage-provisioner"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-scheduler-minikube",label_component="kube-scheduler",label_tier="control-plane"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",label_k8s_app="kube-state-metrics",label_pod_template_hash="898d4db8d"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-addon-manager-minikube",label_component="kube-addon-manager",label_kubernetes_io_minikube_addons="addon-manager",label_version="v9.0.2"} 1
+kube_pod_labels{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",label_k8s_app="kube-dns",label_pod_template_hash="5644d7b6d9"} 1
+kube_pod_labels{namespace="kube-system",pod="etcd-minikube",label_component="etcd",label_tier="control-plane"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-apiserver-minikube",label_component="kube-apiserver",label_tier="control-plane"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-proxy-np9tm",label_controller_revision_hash="56ffd4ff47",label_k8s_app="kube-proxy",label_pod_template_generation="1"} 1
+kube_pod_labels{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",label_k8s_app="kube-dns",label_pod_template_hash="5644d7b6d9"} 1
+# HELP kube_pod_created Unix creation timestamp
+# TYPE kube_pod_created gauge
+kube_pod_created{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb"} 1.575044549e+09
+kube_pod_created{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4"} 1.574715537e+09
+kube_pod_created{namespace="kube-system",pod="etcd-minikube"} 1.574715598e+09
+kube_pod_created{namespace="kube-system",pod="kube-apiserver-minikube"} 1.574715609e+09
+kube_pod_created{namespace="kube-system",pod="kube-proxy-np9tm"} 1.574715537e+09
+kube_pod_created{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm"} 1.57487164e+09
+kube_pod_created{namespace="kube-system",pod="kube-addon-manager-minikube"} 1.574715527e+09
+kube_pod_created{namespace="default",pod="playground"} 1.57487538e+09
+kube_pod_created{namespace="kube-system",pod="kube-controller-manager-minikube"} 1.575047029e+09
+kube_pod_created{namespace="kube-system",pod="storage-provisioner"} 1.57471554e+09
+kube_pod_created{namespace="kube-system",pod="kube-scheduler-minikube"} 1.574715584e+09
+# HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
+# TYPE kube_pod_restart_policy gauge
+kube_pod_restart_policy{namespace="kube-system",pod="storage-provisioner",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-scheduler-minikube",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-addon-manager-minikube",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="playground",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-controller-manager-minikube",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-apiserver-minikube",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-proxy-np9tm",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="etcd-minikube",type="Always"} 1
+# HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
+# TYPE kube_pod_status_scheduled_time gauge
+kube_pod_status_scheduled_time{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4"} 1.574715537e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="etcd-minikube"} 1.575047009e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-apiserver-minikube"} 1.575047009e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-proxy-np9tm"} 1.574715537e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb"} 1.575044549e+09
+kube_pod_status_scheduled_time{namespace="default",pod="playground"} 1.57487538e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-controller-manager-minikube"} 1.575047009e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="storage-provisioner"} 1.57471554e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-scheduler-minikube"} 1.575047009e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm"} 1.57487164e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-addon-manager-minikube"} 1.575047009e+09
+# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
+# TYPE kube_pod_status_unschedulable gauge
+# HELP kube_pod_status_phase The pods current phase.
+# TYPE kube_pod_status_phase gauge
+kube_pod_status_phase{namespace="kube-system",pod="kube-apiserver-minikube",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-apiserver-minikube",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-apiserver-minikube",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-apiserver-minikube",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-apiserver-minikube",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-np9tm",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-np9tm",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-np9tm",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-np9tm",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-np9tm",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="etcd-minikube",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="etcd-minikube",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="etcd-minikube",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="etcd-minikube",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="etcd-minikube",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="storage-provisioner",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="storage-provisioner",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="storage-provisioner",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="storage-provisioner",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="storage-provisioner",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-scheduler-minikube",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-scheduler-minikube",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-scheduler-minikube",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-scheduler-minikube",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-scheduler-minikube",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-addon-manager-minikube",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-addon-manager-minikube",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-addon-manager-minikube",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-addon-manager-minikube",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-addon-manager-minikube",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="playground",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="playground",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="playground",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="playground",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="playground",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-controller-manager-minikube",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-controller-manager-minikube",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-controller-manager-minikube",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-controller-manager-minikube",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-controller-manager-minikube",phase="Unknown"} 0
+# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# TYPE kube_pod_status_ready gauge
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="etcd-minikube",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="etcd-minikube",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="etcd-minikube",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-apiserver-minikube",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-apiserver-minikube",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-apiserver-minikube",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-np9tm",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-np9tm",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-np9tm",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-addon-manager-minikube",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-addon-manager-minikube",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-addon-manager-minikube",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="playground",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="playground",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="playground",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-controller-manager-minikube",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-controller-manager-minikube",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-controller-manager-minikube",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="storage-provisioner",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="storage-provisioner",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="storage-provisioner",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-scheduler-minikube",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-scheduler-minikube",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-scheduler-minikube",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="unknown"} 0
+# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
+# TYPE kube_pod_status_scheduled gauge
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-controller-manager-minikube",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-controller-manager-minikube",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-controller-manager-minikube",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="storage-provisioner",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="storage-provisioner",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="storage-provisioner",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-scheduler-minikube",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-scheduler-minikube",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-scheduler-minikube",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-addon-manager-minikube",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-addon-manager-minikube",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-addon-manager-minikube",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="playground",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="playground",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="playground",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="etcd-minikube",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="etcd-minikube",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="etcd-minikube",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-apiserver-minikube",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-apiserver-minikube",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-apiserver-minikube",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-np9tm",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-np9tm",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-np9tm",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",condition="unknown"} 0
+# HELP kube_pod_container_info Information about a container in a pod.
+# TYPE kube_pod_container_info gauge
+kube_pod_container_info{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",image="gcr.io/k8s-minikube/storage-provisioner:v1.8.1",image_id="docker://sha256:4689081edb103a9e8174bf23a255bfbe0b2d9ed82edc907abab6989d1c60f02c",container_id="docker://1c504e6d33288984e4f624354076ca10c3b6764179f778b226f389d5984c0fb5"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",image="k8s.gcr.io/kube-scheduler:v1.16.2",image_id="docker-pullable://k8s.gcr.io/kube-scheduler@sha256:00a8ef7932173272fc6352c799f4e9c33240e4f6b92580d24989008faa31cb0d",container_id="docker://e03f9419fb6f126d20fb2427afbfd63b5a4a65be24e4b2f90ac1e18c5cdb26ca"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",image="quay.io/coreos/kube-state-metrics:v1.8.0",image_id="docker-pullable://quay.io/coreos/kube-state-metrics@sha256:f75c3e5c5c7f65846ddd6883d6187b38f77721a3938f241c9e5d0ebe7beb8e19",container_id="docker://d6eade86b66a87f40bf80d6b9c0bf57e6e9055026416e9329d677b866ad1bf5e"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",image="k8s.gcr.io/kube-addon-manager:v9.0.2",image_id="docker-pullable://k8s.gcr.io/kube-addon-manager@sha256:3e315022a842d782a28e729720f21091dde21f1efea28868d65ec595ad871616",container_id="docker://5d5d32b779a4d472a33ffdc5aeaffc03643bec9511e690e3038277039215fa81"} 1
+kube_pod_container_info{namespace="default",pod="playground",container="ubuntu",image="ubuntu:latest",image_id="docker-pullable://ubuntu@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d",container_id="docker://38f2fc1c4d42221e0e992b2f04026694dc7bf2e7a5c99b52c73cab6280c1f8bd"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",image="k8s.gcr.io/kube-controller-manager:v1.16.2",image_id="docker-pullable://k8s.gcr.io/kube-controller-manager@sha256:d24ea0e3d735fcd81801482e3ba14e60f2b5b71c639c60db303f7287fbfc5eec",container_id="docker://b7438fb4685daea0cab42b68cf2c39254c09cf52e948fcf9ba77d520dc7500c6"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",image="k8s.gcr.io/kube-apiserver:v1.16.2",image_id="docker-pullable://k8s.gcr.io/kube-apiserver@sha256:8c31925d4d86a8a4b45edbebba17f0a9bc00acb8a80796085f18218feb9471cf",container_id="docker://6c934771d719062f18797ade90b5540b1d53038b786c2d107e95a67eb59632d7"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",image="k8s.gcr.io/kube-proxy:v1.16.2",image_id="docker-pullable://k8s.gcr.io/kube-proxy@sha256:dea8ba1d374a2e5bf0498d32a6fd32b6bf09d18f74db3758c641b54d7010a01f",container_id="docker://6aa6e2d80ddcc8bb03dc5c62f81ac6348d4d489a2167188438607117f57b5d08"} 1
+kube_pod_container_info{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",image="k8s.gcr.io/coredns:1.6.2",image_id="docker-pullable://k8s.gcr.io/coredns@sha256:12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5",container_id="docker://096d1403b90f39375528fb7775cb6953401d3bf78909c3d1a07e263a5528b9b1"} 1
+kube_pod_container_info{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",image="k8s.gcr.io/coredns:1.6.2",image_id="docker-pullable://k8s.gcr.io/coredns@sha256:12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5",container_id="docker://6597e7f55144fd86733f46ff583c92ba9152190e6e5c73ae4b5ebf75aade6a5b"} 1
+kube_pod_container_info{namespace="kube-system",pod="etcd-minikube",container="etcd",image="k8s.gcr.io/etcd:3.3.15-0",image_id="docker-pullable://k8s.gcr.io/etcd@sha256:12c2c5e5731c3bcd56e6f1c05c0f9198b6f06793fa7fca2fb43aab9622dc4afa",container_id="docker://0557fef39ba5be51fbf7be53bb27ce7c8b3513a4151a8b5ed996235c383cfc7f"} 1
+# HELP kube_pod_init_container_info Information about an init container in a pod.
+# TYPE kube_pod_init_container_info gauge
+# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting gauge
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager"} 0
+kube_pod_container_status_waiting{namespace="default",pod="playground",container="ubuntu"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="etcd-minikube",container="etcd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy"} 0
+# HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
+# TYPE kube_pod_init_container_status_waiting gauge
+# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting_reason gauge
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="playground",container="ubuntu",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="InvalidImageName"} 0
+# HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
+# TYPE kube_pod_init_container_status_waiting_reason gauge
+# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+# TYPE kube_pod_container_status_running gauge
+kube_pod_container_status_running{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager"} 1
+kube_pod_container_status_running{namespace="default",pod="playground",container="ubuntu"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="etcd-minikube",container="etcd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns"} 1
+# HELP kube_pod_init_container_status_running Describes whether the init container is currently in running state.
+# TYPE kube_pod_init_container_status_running gauge
+# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated gauge
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager"} 0
+kube_pod_container_status_terminated{namespace="default",pod="playground",container="ubuntu"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="etcd-minikube",container="etcd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy"} 0
+# HELP kube_pod_init_container_status_terminated Describes whether the init container is currently in terminated state.
+# TYPE kube_pod_init_container_status_terminated gauge
+# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated_reason gauge
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="DeadlineExceeded"} 0
+# HELP kube_pod_init_container_status_terminated_reason Describes the reason the init container is currently in terminated state.
+# TYPE kube_pod_init_container_status_terminated_reason gauge
+# HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
+# TYPE kube_pod_container_status_last_terminated_reason gauge
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="playground",container="ubuntu",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="Completed"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="Completed"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="Completed"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="etcd-minikube",container="etcd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="Completed"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="Error"} 1
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy",reason="DeadlineExceeded"} 0
+# HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
+# TYPE kube_pod_init_container_status_last_terminated_reason gauge
+# HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
+# TYPE kube_pod_container_status_ready gauge
+kube_pod_container_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="etcd-minikube",container="etcd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager"} 1
+kube_pod_container_status_ready{namespace="default",pod="playground",container="ubuntu"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler"} 1
+# HELP kube_pod_init_container_status_ready Describes whether the init containers readiness check succeeded.
+# TYPE kube_pod_init_container_status_ready gauge
+# HELP kube_pod_container_status_restarts_total The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts_total counter
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager"} 1
+kube_pod_container_status_restarts_total{namespace="default",pod="playground",container="ubuntu"} 1
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager"} 3
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="storage-provisioner",container="storage-provisioner"} 1
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler"} 11
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-state-metrics-898d4db8d-c9rcm",container="kube-state-metrics"} 13
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns"} 1
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns"} 1
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="etcd-minikube",container="etcd"} 1
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver"} 7
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-proxy-np9tm",container="kube-proxy"} 1
+# HELP kube_pod_init_container_status_restarts_total The number of restarts for the init container.
+# TYPE kube_pod_init_container_status_restarts_total counter
+# HELP kube_pod_container_resource_requests The number of requested request resource by a container.
+# TYPE kube_pod_container_resource_requests gauge
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",node="minikube",resource="cpu",unit="core"} 0.005
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",node="minikube",resource="memory",unit="byte"} 5.24288e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",node="minikube",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",node="minikube",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube",resource="memory",unit="byte"} 7.340032e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube",resource="memory",unit="byte"} 7.340032e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",node="minikube",resource="cpu",unit="core"} 0.25
+# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
+# TYPE kube_pod_container_resource_limits gauge
+kube_pod_container_resource_limits{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube",resource="memory",unit="byte"} 1.7825792e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube",resource="memory",unit="byte"} 1.7825792e+08
+# HELP kube_pod_init_container_resource_limits The number of requested limit resource by the init container.
+# TYPE kube_pod_init_container_resource_limits gauge
+# HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
+# TYPE kube_pod_container_resource_requests_cpu_cores gauge
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-apiserver-minikube",container="kube-apiserver",node="minikube"} 0.25
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-controller-manager-minikube",container="kube-controller-manager",node="minikube"} 0.2
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-scheduler-minikube",container="kube-scheduler",node="minikube"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",node="minikube"} 0.005
+# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes by a container.
+# TYPE kube_pod_container_resource_requests_memory_bytes gauge
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-addon-manager-minikube",container="kube-addon-manager",node="minikube"} 5.24288e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube"} 7.340032e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube"} 7.340032e+07
+# HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
+# TYPE kube_pod_container_resource_limits_cpu_cores gauge
+# HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
+# TYPE kube_pod_container_resource_limits_memory_bytes gauge
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="coredns-5644d7b6d9-n7fdb",container="coredns",node="minikube"} 1.7825792e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="coredns-5644d7b6d9-88sz4",container="coredns",node="minikube"} 1.7825792e+08
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
+# HELP kube_replicaset_created Unix creation timestamp
+# TYPE kube_replicaset_created gauge
+kube_replicaset_created{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 1.574715537e+09
+kube_replicaset_created{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 1.575044549e+09
+kube_replicaset_created{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1.574871639e+09
+# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
+# TYPE kube_replicaset_status_replicas gauge
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 2
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 0
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
+# TYPE kube_replicaset_status_fully_labeled_replicas gauge
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 2
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
+# TYPE kube_replicaset_status_ready_replicas gauge
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 2
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 0
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
+# TYPE kube_replicaset_status_observed_generation gauge
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 3
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 3
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
+# TYPE kube_replicaset_spec_replicas gauge
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 2
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 0
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_replicaset_metadata_generation gauge
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="coredns-5644d7b6d9"} 3
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="coredns-5d85cf8b95"} 3
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d"} 1
+# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
+# TYPE kube_replicaset_owner gauge
+kube_replicaset_owner{namespace="kube-system",replicaset="coredns-5644d7b6d9",owner_kind="Deployment",owner_name="coredns",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="coredns-5d85cf8b95",owner_kind="Deployment",owner_name="coredns",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d",owner_kind="Deployment",owner_name="kube-state-metrics",owner_is_controller="true"} 1
+# HELP kube_replicaset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_replicaset_labels gauge
+kube_replicaset_labels{namespace="kube-system",replicaset="coredns-5644d7b6d9",label_k8s_app="kube-dns",label_pod_template_hash="5644d7b6d9"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="coredns-5d85cf8b95",label_k8s_app="kube-dns",label_pod_template_hash="5d85cf8b95"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="kube-state-metrics-898d4db8d",label_k8s_app="kube-state-metrics",label_pod_template_hash="898d4db8d"} 1
+# HELP kube_replicationcontroller_created Unix creation timestamp
+# TYPE kube_replicationcontroller_created gauge
+# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_replicas gauge
+# HELP kube_replicationcontroller_status_fully_labeled_replicas The number of fully labeled replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_fully_labeled_replicas gauge
+# HELP kube_replicationcontroller_status_ready_replicas The number of ready replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_ready_replicas gauge
+# HELP kube_replicationcontroller_status_available_replicas The number of available replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_available_replicas gauge
+# HELP kube_replicationcontroller_status_observed_generation The generation observed by the ReplicationController controller.
+# TYPE kube_replicationcontroller_status_observed_generation gauge
+# HELP kube_replicationcontroller_spec_replicas Number of desired pods for a ReplicationController.
+# TYPE kube_replicationcontroller_spec_replicas gauge
+# HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_replicationcontroller_metadata_generation gauge
+# HELP kube_resourcequota_created Unix creation timestamp
+# TYPE kube_resourcequota_created gauge
+# HELP kube_resourcequota Information about resource quota.
+# TYPE kube_resourcequota gauge
+# HELP kube_secret_info Information about secret.
+# TYPE kube_secret_info gauge
+kube_secret_info{namespace="kube-system",secret="kube-state-metrics-token-bltk4"} 1
+kube_secret_info{namespace="kube-system",secret="default-token-96x7j"} 1
+kube_secret_info{namespace="kube-system",secret="istio.cronjob-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.replication-controller"} 1
+kube_secret_info{namespace="kube-system",secret="persistent-volume-binder-token-lstt7"} 1
+kube_secret_info{namespace="kube-node-lease",secret="istio.default"} 1
+kube_secret_info{namespace="kube-system",secret="service-account-controller-token-cvxmc"} 1
+kube_secret_info{namespace="kube-system",secret="istio.bootstrap-signer"} 1
+kube_secret_info{namespace="kube-system",secret="istio.horizontal-pod-autoscaler"} 1
+kube_secret_info{namespace="kube-system",secret="storage-provisioner-token-4wwvv"} 1
+kube_secret_info{namespace="kube-system",secret="istio.generic-garbage-collector"} 1
+kube_secret_info{namespace="kube-system",secret="certificate-controller-token-78pd4"} 1
+kube_secret_info{namespace="kube-system",secret="istio.statefulset-controller"} 1
+kube_secret_info{namespace="kube-node-lease",secret="default-token-b4sgm"} 1
+kube_secret_info{namespace="kube-system",secret="job-controller-token-9hfql"} 1
+kube_secret_info{namespace="kube-public",secret="default-token-gg74l"} 1
+kube_secret_info{namespace="default",secret="bookinfo-ratings-token-zspj9"} 1
+kube_secret_info{namespace="kube-system",secret="service-controller-token-fm9q8"} 1
+kube_secret_info{namespace="kube-system",secret="istio.service-controller"} 1
+kube_secret_info{namespace="default",secret="istio.bookinfo-ratings"} 1
+kube_secret_info{namespace="kube-system",secret="kube-proxy-token-8tdc6"} 1
+kube_secret_info{namespace="kube-system",secret="istio.node-controller"} 1
+kube_secret_info{namespace="default",secret="istio.default"} 1
+kube_secret_info{namespace="kube-system",secret="istio.ttl-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.job-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.kube-state-metrics"} 1
+kube_secret_info{namespace="default",secret="istio.metricbeat-kube"} 1
+kube_secret_info{namespace="kube-system",secret="bootstrap-signer-token-rptkl"} 1
+kube_secret_info{namespace="kube-system",secret="istio.attachdetach-controller"} 1
+kube_secret_info{namespace="kube-system",secret="replicaset-controller-token-q8crf"} 1
+kube_secret_info{namespace="kube-system",secret="expand-controller-token-qpp7l"} 1
+kube_secret_info{namespace="default",secret="istio.bookinfo-reviews"} 1
+kube_secret_info{namespace="kube-system",secret="istio.expand-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.default"} 1
+kube_secret_info{namespace="kube-system",secret="istio.namespace-controller"} 1
+kube_secret_info{namespace="kube-system",secret="generic-garbage-collector-token-p59vw"} 1
+kube_secret_info{namespace="default",secret="bookinfo-details-token-djbwj"} 1
+kube_secret_info{namespace="kube-system",secret="istio.disruption-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.resourcequota-controller"} 1
+kube_secret_info{namespace="kube-system",secret="namespace-controller-token-v5bd8"} 1
+kube_secret_info{namespace="kube-system",secret="pvc-protection-controller-token-rvtdq"} 1
+kube_secret_info{namespace="kube-system",secret="istio.storage-provisioner"} 1
+kube_secret_info{namespace="kube-system",secret="coredns-token-5m6qx"} 1
+kube_secret_info{namespace="kube-system",secret="resourcequota-controller-token-5bhlj"} 1
+kube_secret_info{namespace="default",secret="istio.bookinfo-productpage"} 1
+kube_secret_info{namespace="kube-system",secret="endpoint-controller-token-rk744"} 1
+kube_secret_info{namespace="kube-system",secret="istio.kube-proxy"} 1
+kube_secret_info{namespace="kube-system",secret="istio.replicaset-controller"} 1
+kube_secret_info{namespace="kube-system",secret="horizontal-pod-autoscaler-token-kxxcw"} 1
+kube_secret_info{namespace="kube-system",secret="istio.certificate-controller"} 1
+kube_secret_info{namespace="kube-system",secret="clusterrole-aggregation-controller-token-b4rpm"} 1
+kube_secret_info{namespace="kube-system",secret="istio.service-account-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.token-cleaner"} 1
+kube_secret_info{namespace="default",secret="bookinfo-productpage-token-gttfp"} 1
+kube_secret_info{namespace="kube-system",secret="disruption-controller-token-465q6"} 1
+kube_secret_info{namespace="kube-system",secret="replication-controller-token-8lbbb"} 1
+kube_secret_info{namespace="default",secret="istio.bookinfo-details"} 1
+kube_secret_info{namespace="kube-system",secret="istio.clusterrole-aggregation-controller"} 1
+kube_secret_info{namespace="default",secret="default-token-495f2"} 1
+kube_secret_info{namespace="default",secret="metricbeat-kube-token-nkkhx"} 1
+kube_secret_info{namespace="kube-system",secret="pv-protection-controller-token-mjc5g"} 1
+kube_secret_info{namespace="kube-system",secret="istio.coredns"} 1
+kube_secret_info{namespace="kube-system",secret="statefulset-controller-token-qp5d6"} 1
+kube_secret_info{namespace="kube-system",secret="istio.daemon-set-controller"} 1
+kube_secret_info{namespace="kube-system",secret="node-controller-token-7rmqx"} 1
+kube_secret_info{namespace="kube-system",secret="daemon-set-controller-token-lcvqq"} 1
+kube_secret_info{namespace="kube-system",secret="token-cleaner-token-9jkvr"} 1
+kube_secret_info{namespace="kube-system",secret="istio.pv-protection-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.deployment-controller"} 1
+kube_secret_info{namespace="kube-system",secret="deployment-controller-token-g4bxm"} 1
+kube_secret_info{namespace="kube-public",secret="istio.default"} 1
+kube_secret_info{namespace="kube-system",secret="istio.pvc-protection-controller"} 1
+kube_secret_info{namespace="kube-system",secret="istio.endpoint-controller"} 1
+kube_secret_info{namespace="kube-system",secret="ttl-controller-token-f8jg8"} 1
+kube_secret_info{namespace="kube-system",secret="attachdetach-controller-token-d47s4"} 1
+kube_secret_info{namespace="kube-system",secret="cronjob-controller-token-77n9l"} 1
+kube_secret_info{namespace="default",secret="bookinfo-reviews-token-l4jks"} 1
+kube_secret_info{namespace="kube-system",secret="istio.pod-garbage-collector"} 1
+kube_secret_info{namespace="kube-system",secret="pod-garbage-collector-token-96hzm"} 1
+kube_secret_info{namespace="kube-system",secret="istio.persistent-volume-binder"} 1
+# HELP kube_secret_type Type about secret.
+# TYPE kube_secret_type gauge
+kube_secret_type{namespace="kube-system",secret="horizontal-pod-autoscaler-token-kxxcw",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.certificate-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.replicaset-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="bookinfo-productpage-token-gttfp",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="disruption-controller-token-465q6",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="clusterrole-aggregation-controller-token-b4rpm",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.service-account-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.token-cleaner",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="pv-protection-controller-token-mjc5g",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.coredns",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="statefulset-controller-token-qp5d6",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="replication-controller-token-8lbbb",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="istio.bookinfo-details",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.clusterrole-aggregation-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="default-token-495f2",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="metricbeat-kube-token-nkkhx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.daemon-set-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="deployment-controller-token-g4bxm",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-public",secret="istio.default",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="node-controller-token-7rmqx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="daemon-set-controller-token-lcvqq",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="token-cleaner-token-9jkvr",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.pv-protection-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.deployment-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="attachdetach-controller-token-d47s4",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="cronjob-controller-token-77n9l",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.pvc-protection-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.endpoint-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="ttl-controller-token-f8jg8",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="pod-garbage-collector-token-96hzm",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.persistent-volume-binder",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="bookinfo-reviews-token-l4jks",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.pod-garbage-collector",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="persistent-volume-binder-token-lstt7",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-node-lease",secret="istio.default",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="kube-state-metrics-token-bltk4",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="default-token-96x7j",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.cronjob-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.replication-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="storage-provisioner-token-4wwvv",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.generic-garbage-collector",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="service-account-controller-token-cvxmc",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.bootstrap-signer",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.horizontal-pod-autoscaler",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-public",secret="default-token-gg74l",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="bookinfo-ratings-token-zspj9",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="certificate-controller-token-78pd4",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.statefulset-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-node-lease",secret="default-token-b4sgm",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="job-controller-token-9hfql",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.service-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="istio.bookinfo-ratings",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="service-controller-token-fm9q8",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.node-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="istio.default",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="kube-proxy-token-8tdc6",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.kube-state-metrics",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="istio.metricbeat-kube",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.ttl-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.job-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="replicaset-controller-token-q8crf",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="expand-controller-token-qpp7l",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="bootstrap-signer-token-rptkl",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.attachdetach-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="generic-garbage-collector-token-p59vw",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="bookinfo-details-token-djbwj",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="istio.bookinfo-reviews",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.expand-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.default",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.namespace-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.disruption-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="istio.resourcequota-controller",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="default",secret="istio.bookinfo-productpage",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="endpoint-controller-token-rk744",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.kube-proxy",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="namespace-controller-token-v5bd8",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="pvc-protection-controller-token-rvtdq",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="istio.storage-provisioner",type="istio.io/key-and-cert"} 1
+kube_secret_type{namespace="kube-system",secret="coredns-token-5m6qx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="resourcequota-controller-token-5bhlj",type="kubernetes.io/service-account-token"} 1
+# HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_secret_labels gauge
+kube_secret_labels{namespace="kube-system",secret="bootstrap-signer-token-rptkl"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.attachdetach-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="replicaset-controller-token-q8crf"} 1
+kube_secret_labels{namespace="kube-system",secret="expand-controller-token-qpp7l"} 1
+kube_secret_labels{namespace="default",secret="istio.bookinfo-reviews"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.expand-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.default"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.namespace-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="generic-garbage-collector-token-p59vw"} 1
+kube_secret_labels{namespace="default",secret="bookinfo-details-token-djbwj"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.disruption-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.resourcequota-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="namespace-controller-token-v5bd8"} 1
+kube_secret_labels{namespace="kube-system",secret="pvc-protection-controller-token-rvtdq"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.storage-provisioner"} 1
+kube_secret_labels{namespace="kube-system",secret="coredns-token-5m6qx"} 1
+kube_secret_labels{namespace="kube-system",secret="resourcequota-controller-token-5bhlj"} 1
+kube_secret_labels{namespace="default",secret="istio.bookinfo-productpage"} 1
+kube_secret_labels{namespace="kube-system",secret="endpoint-controller-token-rk744"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.kube-proxy"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.replicaset-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="horizontal-pod-autoscaler-token-kxxcw"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.certificate-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="clusterrole-aggregation-controller-token-b4rpm"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.service-account-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.token-cleaner"} 1
+kube_secret_labels{namespace="default",secret="bookinfo-productpage-token-gttfp"} 1
+kube_secret_labels{namespace="kube-system",secret="disruption-controller-token-465q6"} 1
+kube_secret_labels{namespace="kube-system",secret="replication-controller-token-8lbbb"} 1
+kube_secret_labels{namespace="default",secret="istio.bookinfo-details"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.clusterrole-aggregation-controller"} 1
+kube_secret_labels{namespace="default",secret="default-token-495f2"} 1
+kube_secret_labels{namespace="default",secret="metricbeat-kube-token-nkkhx"} 1
+kube_secret_labels{namespace="kube-system",secret="pv-protection-controller-token-mjc5g"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.coredns"} 1
+kube_secret_labels{namespace="kube-system",secret="statefulset-controller-token-qp5d6"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.daemon-set-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="node-controller-token-7rmqx"} 1
+kube_secret_labels{namespace="kube-system",secret="daemon-set-controller-token-lcvqq"} 1
+kube_secret_labels{namespace="kube-system",secret="token-cleaner-token-9jkvr"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.pv-protection-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.deployment-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="deployment-controller-token-g4bxm"} 1
+kube_secret_labels{namespace="kube-public",secret="istio.default"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.pvc-protection-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.endpoint-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="ttl-controller-token-f8jg8"} 1
+kube_secret_labels{namespace="kube-system",secret="attachdetach-controller-token-d47s4"} 1
+kube_secret_labels{namespace="kube-system",secret="cronjob-controller-token-77n9l"} 1
+kube_secret_labels{namespace="default",secret="bookinfo-reviews-token-l4jks"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.pod-garbage-collector"} 1
+kube_secret_labels{namespace="kube-system",secret="pod-garbage-collector-token-96hzm"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.persistent-volume-binder"} 1
+kube_secret_labels{namespace="kube-system",secret="kube-state-metrics-token-bltk4"} 1
+kube_secret_labels{namespace="kube-system",secret="default-token-96x7j"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.cronjob-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.replication-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="persistent-volume-binder-token-lstt7"} 1
+kube_secret_labels{namespace="kube-node-lease",secret="istio.default"} 1
+kube_secret_labels{namespace="kube-system",secret="service-account-controller-token-cvxmc"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.bootstrap-signer"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.horizontal-pod-autoscaler"} 1
+kube_secret_labels{namespace="kube-system",secret="storage-provisioner-token-4wwvv"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.generic-garbage-collector"} 1
+kube_secret_labels{namespace="kube-system",secret="certificate-controller-token-78pd4"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.statefulset-controller"} 1
+kube_secret_labels{namespace="kube-node-lease",secret="default-token-b4sgm"} 1
+kube_secret_labels{namespace="kube-system",secret="job-controller-token-9hfql"} 1
+kube_secret_labels{namespace="kube-public",secret="default-token-gg74l"} 1
+kube_secret_labels{namespace="default",secret="bookinfo-ratings-token-zspj9"} 1
+kube_secret_labels{namespace="kube-system",secret="service-controller-token-fm9q8"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.service-controller"} 1
+kube_secret_labels{namespace="default",secret="istio.bookinfo-ratings"} 1
+kube_secret_labels{namespace="kube-system",secret="kube-proxy-token-8tdc6"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.node-controller"} 1
+kube_secret_labels{namespace="default",secret="istio.default"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.ttl-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.job-controller"} 1
+kube_secret_labels{namespace="kube-system",secret="istio.kube-state-metrics"} 1
+kube_secret_labels{namespace="default",secret="istio.metricbeat-kube"} 1
+# HELP kube_secret_created Unix creation timestamp
+# TYPE kube_secret_created gauge
+kube_secret_created{namespace="kube-system",secret="istio.disruption-controller"} 1.574715688e+09
+kube_secret_created{namespace="kube-system",secret="istio.resourcequota-controller"} 1.574715696e+09
+kube_secret_created{namespace="kube-system",secret="endpoint-controller-token-rk744"} 1.574715532e+09
+kube_secret_created{namespace="kube-system",secret="istio.kube-proxy"} 1.574715696e+09
+kube_secret_created{namespace="kube-system",secret="namespace-controller-token-v5bd8"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="pvc-protection-controller-token-rvtdq"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.storage-provisioner"} 1.574715686e+09
+kube_secret_created{namespace="kube-system",secret="coredns-token-5m6qx"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="resourcequota-controller-token-5bhlj"} 1.574715535e+09
+kube_secret_created{namespace="default",secret="istio.bookinfo-productpage"} 1.574716117e+09
+kube_secret_created{namespace="kube-system",secret="horizontal-pod-autoscaler-token-kxxcw"} 1.574715534e+09
+kube_secret_created{namespace="kube-system",secret="istio.certificate-controller"} 1.574715684e+09
+kube_secret_created{namespace="kube-system",secret="istio.replicaset-controller"} 1.574715694e+09
+kube_secret_created{namespace="default",secret="bookinfo-productpage-token-gttfp"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="disruption-controller-token-465q6"} 1.574715533e+09
+kube_secret_created{namespace="kube-system",secret="clusterrole-aggregation-controller-token-b4rpm"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.service-account-controller"} 1.574715694e+09
+kube_secret_created{namespace="kube-system",secret="istio.token-cleaner"} 1.57471569e+09
+kube_secret_created{namespace="kube-system",secret="istio.coredns"} 1.574715693e+09
+kube_secret_created{namespace="kube-system",secret="statefulset-controller-token-qp5d6"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="replication-controller-token-8lbbb"} 1.574715534e+09
+kube_secret_created{namespace="default",secret="istio.bookinfo-details"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="istio.clusterrole-aggregation-controller"} 1.574715688e+09
+kube_secret_created{namespace="default",secret="default-token-495f2"} 1.574715537e+09
+kube_secret_created{namespace="default",secret="metricbeat-kube-token-nkkhx"} 1.57487538e+09
+kube_secret_created{namespace="kube-system",secret="pv-protection-controller-token-mjc5g"} 1.574715533e+09
+kube_secret_created{namespace="kube-system",secret="istio.daemon-set-controller"} 1.574715684e+09
+kube_secret_created{namespace="kube-system",secret="deployment-controller-token-g4bxm"} 1.574715536e+09
+kube_secret_created{namespace="kube-public",secret="istio.default"} 1.574715687e+09
+kube_secret_created{namespace="kube-system",secret="node-controller-token-7rmqx"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="daemon-set-controller-token-lcvqq"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="token-cleaner-token-9jkvr"} 1.574715536e+09
+kube_secret_created{namespace="kube-system",secret="istio.pv-protection-controller"} 1.57471569e+09
+kube_secret_created{namespace="kube-system",secret="istio.deployment-controller"} 1.5747157e+09
+kube_secret_created{namespace="kube-system",secret="attachdetach-controller-token-d47s4"} 1.574715535e+09
+kube_secret_created{namespace="kube-system",secret="cronjob-controller-token-77n9l"} 1.574715533e+09
+kube_secret_created{namespace="kube-system",secret="istio.pvc-protection-controller"} 1.574715683e+09
+kube_secret_created{namespace="kube-system",secret="istio.endpoint-controller"} 1.574715698e+09
+kube_secret_created{namespace="kube-system",secret="ttl-controller-token-f8jg8"} 1.574715536e+09
+kube_secret_created{namespace="kube-system",secret="pod-garbage-collector-token-96hzm"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.persistent-volume-binder"} 1.574715694e+09
+kube_secret_created{namespace="default",secret="bookinfo-reviews-token-l4jks"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="istio.pod-garbage-collector"} 1.574715688e+09
+kube_secret_created{namespace="kube-system",secret="persistent-volume-binder-token-lstt7"} 1.574715532e+09
+kube_secret_created{namespace="kube-node-lease",secret="istio.default"} 1.574715683e+09
+kube_secret_created{namespace="kube-system",secret="kube-state-metrics-token-bltk4"} 1.574871639e+09
+kube_secret_created{namespace="kube-system",secret="default-token-96x7j"} 1.574715537e+09
+kube_secret_created{namespace="kube-system",secret="istio.cronjob-controller"} 1.574715686e+09
+kube_secret_created{namespace="kube-system",secret="istio.replication-controller"} 1.574715682e+09
+kube_secret_created{namespace="kube-system",secret="storage-provisioner-token-4wwvv"} 1.57471554e+09
+kube_secret_created{namespace="kube-system",secret="istio.generic-garbage-collector"} 1.574715684e+09
+kube_secret_created{namespace="kube-system",secret="service-account-controller-token-cvxmc"} 1.574715532e+09
+kube_secret_created{namespace="kube-system",secret="istio.bootstrap-signer"} 1.57471569e+09
+kube_secret_created{namespace="kube-system",secret="istio.horizontal-pod-autoscaler"} 1.574715699e+09
+kube_secret_created{namespace="kube-public",secret="default-token-gg74l"} 1.574715537e+09
+kube_secret_created{namespace="default",secret="bookinfo-ratings-token-zspj9"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="certificate-controller-token-78pd4"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.statefulset-controller"} 1.574715698e+09
+kube_secret_created{namespace="kube-node-lease",secret="default-token-b4sgm"} 1.574715537e+09
+kube_secret_created{namespace="kube-system",secret="job-controller-token-9hfql"} 1.574715532e+09
+kube_secret_created{namespace="kube-system",secret="istio.service-controller"} 1.574715686e+09
+kube_secret_created{namespace="default",secret="istio.bookinfo-ratings"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="service-controller-token-fm9q8"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.node-controller"} 1.574715693e+09
+kube_secret_created{namespace="default",secret="istio.default"} 1.574715696e+09
+kube_secret_created{namespace="kube-system",secret="kube-proxy-token-8tdc6"} 1.574715531e+09
+kube_secret_created{namespace="kube-system",secret="istio.kube-state-metrics"} 1.57487164e+09
+kube_secret_created{namespace="default",secret="istio.metricbeat-kube"} 1.57487538e+09
+kube_secret_created{namespace="kube-system",secret="istio.ttl-controller"} 1.574715685e+09
+kube_secret_created{namespace="kube-system",secret="istio.job-controller"} 1.574715699e+09
+kube_secret_created{namespace="kube-system",secret="replicaset-controller-token-q8crf"} 1.574715537e+09
+kube_secret_created{namespace="kube-system",secret="expand-controller-token-qpp7l"} 1.574715535e+09
+kube_secret_created{namespace="kube-system",secret="bootstrap-signer-token-rptkl"} 1.574715537e+09
+kube_secret_created{namespace="kube-system",secret="istio.attachdetach-controller"} 1.574715682e+09
+kube_secret_created{namespace="kube-system",secret="generic-garbage-collector-token-p59vw"} 1.574715534e+09
+kube_secret_created{namespace="default",secret="bookinfo-details-token-djbwj"} 1.574716116e+09
+kube_secret_created{namespace="default",secret="istio.bookinfo-reviews"} 1.574716116e+09
+kube_secret_created{namespace="kube-system",secret="istio.expand-controller"} 1.574715689e+09
+kube_secret_created{namespace="kube-system",secret="istio.default"} 1.574715685e+09
+kube_secret_created{namespace="kube-system",secret="istio.namespace-controller"} 1.574715698e+09
+# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
+# TYPE kube_secret_metadata_resource_version gauge
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.disruption-controller",resource_version="1159"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.resourcequota-controller",resource_version="1195"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="coredns-token-5m6qx",resource_version="202"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="resourcequota-controller-token-5bhlj",resource_version="290"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.bookinfo-productpage",resource_version="2010"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="endpoint-controller-token-rk744",resource_version="243"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.kube-proxy",resource_version="1191"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="namespace-controller-token-v5bd8",resource_version="203"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pvc-protection-controller-token-rvtdq",resource_version="212"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.storage-provisioner",resource_version="1146"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="horizontal-pod-autoscaler-token-kxxcw",resource_version="281"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.certificate-controller",resource_version="1132"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.replicaset-controller",resource_version="1188"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="bookinfo-productpage-token-gttfp",resource_version="1999"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="disruption-controller-token-465q6",resource_version="257"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="clusterrole-aggregation-controller-token-b4rpm",resource_version="224"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.service-account-controller",resource_version="1186"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.token-cleaner",resource_version="1161"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="default-token-495f2",resource_version="319"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="metricbeat-kube-token-nkkhx",resource_version="197528"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pv-protection-controller-token-mjc5g",resource_version="267"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.coredns",resource_version="1180"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="statefulset-controller-token-qp5d6",resource_version="233"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="replication-controller-token-8lbbb",resource_version="271"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.bookinfo-details",resource_version="1952"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.clusterrole-aggregation-controller",resource_version="1155"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.daemon-set-controller",resource_version="1127"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.pv-protection-controller",resource_version="1167"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.deployment-controller",resource_version="1227"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="deployment-controller-token-g4bxm",resource_version="293"} 1
+kube_secret_metadata_resource_version{namespace="kube-public",secret="istio.default",resource_version="1147"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="node-controller-token-7rmqx",resource_version="221"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="daemon-set-controller-token-lcvqq",resource_version="215"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="token-cleaner-token-9jkvr",resource_version="301"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="attachdetach-controller-token-d47s4",resource_version="284"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="cronjob-controller-token-77n9l",resource_version="262"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.pvc-protection-controller",resource_version="1120"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.endpoint-controller",resource_version="1221"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="ttl-controller-token-f8jg8",resource_version="296"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pod-garbage-collector-token-96hzm",resource_version="228"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.persistent-volume-binder",resource_version="1182"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="bookinfo-reviews-token-l4jks",resource_version="1954"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.pod-garbage-collector",resource_version="1158"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.replication-controller",resource_version="1108"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="persistent-volume-binder-token-lstt7",resource_version="238"} 1
+kube_secret_metadata_resource_version{namespace="kube-node-lease",secret="istio.default",resource_version="1115"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="kube-state-metrics-token-bltk4",resource_version="192909"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="default-token-96x7j",resource_version="321"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.cronjob-controller",resource_version="1145"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="storage-provisioner-token-4wwvv",resource_version="370"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.generic-garbage-collector",resource_version="1135"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="service-account-controller-token-cvxmc",resource_version="248"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.bootstrap-signer",resource_version="1165"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.horizontal-pod-autoscaler",resource_version="1223"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="job-controller-token-9hfql",resource_version="253"} 1
+kube_secret_metadata_resource_version{namespace="kube-public",secret="default-token-gg74l",resource_version="323"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="bookinfo-ratings-token-zspj9",resource_version="1929"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="certificate-controller-token-78pd4",resource_version="218"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.statefulset-controller",resource_version="1220"} 1
+kube_secret_metadata_resource_version{namespace="kube-node-lease",secret="default-token-b4sgm",resource_version="326"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.service-controller",resource_version="1142"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.bookinfo-ratings",resource_version="1961"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="service-controller-token-fm9q8",resource_version="209"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.node-controller",resource_version="1181"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.default",resource_version="1200"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="kube-proxy-token-8tdc6",resource_version="205"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.kube-state-metrics",resource_version="192915"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.metricbeat-kube",resource_version="197536"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.ttl-controller",resource_version="1136"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.job-controller",resource_version="1222"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="replicaset-controller-token-q8crf",resource_version="305"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="expand-controller-token-qpp7l",resource_version="287"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="bootstrap-signer-token-rptkl",resource_version="308"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.attachdetach-controller",resource_version="1109"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.namespace-controller",resource_version="1215"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="generic-garbage-collector-token-p59vw",resource_version="275"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="bookinfo-details-token-djbwj",resource_version="1914"} 1
+kube_secret_metadata_resource_version{namespace="default",secret="istio.bookinfo-reviews",resource_version="1997"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.expand-controller",resource_version="1160"} 1
+kube_secret_metadata_resource_version{namespace="kube-system",secret="istio.default",resource_version="1137"} 1
+# HELP kube_service_info Information about service.
+# TYPE kube_service_info gauge
+kube_service_info{namespace="default",service="kubernetes",cluster_ip="10.96.0.1",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="reviews",cluster_ip="10.100.75.221",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="kube-dns",cluster_ip="10.96.0.10",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="productpage",cluster_ip="10.104.43.66",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="ratings",cluster_ip="10.111.153.171",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="kube-state-metrics",cluster_ip="10.98.74.75",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="details",cluster_ip="10.98.67.200",external_name="",load_balancer_ip=""} 1
+# HELP kube_service_created Unix creation timestamp
+# TYPE kube_service_created gauge
+kube_service_created{namespace="default",service="kubernetes"} 1.574715527e+09
+kube_service_created{namespace="default",service="reviews"} 1.574716116e+09
+kube_service_created{namespace="kube-system",service="kube-dns"} 1.574715529e+09
+kube_service_created{namespace="default",service="productpage"} 1.574716116e+09
+kube_service_created{namespace="default",service="ratings"} 1.574716116e+09
+kube_service_created{namespace="kube-system",service="kube-state-metrics"} 1.574871639e+09
+kube_service_created{namespace="default",service="details"} 1.574716116e+09
+# HELP kube_service_spec_type Type about service.
+# TYPE kube_service_spec_type gauge
+kube_service_spec_type{namespace="kube-system",service="kube-state-metrics",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="details",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="kubernetes",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="reviews",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="kube-dns",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="productpage",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="ratings",type="ClusterIP"} 1
+# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_service_labels gauge
+kube_service_labels{namespace="default",service="ratings",label_app="ratings",label_service="ratings"} 1
+kube_service_labels{namespace="kube-system",service="kube-state-metrics",label_k8s_app="kube-state-metrics"} 1
+kube_service_labels{namespace="default",service="details",label_app="details",label_service="details"} 1
+kube_service_labels{namespace="default",service="kubernetes",label_component="apiserver",label_provider="kubernetes"} 1
+kube_service_labels{namespace="default",service="reviews",label_app="reviews",label_service="reviews"} 1
+kube_service_labels{namespace="kube-system",service="kube-dns",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS"} 1
+kube_service_labels{namespace="default",service="productpage",label_app="productpage",label_service="productpage"} 1
+# HELP kube_service_spec_external_ip Service external ips. One series for each ip
+# TYPE kube_service_spec_external_ip gauge
+# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status
+# TYPE kube_service_status_load_balancer_ingress gauge
+# HELP kube_statefulset_created Unix creation timestamp
+# TYPE kube_statefulset_created gauge
+# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas gauge
+# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_current gauge
+# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_ready gauge
+# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_updated gauge
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# TYPE kube_statefulset_status_observed_generation gauge
+# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
+# TYPE kube_statefulset_replicas gauge
+# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
+# TYPE kube_statefulset_metadata_generation gauge
+# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_statefulset_labels gauge
+# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+# TYPE kube_statefulset_status_current_revision gauge
+# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+# TYPE kube_statefulset_status_update_revision gauge
+# HELP kube_storageclass_info Information about storageclass.
+# TYPE kube_storageclass_info gauge
+kube_storageclass_info{storageclass="standard",provisioner="k8s.io/minikube-hostpath",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+# HELP kube_storageclass_created Unix creation timestamp
+# TYPE kube_storageclass_created gauge
+kube_storageclass_created{storageclass="standard"} 1.574715539e+09
+# HELP kube_storageclass_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_storageclass_labels gauge
+kube_storageclass_labels{storageclass="standard",label_addonmanager_kubernetes_io_mode="EnsureExists"} 1

--- a/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.8.plain-expected.json
+++ b/metricbeat/module/kubernetes/state_service/_meta/testdata/kube-state-metrics.1.8.plain-expected.json
@@ -1,0 +1,194 @@
+[
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "app": "ratings"
+            },
+            "namespace": "default",
+            "service": {
+                "cluster_ip": "10.111.153.171",
+                "created": "2019-11-25T21:08:36.000Z",
+                "name": "ratings",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "app": "reviews"
+            },
+            "namespace": "default",
+            "service": {
+                "cluster_ip": "10.100.75.221",
+                "created": "2019-11-25T21:08:36.000Z",
+                "name": "reviews",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "k8s_app": "kube-state-metrics"
+            },
+            "namespace": "kube-system",
+            "service": {
+                "cluster_ip": "10.98.74.75",
+                "created": "2019-11-27T16:20:39.000Z",
+                "name": "kube-state-metrics",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "app": "productpage"
+            },
+            "namespace": "default",
+            "service": {
+                "cluster_ip": "10.104.43.66",
+                "created": "2019-11-25T21:08:36.000Z",
+                "name": "productpage",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "component": "apiserver",
+                "provider": "kubernetes"
+            },
+            "namespace": "default",
+            "service": {
+                "cluster_ip": "10.96.0.1",
+                "created": "2019-11-25T20:58:47.000Z",
+                "name": "kubernetes",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "k8s_app": "kube-dns",
+                "kubernetes_io_cluster_service": "true",
+                "kubernetes_io_name": "KubeDNS"
+            },
+            "namespace": "kube-system",
+            "service": {
+                "cluster_ip": "10.96.0.10",
+                "created": "2019-11-25T20:58:49.000Z",
+                "name": "kube-dns",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.service",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "labels": {
+                "app": "details"
+            },
+            "namespace": "default",
+            "service": {
+                "cluster_ip": "10.98.67.200",
+                "created": "2019-11-25T21:08:36.000Z",
+                "name": "details",
+                "type": "ClusterIP"
+            }
+        },
+        "metricset": {
+            "name": "state_service",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    }
+]

--- a/metricbeat/module/kubernetes/state_service/state_service.go
+++ b/metricbeat/module/kubernetes/state_service/state_service.go
@@ -51,8 +51,13 @@ func NewServiceMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		prometheus:    prometheus,
 		mapping: &p.MetricsMapping{
 			Metrics: map[string]p.MetricMap{
-				"kube_service_info":                         p.InfoMetric(),
-				"kube_service_labels":                       p.ExtendedInfoMetric(p.Configuration{StoreNonMappedLabels: true, NonMappedLabelsPlacement: "labels"}),
+				"kube_service_info": p.InfoMetric(),
+				"kube_service_labels": p.ExtendedInfoMetric(
+					p.Configuration{
+						StoreNonMappedLabels:     true,
+						NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
+						MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
+					}),
 				"kube_service_created":                      p.Metric("created", p.OpUnixTimestampValue()),
 				"kube_service_spec_type":                    p.InfoMetric(),
 				"kube_service_spec_external_ip":             p.InfoMetric(),


### PR DESCRIPTION
Merging https://github.com/elastic/beats/pull/15066 included:

- setting label fields at the kubernetes module level at the event
- removing label prefixes for those that begin with `label_`

this PR brings those changes to the already merged `state_service` metricset.
The metricset is new, non released yet, there is no need for CHANGELOG nor does it breaks compatibility.