### PR TITLE
Fix/filebeat docker events 15096

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -324,6 +324,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Add a friendly log message when a request to docker has exceeded the deadline. {pull}15336[15336]
 - Decouple Debug logging from fail_on_error logic for rename, copy, truncate processors {pull}12451[12451]
 - Add an option to append to existing logs rather than always rotate on start. {pull}11953[11953]
 - Add `network` condition to processors for matching IP addresses against CIDRs. {pull}10743[10743]

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -309,7 +309,7 @@ func (w *watcher) watch() {
 			case err := <-errors:
 				// Restart watch call
 				if err == context.DeadlineExceeded {
-					logp.Info("Context deadline exceeded for docker request, restarting watch call", dockerWatchRequestTimeout)
+					logp.Info("Context deadline exceeded for docker request, restarting watch call")
 				} else {
 					logp.Err("Error watching for docker events: %v", err)
 				}

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -308,7 +308,12 @@ func (w *watcher) watch() {
 
 			case err := <-errors:
 				// Restart watch call
-				logp.Err("Error watching for docker events: %v", err)
+				if err == context.DeadlineExceeded {
+					logp.Info("Context deadline exceeded for docker request, restarting watch call", dockerWatchRequestTimeout)
+				} else {
+					logp.Err("Error watching for docker events: %v", err)
+				}
+
 				time.Sleep(1 * time.Second)
 				break WATCH
 

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -319,7 +319,7 @@ func (w *watcher) watch() {
 
 			case <-tickChan.C:
 				if time.Since(w.lastWatchReceivedEventTime) > dockerEventsWatchPityTimerTimeout {
-					logp.Info("No events received withing %s, restarting watch call", dockerEventsWatchPityTimerTimeout)
+					logp.Info("No events received within %s, restarting watch call", dockerEventsWatchPityTimerTimeout)
 					time.Sleep(1 * time.Second)
 					break WATCH
 				}


### PR DESCRIPTION
This should fix elastic/beats#15096 by adding a friendly log message when a request to docker has exceeded the deadline.