### PR TITLE
[6.8] Move HTTP calls to Kibana from New() to Fetch() (#15270)

### DIFF
--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -68,46 +68,74 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	statsHTTP, err := helper.NewHTTP(base)
+	return &MetricSet{
+		MetricSet: ms,
+	}, nil
+}
+
+// Fetch methods implements the data gathering and data conversion to the right format
+// It returns the event which is then forward to the output. In case of an error, a
+// descriptive error must be returned.
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
+	err := m.init()
 	if err != nil {
-		return nil, err
+		if m.XPackEnabled {
+			m.Logger().Error(err)
+			return nil
+		}
+		return err
+	}
+
+	now := time.Now()
+
+	err = m.fetchStats(r, now)
+	if err != nil {
+		if m.XPackEnabled {
+			m.Logger().Error(err)
+			return nil
+		}
+		return err
+	}
+
+	if m.XPackEnabled {
+		m.fetchSettings(r, now)
+	}
+
+	return nil
+}
+
+func (m *MetricSet) init() error {
+	statsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
+	if err != nil {
+		return err
 	}
 
 	kibanaVersion, err := kibana.GetVersion(statsHTTP, statsPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
-	if err != nil {
-		return nil, err
-	}
-
 	if !isStatsAPIAvailable {
-		const errorMsg = "The %v metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, base.FullyQualifiedName(), kibana.StatsAPIAvailableVersion, kibanaVersion)
+		const errorMsg = "the %v metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.StatsAPIAvailableVersion, kibanaVersion)
 	}
-
-	if ms.XPackEnabled {
+	if m.XPackEnabled {
 		// Use legacy API response so we can passthru usage as-is
 		statsHTTP.SetURI(statsHTTP.GetURI() + "&legacy=true")
 	}
 
 	var settingsHTTP *helper.HTTP
-	if ms.XPackEnabled {
+	if m.XPackEnabled {
 		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
-		if err != nil {
-			return nil, err
-		}
-
 		if !isSettingsAPIAvailable {
-			const errorMsg = "The %v metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
-			return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), kibana.SettingsAPIAvailableVersion, kibanaVersion)
+			const errorMsg = "the %v metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
+			return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.SettingsAPIAvailableVersion, kibanaVersion)
 		}
 
-		settingsHTTP, err = helper.NewHTTP(base)
+		settingsHTTP, err = helper.NewHTTP(m.BaseMetricSet)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// HACK! We need to do this because there might be a basepath involved, so we
@@ -116,37 +144,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		settingsHTTP.SetURI(settingsURI)
 	}
 
-	return &MetricSet{
-		ms,
-		statsHTTP,
-		settingsHTTP,
-		time.Time{},
-		kibana.IsUsageExcludable(kibanaVersion),
-	}, nil
-}
+	m.statsHTTP = statsHTTP
+	m.settingsHTTP = settingsHTTP
+	m.isUsageExcludable = kibana.IsUsageExcludable(kibanaVersion)
 
-// Fetch methods implements the data gathering and data conversion to the right format
-// It returns the event which is then forward to the output. In case of an error, a
-// descriptive error must be returned.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	now := time.Now()
-
-	err := m.fetchStats(r, now)
-	if err != nil {
-		if m.XPackEnabled {
-			m.Log.Error(err)
-		} else {
-			elastic.ReportAndLogError(err, r, m.Log)
-		}
-		return
-	}
-
-	if m.XPackEnabled {
-		err = m.fetchSettings(r, now)
-		if err != nil {
-			m.Log.Error(err)
-		}
-	}
+	return nil
 }
 
 func (m *MetricSet) fetchStats(r mb.ReporterV2, now time.Time) error {


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Move HTTP calls to Kibana from New() to Fetch() (#15270)