### PR TITLE
Cherry-pick #15224 to 7.x: [metricbeat]Docker: add size flag to docker.container

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -284,6 +284,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix docker network stats when multiple interfaces are configured. {issue}14586[14586] {pull}14825[14825]
 - Fix ListMetrics pagination in aws module. {issue}14926[14926] {pull}14942[14942]
 - Fix mixed modules loading standard and light metricsets {pull}15011[15011]
+- Fix `docker.container.size` fields values {issue}14979[14979] {pull}15224[15224]
 - Make `kibana` module more resilient to Kibana unavailability. {issue}15258[15258] {pull}15270[15270]
 
 *Packetbeat*

--- a/metricbeat/module/docker/container/_meta/data.json
+++ b/metricbeat/module/docker/container/_meta/data.json
@@ -38,8 +38,8 @@
                 "org_label-schema_version": "6.5.1"
             },
             "size": {
-                "root_fs": 0,
-                "rw": 0
+                "rw": 193031181,
+                "root_fs": 1290400448
             },
             "status": "Up 7 minutes (healthy)"
         }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -67,7 +67,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // This is based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-containers.
 func (m *MetricSet) Fetch(ctx context.Context, r mb.ReporterV2) error {
 	// Fetch a list of all containers.
-	containers, err := m.dockerClient.ContainerList(ctx, types.ContainerListOptions{})
+	containers, err := m.dockerClient.ContainerList(ctx, types.ContainerListOptions{Size: true})
 	if err != nil {
 		return errors.Wrap(err, "failed to get docker containers list")
 	}


### PR DESCRIPTION
Cherry-pick of PR #15224 to 7.x branch. Original message: 

Solves https://github.com/elastic/beats/issues/14979

Docker container metricset is not retrieving size info.


Testing instructions:
- create a docker container
- configura metricbeat enabling docker.container
- make sure `docker.container.size.root_fs` and `docker.container.size.rw` are non 0 values
