### PR TITLE
[Auditbeat] Removed GUID from dashboard definition

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,6 +159,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
 - Host dataset: Export Host fields to gob encoder. {pull}12940[12940]
 - Socket dataset: Fix start errors when IPv6 is disabled on the kernel. {issue}13953[13953] {pull}13966[13966]
+- Removed GUID from auditbeat dashboard  definition {pull}TODO[TODO]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,7 +159,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
 - Host dataset: Export Host fields to gob encoder. {pull}12940[12940]
 - Socket dataset: Fix start errors when IPv6 is disabled on the kernel. {issue}13953[13953] {pull}13966[13966]
-- Removed GUID from auditbeat dashboard  definition {pull}15314[15314]
+- Removed GUID index pattern reference from Auditbeat dashboard definition. {pull}15314[15314]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,7 +159,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
 - Host dataset: Export Host fields to gob encoder. {pull}12940[12940]
 - Socket dataset: Fix start errors when IPv6 is disabled on the kernel. {issue}13953[13953] {pull}13966[13966]
-- Removed GUID from auditbeat dashboard  definition {pull}TODO[TODO]
+- Removed GUID from auditbeat dashboard  definition {pull}15314[15314]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/_meta/kibana/7/dashboard/auditbeat-system-host-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/7/dashboard/auditbeat-system-host-dashboard.json
@@ -625,7 +625,7 @@
                 "meta": {
                   "alias": null,
                   "disabled": false,
-                  "index": "dfce2b60-18c7-11e9-9094-c50574723088",
+                  "index": "auditbeat-*",
                   "key": "event.dataset",
                   "negate": false,
                   "params": {


### PR DESCRIPTION
Removed GUID from dashboard definition.

Customer was complaining that Exporting in kibana fails on
```
"missingRefCount":1,"missingReferences":[{"id":"dfce2b60-18c7-11e9-9094-c50574723088","type":"index-pattern"}
```

as kibana evaluates `dfce2b60-18c7-11e9-9094-c50574723088` as a referenced index and this cannot be found