### PR TITLE
[Agent] Parse and pass correct configuration sections into corresponding components

### DIFF
--- a/x-pack/agent/pkg/agent/application/application.go
+++ b/x-pack/agent/pkg/agent/application/application.go
@@ -52,7 +52,7 @@ func createApplication(
 	switch mgmt.Mode {
 	case localMode:
 		log.Info("Agent is managed locally")
-		return newLocal(log, pathConfigFile, c.Management)
+		return newLocal(log, pathConfigFile, config)
 	case fleetMode:
 		log.Info("Agent is managed by Fleet")
 		return newManaged(log, config)

--- a/x-pack/agent/pkg/agent/application/config.go
+++ b/x-pack/agent/pkg/agent/application/config.go
@@ -72,14 +72,14 @@ type localConfig struct {
 }
 
 type localManagementConfig struct {
-	Reload    *reloadConfig       `config:"reload" yaml:"reload`
-	Path      string              `config:"path" yaml:"path`
-	Reporting *logreporter.Config `config:"reporting" yaml:"reporting`
+	Reload    *reloadConfig       `config:"reload" yaml:"reload"`
+	Path      string              `config:"path" yaml:"path"`
+	Reporting *logreporter.Config `config:"reporting" yaml:"reporting"`
 }
 
 type reloadConfig struct {
-	Enabled bool          `config:"enabled" yaml:"enabled`
-	Period  time.Duration `config:"period" yaml:"period`
+	Enabled bool          `config:"enabled" yaml:"enabled"`
+	Period  time.Duration `config:"period" yaml:"period"`
 }
 
 func (r *reloadConfig) Validate() error {

--- a/x-pack/agent/pkg/agent/application/config.go
+++ b/x-pack/agent/pkg/agent/application/config.go
@@ -68,14 +68,18 @@ func defaultManagementConfig() *ManagementConfig {
 }
 
 type localConfig struct {
-	Reload    *reloadConfig       `config:"reload"`
-	Path      string              `config:"path"`
-	Reporting *logreporter.Config `config:"reporting"`
+	Management *localManagementConfig `config:"management" yaml:"management"`
+}
+
+type localManagementConfig struct {
+	Reload    *reloadConfig       `config:"reload" yaml:"reload`
+	Path      string              `config:"path" yaml:"path`
+	Reporting *logreporter.Config `config:"reporting" yaml:"reporting`
 }
 
 type reloadConfig struct {
-	Enabled bool          `config:"enabled"`
-	Period  time.Duration `config:"period"`
+	Enabled bool          `config:"enabled" yaml:"enabled`
+	Period  time.Duration `config:"period" yaml:"period`
 }
 
 func (r *reloadConfig) Validate() error {
@@ -89,11 +93,13 @@ func (r *reloadConfig) Validate() error {
 
 func localConfigDefault() *localConfig {
 	return &localConfig{
-		Reload: &reloadConfig{
-			Enabled: true,
-			Period:  10 * time.Second,
+		Management: &localManagementConfig{
+			Reload: &reloadConfig{
+				Enabled: true,
+				Period:  10 * time.Second,
+			},
+			Reporting: logreporter.DefaultLogConfig(),
 		},
-		Reporting: logreporter.DefaultLogConfig(),
 	}
 }
 

--- a/x-pack/agent/pkg/agent/application/local_mode.go
+++ b/x-pack/agent/pkg/agent/application/local_mode.go
@@ -60,7 +60,7 @@ func newLocal(
 		return nil, errors.Wrap(err, "initialize local mode")
 	}
 
-	logR := logreporter.NewReporter(log, c.Reporting)
+	logR := logreporter.NewReporter(log, c.Management.Reporting)
 
 	reporter := reporting.NewReporter(log, agentID, logR)
 
@@ -69,16 +69,16 @@ func newLocal(
 		return nil, errors.Wrap(err, "fail to initialize pipeline router")
 	}
 
-	discover := discoverer(pathConfigFile, c.Path)
+	discover := discoverer(pathConfigFile, c.Management.Path)
 	emit := emitter(log, router, injectMonitoring)
 
 	var cfgSource source
-	if !c.Reload.Enabled {
+	if !c.Management.Reload.Enabled {
 		log.Debug("Reloading of configuration is off")
 		cfgSource = newOnce(log, discover, emit)
 	} else {
-		log.Debugf("Reloading of configuration is on, frequency is set to %s", c.Reload.Period)
-		cfgSource = newPeriodic(log, c.Reload.Period, discover, emit)
+		log.Debugf("Reloading of configuration is on, frequency is set to %s", c.Management.Reload.Period)
+		cfgSource = newPeriodic(log, c.Management.Reload.Period, discover, emit)
 	}
 
 	return &Local{


### PR DESCRIPTION
At the moments Management section is passed to local_mode.go which then tries to create operator and other components. These components needs different parts of unpassed configuration to initialize properly. 