### PR TITLE
Cherry-pick #15207 to 7.x: Enable apt retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,8 @@ jobs:
       stage: test
       addons:
         apt:
+          config:
+            retries: true
           update: true
           packages:
             - python-virtualenv
@@ -206,6 +208,8 @@ jobs:
 
 addons:
   apt:
+    config:
+      retries: true
     update: true
     packages:
       - python-virtualenv


### PR DESCRIPTION
Cherry-pick of PR #15207 to 7.x branch. Original message: 

This PR enables apt retries according to the PR https://github.com/travis-ci/travis-build/pull/1343

Issue: https://github.com/elastic/beats/issues/15206