### PR TITLE
Retries on error when communicating with Fleet

### DIFF
--- a/agent/kibana/client.go
+++ b/agent/kibana/client.go
@@ -57,14 +57,21 @@ type Client struct {
 	log     *logger.Logger
 	request requestFunc
 	client  http.Client
+	config  *Config
 }
 
 // New creates new Kibana API client.
-func New(log *logger.Logger, factory requestFunc, httpClient http.Client) (*Client, error) {
+func New(
+	log *logger.Logger,
+	factory requestFunc,
+	cfg *Config,
+	httpClient http.Client,
+) (*Client, error) {
 	c := &Client{
 		log:     log,
 		request: factory,
 		client:  httpClient,
+		config:  cfg,
 	}
 	return c, nil
 }
@@ -150,7 +157,7 @@ func NewWithConfig(log *logger.Logger, cfg *Config, wrapper wrapperFunc) (*Clien
 		return nil, errors.Wrap(err, "invalid Kibana endpoint")
 	}
 
-	return New(log, prefixRequestFactory(kibanaURL), httpClient)
+	return New(log, prefixRequestFactory(kibanaURL), cfg, httpClient)
 }
 
 // Send executes a direct calls agains't the Kibana API, the method will takes cares of cloning
@@ -188,6 +195,11 @@ func (c *Client) Send(
 	}
 
 	return c.client.Do(req)
+}
+
+// URI returns the remote URI.
+func (c *Client) URI() string {
+	return string(c.config.Protocol) + "://" + c.config.Host + "/" + c.config.Path
 }
 
 func prefixRequestFactory(URL string) requestFunc {

--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -34,6 +34,8 @@ type clienter interface {
 		headers http.Header,
 		body io.Reader,
 	) (*http.Response, error)
+
+	URI() string
 }
 
 // EnrollCmd is an enroll subcommand that interacts between the Kibana API and the Agent.

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -8,9 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/libbeat/common/backoff"
+	"github.com/elastic/beats/x-pack/agent/pkg/agent/errors"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
 	"github.com/elastic/beats/x-pack/agent/pkg/scheduler"
@@ -125,7 +124,7 @@ func (f *fleetGateway) worker() {
 			}
 
 			if err := f.dispatcher.Dispatch(actions...); err != nil {
-				f.log.Errorf("Failed to dispatch actions, error: %s", err)
+				f.log.Errorf("failed to dispatch actions, error: %s", err)
 			}
 
 			f.log.Debugf("FleetGateway is sleeping, next update in %s", f.settings.Duration)
