### PR TITLE
[7.x] Allow console output to make local debugging easier (#15143)

### DIFF
--- a/x-pack/functionbeat/function/beater/functionbeat.go
+++ b/x-pack/functionbeat/function/beater/functionbeat.go
@@ -29,6 +29,7 @@ var (
 	supportedOutputs = []string{
 		"elasticsearch",
 		"logstash",
+		"console", // for local debugging
 	}
 )
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Allow console output to make local debugging easier  (#15143)