### PR TITLE
Update go-sysinfo to v1.2.1

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1114,8 +1114,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Version: v1.2.0
-Revision: bd0a84193268134cbe6cdd21b0a5618aee1f5791
+Version: v1.2.1
+Revision: cee67141de1bdfb666367301f44e559e58b16734
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------
@@ -1123,7 +1123,7 @@ Apache License 2.0
 
 -------NOTICE.txt-----
 Elastic go-sysinfo
-Copyright 2017-2019 Elasticsearch B.V.
+Copyright 2017-2020 Elasticsearch B.V.
 
 This product includes software developed at
 Elasticsearch, B.V. (https://www.elastic.co/).

--- a/vendor/github.com/elastic/go-sysinfo/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-sysinfo/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [unreleased]
 
 ### Added
 
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+## [1.2.1] - 2020-1-3
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- create a sidToString function to deal with API changes in various versions of golang.org/x/sys/windows [#74](https://github.com/elastic/go-sysinfo/pull/74)
 
 ## [1.2.0] - 2019-12-09
 
@@ -69,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the host containerized check to reduce false positives. [#42](https://github.com/elastic/go-sysinfo/pull/42) [#43](https://github.com/elastic/go-sysinfo/pull/43)
 
-[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/elastic/go-sysinfo/releases/tag/v1.2.1
 [1.2.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.2.0
 [1.1.1]: https://github.com/elastic/go-sysinfo/releases/tag/v1.1.0
 [1.1.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.1.0

--- a/vendor/github.com/elastic/go-sysinfo/NOTICE.txt
+++ b/vendor/github.com/elastic/go-sysinfo/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic go-sysinfo
-Copyright 2017-2019 Elasticsearch B.V.
+Copyright 2017-2020 Elasticsearch B.V.
 
 This product includes software developed at
 Elasticsearch, B.V. (https://www.elastic.co/).

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
@@ -49,7 +49,7 @@ func isContainerizedCgroup(data []byte) (bool, error) {
 
 		// Following a suggestion on Stack Overflow on how to detect
 		// being inside a container: https://stackoverflow.com/a/20012536/235203
-		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte("lxc")) {
+		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte(".slice")) || bytes.Contains(line, []byte("lxc")) {
 			return true, nil
 		}
 	}

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/host_linux.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/host_linux.go
@@ -81,6 +81,29 @@ func (h *host) VMStat() (*types.VMStatInfo, error) {
 	return parseVMStat(content)
 }
 
+// NetworkCounters reports data from /proc/net on linux
+func (h *host) NetworkCounters() (*types.NetworkCountersInfo, error) {
+	snmpRaw, err := ioutil.ReadFile(h.procFS.path("net/snmp"))
+	if err != nil {
+		return nil, err
+	}
+	snmp, err := getNetSnmpStats(snmpRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	netstatRaw, err := ioutil.ReadFile(h.procFS.path("net/netstat"))
+	if err != nil {
+		return nil, err
+	}
+	netstat, err := getNetstatStats(netstatRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.NetworkCountersInfo{SNMP: snmp, Netstat: netstat}, nil
+}
+
 func (h *host) CPUTime() (types.CPUTimes, error) {
 	stat, err := h.procFS.NewStat()
 	if err != nil {

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/machineid.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/machineid.go
@@ -27,11 +27,9 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
-var (
-	// Possible (current and historic) locations of the machine-id file.
-	// These will be searched in order.
-	machineIDFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
-)
+// Possible (current and historic) locations of the machine-id file.
+// These will be searched in order.
+var machineIDFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
 
 func MachineID() (string, error) {
 	var contents []byte

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/os.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/os.go
@@ -205,7 +205,7 @@ func findDistribRelease(baseDir string) (*types.OSInfo, error) {
 		}
 
 		info, err := os.Lstat(path)
-		if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+		if err != nil || info.Size() == 0 {
 			continue
 		}
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/procnet.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/procnet.go
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package linux
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/go-sysinfo/types"
+)
+
+// fillStruct is some reflection work that can dynamically fill one of our tagged `netstat` structs with netstat data
+func fillStruct(str interface{}, data map[string]map[string]int64) {
+	val := reflect.ValueOf(str).Elem()
+	typ := reflect.TypeOf(str).Elem()
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if tag := field.Tag.Get("netstat"); tag != "" {
+			if values, ok := data[tag]; ok {
+				val.Field(i).Set(reflect.ValueOf(values))
+			}
+		}
+	}
+}
+
+// parseEntry parses two lines from the net files, the first line being keys, the second being values
+func parseEntry(line1, line2 string) (map[string]int64, error) {
+	keyArr := strings.Split(strings.TrimSpace(line1), " ")
+	valueArr := strings.Split(strings.TrimSpace(line2), " ")
+
+	if len(keyArr) != len(valueArr) {
+		return nil, errors.New("key and value lines are mismatched")
+	}
+
+	counters := make(map[string]int64, len(valueArr))
+	for iter, value := range valueArr {
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing string to int in line: %#v", valueArr)
+		}
+		counters[keyArr[iter]] = parsed
+	}
+	return counters, nil
+}
+
+// parseNetFile parses an entire file, and returns a 2D map, representing how files are sorted by protocol
+func parseNetFile(body string) (map[string]map[string]int64, error) {
+	fileMetrics := make(map[string]map[string]int64)
+	bodySplit := strings.Split(strings.TrimSpace(body), "\n")
+	// There should be an even number of lines. If not, something is wrong.
+	if len(bodySplit)%2 != 0 {
+		return nil, fmt.Errorf("badly parsed body: %s", body)
+	}
+	// in the network counters, data is divided into two-line sections: a line of keys, and a line of values
+	// With each line
+	for index := 0; index < len(bodySplit); index += 2 {
+		keysSplit := strings.Split(bodySplit[index], ":")
+		valuesSplit := strings.Split(bodySplit[index+1], ":")
+		if len(keysSplit) != 2 || len(valuesSplit) != 2 {
+			return nil, fmt.Errorf("wrong number of keys: %#v", keysSplit)
+		}
+		valMap, err := parseEntry(keysSplit[1], valuesSplit[1])
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing lines")
+		}
+		fileMetrics[valuesSplit[0]] = valMap
+	}
+	return fileMetrics, nil
+}
+
+// getNetSnmpStats pulls snmp stats from /proc/net
+func getNetSnmpStats(raw []byte) (types.SNMP, error) {
+	snmpData, err := parseNetFile(string(raw))
+	if err != nil {
+		return types.SNMP{}, errors.Wrap(err, "error parsing SNMP")
+	}
+	output := types.SNMP{}
+	fillStruct(&output, snmpData)
+
+	return output, nil
+}
+
+// getNetstatStats pulls netstat stats from /proc/net
+func getNetstatStats(raw []byte) (types.Netstat, error) {
+	netstatData, err := parseNetFile(string(raw))
+	if err != nil {
+		return types.Netstat{}, errors.Wrap(err, "error parsing netstat")
+	}
+	output := types.Netstat{}
+	fillStruct(&output, netstatData)
+	return output, nil
+}

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/helpers_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/helpers_windows.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package windows
+
+import (
+	"fmt"
+
+	syswin "golang.org/x/sys/windows"
+)
+
+// sidToString wraps the `String()` functions used to return SID strings in golang.org/x/sys
+// These can return an error or no error, depending on the release.
+func sidToString(strFunc *syswin.SID) (string, error) {
+	switch sig := (interface{})(strFunc).(type) {
+	case fmt.Stringer:
+		return sig.String(), nil
+	case errString:
+		return sig.String()
+	default:
+		return "", fmt.Errorf("missing or unexpected String() function signature for %#v", sig)
+	}
+}
+
+type errString interface {
+	String() (string, error)
+}

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
@@ -304,18 +304,27 @@ func (p *process) User() (types.UserInfo, error) {
 		return types.UserInfo{}, errors.Wrap(err, "GetTokenUser failed")
 	}
 
-	sid, err := tokenUser.User.Sid.String()
-	if err != nil {
-		return types.UserInfo{}, errors.Wrap(err, "failed to look up user SID")
+	sid, err := sidToString(tokenUser.User.Sid)
+	if sid == "" || err != nil {
+		const errStr = "failed to look up user SID"
+		if err != nil {
+			return types.UserInfo{}, errors.Wrap(err, errStr)
+		}
+		return types.UserInfo{}, errors.New(errStr)
 	}
 
 	tokenGroup, err := accessToken.GetTokenPrimaryGroup()
 	if err != nil {
 		return types.UserInfo{}, errors.Wrap(err, "GetTokenPrimaryGroup failed")
 	}
-	gsid, err := tokenGroup.PrimaryGroup.String()
-	if err != nil {
-		return types.UserInfo{}, errors.Wrap(err, "failed to look up primary group SID")
+
+	gsid, err := sidToString(tokenGroup.PrimaryGroup)
+	if gsid == "" || err != nil {
+		const errStr = "failed to look up primary group SID"
+		if err != nil {
+			return types.UserInfo{}, errors.Wrap(err, errStr)
+		}
+		return types.UserInfo{}, errors.New(errStr)
 	}
 
 	return types.UserInfo{

--- a/vendor/github.com/elastic/go-sysinfo/types/host.go
+++ b/vendor/github.com/elastic/go-sysinfo/types/host.go
@@ -26,6 +26,33 @@ type Host interface {
 	Memory() (*HostMemoryInfo, error)
 }
 
+// NetworkCounters represents network stats from /proc/net
+type NetworkCounters interface {
+	NetworkCounters() (*NetworkCountersInfo, error)
+}
+
+// SNMP represents the data from /proc/net/snmp
+type SNMP struct {
+	IP      map[string]int64 `json:"ip" netstat:"Ip"`
+	ICMP    map[string]int64 `json:"icmp" netstat:"Icmp"`
+	ICMPMsg map[string]int64 `json:"icmp_msg" netstat:"IcmpMsg"`
+	TCP     map[string]int64 `json:"tcp" netstat:"Tcp"`
+	UDP     map[string]int64 `json:"udp" netstat:"Udp"`
+	UDPLite map[string]int64 `json:"udp_lite" netstat:"UdpLite"`
+}
+
+// Netstat represents the data from /proc/net/netstat
+type Netstat struct {
+	TCPExt map[string]int64 `json:"tcp_ext" netstat:"TcpExt"`
+	IPExt  map[string]int64 `json:"ip_ext" netstat:"IpExt"`
+}
+
+// NetworkCountersInfo represents available network counters from /proc/net
+type NetworkCountersInfo struct {
+	SNMP    SNMP    `json:"snmp"`
+	Netstat Netstat `json:"netstat"`
+}
+
 // VMStat is the interface wrapper for platforms that support /proc/vmstat.
 type VMStat interface {
 	VMStat() (*VMStatInfo, error)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2835,60 +2835,60 @@
 			"versionExact": "v0.0.6"
 		},
 		{
-			"checksumSHA1": "rQiXI5O9NmODCPE2GZllkZMZPn8=",
+			"checksumSHA1": "s37l3najJFu22RNPP9udnam+YnU=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "bd0a84193268134cbe6cdd21b0a5618aee1f5791",
-			"revisionTime": "2019-12-09T20:02:09Z",
-			"version": "v1.2.0",
-			"versionExact": "v1.2.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
 			"checksumSHA1": "dVSTUnZHCLNd0tYIENqdj05RyI8=",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
-			"checksumSHA1": "7Spkw81dzevqmPbUGZO1UM3K3oc=",
+			"checksumSHA1": "Kc5GlAf7iwLd/d1X68JFM8b12GM=",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
-			"checksumSHA1": "E+yrwS/aZemnWUvwTvEhiczYuD8=",
+			"checksumSHA1": "SI4WoiEzBJFS73GRQV6EsfA90RI=",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
-			"checksumSHA1": "u2RbbYcB7B4uhi/eJ01qiiBa41E=",
+			"checksumSHA1": "dtxTdCkTAMgGmJS7Bn5jDXsQ8nA=",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "51d9d1362d77a4792dfb39a7a19f056cdf1b9840",
-			"revisionTime": "2019-08-22T16:44:40Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "cee67141de1bdfb666367301f44e559e58b16734",
+			"revisionTime": "2020-01-03T17:30:45Z",
+			"version": "v1.2.1",
+			"versionExact": "v1.2.1"
 		},
 		{
 			"checksumSHA1": "bNf3GDGhZh86bfCIMM5c5AYfo3g=",


### PR DESCRIPTION
This update is an attempt to make the changes needed for #15196 to play nice.

Some APIs in `x/sys/windows` have changed, breaking thinks between releases. 