### PR TITLE
Cherry-pick #15114 to 7.x: [Metricbeat] Run Go integration tests sequentially

### DIFF
--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -31,6 +31,8 @@ import (
 
 	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
 )
 
 func init() {
@@ -149,13 +151,6 @@ func Docs() {
 	mg.Deps(auditbeat.ModuleDocs, auditbeat.FieldDocs)
 }
 
-// IntegTest executes integration tests (it uses Docker to run the tests).
-func IntegTest() {
-	devtools.AddIntegTestUsage()
-	defer devtools.StopIntegTestEnv()
-	mg.SerialDeps(GoIntegTest, PythonIntegTest)
-}
-
 // UnitTest executes the unit tests.
 func UnitTest() {
 	mg.SerialDeps(GoUnitTest, PythonUnitTest)
@@ -169,29 +164,8 @@ func GoUnitTest(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
 
-// GoIntegTest executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoIntegTest(ctx context.Context) error {
-	mg.Deps(Fields)
-	return devtools.RunIntegTest("goIntegTest", func() error {
-		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-	})
-}
-
 // PythonUnitTest executes the python system tests.
 func PythonUnitTest() error {
 	mg.Deps(devtools.BuildSystemTestBinary)
 	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
-}
-
-// PythonIntegTest executes the python system tests in the integration environment (Docker).
-func PythonIntegTest(ctx context.Context) error {
-	if !devtools.IsInIntegTestEnv() {
-		mg.SerialDeps(Fields, Dashboards)
-	}
-	return devtools.RunIntegTest("pythonIntegTest", func() error {
-		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
-	})
 }

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -74,6 +74,22 @@ func makeGoTestArgs(name string) GoTestArgs {
 	return params
 }
 
+func makeGoTestArgsForModule(name, module string) GoTestArgs {
+	fileName := fmt.Sprintf("build/TEST-go-%s-%s", strings.Replace(strings.ToLower(name), " ", "_", -1),
+		strings.Replace(strings.ToLower(module), " ", "_", -1))
+	params := GoTestArgs{
+		TestName:        fmt.Sprintf("%s-%s", name, module),
+		Race:            RaceDetector,
+		Packages:        []string{fmt.Sprintf("./module/%s/...", module)},
+		OutputFile:      fileName + ".out",
+		JUnitReportFile: fileName + ".xml",
+	}
+	if TestCoverage {
+		params.CoverageProfileFile = fileName + ".cov"
+	}
+	return params
+}
+
 // DefaultGoTestUnitArgs returns a default set of arguments for running
 // all unit tests. We tag unit test files with '!integration'.
 func DefaultGoTestUnitArgs() GoTestArgs { return makeGoTestArgs("Unit") }
@@ -86,12 +102,53 @@ func DefaultGoTestIntegrationArgs() GoTestArgs {
 	return args
 }
 
+// GoTestIntegrationArgsForModule returns a default set of arguments for running
+// module integration tests. We tag integration test files with 'integration'.
+func GoTestIntegrationArgsForModule(module string) GoTestArgs {
+	args := makeGoTestArgsForModule("Integration", module)
+	args.Tags = append(args.Tags, "integration")
+	return args
+}
+
 // DefaultTestBinaryArgs returns the default arguments for building
 // a binary for testing.
 func DefaultTestBinaryArgs() TestBinaryArgs {
 	return TestBinaryArgs{
 		Name: BeatName,
 	}
+}
+
+// GoTestIntegrationForModule executes the Go integration tests sequentially.
+// Currently all test cases must be present under "./module" directory.
+//
+// Motivation: previous implementation executed all integration tests at once,
+// causing high CPU load, high memory usage and resulted in timeouts.
+//
+// This method executes integration tests for a single module at a time.
+// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use RACE_DETECTOR=true to enable the race detector.
+func GoTestIntegrationForModule(ctx context.Context) error {
+	return RunIntegTest("goIntegTest", func() error {
+		modulesFileInfo, err := ioutil.ReadDir("./module")
+		if err != nil {
+			return err
+		}
+
+		var failed bool
+		for _, fi := range modulesFileInfo {
+			if !fi.IsDir() {
+				continue
+			}
+			err := GoTest(ctx, GoTestIntegrationArgsForModule(fi.Name()))
+			if err != nil {
+				failed = true
+			}
+		}
+		if failed {
+			return errors.New("integration tests failed")
+		}
+		return nil
+	})
 }
 
 // GoTest invokes "go test" and reports the results to stdout. It returns an

--- a/dev-tools/mage/target/integtest/integtest.go
+++ b/dev-tools/mage/target/integtest/integtest.go
@@ -62,12 +62,7 @@ func IntegTest() {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoIntegTest(ctx context.Context) error {
-	if !devtools.IsInIntegTestEnv() {
-		mg.SerialDeps(goTestDeps...)
-	}
-	return devtools.RunIntegTest("goIntegTest", func() error {
-		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-	}, whitelistedEnvVars...)
+	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).

--- a/dev-tools/mage/target/integtest/notests/integtest.go
+++ b/dev-tools/mage/target/integtest/notests/integtest.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package notests
+
+import "fmt"
+
+// IntegTest method fallbacks to GoIntegTest()
+func IntegTest() {
+	GoIntegTest()
+}
+
+// GoIntegTest method informs that no integration tests will be executed.
+func GoIntegTest() {
+	fmt.Println(">> integTest: Complete (no tests require the integ test environment)")
+}

--- a/dev-tools/make/xpack.mk
+++ b/dev-tools/make/xpack.mk
@@ -44,7 +44,7 @@ stop-environment:
 
 .PHONY: testsuite
 testsuite: mage
-	-rm build/TEST-go-integration.out
+	rm -f build/TEST-go-integration.out
 	mage update build unitTest integTest || ( cat build/TEST-go-integration.out && false )
 
 .PHONY: update

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -196,9 +196,7 @@ func GoUnitTest(ctx context.Context) error {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoIntegTest(ctx context.Context) error {
-	return devtools.RunIntegTest("goIntegTest", func() error {
-		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-	})
+	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }
 
 // PythonUnitTest executes the python system tests.

--- a/heartbeat/magefile.go
+++ b/heartbeat/magefile.go
@@ -33,6 +33,8 @@ import (
 
 	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
 )
 
 func init() {
@@ -125,13 +127,6 @@ func Imports() error {
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// GoTestIntegration executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestIntegration(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }
 
 func customizePackaging() {

--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -33,6 +33,8 @@ import (
 
 	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
 )
 
 func init() {
@@ -117,13 +119,6 @@ func Fields() error {
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// GoTestIntegration executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestIntegration(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }
 
 // -----------------------------------------------------------------------------

--- a/libbeat/magefile.go
+++ b/libbeat/magefile.go
@@ -45,14 +45,14 @@ func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
 
-// GoTestIntegration executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestIntegration(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-}
-
 // Config generates example and reference configuration for libbeat.
 func Config() error {
 	return devtools.Config(devtools.ShortConfigType|devtools.ReferenceConfigType, devtools.ConfigFileParams{}, ".")
+}
+
+// GoIntegTest executes the Go integration tests.
+// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use RACE_DETECTOR=true to enable the race detector.
+func GoIntegTest(ctx context.Context) error {
+	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -192,9 +192,6 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 			return nil, errNoTopicsSelected
 		}
 		msg.topic = topic
-		if logp.IsDebug(debugSelector) {
-			debugf("setting event.Meta[\"topic\"] = %v", topic)
-		}
 		if _, err := data.Cache.Put("topic", topic); err != nil {
 			return nil, fmt.Errorf("setting kafka topic in publisher event failed: %v", err)
 		}

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -128,9 +128,6 @@ func (p *messagePartitioner) Partition(
 
 	msg.partition = partition
 
-	if logp.IsDebug(debugSelector) {
-		debugf("setting event.Meta[\"partition\"] = %v", partition)
-	}
 	if _, err := msg.data.Cache.Put("partition", partition); err != nil {
 		return 0, fmt.Errorf("setting kafka partition in publisher event failed: %v", err)
 	}

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -217,8 +217,6 @@ func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 	var messages [][]byte
 	assert.NoError(t, conn.Err())
 	for conn.Err() == nil {
-		t.Logf("try collect message")
-
 		switch v := psc.Receive().(type) {
 		case redis.Message:
 			messages = append(messages, v.Data)

--- a/libbeat/processors/script/javascript/session.go
+++ b/libbeat/processors/script/javascript/session.go
@@ -96,8 +96,7 @@ func newSession(p *goja.Program, conf Config, test bool) (*session, error) {
 	}
 
 	// Register modules.
-	for name, registerModule := range sessionHooks {
-		s.log.Debugf("Registering module %v with the Javascript runtime.", name)
+	for _, registerModule := range sessionHooks {
 		registerModule(s)
 	}
 

--- a/libbeat/publisher/queue/spool/spool_test.go
+++ b/libbeat/publisher/queue/spool/spool_test.go
@@ -44,6 +44,8 @@ type testLogger struct {
 	t *testing.T
 }
 
+type silentLogger struct{}
+
 func init() {
 	flag.Int64Var(&seed, "seed", time.Now().UnixNano(), "test random seed")
 	flag.BoolVar(&debug, "noisy", false, "print test logs to console")
@@ -95,7 +97,14 @@ func makeTestQueue(
 			}
 		}()
 
-		spool, err := NewSpool(&testLogger{t}, path, Settings{
+		var logger logger
+		if debug {
+			logger = &testLogger{t}
+		} else {
+			logger = new(silentLogger)
+		}
+
+		spool, err := NewSpool(logger, path, Settings{
 			WriteBuffer:       writeBuffer,
 			WriteFlushTimeout: flushTimeout,
 			Codec:             codecCBORL,
@@ -133,15 +142,18 @@ func (l *testLogger) Errorf(fmt string, vs ...interface{}) { l.reportf("Error", 
 func (l *testLogger) report(level string, vs []interface{}) {
 	args := append([]interface{}{level, ":"}, vs...)
 	l.t.Log(args...)
-	if debug {
-		fmt.Println(args...)
-	}
+	fmt.Println(args...)
 }
 
 func (l *testLogger) reportf(level string, str string, vs []interface{}) {
 	str = level + ": " + str
 	l.t.Logf(str, vs...)
-	if debug {
-		fmt.Printf(str, vs...)
-	}
+	fmt.Printf(str, vs...)
 }
+
+func (*silentLogger) Debug(vs ...interface{})              {}
+func (*silentLogger) Debugf(fmt string, vs ...interface{}) {}
+func (*silentLogger) Info(vs ...interface{})               {}
+func (*silentLogger) Infof(fmt string, vs ...interface{})  {}
+func (*silentLogger) Error(vs ...interface{})              {}
+func (*silentLogger) Errorf(fmt string, vs ...interface{}) {}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -183,12 +183,10 @@ unit: ## @testing Runs the unit tests without coverage reports.
 
 .PHONY: integration-tests
 integration-tests: ## @testing Run integration tests. Unit tests are run as part of the integration tests.
-integration-tests: prepare-tests
+integration-tests: prepare-tests mage
 	rm -f docker-compose.yml.lock
-	go test -i ${GOPACKAGES}
-	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
+	mage goIntegTest
 
-#
 .PHONY: integration-tests-environment
 integration-tests-environment:  ## @testing Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 integration-tests-environment: prepare-tests build-image

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -135,13 +135,6 @@ func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
 
-// GoTestIntegration executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestIntegration(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-}
-
 // ExportDashboard exports a dashboard and writes it into the correct directory
 //
 // Required ENV variables:
@@ -168,4 +161,11 @@ func FieldsDocs() error {
 // CollectDocs creates the documentation under docs/
 func CollectDocs() error {
 	return metricbeat.CollectDocs()
+}
+
+// GoIntegTest executes the Go integration tests.
+// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use RACE_DETECTOR=true to enable the race detector.
+func GoIntegTest(ctx context.Context) error {
+	return devtools.GoTestIntegrationForModule(ctx)
 }

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -36,6 +36,8 @@ import (
 
 	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
 )
 
 func init() {
@@ -188,11 +190,6 @@ func fieldDocs() error {
 // Dashboards collects all the dashboards and generates index patterns.
 func Dashboards() error {
 	return devtools.KibanaDashboards("protos")
-}
-
-// IntegTest executes integration tests (it uses Docker to run the tests).
-func IntegTest() {
-	fmt.Println(">> integTest: Complete (no tests require the integ test environment)")
 }
 
 // UnitTest executes the unit tests.

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -20,6 +20,8 @@ import (
 
 	// mage:import
 	"github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
 )
 
 func init() {
@@ -125,13 +127,6 @@ func Dashboards() error {
 	return devtools.KibanaDashboards(devtools.OSSBeatDir("module"), "module")
 }
 
-// IntegTest executes integration tests (it uses Docker to run the tests).
-func IntegTest() {
-	devtools.AddIntegTestUsage()
-	defer devtools.StopIntegTestEnv()
-	mg.SerialDeps(GoIntegTest, PythonIntegTest)
-}
-
 // UnitTest executes the unit tests.
 func UnitTest() {
 	mg.SerialDeps(GoUnitTest, PythonUnitTest)
@@ -144,30 +139,10 @@ func GoUnitTest(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
 
-// GoIntegTest executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoIntegTest(ctx context.Context) error {
-	return devtools.RunIntegTest("goIntegTest", func() error {
-		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-	})
-}
-
 // PythonUnitTest executes the python system tests.
 func PythonUnitTest() error {
 	mg.SerialDeps(Fields, devtools.BuildSystemTestBinary)
 	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
-}
-
-// PythonIntegTest executes the python system tests in the integration environment (Docker).
-func PythonIntegTest(ctx context.Context) error {
-	if !devtools.IsInIntegTestEnv() {
-		mg.Deps(Fields)
-	}
-	return devtools.RunIntegTest("pythonIntegTest", func() error {
-		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
-	})
 }
 
 // -----------------------------------------------------------------------------

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -19,9 +19,9 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/pkg"
 	// mage:import
-	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
-	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
 	functionbeat "github.com/elastic/beats/x-pack/functionbeat/scripts/mage"

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -13,6 +13,8 @@ import (
 
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
 )
 
 func init() {
@@ -34,13 +36,6 @@ func Fields() error {
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// GoTestIntegration executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestIntegration(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 }
 
 // Config generates example and reference configuration for libbeat.

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -130,13 +130,6 @@ func Update() {
 		devtools.GenerateModuleIncludeListGo)
 }
 
-// IntegTest executes integration tests (it uses Docker to run the tests).
-func IntegTest() {
-	devtools.AddIntegTestUsage()
-	defer devtools.StopIntegTestEnv()
-	mg.SerialDeps(GoIntegTest, PythonIntegTest)
-}
-
 // UnitTest executes the unit tests.
 func UnitTest() {
 	mg.SerialDeps(GoUnitTest, PythonUnitTest)
@@ -149,30 +142,10 @@ func GoUnitTest(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
 
-// GoIntegTest executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoIntegTest(ctx context.Context) error {
-	return devtools.RunIntegTest("goIntegTest", func() error {
-		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-	})
-}
-
 // PythonUnitTest executes the python system tests.
 func PythonUnitTest() error {
 	mg.Deps(devtools.BuildSystemTestBinary)
 	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
-}
-
-// PythonIntegTest executes the python system tests in the integration environment (Docker).
-func PythonIntegTest(ctx context.Context) error {
-	if !devtools.IsInIntegTestEnv() {
-		mg.Deps(Fields)
-	}
-	return devtools.RunIntegTest("pythonIntegTest", func() error {
-		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
-	})
 }
 
 // prepareLightModules generates light modules
@@ -245,4 +218,29 @@ func packageLightModules() error {
 		}
 	}
 	return nil
+}
+
+// IntegTest executes integration tests (it uses Docker to run the tests).
+func IntegTest() {
+	devtools.AddIntegTestUsage()
+	defer devtools.StopIntegTestEnv()
+	mg.SerialDeps(GoIntegTest, PythonIntegTest)
+}
+
+// GoIntegTest executes the Go integration tests.
+// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use RACE_DETECTOR=true to enable the race detector.
+func GoIntegTest(ctx context.Context) error {
+	return devtools.GoTestIntegrationForModule(ctx)
+}
+
+// PythonIntegTest executes the python system tests in the integration environment (Docker).
+func PythonIntegTest(ctx context.Context) error {
+	if !devtools.IsInIntegTestEnv() {
+		mg.SerialDeps(Fields, Dashboards)
+	}
+	return devtools.RunIntegTest("pythonIntegTest", func() error {
+		mg.Deps(devtools.BuildSystemTestBinary)
+		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
+	})
 }

--- a/x-pack/metricbeat/module/appsearch/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/appsearch/_meta/Dockerfile
@@ -1,2 +1,6 @@
-FROM docker.elastic.co/app-search/app-search:7.4.0
+FROM docker.elastic.co/app-search/app-search:7.5.0
+
+COPY docker-entrypoint-dependencies.sh /usr/local/bin/
+ENTRYPOINT /usr/local/bin/docker-entrypoint-dependencies.sh
+
 HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:3002/swiftype-app-version"); data = json.loads(response.read()); exit(0);'

--- a/x-pack/metricbeat/module/appsearch/_meta/docker-entrypoint-dependencies.sh
+++ b/x-pack/metricbeat/module/appsearch/_meta/docker-entrypoint-dependencies.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+until curl -f -s "http://elasticsearch:9200/_license"; do
+  echo "Elasticsearch not available yet".
+  sleep 1
+done
+
+/usr/local/bin/docker-entrypoint.sh "$@"

--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2.3'
+
+services:
+  appsearch:
+    build:
+      context: ./_meta
+    depends_on:
+      - elasticsearch
+    environment:
+      - "elasticsearch.host=http://elasticsearch:9200"
+      - "allow_es_settings_modification=true"
+      - "JAVA_OPTS=-Xms2g -Xmx2g"
+    ports:
+      - 3002
+    command: --process app-server
+
+  elasticsearch:
+    extends:
+      file: ../../../metricbeat/docker-compose.yml
+      service: elasticsearch
+    environment:
+      - "bootstrap.memory_lock=true"
+      - "action.auto_create_index=.app-search-*-logs-*,-.app-search-*,+*"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/x-pack/metricbeat/tests/system/test_appsearch.py
+++ b/x-pack/metricbeat/tests/system/test_appsearch.py
@@ -7,8 +7,7 @@ class Test(XPackTest):
     COMPOSE_SERVICES = ['appsearch']
     COMPOSE_TIMEOUT = 600
 
-    # This test timeouts in CI https://github.com/elastic/beats/issues/14057
-    @unittest.skip("temporarily disabled")
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_stats(self):
         self.render_config_template(modules=[{
             "name": "appsearch",


### PR DESCRIPTION
Cherry-pick of PR #15114 to 7.x branch. Original message: 

Ok, now this PR needs a couple of notes.

Go tests run in parallel which means that too many containers are spawned in the same time. This leads to read timeouts, build failures, flakiness, etc.
The PR adjusts test execution to verify only one module in the same time. 
Also, updated app-search module and added small waiting routine for Elasticsearch endpoint.
Verbose mode has been enabled for Go tests to allow go-junit-report properly parse and report stats (missing PASS entries).


~~This PR adds a retry loop for appsearch.~~

~~While investigating I managed to replicate some flakiness:~~

```
---- appsearch_1
Found java executable in PATH
Java version: 1.8.0_222

Running Elastic App Search in a single-process mode (process = app-server)!

WARNING: Failure to run all of the components of Elastic App Search will result in a broken service!
         This is an unsupported mode! The single-process mode should only be used in advanced
         situations when all of App Search components are deployed and scaled separately.

scripting container class loader urls: [file:/tmp/jruby1382536578408950512extract/lib/jruby-core-9.2.5.0-complete.jar, file:/tmp/jruby1382536578408950512extract/lib/jruby-rack-1.1.21.jar, file:/tmp/jruby1382536578408950512extract/lib/jruby-stdlib-9.2.5.0.jar]
setting GEM_HOME to /tmp/jruby1382536578408950512extract/gems
... and BUNDLE_GEMFILE to /tmp/jruby1382536578408950512extract/Gemfile
loading resource: /tmp/jruby1382536578408950512extract/./META-INF/rails.rb
invoking /tmp/jruby1382536578408950512extract/./META-INF/rails.rb with: [runner, LocoTogo.start_app_server!]
[2019-12-16T08:40:26.917+00:00][15][2002][app-server][ERROR]:
--------------------------------------------------------------------------------

Elasticsearch cluster must be licensed. OSS versions of Elasticsearch do not contain a supported license. Please download and run an Elasticsearch binary from https://elastic.co/downloads/elasticsearch to acquire a free, Basic license.

--------------------------------------------------------------------------------


ERROR: org.jruby.exceptions.SystemExit: (SystemExit) exit
org.jruby.exceptions.SystemExit: (SystemExit) exit
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:741)
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:704)
	at RUBY.fatal_error(/tmp/jruby1382536578408950512extract/shared_togo/lib/shared_togo.class:694)
	at RUBY.check_elasticsearch_license!(/tmp/jruby1382536578408950512extract/loco_togo/lib/loco_togo.class:64)
	at RUBY.configure!(/tmp/jruby1382536578408950512extract/shared_togo/lib/shared_togo.class:177)
	at RUBY.configure!(/tmp/jruby1382536578408950512extract/shared_togo/lib/shared_togo.class:31)
	at RUBY.<main>(/tmp/jruby1382536578408950512extract/config/application.class:24)
	at org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:1007)
	at RUBY.<main>(/tmp/jruby1382536578408950512extract/config/application.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:983)
	at RUBY.<main>(/tmp/jruby1382536578408950512extract/config/application.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:983)
	at RUBY.(root)(/tmp/jruby1382536578408950512extract/gems/gems/railties-4.2.11.1/lib/rails/commands/runner.rb:1)
	at RUBY.<main>(/tmp/jruby1382536578408950512extract/gems/gems/railties-4.2.11.1/lib/rails/commands/runner.rb:51)
	at RUBY.(root)(/tmp/jruby1382536578408950512extract/gems/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:1)
	at RUBY.<main>(/tmp/jruby1382536578408950512extract/gems/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:123)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:983)
	at tmp.jruby1382536578408950512extract.$_dot_.META_minus_INF.rails.<main>(/tmp/jruby1382536578408950512extract/./META-INF/rails.rb:7)
```