### PR TITLE
Scheduler now add some jitter when waiting on Tick.

### DIFF
--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -40,6 +40,7 @@ type fleetGateway struct {
 
 type fleetGatewaySettings struct {
 	Duration time.Duration
+	Jitter   time.Duration
 }
 
 func newFleetGateway(
@@ -50,7 +51,7 @@ func newFleetGateway(
 	d dispatcher,
 	r fleetReporter,
 ) (*fleetGateway, error) {
-	scheduler := scheduler.NewPeriodic(settings.Duration)
+	scheduler := scheduler.NewPeriodicJitter(settings.Duration, settings.Jitter)
 	return newFleetGatewayWithScheduler(
 		log,
 		settings,
@@ -135,4 +136,5 @@ func (f *fleetGateway) Start() {
 
 func (f *fleetGateway) Stop() {
 	close(f.done)
+	f.scheduler.Stop()
 }

--- a/x-pack/agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/agent/pkg/agent/application/managed_mode.go
@@ -23,7 +23,10 @@ import (
 	logreporter "github.com/elastic/beats/x-pack/agent/pkg/reporter/log"
 )
 
-var durationTick = 10 * time.Second
+var gatewaySettings = &fleetGatewaySettings{
+	Duration: 30 * time.Second,
+	Jitter:   5 * time.Second,
+}
 
 type apiClient interface {
 	Send(
@@ -118,7 +121,7 @@ func newManaged(
 
 	gateway, err := newFleetGateway(
 		log,
-		&fleetGatewaySettings{Duration: durationTick},
+		gatewaySettings,
 		agentInfo,
 		client,
 		actionDispatcher,

--- a/x-pack/agent/pkg/scheduler/scheduler.go
+++ b/x-pack/agent/pkg/scheduler/scheduler.go
@@ -4,7 +4,10 @@
 
 package scheduler
 
-import "time"
+import (
+	"math/rand"
+	"time"
+)
 
 // Scheduler simple interface that encapsulate the scheduling logic, this is useful if you want to
 // test asynchronous code in a synchronous way.
@@ -70,4 +73,57 @@ func (p *Periodic) WaitTick() <-chan time.Time {
 // using another mechanism.
 func (p *Periodic) Stop() {
 	p.Ticker.Stop()
+}
+
+// PeriodicJitter is as scheduler that will periodically create a timer ticker and sleep, to
+// better distribute the load on the network and remote endpoint the timer will introduce variance
+// on each sleep.
+type PeriodicJitter struct {
+	C        chan time.Time
+	ran      bool
+	d        time.Duration
+	variance time.Duration
+	done     chan struct{}
+}
+
+func NewPeriodicJitter(d, variance time.Duration) *PeriodicJitter {
+	return &PeriodicJitter{
+		C:        make(chan time.Time, 1),
+		d:        d,
+		variance: variance,
+		done:     make(chan struct{}),
+	}
+}
+
+func (p *PeriodicJitter) WaitTick() <-chan time.Time {
+	if !p.ran {
+		// Sleep for only the variance, this will smooth the initial bootstrap of all the agents.
+		select {
+		case <-time.After(p.delay()):
+			p.C <- time.Now()
+		case <-p.done:
+			p.C <- time.Now()
+			close(p.C)
+		}
+		return p.C
+	}
+
+	select {
+	case <-time.After(p.d + p.delay()):
+		p.C <- time.Now()
+	case <-p.done:
+		p.C <- time.Now()
+		close(p.C)
+	}
+
+	return p.C
+}
+
+func (p *PeriodicJitter) Stop() {
+	close(p.done)
+}
+
+func (p *PeriodicJitter) delay() time.Duration {
+	t := int64(p.variance)
+	return time.Duration(rand.Int63n(t))
 }

--- a/x-pack/agent/pkg/scheduler/scheduler.go
+++ b/x-pack/agent/pkg/scheduler/scheduler.go
@@ -86,6 +86,7 @@ type PeriodicJitter struct {
 	done     chan struct{}
 }
 
+// NewPeriodicJitter creates a new PeriodicJitter.
 func NewPeriodicJitter(d, variance time.Duration) *PeriodicJitter {
 	return &PeriodicJitter{
 		C:        make(chan time.Time, 1),
@@ -95,6 +96,8 @@ func NewPeriodicJitter(d, variance time.Duration) *PeriodicJitter {
 	}
 }
 
+// WaitTick wait on the duration plus some jitter to unblock the channel.
+// Note: you should not keep a reference to the channel.
 func (p *PeriodicJitter) WaitTick() <-chan time.Time {
 	if !p.ran {
 		// Sleep for only the variance, this will smooth the initial bootstrap of all the agents.
@@ -119,6 +122,7 @@ func (p *PeriodicJitter) WaitTick() <-chan time.Time {
 	return p.C
 }
 
+// Stop stops the PeriodicJitter scheduler.
 func (p *PeriodicJitter) Stop() {
 	close(p.done)
 }

--- a/x-pack/agent/pkg/scheduler/scheduler_test.go
+++ b/x-pack/agent/pkg/scheduler/scheduler_test.go
@@ -41,6 +41,8 @@ func (m *tickRecorder) Stop() {
 
 func TestScheduler(t *testing.T) {
 	t.Run("Step scheduler", testStepScheduler)
+	t.Run("Periodic scheduler", testPeriodic)
+	t.Run("PeriodicJitter scheduler", testPeriodicJitter)
 }
 
 func newTickRecorder(scheduler Scheduler) *tickRecorder {
@@ -88,7 +90,7 @@ func testPeriodic(t *testing.T) {
 		require.True(t, nE.at.Sub(startedAt) < duration)
 	})
 
-	t.Run("multiple tick", func(t *testing.T) {
+	t.Run("multiple ticks", func(t *testing.T) {
 		duration := 1 * time.Millisecond
 		scheduler := NewPeriodic(duration)
 		defer scheduler.Stop()
@@ -103,5 +105,77 @@ func testPeriodic(t *testing.T) {
 		require.Equal(t, 2, nE.count)
 		nE = <-recorder.recorder
 		require.Equal(t, 3, nE.count)
+	})
+}
+
+func testPeriodicJitter(t *testing.T) {
+	t.Run("tick than wait", func(t *testing.T) {
+		duration := 1 * time.Minute
+		variance := 2 * time.Second
+		scheduler := NewPeriodicJitter(duration, variance)
+		defer scheduler.Stop()
+
+		startedAt := time.Now()
+		recorder := newTickRecorder(scheduler)
+		go recorder.Start()
+		defer recorder.Stop()
+
+		nE := <-recorder.recorder
+
+		require.True(t, nE.at.Sub(startedAt) <= variance)
+	})
+
+	t.Run("multiple ticks", func(t *testing.T) {
+		duration := 1 * time.Millisecond
+		variance := 100 * time.Millisecond
+		scheduler := NewPeriodicJitter(duration, variance)
+		defer scheduler.Stop()
+
+		recorder := newTickRecorder(scheduler)
+		go recorder.Start()
+		defer recorder.Stop()
+
+		nE := <-recorder.recorder
+		require.Equal(t, 1, nE.count)
+		nE = <-recorder.recorder
+		require.Equal(t, 2, nE.count)
+		nE = <-recorder.recorder
+		require.Equal(t, 3, nE.count)
+	})
+
+	t.Run("unblock on first tick", func(t *testing.T) {
+		duration := 30 * time.Minute
+		variance := 30 * time.Minute
+		scheduler := NewPeriodicJitter(duration, variance)
+
+		go func() {
+			// Not a fan of introducing sync-timing-code but
+			// give us a chance to be waiting.
+			<-time.After(500 * time.Millisecond)
+			scheduler.Stop()
+		}()
+
+		<-scheduler.WaitTick()
+	})
+
+	t.Run("unblock on any tick", func(t *testing.T) {
+		duration := 1 * time.Millisecond
+		variance := 2 * time.Second
+		scheduler := NewPeriodicJitter(duration, variance)
+
+		<-scheduler.WaitTick()
+
+		// Increase time between next tick
+		scheduler.d = 20 * time.Minute
+		scheduler.variance = 20 * time.Minute
+
+		go func() {
+			// Not a fan of introducing sync-timing-code but
+			// give us a chance to be waiting.
+			<-time.After(500 * time.Millisecond)
+			scheduler.Stop()
+		}()
+
+		<-scheduler.WaitTick()
 	})
 }


### PR DESCRIPTION
The Periodic scheduler is based on time.Timer and the problem and might
cause issue when you have lot of beats peridically polling the remote
API. Its possible that the Agent become in sync overtime, meaning the
load will be peridically increase on Kibana.

This PR does add a bit of jitter over the 30secs timer, so this help to
distribute the load of multiple agents on Kibana.

ref: #15283