### PR TITLE
Use travis_wait to extend no output timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,9 @@ before_install:
 install: true
 
 script:
-  # Replacement for travis_wait which doesn't print output in real time.q
+  # Replacement for travis_wait which doesn't print output in real time.
+  # Default Travis timeout is 10min, so this workaround prints timestamps every 9min to reset the counter.
+  # Using seconds (540s = 9min) instead of minutes for shell compatibility reasons.
   - while sleep 540; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
   - make $TARGETS
   - kill %1

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,10 @@ before_install:
 install: true
 
 script:
-  - travis_wait 30 make $TARGETS
+  # Replacement for travis_wait which doesn't print output in real time.
+  - while sleep 9m; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
+  - make $TARGETS
+  - kill %1
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,8 +241,8 @@ before_install:
 install: true
 
 script:
-  # Replacement for travis_wait which doesn't print output in real time.
-  - while sleep 9m; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
+  # Replacement for travis_wait which doesn't print output in real time.q
+  - while sleep 540; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
   - make $TARGETS
   - kill %1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,7 @@ before_install:
 install: true
 
 script:
-  - make $TARGETS
+  - travis_wait 30 make $TARGETS
 
 notifications:
   slack:


### PR DESCRIPTION
This PR adds travis_wait function to extend the no output timeout to 30 minutes.

Issue: https://github.com/elastic/beats/issues/15201