### PR TITLE
[7.x] overwrite inherited org.label-schema labels (#15255)

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -5,8 +5,10 @@
 FROM {{ .from }}
 
 LABEL \
+  org.label-schema.build-date="{{ date }}" \
   org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="{{ .BeatVendor }}" \
+  org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
   org.label-schema.version="{{ beat_version }}" \
   org.label-schema.url="{{ .BeatURL }}" \


### PR DESCRIPTION
Backports the following commits to 7.x:
 - overwrite inherited org.label-schema labels (#15255)