### PR TITLE
Make cloud.id work for monitoring Elasticsearch reporter

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Running `setup` cmd respects `setup.ilm.overwrite` setting for improved support of custom policies. {pull}14741[14741]
 - Libbeat: Do not overwrite agent.*, ecs.version, and host.name. {pull}14407[14407]
 - Libbeat: Cleanup the x-pack licenser code to use the new license endpoint and the new format. {pull}15091[15091]
+- Users can now specify `monitoring.cloud.*` to override `monitoring.elasticsearch.*` settings. {issue}14399[14399] {pull}15254[15254]
 
 *Auditbeat*
 

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -33,6 +33,110 @@ import (
 
 const defaultCloudPort = "443"
 
+type CloudID struct {
+	id     string
+	esURL  string
+	kibURL string
+
+	auth     string
+	username string
+	password string
+}
+
+func NewCloudID(cloudID string, cloudAuth string) (*CloudID, error) {
+	cid := CloudID{
+		id:   cloudID,
+		auth: cloudAuth,
+	}
+
+	if err := cid.decode(); err != nil {
+		return nil, err
+	}
+
+	return &cid, nil
+}
+
+func (c *CloudID) ElasticsearchURL() string {
+	return c.esURL
+}
+
+func (c *CloudID) KibanaURL() string {
+	return c.kibURL
+}
+
+func (c *CloudID) Username() string {
+	return c.username
+}
+
+func (c *CloudID) Password() string {
+	return c.password
+}
+
+func (c *CloudID) decode() error {
+	var err error
+	if err = c.decodeCloudID(); err != nil {
+		return err
+	}
+
+	if c.auth != "" {
+		if err = c.decodeCloudAuth(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// decodeCloudID decodes the c.id into c.esURL and c.kibURL
+func (c *CloudID) decodeCloudID() error {
+	cloudID := c.id
+
+	// 1. Ignore anything before `:`.
+	idx := strings.LastIndex(cloudID, ":")
+	if idx >= 0 {
+		cloudID = cloudID[idx+1:]
+	}
+
+	// 2. base64 decode
+	decoded, err := base64.StdEncoding.DecodeString(cloudID)
+	if err != nil {
+		return errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
+	}
+
+	// 3. separate based on `$`
+	words := strings.Split(string(decoded), "$")
+	if len(words) < 3 {
+		return errors.Errorf("Expected at least 3 parts in %s", string(decoded))
+	}
+
+	// 4. extract port from the ES and Kibana host, or use 443 as the default
+	host, port := extractPortFromName(words[0], defaultCloudPort)
+	esID, esPort := extractPortFromName(words[1], port)
+	kbID, kbPort := extractPortFromName(words[2], port)
+
+	// 5. form the URLs
+	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
+	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
+
+	c.esURL = esURL.String()
+	c.kibURL = kibanaURL.String()
+
+	return nil
+}
+
+// decodeCloudAuth splits the c.auth into c.username and c.password.
+func (c *CloudID) decodeCloudAuth() error {
+	cloudAuth := c.auth
+	idx := strings.Index(cloudAuth, ":")
+	if idx < 0 {
+		return errors.New("cloud.auth setting doesn't contain `:` to split between username and password")
+	}
+
+	c.username = cloudAuth[0:idx]
+	c.password = cloudAuth[idx+1:]
+	return nil
+}
+
 // OverwriteSettings modifies the received config object by overwriting the
 // output.elasticsearch.hosts, output.elasticsearch.username, output.elasticsearch.password,
 // setup.kibana.host settings based on values derived from the cloud.id and cloud.auth
@@ -53,14 +157,14 @@ func OverwriteSettings(cfg *common.Config) error {
 	}
 
 	// cloudID overwrites
-	esURL, kibanaURL, err := DecodeCloudID(cloudID)
+	cid, err := NewCloudID(cloudID, cloudAuth)
 	if err != nil {
 		return errors.Errorf("Error decoding cloud.id: %v", err)
 	}
 
-	logp.Info("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", esURL, kibanaURL)
+	logp.Info("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", cid.esURL, cid.kibURL)
 
-	esURLConfig, err := common.NewConfigFrom([]string{esURL})
+	esURLConfig, err := common.NewConfigFrom([]string{cid.ElasticsearchURL()})
 	if err != nil {
 		return err
 	}
@@ -81,24 +185,19 @@ func OverwriteSettings(cfg *common.Config) error {
 		return err
 	}
 
-	err = cfg.SetString("setup.kibana.host", -1, kibanaURL)
+	err = cfg.SetString("setup.kibana.host", -1, cid.KibanaURL())
 	if err != nil {
 		return err
 	}
 
 	if cloudAuth != "" {
 		// cloudAuth overwrites
-		username, password, err := DecodeCloudAuth(cloudAuth)
+		err = cfg.SetString("output.elasticsearch.username", -1, cid.Username())
 		if err != nil {
 			return err
 		}
 
-		err = cfg.SetString("output.elasticsearch.username", -1, username)
-		if err != nil {
-			return err
-		}
-
-		err = cfg.SetString("output.elasticsearch.password", -1, password)
+		err = cfg.SetString("output.elasticsearch.password", -1, cid.Password())
 		if err != nil {
 			return err
 		}
@@ -115,48 +214,4 @@ func extractPortFromName(word string, defaultPort string) (id, port string) {
 		return word[:idx], word[idx+1:]
 	}
 	return word, defaultPort
-}
-
-// DecodeCloudID decodes the cloud.id into elasticsearch-URL and kibana-URL
-func DecodeCloudID(cloudID string) (string, string, error) {
-
-	// 1. Ignore anything before `:`.
-	idx := strings.LastIndex(cloudID, ":")
-	if idx >= 0 {
-		cloudID = cloudID[idx+1:]
-	}
-
-	// 2. base64 decode
-	decoded, err := base64.StdEncoding.DecodeString(cloudID)
-	if err != nil {
-		return "", "", errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
-	}
-
-	// 3. separate based on `$`
-	words := strings.Split(string(decoded), "$")
-	if len(words) < 3 {
-		return "", "", errors.Errorf("Expected at least 3 parts in %s", string(decoded))
-	}
-
-	// 4. extract port from the ES and Kibana host, or use 443 as the default
-	host, port := extractPortFromName(words[0], defaultCloudPort)
-	esID, esPort := extractPortFromName(words[1], port)
-	kbID, kbPort := extractPortFromName(words[2], port)
-
-	// 5. form the URLs
-	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
-	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
-
-	return esURL.String(), kibanaURL.String(), nil
-}
-
-// DecodeCloudAuth splits the cloud.auth into username and password.
-func DecodeCloudAuth(cloudAuth string) (string, string, error) {
-
-	idx := strings.Index(cloudAuth, ":")
-	if idx < 0 {
-		return "", "", errors.New("cloud.auth setting doesn't contain `:` to split between username and password")
-	}
-
-	return cloudAuth[0:idx], cloudAuth[idx+1:], nil
 }

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -81,12 +81,12 @@ func (c *CloudID) Password() string {
 func (c *CloudID) decode() error {
 	var err error
 	if err = c.decodeCloudID(); err != nil {
-		return err
+		return errors.Wrapf(err, "invalid cloud id '%v'", c.id)
 	}
 
 	if c.auth != "" {
 		if err = c.decodeCloudAuth(); err != nil {
-			return err
+			return errors.Wrap(err, "invalid cloud auth")
 		}
 	}
 

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -53,7 +53,7 @@ func OverwriteSettings(cfg *common.Config) error {
 	}
 
 	// cloudID overwrites
-	esURL, kibanaURL, err := decodeCloudID(cloudID)
+	esURL, kibanaURL, err := DecodeCloudID(cloudID)
 	if err != nil {
 		return errors.Errorf("Error decoding cloud.id: %v", err)
 	}
@@ -88,7 +88,7 @@ func OverwriteSettings(cfg *common.Config) error {
 
 	if cloudAuth != "" {
 		// cloudAuth overwrites
-		username, password, err := decodeCloudAuth(cloudAuth)
+		username, password, err := DecodeCloudAuth(cloudAuth)
 		if err != nil {
 			return err
 		}
@@ -117,8 +117,8 @@ func extractPortFromName(word string, defaultPort string) (id, port string) {
 	return word, defaultPort
 }
 
-// decodeCloudID decodes the cloud.id into elasticsearch-URL and kibana-URL
-func decodeCloudID(cloudID string) (string, string, error) {
+// DecodeCloudID decodes the cloud.id into elasticsearch-URL and kibana-URL
+func DecodeCloudID(cloudID string) (string, string, error) {
 
 	// 1. Ignore anything before `:`.
 	idx := strings.LastIndex(cloudID, ":")
@@ -150,8 +150,8 @@ func decodeCloudID(cloudID string) (string, string, error) {
 	return esURL.String(), kibanaURL.String(), nil
 }
 
-// decodeCloudAuth splits the cloud.auth into username and password.
-func decodeCloudAuth(cloudAuth string) (string, string, error) {
+// DecodeCloudAuth splits the cloud.auth into username and password.
+func DecodeCloudAuth(cloudAuth string) (string, string, error) {
 
 	idx := strings.Index(cloudAuth, ":")
 	if idx < 0 {

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -33,6 +33,7 @@ import (
 
 const defaultCloudPort = "443"
 
+// CloudID encapsulates the encoded (i.e. raw) and decoded parts of Elastic Cloud ID.
 type CloudID struct {
 	id     string
 	esURL  string
@@ -43,6 +44,7 @@ type CloudID struct {
 	password string
 }
 
+// NewCloudID constructs a new CloudID object by decoding the given cloud ID and cloud auth.
 func NewCloudID(cloudID string, cloudAuth string) (*CloudID, error) {
 	cid := CloudID{
 		id:   cloudID,
@@ -56,18 +58,22 @@ func NewCloudID(cloudID string, cloudAuth string) (*CloudID, error) {
 	return &cid, nil
 }
 
+// ElasticsearchURL returns the Elasticsearch URL decoded from the cloud ID.
 func (c *CloudID) ElasticsearchURL() string {
 	return c.esURL
 }
 
+// KibanaURL returns the Kibana URL decoded from the cloud ID.
 func (c *CloudID) KibanaURL() string {
 	return c.kibURL
 }
 
+// Username returns the username decoded from the cloud auth.
 func (c *CloudID) Username() string {
 	return c.username
 }
 
+// Password returns the password decoded from the cloud auth.
 func (c *CloudID) Password() string {
 	return c.password
 }

--- a/libbeat/cloudid/cloudid_test.go
+++ b/libbeat/cloudid/cloudid_test.go
@@ -82,8 +82,8 @@ func TestDecode(t *testing.T) {
 		cid, err := NewCloudID(test.cloudID, "")
 		assert.NoError(t, err, test.cloudID)
 
-		assert.Equal(t, cid.esURL, test.expectedEsURL, test.cloudID)
-		assert.Equal(t, cid.kibURL, test.expectedKibanaURL, test.cloudID)
+		assert.Equal(t, cid.ElasticsearchURL(), test.expectedEsURL, test.cloudID)
+		assert.Equal(t, cid.KibanaURL(), test.expectedKibanaURL, test.cloudID)
 	}
 }
 

--- a/libbeat/cloudid/cloudid_test.go
+++ b/libbeat/cloudid/cloudid_test.go
@@ -79,7 +79,7 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		esURL, kbURL, err := decodeCloudID(test.cloudID)
+		esURL, kbURL, err := DecodeCloudID(test.cloudID)
 		assert.NoError(t, err, test.cloudID)
 
 		assert.Equal(t, esURL, test.expectedEsURL, test.cloudID)
@@ -103,7 +103,7 @@ func TestDecodeError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, _, err := decodeCloudID(test.cloudID)
+		_, _, err := DecodeCloudID(test.cloudID)
 		assert.Error(t, err, test.cloudID)
 		assert.Contains(t, err.Error(), test.errorMsg, test.cloudID)
 	}

--- a/libbeat/cloudid/cloudid_test.go
+++ b/libbeat/cloudid/cloudid_test.go
@@ -79,11 +79,11 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		esURL, kbURL, err := DecodeCloudID(test.cloudID)
+		cid, err := NewCloudID(test.cloudID, "")
 		assert.NoError(t, err, test.cloudID)
 
-		assert.Equal(t, esURL, test.expectedEsURL, test.cloudID)
-		assert.Equal(t, kbURL, test.expectedKibanaURL, test.cloudID)
+		assert.Equal(t, cid.esURL, test.expectedEsURL, test.cloudID)
+		assert.Equal(t, cid.kibURL, test.expectedKibanaURL, test.cloudID)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestDecodeError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, _, err := DecodeCloudID(test.cloudID)
+		_, err := NewCloudID(test.cloudID, "")
 		assert.Error(t, err, test.cloudID)
 		assert.Contains(t, err.Error(), test.errorMsg, test.cloudID)
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -889,6 +889,11 @@ func (b *Beat) setupMonitoring(settings Settings) (report.Reporter, error) {
 	}
 
 	if monitoring.IsEnabled(monitoringCfg) {
+		err := monitoring.OverrideWithCloudSettings(monitoringCfg)
+		if err != nil {
+			return nil, err
+		}
+
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 			Format:          reporterSettings.Format,

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -48,6 +48,18 @@ monitoring:
 --------------------
 <1> Specify one of `api_key` or `username`/`password`.
 +
+If you want to send monitoring events to an https://cloud.elastic.co/[{ecloud}]
+monitoring cluster, you can use two simpler settings. When defined, these settings
+overwrite settings from other parts in the configuration. For example:
++
+[source,yaml]
+--------------------
+monitoring:
+  enabled: true
+  cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+  cloud.auth: "elastic:{pwd}"
+--------------------
++
 If you
 ifndef::no-output-logstash[]
 configured a different output, such as {ls} or you

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -56,8 +56,8 @@ overwrite settings from other parts in the configuration. For example:
 --------------------
 monitoring:
   enabled: true
-  cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-  cloud.auth: "elastic:{pwd}"
+  cloud.id: 'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=='
+  cloud.auth: 'elastic:{pwd}'
 --------------------
 +
 If you

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -1,0 +1,1 @@
+package monitoring

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -60,14 +60,14 @@ func OverrideWithCloudSettings(monitoringCfg *common.Config) error {
 		return ErrCloudCfg{err}
 	}
 
+	if config.Cloud.Auth != "" && config.Cloud.ID == "" {
+		return ErrCloudCfgIncomplete
+	}
+
 	// We remove monitoring.cloud.* so that "cloud" is not treated as a type of
 	// monitoring reporter later.
 	if _, err := monitoringCfg.Remove("cloud", -1); err != nil {
 		return ErrCloudCfg{err}
-	}
-
-	if config.Cloud.Auth != "" && config.Cloud.ID == "" {
-		return ErrCloudCfgIncomplete
 	}
 
 	if err := overwriteWithCloudID(config, monitoringCfg); err != nil {

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -38,12 +38,12 @@ type ErrCloudCfg struct {
 	cause error
 }
 
-// (ErrCloudCfg).Error returns the error as a string.
+// Error returns the error as a string.
 func (e ErrCloudCfg) Error() string {
 	return fmt.Sprintf("error using monitoring.cloud.* settings: %v", e.cause)
 }
 
-// (ErrCloudCfg).Unwrap returns the underlying cause of the error.
+// Unwrap returns the underlying cause of the error.
 func (e ErrCloudCfg) Unwrap() error {
 	return e.cause
 }

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -20,9 +20,9 @@ package monitoring
 import (
 	"errors"
 
-	"github.com/elastic/beats/libbeat/cloudid"
 	errw "github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/cloudid"
 	"github.com/elastic/beats/libbeat/common"
 )
 

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -1,1 +1,116 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package monitoring
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/cloudid"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type cloudConfig struct {
+	Cloud struct {
+		ID   string `config:"id"`
+		Auth string `config:"auth"`
+	} `config:"cloud"`
+}
+
+type ErrCloudCfg struct{ cause error }
+
+func (e ErrCloudCfg) Error() string {
+	return fmt.Sprintf("error using monitoring.cloud.* settings: %v", e.cause)
+}
+
+func (e ErrCloudCfg) Unwrap() error {
+	return e.cause
+}
+
+var ErrCloudCfgIncomplete = ErrCloudCfg{errors.New("monitoring.cloud.auth specified but monitoring.cloud.id is empty. Please specify both.")}
+
+func OverrideWithCloudSettings(monitoringCfg *common.Config) error {
+	var config cloudConfig
+	if err := monitoringCfg.Unpack(&config); err != nil {
+		return ErrCloudCfg{err}
+	}
+	if _, err := monitoringCfg.Remove("cloud", -1); err != nil {
+		return ErrCloudCfg{err}
+	}
+
+	if config.Cloud.Auth != "" && config.Cloud.ID == "" {
+		return ErrCloudCfgIncomplete
+
+	}
+
+	if err := overwriteWithCloudID(config, monitoringCfg); err != nil {
+		return ErrCloudCfg{err}
+	}
+
+	if err := overwriteWithCloudAuth(config, monitoringCfg); err != nil {
+		return ErrCloudCfg{err}
+	}
+
+	return nil
+}
+
+func overwriteWithCloudID(config cloudConfig, monitoringCfg *common.Config) error {
+	if config.Cloud.ID == "" {
+		// Nothing to do
+		return nil
+	}
+
+	esURL, _, err := cloudid.DecodeCloudID(config.Cloud.ID)
+	if err != nil {
+		return err
+	}
+
+	esURLConfig, err := common.NewConfigFrom([]string{esURL})
+	if err != nil {
+		return err
+	}
+
+	if err := monitoringCfg.SetChild("elasticsearch.hosts", -1, esURLConfig); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func overwriteWithCloudAuth(config cloudConfig, monitoringCfg *common.Config) error {
+	if config.Cloud.Auth == "" {
+		// Nothing to do
+		return nil
+	}
+
+	username, password, err := cloudid.DecodeCloudAuth(config.Cloud.Auth)
+	if err != nil {
+		return err
+	}
+
+	if err := monitoringCfg.SetString("elasticsearch.username", -1, username); err != nil {
+		return err
+	}
+
+	if err := monitoringCfg.SetString("elasticsearch.password", -1, password); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -50,13 +50,15 @@ func OverrideWithCloudSettings(monitoringCfg *common.Config) error {
 	if err := monitoringCfg.Unpack(&config); err != nil {
 		return ErrCloudCfg{err}
 	}
+
+	// We remove monitoring.cloud.* so that "cloud" is not treated as a type of
+	// monitoring reporter later.
 	if _, err := monitoringCfg.Remove("cloud", -1); err != nil {
 		return ErrCloudCfg{err}
 	}
 
 	if config.Cloud.Auth != "" && config.Cloud.ID == "" {
 		return ErrCloudCfgIncomplete
-
 	}
 
 	if err := overwriteWithCloudID(config, monitoringCfg); err != nil {

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -33,8 +33,7 @@ type cloudConfig struct {
 	} `config:"cloud"`
 }
 
-// ErrCloudConfig represents an error when trying to use monitoring.cloud.*
-// settings.
+// ErrCloudCfg represents an error when trying to use monitoring.cloud.* settings.
 type ErrCloudCfg struct {
 	cause error
 }

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -33,18 +33,28 @@ type cloudConfig struct {
 	} `config:"cloud"`
 }
 
-type ErrCloudCfg struct{ cause error }
+// ErrCloudConfig represents an error when trying to use monitoring.cloud.*
+// settings.
+type ErrCloudCfg struct {
+	cause error
+}
 
+// (ErrCloudCfg).Error returns the error as a string.
 func (e ErrCloudCfg) Error() string {
 	return fmt.Sprintf("error using monitoring.cloud.* settings: %v", e.cause)
 }
 
+// (ErrCloudCfg).Unwrap returns the underlying cause of the error.
 func (e ErrCloudCfg) Unwrap() error {
 	return e.cause
 }
 
-var ErrCloudCfgIncomplete = ErrCloudCfg{errors.New("monitoring.cloud.auth specified but monitoring.cloud.id is empty. Please specify both.")}
+// ErrCloudCfgIncomplete is an error indicating that monitoring.cloud.auth has
+// been specified but monitoring.cloud.id has not.
+var ErrCloudCfgIncomplete = ErrCloudCfg{errors.New("monitoring.cloud.auth specified but monitoring.cloud.id is empty. Please specify both")}
 
+// OverrideWithCloudSettings overrides monitoring.elasticsearch.* with
+// monitoring.cloud.* if the latter are set.
 func OverrideWithCloudSettings(monitoringCfg *common.Config) error {
 	var config cloudConfig
 	if err := monitoringCfg.Unpack(&config); err != nil {

--- a/libbeat/monitoring/cloudid_test.go
+++ b/libbeat/monitoring/cloudid_test.go
@@ -1,0 +1,1 @@
+package monitoring

--- a/libbeat/monitoring/cloudid_test.go
+++ b/libbeat/monitoring/cloudid_test.go
@@ -20,6 +20,8 @@ package monitoring
 import (
 	"testing"
 
+	errw "github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -84,7 +86,7 @@ func TestOverrideWithCloudSettings(t *testing.T) {
 				"cloud.auth": "elastic:changeme",
 			},
 			func(t assert.TestingT, err error, _ ...interface{}) bool {
-				return assert.EqualError(t, ErrCloudCfgIncomplete, err.Error())
+				return assert.EqualError(t, errCloudCfgIncomplete, errw.Cause(err).Error())
 			},
 		}}
 

--- a/libbeat/monitoring/cloudid_test.go
+++ b/libbeat/monitoring/cloudid_test.go
@@ -1,1 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package monitoring
+
+// TODO: test if monitoring.cloud.id is set but no monitoring.elasticsearch.* is set
+// - test that monitoring.elasticsearch.hosts is set
+// - test that monitoring.cloud is removed
+
+// TODO: test if monitoring.cloud.id is set and monitoring.elasticsearch.* is set
+// - test that monitoring.elasticsearch.hosts is overridden
+// - test that monitoring.cloud is removed
+
+// TODO: test if monitoring.cloud.auth is set but no monitoring.cloud.id is set
+// - test that error is returned
+// - test that monitoring.cloud is removed


### PR DESCRIPTION
Resolves #14399.

This PR allows users to specify two new optional settings:
- `monitoring.cloud.id`. If specified, it's value will be decoded and used to override `monitoring.elasticsearch.hosts`.
- `monitoring.cloud.auth`. If specified, it's value will be decoded and used to override `monitoring.elasticsearch.username` and `monitoring.elasticsearch.password`.

### Before this PR
The `monitoring.elasticsearch.*` settings were determined using the following precedence order:

* Is `monitoring.elasticsearch.*` set?
   * Yes: `monitoring.elasticsearch.*` will be used.
   * No:
      * Is `cloud.*` set?
         * Yes: `cloud.*` will be decoded and used to set `elasticsearch.*` and `monitoring.elasticsearch.*`.
         * No: 
            * Is `elasticsearch.*` set?
               * Yes: It will be used to set `monitoring.elasticsearch.*`.
               * No: No `monitoring.elasticsearch.*` will be set.

### After this PR
The `monitoring.elasticsearch.*` settings will be determined using the following precedence order (new settings and related precedence rules are **bolded**):

* **Is `monitoring.cloud.*` set?**
   * **Yes: `monitoring.cloud.*` will be decoded and used to override `monitoring.elasticsearch.*`.**
   * **No:**
      * Is `monitoring.elasticsearch.*` set?
         * Yes: `monitoring.elasticsearch.*` will be used.
         * No:
            * Is `cloud.*` set?
               * Yes: `cloud.*` will be decoded and used to set `elasticsearch.*` and `monitoring.elasticsearch.*`.
               * No: 
                  * Is `elasticsearch.*` set?
                     * Yes: It will be used to set `monitoring.elasticsearch.*`.
                     * No: No `monitoring.elasticsearch.*` will be set.

### Important Note

The enhancement introduced by this PR has no impact on the deprecated `xpack.monitoring.*` settings. That is, even with this PR, users won't be able to set `xpack.monitoring.cloud.*` nor will setting `monitoring.cloud.*` cause `xpack.monitoring.elasticsearch.*` to be set or overridden. 

### Testing this PR

1. Create a deployment on [cloud.elastic.co](https://cloud.elastic.co/).
2. Grab the values for `cloud.id` and `cloud.auth` from your deployment.
3. Build a Beat, say Filebeat, with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/filebeat
   mage build
   ```
4. Configure your beat with the following monitoring settings:
   ```yml
   monitoring:
     enabled: true
     cloud:
       id: YOUR_CLOUD_ID
       auth: YOUR_CLOUD_AUTH
   ```
5. Make any other necessary configuration for the Beat to ingest some data.
6. Start the Beat.
7. Verify in your Cloud deployment's ES cluster that there's `.monitoring-beats-*` indices and documents in those indices.