### PR TITLE
Document metricsets that require specific permissions

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -27,6 +27,107 @@ The System module comes with a predefined dashboard. For example:
 
 image::./images/metricbeat_system_dashboard.png[]
 
+[float]
+=== Required permissions
+
+The System metricsets collect different kinds of metric data, which may require dedicated permissions
+to be fetched. For security reasons it's advised to grant the lowest possible permissions. This section
+justifies which permissions must be present for particular metricsets.
+
+Please notice that modern Linux implementations divide the privileges traditionally associated with superuser
+into distinct units, known as capabilities, which can be independently enabled and disabled.
+Capabilities are a per-thread attribute.
+
+==== cpu
+
+CPU statistics (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
+elevated permissions.
+
+==== load
+
+CPU load data (1 min, 5 min, 15 min, cores) should be available without elevated permissions.
+
+==== memory
+
+Memory statistics (swap, total, used, free, actual) should be available without elevated permissions.
+
+==== network
+
+Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without escalated
+permissions.
+
+==== process
+
+Process execution data (state, memory, cpu, cmdline) should be available for an authorized user.
+
+If the beats process is running as less privileged user, it may not be able to read process data belonging to
+other users. The issue should be reported in application logs:
+
+```
+2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
+```
+
+==== process_summary
+
+General process summary (unknown, dead, total, sleeping, running, idle, stopped, zombie) should be available without
+elevated permissions. Please notice that if the process data belongs to the other users, it will be counted as unknown
+value (no error will be reported in application logs).
+
+==== socket_summary
+
+Used sockets summary (TCP, UDP, count, listening, established, wait, etc.) should be available without elevated
+permissions.
+
+==== entropy
+
+Entropy data (available, pool size) requires access to the `/proc/sys/kernel/random` path.
+Otherwise an error will be reported.
+
+==== core
+
+Usage statistics for each CPU core (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
+elevated permissions.
+
+==== diskio
+
+Disk IO metrics (io, read, write) should be available without elevated permissions.
+
+==== socket
+
+Events for each new TCP socket should be available for an authorized user.
+
+If the beats process is running as less privileged user, it may not be able to view socket data belonging to
+other users.
+
+==== service
+
+Systemd service data (memory, tasks, states) should be available for an authorized user.
+
+If the beats process is running as less privileged user, it may not be able to read process data belonging to
+other users. The issue should be reported in application logs:
+
+```
+2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
+```
+
+==== filesystem
+
+Filesystem metrics data (total, available, type, mount point, files, free, used) should be available without elevated
+permissions.
+
+==== fsstat
+
+Fsstat metrics data (total size, free, total, used count) should be available without elevated permissions.
+
+==== uptime
+
+Uptime metrics data (duration) should be available without elevated permissions.
+
+==== raid
+
+RAID metrics data (block, disks) requires access to the `/sys/block` mount point and all referenced devices.
+Otherwise an error will be reported.
+
 
 [float]
 === Example configuration

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -38,24 +38,29 @@ Please notice that modern Linux implementations divide the privileges traditiona
 into distinct units, known as capabilities, which can be independently enabled and disabled.
 Capabilities are a per-thread attribute.
 
+[float]
 ==== cpu
 
 CPU statistics (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
 elevated permissions.
 
+[float]
 ==== load
 
 CPU load data (1 min, 5 min, 15 min, cores) should be available without elevated permissions.
 
+[float]
 ==== memory
 
 Memory statistics (swap, total, used, free, actual) should be available without elevated permissions.
 
+[float]
 ==== network
 
 Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without elevated
 permissions.
 
+[float]
 ==== process
 
 Process execution data (state, memory, cpu, cmdline) should be available for an authorized user.
@@ -67,31 +72,37 @@ other users. The issue should be reported in application logs:
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
 ```
 
+[float]
 ==== process_summary
 
 General process summary (unknown, dead, total, sleeping, running, idle, stopped, zombie) should be available without
 elevated permissions. Please notice that if the process data belongs to the other users, it will be counted as unknown
 value (no error will be reported in application logs).
 
+[float]
 ==== socket_summary
 
 Used sockets summary (TCP, UDP, count, listening, established, wait, etc.) should be available without elevated
 permissions.
 
+[float]
 ==== entropy
 
 Entropy data (available, pool size) requires access to the `/proc/sys/kernel/random` path.
 Otherwise an error will be reported.
 
+[float]
 ==== core
 
 Usage statistics for each CPU core (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
 elevated permissions.
 
+[float]
 ==== diskio
 
 Disk IO metrics (io, read, write) should be available without elevated permissions.
 
+[float]
 ==== socket
 
 Events for each new TCP socket should be available for an authorized user.
@@ -99,6 +110,7 @@ Events for each new TCP socket should be available for an authorized user.
 If the beats process is running as less privileged user, it may not be able to view socket data belonging to
 other users.
 
+[float]
 ==== service
 
 Systemd service data (memory, tasks, states) should be available for an authorized user.
@@ -110,19 +122,23 @@ other users. The issue should be reported in application logs:
 2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
 ```
 
+[float]
 ==== filesystem
 
 Filesystem metrics data (total, available, type, mount point, files, free, used) should be available without elevated
 permissions.
 
+[float]
 ==== fsstat
 
 Fsstat metrics data (total size, free, total, used count) should be available without elevated permissions.
 
+[float]
 ==== uptime
 
 Uptime metrics data (duration) should be available without elevated permissions.
 
+[float]
 ==== raid
 
 RAID metrics data (block, disks) requires access to the `/sys/block` mount point and all referenced devices.

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -53,7 +53,7 @@ Memory statistics (swap, total, used, free, actual) should be available without 
 
 ==== network
 
-Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without escalated
+Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without elevated
 permissions.
 
 ==== process

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -19,3 +19,44 @@ directly.
 The System module comes with a predefined dashboard. For example:
 
 image::./images/metricbeat_system_dashboard.png[]
+
+[float]
+=== Required permissions
+
+The System metricsets collect different kinds of metric data, which may require dedicated permissions
+to be fetched. For security reasons it's advised to grant the lowest possible permissions. This section
+justifies which permissions must be present for particular metricsets.
+
+Please notice that modern Linux implementations divide the privileges traditionally associated with superuser
+into distinct units, known as capabilities, which can be independently enabled and disabled.
+Capabilities are a per-thread attribute.
+
+==== cpu
+
+CPU statistics (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
+escalated permissions.
+
+==== load
+
+CPU load data (1 min, 5 min, 15 min, cores) should be available without escalated permissions.
+
+==== memory
+
+Memory statistics (swap, total, used, free, actual) should be available without escalated permissions.
+
+==== network
+
+Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without escalated
+permissions.
+
+==== process
+
+Process execution data (state, memory, cpu, cmdline) should be available for the authorized user.
+
+If the beats process is running as less privileged user, it may not be able to read process data belonging to
+other users. The issue should be reported in application logs:
+
+```
+2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
+5
+```

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -46,7 +46,7 @@ Memory statistics (swap, total, used, free, actual) should be available without 
 
 ==== network
 
-Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without escalated
+Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without elevated
 permissions.
 
 ==== process

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -58,7 +58,6 @@ other users. The issue should be reported in application logs:
 
 ```
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
-5
 ```
 
 ==== process_summary
@@ -74,7 +73,8 @@ permissions.
 
 ==== entropy
 
-TODO
+Entropy data (available, pool size) requires access to the `/proc/sys/kernel/random` path.
+Otherwise an error will be reported.
 
 ==== core
 
@@ -94,7 +94,14 @@ other users.
 
 ==== service
 
-TODO
+Systemd service data (memory, tasks, states) should be available for an authorized user.
+
+If the beats process is running as less privileged user, it may not be able to read process data belonging to
+other users. The issue should be reported in application logs:
+
+```
+2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
+```
 
 ==== filesystem
 
@@ -111,4 +118,5 @@ Uptime metrics data (duration) should be available without elevated permissions.
 
 ==== raid
 
-TODO
+RAID metrics data (block, disks) requires access to the `/sys/block` mount point and all referenced devices.
+Otherwise an error will be reported.

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -31,24 +31,29 @@ Please notice that modern Linux implementations divide the privileges traditiona
 into distinct units, known as capabilities, which can be independently enabled and disabled.
 Capabilities are a per-thread attribute.
 
+[float]
 ==== cpu
 
 CPU statistics (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
 elevated permissions.
 
+[float]
 ==== load
 
 CPU load data (1 min, 5 min, 15 min, cores) should be available without elevated permissions.
 
+[float]
 ==== memory
 
 Memory statistics (swap, total, used, free, actual) should be available without elevated permissions.
 
+[float]
 ==== network
 
 Network metrics for interfaces (in, out, errors, dropped, bytes, packets) should be available without elevated
 permissions.
 
+[float]
 ==== process
 
 Process execution data (state, memory, cpu, cmdline) should be available for an authorized user.
@@ -60,31 +65,37 @@ other users. The issue should be reported in application logs:
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
 ```
 
+[float]
 ==== process_summary
 
 General process summary (unknown, dead, total, sleeping, running, idle, stopped, zombie) should be available without
 elevated permissions. Please notice that if the process data belongs to the other users, it will be counted as unknown
 value (no error will be reported in application logs).
 
+[float]
 ==== socket_summary
 
 Used sockets summary (TCP, UDP, count, listening, established, wait, etc.) should be available without elevated
 permissions.
 
+[float]
 ==== entropy
 
 Entropy data (available, pool size) requires access to the `/proc/sys/kernel/random` path.
 Otherwise an error will be reported.
 
+[float]
 ==== core
 
 Usage statistics for each CPU core (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
 elevated permissions.
 
+[float]
 ==== diskio
 
 Disk IO metrics (io, read, write) should be available without elevated permissions.
 
+[float]
 ==== socket
 
 Events for each new TCP socket should be available for an authorized user.
@@ -92,6 +103,7 @@ Events for each new TCP socket should be available for an authorized user.
 If the beats process is running as less privileged user, it may not be able to view socket data belonging to
 other users.
 
+[float]
 ==== service
 
 Systemd service data (memory, tasks, states) should be available for an authorized user.
@@ -103,19 +115,23 @@ other users. The issue should be reported in application logs:
 2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
 ```
 
+[float]
 ==== filesystem
 
 Filesystem metrics data (total, available, type, mount point, files, free, used) should be available without elevated
 permissions.
 
+[float]
 ==== fsstat
 
 Fsstat metrics data (total size, free, total, used count) should be available without elevated permissions.
 
+[float]
 ==== uptime
 
 Uptime metrics data (duration) should be available without elevated permissions.
 
+[float]
 ==== raid
 
 RAID metrics data (block, disks) requires access to the `/sys/block` mount point and all referenced devices.

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -98,4 +98,17 @@ TODO
 
 ==== filesystem
 
-Fil
+Filesystem metrics data (total, available, type, mount point, files, free, used) should be available without elevated
+permissions.
+
+==== fsstat
+
+Fsstat metrics data (total size, free, total, used count) should be available without elevated permissions.
+
+==== uptime
+
+Uptime metrics data (duration) should be available without elevated permissions.
+
+==== raid
+
+TODO

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -34,15 +34,15 @@ Capabilities are a per-thread attribute.
 ==== cpu
 
 CPU statistics (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
-escalated permissions.
+elevated permissions.
 
 ==== load
 
-CPU load data (1 min, 5 min, 15 min, cores) should be available without escalated permissions.
+CPU load data (1 min, 5 min, 15 min, cores) should be available without elevated permissions.
 
 ==== memory
 
-Memory statistics (swap, total, used, free, actual) should be available without escalated permissions.
+Memory statistics (swap, total, used, free, actual) should be available without elevated permissions.
 
 ==== network
 
@@ -51,7 +51,7 @@ permissions.
 
 ==== process
 
-Process execution data (state, memory, cpu, cmdline) should be available for the authorized user.
+Process execution data (state, memory, cpu, cmdline) should be available for an authorized user.
 
 If the beats process is running as less privileged user, it may not be able to read process data belonging to
 other users. The issue should be reported in application logs:
@@ -60,3 +60,42 @@ other users. The issue should be reported in application logs:
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
 5
 ```
+
+==== process_summary
+
+General process summary (unknown, dead, total, sleeping, running, idle, stopped, zombie) should be available without
+elevated permissions. Please notice that if the process data belongs to the other users, it will be counted as unknown
+value (no error will be reported in application logs).
+
+==== socket_summary
+
+Used sockets summary (TCP, UDP, count, listening, established, wait, etc.) should be available without elevated
+permissions.
+
+==== entropy
+
+TODO
+
+==== core
+
+Usage statistics for each CPU core (idle, irq, user, system, iowait, softirq, cores, nice, steal, total) should be available without
+elevated permissions.
+
+==== diskio
+
+Disk IO metrics (io, read, write) should be available without elevated permissions.
+
+==== socket
+
+Events for each new TCP socket should be available for an authorized user.
+
+If the beats process is running as less privileged user, it may not be able to view socket data belonging to
+other users.
+
+==== service
+
+TODO
+
+==== filesystem
+
+Fil


### PR DESCRIPTION
This PR updates beats documentation with information about required root permissions for system metricsets.

Preview: https://github.com/mtojek/beats/blob/14385-root-permissions/metricbeat/docs/modules/system.asciidoc

Issue: https://github.com/elastic/beats/issues/14385