@@ -142,7 +141,7 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 		if err != nil {
 			f.log.Errorf("Could not communicate with Checking API will retry, error: %s", err)
 			if !f.backoff.Wait() {
-				return nil, errors.New("execute retry loop was stopped")
+				return nil, errors.M(errors.TypeNetwork, "execute retry loop was stopped")
 			}
 			continue
 		}

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -141,7 +141,11 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 		if err != nil {
 			f.log.Errorf("Could not communicate with Checking API will retry, error: %s", err)
 			if !f.backoff.Wait() {
-				return nil, errors.M(errors.TypeNetwork, "execute retry loop was stopped")
+				return nil, errors.New(
+					"execute retry loop was stopped",
+					errors.TypeNetwork,
+					errors.M(errors.MetaKeyPath, f.client.URI()),
+				)
 			}
 			continue
 		}

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -144,7 +144,7 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 				return nil, errors.New(
 					"execute retry loop was stopped",
 					errors.TypeNetwork,
-					errors.M(errors.MetaKeyPath, f.client.URI()),
+					errors.M(errors.MetaKeyURI, f.client.URI()),
 				)
 			}
 			continue

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -5,8 +5,12 @@
 package application
 
 import (
+	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common/backoff"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
 	"github.com/elastic/beats/x-pack/agent/pkg/scheduler"
@@ -33,14 +37,23 @@ type fleetGateway struct {
 	dispatcher dispatcher
 	client     clienter
 	scheduler  scheduler.Scheduler
+	backoff    backoff.Backoff
+	settings   *fleetGatewaySettings
 	agentInfo  agentInfo
 	reporter   fleetReporter
 	done       chan struct{}
+	wg         sync.WaitGroup
 }
 
 type fleetGatewaySettings struct {
 	Duration time.Duration
 	Jitter   time.Duration
+	Backoff  backoffSettings
+}
+
+type backoffSettings struct {
+	Init time.Duration
+	Max  time.Duration
 }
 
 func newFleetGateway(
@@ -72,14 +85,22 @@ func newFleetGatewayWithScheduler(
 	scheduler scheduler.Scheduler,
 	r fleetReporter,
 ) (*fleetGateway, error) {
+	done := make(chan struct{})
+
 	return &fleetGateway{
 		log:        log,
 		dispatcher: d,
 		client:     client,
-		agentInfo:  agentInfo, //TODO(ph): this need to be a struct.
+		settings:   settings,
+		agentInfo:  agentInfo,
 		scheduler:  scheduler,
-		done:       make(chan struct{}),
-		reporter:   r,
+		backoff: backoff.NewEqualJitterBackoff(
+			done,
+			settings.Backoff.Init,
+			settings.Backoff.Max,
+		),
+		done:     done,
+		reporter: r,
 	}, nil
 }
 
@@ -88,7 +109,11 @@ func (f *fleetGateway) worker() {
 		select {
 		case <-f.scheduler.WaitTick():
 			f.log.Debug("FleetGateway calling Checkin API")
-			resp, err := f.execute()
+
+			// Execute the checkin call and for any errors returned by the fleet API
+			// the function will retry to communicate with fleet with an exponential delay and some
+			// jitter to help better distribute the load from a fleet of agents.
+			resp, err := f.doExecute()
 			if err != nil {
 				f.log.Error(err)
 				continue
@@ -100,13 +125,28 @@ func (f *fleetGateway) worker() {
 			}
 
 			if err := f.dispatcher.Dispatch(actions...); err != nil {
-				f.log.Error(err)
+				f.log.Errorf("Failed to dispatch actions, error: %s", err)
 			}
 
-			f.log.Debug("FleetGateway sleeping")
+			f.log.Debugf("FleetGateway is sleeping, next update in %s", f.settings.Duration)
 		case <-f.done:
 			return
 		}
+	}
+}
+
+func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
+	f.backoff.Reset()
+	for {
+		resp, err := f.execute()
+		if err != nil {
+			f.log.Errorf("Could not communicate with Checking API will retry, error: %s", err)
+			if !f.backoff.Wait() {
+				return nil, errors.New("execute retry loop was stopped")
+			}
+			continue
+		}
+		return resp, nil
 	}
 }
 
@@ -131,10 +171,15 @@ func (f *fleetGateway) execute() (*fleetapi.CheckinResponse, error) {
 }
 
 func (f *fleetGateway) Start() {
-	go f.worker()
+	f.wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		f.worker()
+	}(&f.wg)
 }
 
 func (f *fleetGateway) Stop() {
 	close(f.done)
 	f.scheduler.Stop()
+	f.wg.Wait()
 }

--- a/x-pack/agent/pkg/agent/application/fleet_gateway_test.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway_test.go
@@ -46,6 +46,10 @@ func (t *testingClient) Send(
 	return t.callback(headers, body)
 }
 
