### PR TITLE
Move json encode to use jsoniter

### DIFF
--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -19,13 +19,13 @@ package kafka
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Shopify/sarama"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/input"
@@ -338,7 +338,7 @@ func (h *groupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sara
 // parseMultipleMessages will try to split the message into multiple ones based on the group field provided by the configuration
 func (h *groupHandler) parseMultipleMessages(bMessage []byte) []string {
 	var obj map[string][]interface{}
-	err := json.Unmarshal(bMessage, &obj)
+	err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(bMessage, &obj)
 	if err != nil {
 		h.log.Errorw(fmt.Sprintf("Kafka desirializing multiple messages using the group object %s", h.expandEventListFromField), "error", err)
 		return []string{}
@@ -346,7 +346,7 @@ func (h *groupHandler) parseMultipleMessages(bMessage []byte) []string {
 	var messages []string
 	if len(obj[h.expandEventListFromField]) > 0 {
 		for _, ms := range obj[h.expandEventListFromField] {
-			js, err := json.Marshal(ms)
+			js, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(ms)
 			if err == nil {
 				messages = append(messages, string(js))
 			} else {

--- a/libbeat/reader/readjson/json.go
+++ b/libbeat/reader/readjson/json.go
@@ -19,9 +19,10 @@ package readjson
 
 import (
 	"bytes"
-	gojson "encoding/json"
 	"fmt"
 	"time"
+
+	gojson "github.com/json-iterator/go"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -83,7 +84,7 @@ func (r *JSONReader) decode(text []byte) ([]byte, common.MapStr) {
 // unmarshal is equivalent with json.Unmarshal but it converts numbers
 // to int64 where possible, instead of using always float64.
 func unmarshal(text []byte, fields *map[string]interface{}) error {
-	dec := gojson.NewDecoder(bytes.NewReader(text))
+	dec := gojson.ConfigCompatibleWithStandardLibrary.NewDecoder(bytes.NewReader(text))
 	dec.UseNumber()
 	err := dec.Decode(fields)
 	if err != nil {


### PR DESCRIPTION
This PR attempts to move json encode/decode in few of the places where it is done to jsoniter. jsoniter is documented to be several times faster than std json library. It is widely used as a replacement for the same in projects like Kubernetes. 

Reference:
https://github.com/json-iterator/go#benchmark