### PR TITLE
Move HTTP calls to Logstash from New() to Fetch()

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -297,6 +297,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix CPU count in docker/cpu in cases where no `online_cpus` are reported {pull}15070[15070]
 - Fix mixed modules loading standard and light metricsets {pull}15011[15011]
 - Make `kibana` module more resilient to Kibana unavailability. {issue}15258[15258] {pull}15270[15270]
+- Make `logstash` module more resilient to Logstash unavailability. {issue}15276[15276] {pull}15306[15306]
 
 *Packetbeat*
 

--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -18,8 +18,6 @@
 package node
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
@@ -92,17 +90,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 func (m *MetricSet) init() error {
 	if m.XPack {
-		logstashVersion, err := logstash.GetVersion(m.MetricSet)
-		if err != nil {
-			return err
-		}
-
-		arePipelineGraphAPIsAvailable := logstash.ArePipelineGraphAPIsAvailable(logstashVersion)
-
-		if !arePipelineGraphAPIsAvailable {
-			const errorMsg = "the %v metricset with X-Pack enabled is only supported with Logstash >= %v. You are currently running Logstash %v"
-			return fmt.Errorf(errorMsg, m.FullyQualifiedName(), logstash.PipelineGraphAPIsAvailableVersion, logstashVersion)
-		}
+		return m.CheckPipelineGraphAPIsAvailable()
 	}
 
 	return nil

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -18,8 +18,6 @@
 package node_stats
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
@@ -100,16 +98,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 func (m *MetricSet) init() error {
 	if m.XPack {
-		logstashVersion, err := logstash.GetVersion(m.MetricSet)
+		err := m.CheckPipelineGraphAPIsAvailable()
 		if err != nil {
 			return err
-		}
-
-		arePipelineGraphAPIsAvailable := logstash.ArePipelineGraphAPIsAvailable(logstashVersion)
-
-		if !arePipelineGraphAPIsAvailable {
-			const errorMsg = "the %v metricset with X-Pack enabled is only supported with Logstash >= %v. You are currently running Logstash %v"
-			return fmt.Errorf(errorMsg, m.FullyQualifiedName(), logstash.PipelineGraphAPIsAvailableVersion, logstashVersion)
 		}
 
 		m.HTTP.SetURI(m.HTTP.GetURI() + "?vertices=true")


### PR DESCRIPTION
Resolves #15276.

This PR makes the `logstash/node` and `logstash/node_stats` metricsets resilient to Logstash's unavailability. 

Before this PR, if Logstash was not already running when Metricbeat was started up with the `logstash-xpack` module enabled, Metricbeat would immediately exit with an error since Logstash was unreachable. 

With this PR, Metricbeat will keep running and retrying to reach Logstash periodically. This also allows Logstash to go away temporarily (say, for an upgrade) and keeps Metricbeat running.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the `logstash-xpack` module.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start up Metricbeat (**without** starting up Logstash).
   ```
   ./metricbeat -e
   ```

4. Note that there are errors in the Metricbeat log about it not being able to connect to Logstash's APIs. But also ensure that Metricbeat keeps running.

5. Start up Logstash.

6. Check the Metricbeat log again. Ensure that eventually (< 1 minute), the connection errors go away. 

7. Ensure that a `.monitoring-logstash-*-mb-*` index for today's date exists. Ensure that it contains recent (`timestamp` within last 20 seconds) documents of `type:logstash_stats`. Ensure that it contains exactly one document per Logstash pipeline of `type:logstash_state` (a new document is created per pipeline, per Logstash node (re)start).
   ```
   POST .monitoring-logstash-*/_search
   {
     "size": 0,
     "aggs": {
       "by_type": {
         "terms": {
           "field": "type",
           "size": 10
         },
         "aggs": {
           "latest_timestamp": {
             "max": {
               "field": "timestamp"
             }
           }
         }
       }
     }
   }
   ```

8. Stop Logstash.

9. Repeat steps 4-7.