### PR TITLE
StateResolver consider errors when updating current state

### DIFF
--- a/x-pack/agent/pkg/agent/operation/operator.go
+++ b/x-pack/agent/pkg/agent/operation/operator.go
@@ -113,7 +113,7 @@ func (o *Operator) State() map[string]state.State {
 
 // HandleConfig handles configuration for a pipeline and performs actions to achieve this configuration.
 func (o *Operator) HandleConfig(cfg configrequest.Request) error {
-	_, steps, err := o.stateResolver.Resolve(cfg)
+	_, steps, ack, err := o.stateResolver.Resolve(cfg)
 	if err != nil {
 		return errors.New(err, errors.TypeConfig, fmt.Sprintf("operator: failed to resolve configuration %s, error: %v", cfg, err))
 	}
@@ -128,6 +128,9 @@ func (o *Operator) HandleConfig(cfg configrequest.Request) error {
 			return errors.New(err, errors.TypeConfig, fmt.Sprintf("operator: failed to execute step %s, error: %v", step.ID, err))
 		}
 	}
+
+	// Ack the resolver should state for next call.
+	ack()
 
 	return nil
 }

--- a/x-pack/agent/pkg/agent/stateresolver/stateresolver_test.go
+++ b/x-pack/agent/pkg/agent/stateresolver/stateresolver_test.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stateresolver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/x-pack/agent/pkg/agent/program"
+	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
+)
+
+func TestStateResolverAcking(t *testing.T) {
+	submit := &cfg{
+		id:        "config-1",
+		createdAt: time.Now(),
+		programs: []program.Program{
+			fb("1"), mb("1"),
+		},
+	}
+
+	t.Run("when we ACK the should state", func(t *testing.T) {
+		log, _ := logger.New()
+		r, err := NewStateResolver(log)
+		require.NoError(t, err)
+
+		// Current state is empty.
+		_, steps, ack, err := r.Resolve(submit)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(steps))
+
+		// Ack the should state.
+		ack()
+
+		// Current sate is not empty lets try to resolve the same configuration.
+		_, steps, ack, err = r.Resolve(submit)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(steps))
+	})
+
+	t.Run("when we don't ACK the should state", func(t *testing.T) {
+		log, _ := logger.New()
+		r, err := NewStateResolver(log)
+		require.NoError(t, err)
+
+		// Current state is empty.
+		_, steps1, _, err := r.Resolve(submit)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(steps1))
+
+		// We didn't ACK the should state, verify that resolve produce the same output.
+		_, steps2, _, err := r.Resolve(submit)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(steps2))
+
+		assert.Equal(t, steps1, steps2)
+	})
+}


### PR DESCRIPTION
Previously after creating the necessary steps to converge from the
current configuration state to the should state, the resolver was
automatically updating internal should state. The problem with this approach
was that if the operator failed to apply a configuration we should never
try to apply the configuration again. This PR changes the behavior and
allow the operator to ACK the should state.

Fixes: elastic/beats#15160