### PR TITLE
[OSX] Set MACOSX_DEPLOYMENT_TARGET to remove linking warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - TRAVIS_GO_VERSION=$(cat .go-version)
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
+    - MACOSX_DEPLOYMENT_TARGET=10.15
 
 jobs:
   include:


### PR DESCRIPTION
This PR tries to git rid of warning:

```
ld: warning: object file (/var/folders/dt/lz9gptg91vzchq7zp5grt85h0000gn/T/go-link-168878093/000012.o) was built for newer OSX version (10.15) than being linked (10.13)
```
Sample build output with warning: https://travis-ci.org/elastic/beats/jobs/627582568?utm_medium=notification&utm_source=github_status

Issue: https://github.com/elastic/beats/issues/15203