### PR TITLE
Cherry-pick #15293 to 7.x: Update elastic/go-sysinfo to v1.2.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1148,13 +1148,19 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Version: v1.1.0
-Revision: 51d9d1362d77a4792dfb39a7a19f056cdf1b9840
+Version: v1.2.0
+Revision: bd0a84193268134cbe6cdd21b0a5618aee1f5791
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------
 Apache License 2.0
 
+-------NOTICE.txt-----
+Elastic go-sysinfo
+Copyright 2017-2019 Elasticsearch B.V.
+
+This product includes software developed at
+Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-txfile

--- a/vendor/github.com/elastic/go-sysinfo/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-sysinfo/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -16,7 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-### Security
+## [1.2.0] - 2019-12-09
+
+### Added
+
+- Added detection of systemd cgroups to the `IsContainerized` check. [#71](https://github.com/elastic/go-sysinfo/pull/71)
+- Added networking counters for Linux hosts. [#72](https://github.com/elastic/go-sysinfo/pull/72)
+
+## [1.1.1] - 2019-10-29
+
+### Fixed
+
+- Fixed an issue determining the Linux distribution for Fedora 30. [#69](https://github.com/elastic/go-sysinfo/pull/69)
 
 ## [1.1.0] - 2019-08-22
 
@@ -57,7 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the host containerized check to reduce false positives. [#42](https://github.com/elastic/go-sysinfo/pull/42) [#43](https://github.com/elastic/go-sysinfo/pull/43)
 
-[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.2.0
+[1.1.1]: https://github.com/elastic/go-sysinfo/releases/tag/v1.1.0
 [1.1.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.1.0
 [1.0.2]: https://github.com/elastic/go-sysinfo/releases/tag/v1.0.2
 [1.0.1]: https://github.com/elastic/go-sysinfo/releases/tag/v1.0.1

--- a/vendor/github.com/elastic/go-sysinfo/NOTICE.txt
+++ b/vendor/github.com/elastic/go-sysinfo/NOTICE.txt
@@ -1,0 +1,5 @@
+Elastic go-sysinfo
+Copyright 2017-2019 Elasticsearch B.V.
+
+This product includes software developed at
+Elasticsearch, B.V. (https://www.elastic.co/).

--- a/vendor/github.com/elastic/go-sysinfo/README.md
+++ b/vendor/github.com/elastic/go-sysinfo/README.md
@@ -37,6 +37,7 @@ that are implemented.
 | `Memory()`       | x      | x     | x       |
 | `CPUTimer`       | x      | x     | x       |
 | `VMStat`         |        | x     |         |
+| `NetworkCounters`|        | x     |         |
 
 | `Process` Features     | Darwin | Linux | Windows |
 |------------------------|--------|-------|---------|

--- a/vendor/github.com/elastic/go-sysinfo/go.mod
+++ b/vendor/github.com/elastic/go-sysinfo/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20190425145619-16072639606e
+	golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb
 )
+
+go 1.13

--- a/vendor/github.com/elastic/go-sysinfo/go.sum
+++ b/vendor/github.com/elastic/go-sysinfo/go.sum
@@ -18,8 +18,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190425145619-16072639606e h1:4ktJgTV34+N3qOZUc5fAaG3Pb11qzMm3PkAoTAgUZ2I=
-golang.org/x/sys v0.0.0-20190425145619-16072639606e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae h1:QoJmnb9uyPCrH8GIg9uRLn4Ta45yhcQtpymCd0AavO8=
+golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2840,12 +2840,12 @@
 			"versionExact": "v0.0.6"
 		},
 		{
-			"checksumSHA1": "rfr1yBSyYTHNU3p1NKftIyzr/eQ=",
+			"checksumSHA1": "rQiXI5O9NmODCPE2GZllkZMZPn8=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "bd0a84193268134cbe6cdd21b0a5618aee1f5791",
+			"revisionTime": "2019-12-09T20:02:09Z",
+			"version": "v1.2.0",
+			"versionExact": "v1.2.0"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",


### PR DESCRIPTION
Cherry-pick of PR #15293 to 7.x branch. Original message: 

Updates elastic/go-sysinfo to latest version.

Closes elastic/beats#14311
Closes elastic/beats#15265