### PR TITLE
Enroll delay

### DIFF
--- a/x-pack/agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/agent/pkg/agent/cmd/enroll.go
@@ -6,7 +6,9 @@ package cmd
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,6 +19,8 @@ import (
 	"github.com/elastic/beats/x-pack/agent/pkg/config"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 )
+
+var defaultDelay = 1 * time.Second
 
 func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
@@ -67,6 +71,8 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 	caStr, _ := cmd.Flags().GetString("certificate-authorities")
 	CAs := cli.StringToSlice(caStr)
 
+	delay(defaultDelay)
+
 	c, err := application.NewEnrollCmd(
 		logger,
 		url,
@@ -87,4 +93,8 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 
 	fmt.Fprintln(streams.Out, "Successfully enrolled the Agent.")
 	return nil
+}
+
+func delay(t time.Duration) {
+	<-time.After(time.Duration(rand.Int63n(int64(t))))
 }


### PR DESCRIPTION
Not sure its completely necessary to add an additionnal delay to enroll
but just in case you are starting that over a large quantity of beats at
the same time using a ochestration tool like ansible it might be good to
try to delay the enroll a bits with a random wait.

Ref: #15283