### PR TITLE
overwrite inherited org.label-schema labels

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -5,8 +5,10 @@
 FROM {{ .from }}
 
 LABEL \
+  org.label-schema.build-date="{{ date }}" \
   org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="{{ .BeatVendor }}" \
+  org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
   org.label-schema.version="{{ beat_version }}" \
   org.label-schema.url="{{ .BeatURL }}" \


### PR DESCRIPTION
When applied to apm-server packaging:

Default dist:
```
"Created": "2019-12-26T15:41:24.8775149Z",
"ContainerConfig": {
  "Labels": {
    "description": "Elastic APM Server",
    "license": "Elastic License",
    "org.label-schema.build-date": "2019-12-26T15:34:28Z",
    "org.label-schema.license": "Elastic License",
    "org.label-schema.name": "apm-server",
    "org.label-schema.schema-version": "1.0",
    "org.label-schema.url": "https://www.elastic.co/products/apm",
    "org.label-schema.vcs-ref": "da3a126540ce3bf618ea4cca626820f330a1e646",
    "org.label-schema.vcs-url": "github.com/elastic/apm-server",
    "org.label-schema.vendor": "Elastic",
    "org.label-schema.version": "8.0.0"
  }
}
```

OSS dist:
```
"Created": "2019-12-26T15:41:25.760535Z",
"ContainerConfig": {
  "Labels": {
    "description": "Elastic APM Server",
    "license": "ASL 2.0",
    "org.label-schema.build-date": "2019-12-26T15:34:28Z",
    "org.label-schema.license": "ASL 2.0",
    "org.label-schema.name": "apm-server",
    "org.label-schema.schema-version": "1.0",
    "org.label-schema.url": "https://www.elastic.co/products/apm",
    "org.label-schema.vcs-ref": "da3a126540ce3bf618ea4cca626820f330a1e646",
    "org.label-schema.vcs-url": "github.com/elastic/apm-server",
    "org.label-schema.vendor": "Elastic",
    "org.label-schema.version": "8.0.0"
  }
}
```

Elasticsearch uses `Apache-2.0`.

The build date doesn't match the output from the version subcommand exactly, in this case:
```
$ docker run --rm docker.elastic.co/apm/apm-server-oss:8.0.0-SNAPSHOT version
apm-server version 8.0.0 (amd64), libbeat 8.0.0 [da3a126540ce3bf618ea4cca626820f330a1e646 built 2019-12-26 15:35:09 +0000 UTC]
```
but I think it's ok that this value is the build date of the image itself.

closes elastic/apm-server#3090