### PR TITLE
Move HTTP calls to Kibana from New() to Fetch()

### DIFF
--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -67,60 +67,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	statsHTTP, err := helper.NewHTTP(base)
-	if err != nil {
-		return nil, err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(statsHTTP, statsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	if !isStatsAPIAvailable {
-		const errorMsg = "The %v metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, base.FullyQualifiedName(), kibana.StatsAPIAvailableVersion, kibanaVersion)
-	}
-
-	if ms.XPackEnabled {
-		// Use legacy API response so we can passthru usage as-is
-		statsHTTP.SetURI(statsHTTP.GetURI() + "&legacy=true")
-	}
-
-	var settingsHTTP *helper.HTTP
-	if ms.XPackEnabled {
-		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		if !isSettingsAPIAvailable {
-			const errorMsg = "The %v metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
-			return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), kibana.SettingsAPIAvailableVersion, kibanaVersion)
-		}
-
-		settingsHTTP, err = helper.NewHTTP(base)
-		if err != nil {
-			return nil, err
-		}
-
-		// HACK! We need to do this because there might be a basepath involved, so we
-		// only search/replace the actual API paths
-		settingsURI := strings.Replace(statsHTTP.GetURI(), statsPath, settingsPath, 1)
-		settingsHTTP.SetURI(settingsURI)
-	}
-
 	return &MetricSet{
-		ms,
-		statsHTTP,
-		settingsHTTP,
-		time.Time{},
-		kibana.IsUsageExcludable(kibanaVersion),
+		MetricSet: ms,
 	}, nil
 }
 
@@ -128,9 +76,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
+	err := m.init()
+	if err != nil {
+		return err
+	}
+
 	now := time.Now()
 
-	err := m.fetchStats(r, now)
+	err = m.fetchStats(r, now)
 	if err != nil {
 		if m.XPackEnabled {
 			m.Logger().Error(err)
@@ -142,6 +95,54 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	if m.XPackEnabled {
 		m.fetchSettings(r, now)
 	}
+
+	return nil
+}
+
+func (m *MetricSet) init() error {
+	statsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
+	if err != nil {
+		return err
+	}
+
+	kibanaVersion, err := kibana.GetVersion(statsHTTP, statsPath)
+	if err != nil {
+		return err
+	}
+
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
+	if !isStatsAPIAvailable {
+		const errorMsg = "the %v metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.StatsAPIAvailableVersion, kibanaVersion)
+	}
+	if m.XPackEnabled {
+		// Use legacy API response so we can passthru usage as-is
+		statsHTTP.SetURI(statsHTTP.GetURI() + "&legacy=true")
+	}
+
+	var settingsHTTP *helper.HTTP
+	if m.XPackEnabled {
+		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
+		if !isSettingsAPIAvailable {
+			const errorMsg = "the %v metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
+			return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.SettingsAPIAvailableVersion, kibanaVersion)
+		}
+
+		settingsHTTP, err = helper.NewHTTP(m.BaseMetricSet)
+		if err != nil {
+			return err
+		}
+
+		// HACK! We need to do this because there might be a basepath involved, so we
+		// only search/replace the actual API paths
+		settingsURI := strings.Replace(statsHTTP.GetURI(), statsPath, settingsPath, 1)
+		settingsHTTP.SetURI(settingsURI)
+	}
+
+	m.statsHTTP = statsHTTP
+	m.settingsHTTP = settingsHTTP
+	m.isUsageExcludable = kibana.IsUsageExcludable(kibanaVersion)
+	m.usageLastCollectedOn = time.Time{}
 
 	return nil
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -146,7 +146,6 @@ func (m *MetricSet) init() error {
 	m.statsHTTP = statsHTTP
 	m.settingsHTTP = settingsHTTP
 	m.isUsageExcludable = kibana.IsUsageExcludable(kibanaVersion)
-	m.usageLastCollectedOn = time.Time{}
 
 	return nil
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -78,6 +78,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	err := m.init()
 	if err != nil {
+		if m.XPackEnabled {
+			m.Logger().Error(err)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Resolves #15258.

This PR makes the `kibana/stats` metricset resilient to Kibana's unavailability. 

Before this PR, if Kibana was not already running when Metricbeat was started up with the `kibana-xpack` module enabled, Metricbeat would immediately exit with an error since Kibana was unreachable. 

With this PR, Metricbeat will keep running and retrying to reach Kibana periodically. This also allows Kibana to go away temporarily (say, for an upgrade) and keeps Metricbeat running.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the `kibana-xpack` module.
   ```
   ./metricbeat modules enable kibana-xpack
   ```

3. Start up Metricbeat (**without** starting up Kibana).
   ```
   ./metricbeat -e
   ```

4. Note that there are errors in the Metricbeat log about it not being able to connect to Kibana's stats API. But also ensure that Metricbeat keeps running.

5. Start up Kibana.

6. Check the Metricbeat log again. Ensure that eventually (< 1 minute), the connection errors go away. You may see 503 errors now; this is expected when Kibana is starting up. Ensure that eventually (< 2 minutes), the 503 errors go away as well.

7. Ensure that a `.monitoring-kibana-*-mb-*` index for today's date exists. Ensure that it contains recent (`timestamp` within last 20 seconds) documents of `type:kibana_stats`.

8. Stop Kibana.

9. Repeat steps 4-7.