### PR TITLE
[Metricbeat] Use single data flag

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -27,6 +27,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - The custom beat generator now uses mage instead of python, `mage GenerateCustomBeat` can be used to create a new beat, and `mage vendorUpdate` to update the vendored libbeat in a custom beat. {pull}13610[13610]
 - Altered all remaining uses of mapval to use the renamed and enhanced version: https://github.com/elastic/go-lookslike[go-lookslike] instead, which is a separate project. The mapval tree is now gone. {pull}14165[14165]
 - Move light modules to OSS. {pull}14369[14369]
+- Deprecate test flags, `generate` and `update_expected`, in favor of `data`. {pull}15292[15292]
 
 ==== Bugfixes
 

--- a/metricbeat/helper/prometheus/ptest/ptest.go
+++ b/metricbeat/helper/prometheus/ptest/ptest.go
@@ -19,7 +19,6 @@ package ptest
 
 import (
 	"encoding/json"
-	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -29,14 +28,13 @@ import (
 
 	"github.com/mitchellh/hashstructure"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/metricbeat/mb/testing/flags"
 )
-
-var dataFlag = flag.Bool("data", false, "Update prometheus expected files")
 
 // TestCases holds the list of test cases to test a metricset
 type TestCases []struct {
@@ -79,7 +77,7 @@ func TestMetricSetEventsFetcher(t *testing.T, module, metricset string, cases Te
 		events, err := f.Fetch()
 		assert.Nil(t, err, "Errors while fetching metrics")
 
-		if *dataFlag {
+		if *flags.DataFlag {
 			sort.SliceStable(events, func(i, j int) bool {
 				h1, _ := hashstructure.Hash(events[i], nil)
 				h2, _ := hashstructure.Hash(events[j], nil)
@@ -160,7 +158,7 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 		events, errs := f.FetchEvents()
 		assert.Nil(t, errs, "Errors while fetching metrics")
 
-		if *dataFlag {
+		if *flags.DataFlag {
 			sort.SliceStable(events, func(i, j int) bool {
 				h1, _ := hashstructure.Hash(events[i], nil)
 				h2, _ := hashstructure.Hash(events[j], nil)

--- a/metricbeat/helper/prometheus/ptest/ptest.go
+++ b/metricbeat/helper/prometheus/ptest/ptest.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedFlag = flag.Bool("update_expected", false, "Update prometheus expected files")
+var dataFlag = flag.Bool("data", false, "Update prometheus expected files")
 
 // TestCases holds the list of test cases to test a metricset
 type TestCases []struct {
@@ -49,7 +49,7 @@ type TestCases []struct {
 
 // TestMetricSetEventsFetcher goes over the given TestCases and ensures that source Prometheus metrics gets converted
 // into the expected events when passed by the given metricset.
-// If -update_expected flag is passed, the expected JSON file will be updated with the result
+// If -data flag is passed, the expected JSON file will be updated with the result
 func TestMetricSetEventsFetcher(t *testing.T, module, metricset string, cases TestCases) {
 	for _, test := range cases {
 		t.Logf("Testing %s file\n", test.MetricsFile)
@@ -79,7 +79,7 @@ func TestMetricSetEventsFetcher(t *testing.T, module, metricset string, cases Te
 		events, err := f.Fetch()
 		assert.Nil(t, err, "Errors while fetching metrics")
 
-		if *expectedFlag {
+		if *dataFlag {
 			sort.SliceStable(events, func(i, j int) bool {
 				h1, _ := hashstructure.Hash(events[i], nil)
 				h2, _ := hashstructure.Hash(events[j], nil)
@@ -130,7 +130,7 @@ func TestMetricSetEventsFetcher(t *testing.T, module, metricset string, cases Te
 
 // TestMetricSet goes over the given TestCases and ensures that source Prometheus metrics gets converted into the expected
 // events when passed by the given metricset.
-// If -update_expected flag is passed, the expected JSON file will be updated with the result
+// If -data flag is passed, the expected JSON file will be updated with the result
 func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 	for _, test := range cases {
 		t.Logf("Testing %s file\n", test.MetricsFile)
@@ -160,7 +160,7 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 		events, errs := f.FetchEvents()
 		assert.Nil(t, errs, "Errors while fetching metrics")
 
-		if *expectedFlag {
+		if *dataFlag {
 			sort.SliceStable(events, func(i, j int) bool {
 				h1, _ := hashstructure.Hash(events[i], nil)
 				h2, _ := hashstructure.Hash(events[j], nil)

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -115,7 +115,7 @@ func MockedTests(ctx context.Context) error {
 	}
 
 	if generate, _ := strconv.ParseBool(os.Getenv("GENERATE")); generate {
-		params.ExtraFlags = append(params.ExtraFlags, "-generate")
+		params.ExtraFlags = append(params.ExtraFlags, "-data")
 	}
 
 	params.Packages = nil

--- a/metricbeat/mb/testing/data/README.md
+++ b/metricbeat/mb/testing/data/README.md
@@ -13,15 +13,15 @@ The idea is simple, head to `beats/metricbeat/mb/testing/data` and run `go test 
 An alternative is to just run from metricbeat `mage mockedTests` to achieve the same result but using environment variables instead of flags, for example: `MODULE=apache GENERATE=true mage mockedTests`
 
 ##### Worth to mention
-- If the input file in `testdata` folder is prefixed (named) `docs`, whatever its extension is, and the flag `-generate` is passed; the framework will also create a `docs.json` file in `_meta` folder of the metricset as historically has been done in Metricbeat.
+- If the input file in `testdata` folder is prefixed (named) `docs`, whatever its extension is, and the flag `-data` is passed; the framework will also create a `docs.json` file in `_meta` folder of the metricset as historically has been done in Metricbeat.
 - Config file **must** be called `config.yml` and be located inside `metricbeat/module/{module}/{metricset}/_meta/testdata`
 
 ### Available flags / environment variables
 
-- `-generate`: It will regenerate the _expected_ JSON file with the output of an event an place it within `testdata` folder. For example: `go test . -generate`. If using mage, a environment variable `GENERATE` is available to 
+- `-data`: It will regenerate the _expected_ JSON file with the output of an event an place it within `testdata` folder. For example: `go test . -data`. If using mage, a environment variable `GENERATE` is available to 
 - `-module`: Test only the specified module. For example `go test . -module=apache`. If using mage `MODULE` environment variable must be set with the _module_ name that must be tested.
 
-> You can also combine both flags with `go test . -generate -module=apache` to generate files for Apache module only.
+> You can also combine both flags with `go test . -data -module=apache` to generate files for Apache module only.
 
 ### Available settings in `config.yml`
 

--- a/metricbeat/mb/testing/data_generator.go
+++ b/metricbeat/mb/testing/data_generator.go
@@ -19,7 +19,6 @@ package testing
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,17 +29,13 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
-)
-
-var (
-	// Use `go test -data` to update files.
-	dataFlag = flag.Bool("data", false, "Write updated data.json files")
+	"github.com/elastic/beats/metricbeat/mb/testing/flags"
 )
 
 // WriteEvent fetches a single event writes the output to a ./_meta/data.json
 // file.
 func WriteEvent(f mb.EventFetcher, t testing.TB) error {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		t.Skip("skip data generation tests")
 	}
 
@@ -64,7 +59,7 @@ func WriteEvents(f mb.EventsFetcher, t testing.TB) error {
 // WriteEventsCond fetches events and writes the first event that matches the condition
 // to a ./_meta/data.json file.
 func WriteEventsCond(f mb.EventsFetcher, t testing.TB, cond func(e common.MapStr) bool) error {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		t.Skip("skip data generation tests")
 	}
 
@@ -108,7 +103,7 @@ func WriteEventsReporterV2WithContext(f mb.ReportingMetricSetV2WithContext, t te
 // WriteEventsReporterV2Cond fetches events and writes the first event that matches
 // the condition to a file.
 func WriteEventsReporterV2Cond(f mb.ReportingMetricSetV2, t testing.TB, path string, cond func(common.MapStr) bool) error {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		t.Skip("skip data generation tests")
 	}
 
@@ -123,7 +118,7 @@ func WriteEventsReporterV2Cond(f mb.ReportingMetricSetV2, t testing.TB, path str
 // WriteEventsReporterV2ErrorCond fetches events and writes the first event that matches
 // the condition to a file.
 func WriteEventsReporterV2ErrorCond(f mb.ReportingMetricSetV2Error, t testing.TB, path string, cond func(common.MapStr) bool) error {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		t.Skip("skip data generation tests")
 	}
 
@@ -138,7 +133,7 @@ func WriteEventsReporterV2ErrorCond(f mb.ReportingMetricSetV2Error, t testing.TB
 // WriteEventsReporterV2WithContextCond fetches events and writes the first event that matches
 // the condition to a file.
 func WriteEventsReporterV2WithContextCond(f mb.ReportingMetricSetV2WithContext, t testing.TB, path string, cond func(common.MapStr) bool) error {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		t.Skip("skip data generation tests")
 	}
 
@@ -203,7 +198,7 @@ func StandardizeEvent(ms mb.MetricSet, e mb.Event, modifiers ...mb.EventModifier
 // a ./_meta/data.json file. If the -data CLI flag is unset or false then the
 // method is a no-op.
 func WriteEventToDataJSON(t testing.TB, fullEvent beat.Event, postfixPath string) {
-	if !*dataFlag {
+	if !*flags.DataFlag {
 		return
 	}
 

--- a/metricbeat/mb/testing/flags/flags.go
+++ b/metricbeat/mb/testing/flags/flags.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flags
+
+import "flag"
+
+var (
+	// DataFlag enables file updates (e.g. it dumps events to data.json file).
+	// Use `go test -data` to update files.
+	DataFlag = flag.Bool("data", false, "Write updated files")
+)

--- a/metricbeat/mb/testing/testdata.go
+++ b/metricbeat/mb/testing/testdata.go
@@ -19,7 +19,6 @@ package testing
 
 import (
 	"encoding/json"
-	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -43,11 +42,6 @@ import (
 
 const (
 	expectedExtension = "-expected.json"
-)
-
-var (
-	// Use `go test -generate` to update files.
-	generateFlag = flag.Bool("generate", false, "Write golden files")
 )
 
 // DataConfig is the configuration for testdata tests
@@ -227,7 +221,7 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Dat
 	}
 
 	// Overwrites the golden files if run with -generate
-	if *generateFlag {
+	if *dataFlag {
 		outputIndented, err := json.MarshalIndent(&data, "", "    ")
 		if err != nil {
 			t.Fatal(err)

--- a/metricbeat/mb/testing/testdata.go
+++ b/metricbeat/mb/testing/testdata.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/mapping"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/mb/testing/flags"
 
 	_ "github.com/elastic/beats/metricbeat/include/fields"
 )
@@ -221,7 +222,7 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Dat
 	}
 
 	// Overwrites the golden files if run with -generate
-	if *dataFlag {
+	if *flags.DataFlag {
 		outputIndented, err := json.MarshalIndent(&data, "", "    ")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This PR deprecates the following test flags - `generate` and `update_expected`, in favor of `data`.

Issue: https://github.com/elastic/beats/issues/13531