### PR TITLE
Cherry-pick #15261 to 7.5: [Filebeat] Update MISP module config file

### DIFF
--- a/filebeat/docs/modules/misp.asciidoc
+++ b/filebeat/docs/modules/misp.asciidoc
@@ -18,7 +18,7 @@ The configuration in the config.yml file uses the following format:
 
  * var.api_key: specifies the API key to access MISP.
  * var.json_objects_array: specifies the array object in MISP response, e.g., "response.Attribute".
- * var.url: URI of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
+ * var.url: URL of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
 
 [float]
 === Example dashboard

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -408,6 +408,14 @@ filebeat.modules:
 - module: misp
   threat:
     enabled: true
+    # API key to access MISP
+    #var.api_key
+
+    # Array object in MISP response
+    #var.json_objects_array
+
+    # URL of the MISP REST API
+    #var.url
 
 #------------------------------- Mongodb Module -------------------------------
 #- module: mongodb

--- a/x-pack/filebeat/module/misp/_meta/config.yml
+++ b/x-pack/filebeat/module/misp/_meta/config.yml
@@ -1,3 +1,11 @@
 - module: misp
   threat:
     enabled: true
+    # API key to access MISP
+    #var.api_key
+
+    # Array object in MISP response
+    #var.json_objects_array
+
+    # URL of the MISP REST API
+    #var.url

--- a/x-pack/filebeat/module/misp/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/misp/_meta/docs.asciidoc
@@ -13,7 +13,7 @@ The configuration in the config.yml file uses the following format:
 
  * var.api_key: specifies the API key to access MISP.
  * var.json_objects_array: specifies the array object in MISP response, e.g., "response.Attribute".
- * var.url: URI of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
+ * var.url: URL of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
 
 [float]
 === Example dashboard

--- a/x-pack/filebeat/modules.d/misp.yml.disabled
+++ b/x-pack/filebeat/modules.d/misp.yml.disabled
@@ -4,3 +4,11 @@
 - module: misp
   threat:
     enabled: true
+    # API key to access MISP
+    #var.api_key
+
+    # Array object in MISP response
+    #var.json_objects_array
+
+    # URL of the MISP REST API
+    #var.url


### PR DESCRIPTION
Cherry-pick of PR #15261 to 7.5 branch. Original message: 

Current MISP module configuration file does not have `var.api_key`, `var.json_objects_array` and `var.url` in the example. This PR is to add them to make it easier to use.