+func (t *testingClient) URI() string {
+	return "http://localhost"
+}
+
 func (t *testingClient) Answer(fn clientCallbackFunc) <-chan struct{} {
 	t.Lock()
 	defer t.Unlock()

--- a/x-pack/agent/pkg/agent/application/fleet_gateway_test.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway_test.go
@@ -85,7 +85,7 @@ func newTestingDispatcher() *testingDispatcher {
 
 type withGatewayFunc func(*testing.T, *fleetGateway, *testingClient, *testingDispatcher, *scheduler.Stepper, repo.Backend)
 
-func withGateway(agentInfo agentInfo, fn withGatewayFunc) func(t *testing.T) {
+func withGateway(agentInfo agentInfo, settings *fleetGatewaySettings, fn withGatewayFunc) func(t *testing.T) {
 	return func(t *testing.T) {
 		scheduler := scheduler.NewStepper()
 		client := newTestingClient()
@@ -96,7 +96,7 @@ func withGateway(agentInfo agentInfo, fn withGatewayFunc) func(t *testing.T) {
 
 		gateway, err := newFleetGatewayWithScheduler(
 			log,
-			&fleetGatewaySettings{},
+			settings,
 			agentInfo,
 			client,
 			dispatcher,
@@ -139,7 +139,12 @@ func wrapStrToResp(code int, body string) *http.Response {
 
 func TestFleetGateway(t *testing.T) {
 	agentInfo := &testAgentInfo{}
-	t.Run("send no event and receive no action", withGateway(agentInfo, func(
+	settings := &fleetGatewaySettings{
+		Duration: 5 * time.Second,
+		Backoff:  backoffSettings{Init: 1 * time.Second, Max: 5 * time.Second},
+	}
+
+	t.Run("send no event and receive no action", withGateway(agentInfo, settings, func(
 		t *testing.T,
 		gateway *fleetGateway,
 		client *testingClient,
@@ -149,7 +154,6 @@ func TestFleetGateway(t *testing.T) {
 	) {
 		received := ackSeq(
 			client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
-				// TODO: assert no events
 				resp := wrapStrToResp(http.StatusOK, `{ "actions": [], "success": true }`)
 				return resp, nil
 			}),
@@ -164,7 +168,7 @@ func TestFleetGateway(t *testing.T) {
 		<-received
 	}))
 
-	t.Run("Successfully connects and receives a series of actions", withGateway(agentInfo, func(
+	t.Run("Successfully connects and receives a series of actions", withGateway(agentInfo, settings, func(
 		t *testing.T,
 		gateway *fleetGateway,
 		client *testingClient,
@@ -216,7 +220,7 @@ func TestFleetGateway(t *testing.T) {
 		log, _ := logger.New()
 		gateway, err := newFleetGatewayWithScheduler(
 			log,
-			&fleetGatewaySettings{},
+			settings,
 			agentInfo,
 			client,
 			dispatcher,
@@ -250,7 +254,7 @@ func TestFleetGateway(t *testing.T) {
 		}
 	})
 
-	t.Run("send event and receive no action", withGateway(agentInfo, func(
+	t.Run("send event and receive no action", withGateway(agentInfo, settings, func(
 		t *testing.T,
 		gateway *fleetGateway,
 		client *testingClient,
@@ -273,7 +277,6 @@ func TestFleetGateway(t *testing.T) {
 
 				require.Equal(t, 1, len(cr.Events))
 
-				// TODO: assert no events
 				resp := wrapStrToResp(http.StatusOK, `{ "actions": [], "success": true }`)
 				return resp, nil
 			}),
@@ -287,11 +290,132 @@ func TestFleetGateway(t *testing.T) {
 		scheduler.Next()
 		<-received
 	}))
-	t.Run("Successfully connects and sends events back to fleet", skip)
+
+	t.Run("Test the wait loop is interruptible", func(t *testing.T) {
+		d := 10 * time.Minute
+		scheduler := scheduler.NewPeriodic(d)
+		client := newTestingClient()
+		dispatcher := newTestingDispatcher()
+
+		log, _ := logger.New()
+		gateway, err := newFleetGatewayWithScheduler(
+			log,
+			&fleetGatewaySettings{
+				Duration: d,
+				Backoff:  backoffSettings{Init: 1 * time.Second, Max: 30 * time.Second},
+			},
+			agentInfo,
+			client,
+			dispatcher,
+			scheduler,
+			getReporter(agentInfo, log, t),
+		)
+
+		go gateway.Start()
+		defer gateway.Stop()
+
+		require.NoError(t, err)
+
+		// Silently dispatch action.
+		go func() { <-dispatcher.Answer(func(actions ...action) error { return nil }) }()
+
+		// Make sure that all API calls to the checkin API are successfull, the following will happen:
+		// 1. Gateway -> checking api.
+		// 2. WaitTick() will block for 10 minutes.
+		// 3. Stop will unblock the Wait.
+		<-client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
+			resp := wrapStrToResp(http.StatusOK, `{ "actions": [], "success": true }`)
+			return resp, nil
+		})
+	})
 }
 
-func skip(t *testing.T) {
-	t.SkipNow()
+func TestRetriesOnFailures(t *testing.T) {
+	agentInfo := &testAgentInfo{}
+	settings := &fleetGatewaySettings{
+		Duration: 5 * time.Second,
+		Backoff:  backoffSettings{Init: 1 * time.Second, Max: 5 * time.Second},
+	}
+
+	t.Run("When the gateway fails to communicate with the checkin API we will retry",
+		withGateway(agentInfo, settings, func(
+			t *testing.T,
+			gateway *fleetGateway,
+			client *testingClient,
+			dispatcher *testingDispatcher,
+			scheduler *scheduler.Stepper,
+			rep repo.Backend,
+		) {
+			rep.Report(&testStateEvent{})
+
+			fail := func(_ http.Header, _ io.Reader) (*http.Response, error) {
+				return wrapStrToResp(http.StatusInternalServerError, "something is bad"), nil
+			}
+
+			// Initial tick is done out of bound so we can block on channels.
+			go scheduler.Next()
+
+			// Simulate a 500 errors for the next 3 calls.
+			<-client.Answer(fail)
+			<-client.Answer(fail)
+			<-client.Answer(fail)
+
+			// API recover
+			received := ackSeq(
+				client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
+					cr := &request{}
+					content, err := ioutil.ReadAll(body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					err = json.Unmarshal(content, &cr)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					require.Equal(t, 1, len(cr.Events))
+
+					resp := wrapStrToResp(http.StatusOK, `{ "actions": [], "success": true }`)
+					return resp, nil
+				}),
+
+				dispatcher.Answer(func(actions ...action) error {
+					require.Equal(t, 0, len(actions))
+					return nil
+				}),
+			)
+
+			<-received
+		}))
+
+	t.Run("The retry loop is interruptible",
+		withGateway(agentInfo, &fleetGatewaySettings{
+			Duration: 0 * time.Second,
+			Backoff:  backoffSettings{Init: 10 * time.Minute, Max: 20 * time.Minute},
+		}, func(
+			t *testing.T,
+			gateway *fleetGateway,
+			client *testingClient,
+			dispatcher *testingDispatcher,
+			scheduler *scheduler.Stepper,
+			rep repo.Backend,
+		) {
+			rep.Report(&testStateEvent{})
+
+			fail := func(_ http.Header, _ io.Reader) (*http.Response, error) {
+				return wrapStrToResp(http.StatusInternalServerError, "something is bad"), nil
+			}
+
+			// Initial tick is done out of bound so we can block on channels.
+			go scheduler.Next()
+
+			// Fail to enter retry loop, all other calls will fails and will force to wait on big initial
+			// delay.
+			<-client.Answer(fail)
+
+			// non-obvious but withGateway on return will stop the gateway before returning and we should
+			// exit the retry loop. The init value of the backoff is set to exceed the test default timeout.
+		}))
 }
 
 func getReporter(info agentInfo, log *logger.Logger, t *testing.T) *fleetreporter.Reporter {


### PR DESCRIPTION
If an error occurs when we try to communicate with Fleet via the checkin
api we will start a retry loop. The retry is controlled by a an
exponential backoff and add some jitter on every calls this allow the
Agent to better distribute the request to the remote server and reduce
the risk of DoS the remote server when it come back online.

ref: #15283