### PR TITLE
Cherry-pick #15149 to 7.x: Enable DEP (Data Execution Protection) for Windows packages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,6 +117,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `add_id` processor. {pull}14524[14524]
 - Enable TLS 1.3 in all beats. {pull}12973[12973]
 - Spooling to disk creates a lockfile on each platform. {pull}15338[15338]
+- Enable DEP (Data Execution Protection) for Windows packages. {pull}15149[15149]
 
 *Auditbeat*
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -88,6 +88,12 @@ func DefaultGolangCrossBuildArgs() BuildArgs {
 	if bp, found := BuildPlatforms.Get(Platform.Name); found {
 		args.CGO = bp.Flags.SupportsCGO()
 	}
+
+	// Enable DEP (data execution protection) for Windows binaries.
+	if Platform.GOOS == "windows" {
+		args.LDFlags = append(args.LDFlags, "-extldflags=-Wl,--nxcompat")
+	}
+
 	return args
 }
 


### PR DESCRIPTION
Cherry-pick of PR #15149 to 7.x branch. Original message: 

Add --nxcompat to the LD flags used to create the distributed binaries for Windows.
This enables Data Execution Protection for the Beat which marks data sections as
non-executable. Marking memory regions as non-executable means that code cannot be
run from that region of memory, which makes it harder for the exploitation of buffer
overruns.

You can verify DEP is enabled by checking Task Manager.

<img width="916" alt="Screen Shot 2019-12-17 at 10 22 12 AM" src="https://user-images.githubusercontent.com/4565752/71009619-86735c80-20b8-11ea-8bf1-808b35661de7.png">
