### PR TITLE
[7.x] Make cloud.id work for monitoring Elasticsearch reporter (#15254)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Running `setup` cmd respects `setup.ilm.overwrite` setting for improved support of custom policies. {pull}14741[14741]
 - Libbeat: Do not overwrite agent.*, ecs.version, and host.name. {pull}14407[14407]
 - Libbeat: Cleanup the x-pack licenser code to use the new license endpoint and the new format. {pull}15091[15091]
+- Users can now specify `monitoring.cloud.*` to override `monitoring.elasticsearch.*` settings. {issue}14399[14399] {pull}15254[15254]
 
 *Auditbeat*
 

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -33,6 +33,116 @@ import (
 
 const defaultCloudPort = "443"
 
+// CloudID encapsulates the encoded (i.e. raw) and decoded parts of Elastic Cloud ID.
+type CloudID struct {
+	id     string
+	esURL  string
+	kibURL string
+
+	auth     string
+	username string
+	password string
+}
+
+// NewCloudID constructs a new CloudID object by decoding the given cloud ID and cloud auth.
+func NewCloudID(cloudID string, cloudAuth string) (*CloudID, error) {
+	cid := CloudID{
+		id:   cloudID,
+		auth: cloudAuth,
+	}
+
+	if err := cid.decode(); err != nil {
+		return nil, err
+	}
+
+	return &cid, nil
+}
+
+// ElasticsearchURL returns the Elasticsearch URL decoded from the cloud ID.
+func (c *CloudID) ElasticsearchURL() string {
+	return c.esURL
+}
+
+// KibanaURL returns the Kibana URL decoded from the cloud ID.
+func (c *CloudID) KibanaURL() string {
+	return c.kibURL
+}
+
+// Username returns the username decoded from the cloud auth.
+func (c *CloudID) Username() string {
+	return c.username
+}
+
+// Password returns the password decoded from the cloud auth.
+func (c *CloudID) Password() string {
+	return c.password
+}
+
+func (c *CloudID) decode() error {
+	var err error
+	if err = c.decodeCloudID(); err != nil {
+		return errors.Wrapf(err, "invalid cloud id '%v'", c.id)
+	}
+
+	if c.auth != "" {
+		if err = c.decodeCloudAuth(); err != nil {
+			return errors.Wrap(err, "invalid cloud auth")
+		}
+	}
+
+	return nil
+}
+
+// decodeCloudID decodes the c.id into c.esURL and c.kibURL
+func (c *CloudID) decodeCloudID() error {
+	cloudID := c.id
+
+	// 1. Ignore anything before `:`.
+	idx := strings.LastIndex(cloudID, ":")
+	if idx >= 0 {
+		cloudID = cloudID[idx+1:]
+	}
+
+	// 2. base64 decode
+	decoded, err := base64.StdEncoding.DecodeString(cloudID)
+	if err != nil {
+		return errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
+	}
+
+	// 3. separate based on `$`
+	words := strings.Split(string(decoded), "$")
+	if len(words) < 3 {
+		return errors.Errorf("Expected at least 3 parts in %s", string(decoded))
+	}
+
+	// 4. extract port from the ES and Kibana host, or use 443 as the default
+	host, port := extractPortFromName(words[0], defaultCloudPort)
+	esID, esPort := extractPortFromName(words[1], port)
+	kbID, kbPort := extractPortFromName(words[2], port)
+
+	// 5. form the URLs
+	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
+	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
+
+	c.esURL = esURL.String()
+	c.kibURL = kibanaURL.String()
+
+	return nil
+}
+
+// decodeCloudAuth splits the c.auth into c.username and c.password.
+func (c *CloudID) decodeCloudAuth() error {
+	cloudAuth := c.auth
+	idx := strings.Index(cloudAuth, ":")
+	if idx < 0 {
+		return errors.New("cloud.auth setting doesn't contain `:` to split between username and password")
+	}
+
+	c.username = cloudAuth[0:idx]
+	c.password = cloudAuth[idx+1:]
+	return nil
+}
+
 // OverwriteSettings modifies the received config object by overwriting the
 // output.elasticsearch.hosts, output.elasticsearch.username, output.elasticsearch.password,
 // setup.kibana.host settings based on values derived from the cloud.id and cloud.auth
@@ -53,14 +163,14 @@ func OverwriteSettings(cfg *common.Config) error {
 	}
 
 	// cloudID overwrites
-	esURL, kibanaURL, err := decodeCloudID(cloudID)
+	cid, err := NewCloudID(cloudID, cloudAuth)
 	if err != nil {
 		return errors.Errorf("Error decoding cloud.id: %v", err)
 	}
 
-	logp.Info("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", esURL, kibanaURL)
+	logp.Info("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", cid.esURL, cid.kibURL)
 
-	esURLConfig, err := common.NewConfigFrom([]string{esURL})
+	esURLConfig, err := common.NewConfigFrom([]string{cid.ElasticsearchURL()})
 	if err != nil {
 		return err
 	}
@@ -81,24 +191,19 @@ func OverwriteSettings(cfg *common.Config) error {
 		return err
 	}
 
-	err = cfg.SetString("setup.kibana.host", -1, kibanaURL)
+	err = cfg.SetString("setup.kibana.host", -1, cid.KibanaURL())
 	if err != nil {
 		return err
 	}
 
 	if cloudAuth != "" {
 		// cloudAuth overwrites
-		username, password, err := decodeCloudAuth(cloudAuth)
+		err = cfg.SetString("output.elasticsearch.username", -1, cid.Username())
 		if err != nil {
 			return err
 		}
 
-		err = cfg.SetString("output.elasticsearch.username", -1, username)
-		if err != nil {
-			return err
-		}
-
-		err = cfg.SetString("output.elasticsearch.password", -1, password)
+		err = cfg.SetString("output.elasticsearch.password", -1, cid.Password())
 		if err != nil {
 			return err
 		}
@@ -115,48 +220,4 @@ func extractPortFromName(word string, defaultPort string) (id, port string) {
 		return word[:idx], word[idx+1:]
 	}
 	return word, defaultPort
-}
-
-// decodeCloudID decodes the cloud.id into elasticsearch-URL and kibana-URL
-func decodeCloudID(cloudID string) (string, string, error) {
-
-	// 1. Ignore anything before `:`.
-	idx := strings.LastIndex(cloudID, ":")
-	if idx >= 0 {
-		cloudID = cloudID[idx+1:]
-	}
-
-	// 2. base64 decode
-	decoded, err := base64.StdEncoding.DecodeString(cloudID)
-	if err != nil {
-		return "", "", errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
-	}
-
-	// 3. separate based on `$`
-	words := strings.Split(string(decoded), "$")
-	if len(words) < 3 {
-		return "", "", errors.Errorf("Expected at least 3 parts in %s", string(decoded))
-	}
-
-	// 4. extract port from the ES and Kibana host, or use 443 as the default
-	host, port := extractPortFromName(words[0], defaultCloudPort)
-	esID, esPort := extractPortFromName(words[1], port)
-	kbID, kbPort := extractPortFromName(words[2], port)
-
-	// 5. form the URLs
-	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
-	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
-
-	return esURL.String(), kibanaURL.String(), nil
-}
-
-// decodeCloudAuth splits the cloud.auth into username and password.
-func decodeCloudAuth(cloudAuth string) (string, string, error) {
-
-	idx := strings.Index(cloudAuth, ":")
-	if idx < 0 {
-		return "", "", errors.New("cloud.auth setting doesn't contain `:` to split between username and password")
-	}
-
-	return cloudAuth[0:idx], cloudAuth[idx+1:], nil
 }

--- a/libbeat/cloudid/cloudid_test.go
+++ b/libbeat/cloudid/cloudid_test.go
@@ -79,11 +79,11 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		esURL, kbURL, err := decodeCloudID(test.cloudID)
+		cid, err := NewCloudID(test.cloudID, "")
 		assert.NoError(t, err, test.cloudID)
 
-		assert.Equal(t, esURL, test.expectedEsURL, test.cloudID)
-		assert.Equal(t, kbURL, test.expectedKibanaURL, test.cloudID)
+		assert.Equal(t, cid.ElasticsearchURL(), test.expectedEsURL, test.cloudID)
+		assert.Equal(t, cid.KibanaURL(), test.expectedKibanaURL, test.cloudID)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestDecodeError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, _, err := decodeCloudID(test.cloudID)
+		_, err := NewCloudID(test.cloudID, "")
 		assert.Error(t, err, test.cloudID)
 		assert.Contains(t, err.Error(), test.errorMsg, test.cloudID)
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -901,6 +901,11 @@ func (b *Beat) setupMonitoring(settings Settings) (report.Reporter, error) {
 	}
 
 	if monitoring.IsEnabled(monitoringCfg) {
+		err := monitoring.OverrideWithCloudSettings(monitoringCfg)
+		if err != nil {
+			return nil, err
+		}
+
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 			Format:          reporterSettings.Format,

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -48,6 +48,18 @@ monitoring:
 --------------------
 <1> Specify one of `api_key` or `username`/`password`.
 +
+If you want to send monitoring events to an https://cloud.elastic.co/[{ecloud}]
+monitoring cluster, you can use two simpler settings. When defined, these settings
+overwrite settings from other parts in the configuration. For example:
++
+[source,yaml]
+--------------------
+monitoring:
+  enabled: true
+  cloud.id: 'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=='
+  cloud.auth: 'elastic:{pwd}'
+--------------------
++
 If you
 ifndef::no-output-logstash[]
 configured a different output, such as {ls} or you

--- a/libbeat/monitoring/cloudid.go
+++ b/libbeat/monitoring/cloudid.go
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package monitoring
+
+import (
+	"errors"
+
+	errw "github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/cloudid"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type cloudConfig struct {
+	Cloud struct {
+		ID   string `config:"id"`
+		Auth string `config:"auth"`
+	} `config:"cloud"`
+}
+
+func cfgError(cause error) error {
+	return errw.Wrap(cause, "error using monitoring.cloud.* settings")
+}
+
+var errCloudCfgIncomplete = errors.New("monitoring.cloud.auth specified but monitoring.cloud.id is empty. Please specify both")
+
+// OverrideWithCloudSettings overrides monitoring.elasticsearch.* with
+// monitoring.cloud.* if the latter are set.
+func OverrideWithCloudSettings(monitoringCfg *common.Config) error {
+	var config cloudConfig
+	if err := monitoringCfg.Unpack(&config); err != nil {
+		return cfgError(err)
+	}
+
+	if config.Cloud.ID == "" && config.Cloud.Auth == "" {
+		// Nothing to do
+		return nil
+	}
+
+	if config.Cloud.ID == "" && config.Cloud.Auth != "" {
+		return cfgError(errCloudCfgIncomplete)
+	}
+
+	// We remove monitoring.cloud.* so that "cloud" is not treated as a type of
+	// monitoring reporter later.
+	if _, err := monitoringCfg.Remove("cloud", -1); err != nil {
+		return cfgError(err)
+	}
+
+	cid, err := cloudid.NewCloudID(config.Cloud.ID, config.Cloud.Auth)
+	if err != nil {
+		return cfgError(err)
+	}
+
+	if err := overwriteWithCloudID(monitoringCfg, cid); err != nil {
+		return cfgError(err)
+	}
+
+	if config.Cloud.Auth != "" {
+		if err := overwriteWithCloudAuth(monitoringCfg, cid); err != nil {
+			return cfgError(err)
+		}
+	}
+
+	return nil
+}
+
+func overwriteWithCloudID(monitoringCfg *common.Config, cid *cloudid.CloudID) error {
+	esURLConfig, err := common.NewConfigFrom([]string{cid.ElasticsearchURL()})
+	if err != nil {
+		return err
+	}
+
+	if err := monitoringCfg.SetChild("elasticsearch.hosts", -1, esURLConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func overwriteWithCloudAuth(monitoringCfg *common.Config, cid *cloudid.CloudID) error {
+	if err := monitoringCfg.SetString("elasticsearch.username", -1, cid.Username()); err != nil {
+		return err
+	}
+
+	if err := monitoringCfg.SetString("elasticsearch.password", -1, cid.Password()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/libbeat/monitoring/cloudid_test.go
+++ b/libbeat/monitoring/cloudid_test.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package monitoring
+
+import (
+	"testing"
+
+	errw "github.com/pkg/errors"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestOverrideWithCloudSettings(t *testing.T) {
+	tests := map[string]struct {
+		in               common.MapStr
+		out              common.MapStr
+		errAssertionFunc assert.ErrorAssertionFunc
+	}{
+		"cloud_id_no_es_hosts": {
+			common.MapStr{
+				"cloud.id": "test:bG9jYWxob3N0JGVzY2x1c3RlciRiMGE1N2RhMTkwNzg0MzZmODcwZmQzNTgwZTRhNjE4ZQ==",
+			},
+			common.MapStr{
+				"elasticsearch.hosts": []string{"https://escluster.localhost:443"},
+			},
+			assert.NoError,
+		},
+		"cloud_id_with_es_hosts": {
+			common.MapStr{
+				"cloud.id":            "test:bG9jYWxob3N0JGVzY2x1c3RlciRiMGE1N2RhMTkwNzg0MzZmODcwZmQzNTgwZTRhNjE4ZQ==",
+				"elasticsearch.hosts": []string{"foo", "bar"},
+			},
+			common.MapStr{
+				"elasticsearch.hosts": []string{"https://escluster.localhost:443"},
+			},
+			assert.NoError,
+		},
+		"cloud_auth_no_es_auth": {
+			common.MapStr{
+				"cloud.id":   "test:bG9jYWxob3N0JGVzY2x1c3RlciRiMGE1N2RhMTkwNzg0MzZmODcwZmQzNTgwZTRhNjE4ZQ==",
+				"cloud.auth": "elastic:changeme",
+			},
+			common.MapStr{
+				"elasticsearch.hosts":    []string{"https://escluster.localhost:443"},
+				"elasticsearch.username": "elastic",
+				"elasticsearch.password": "changeme",
+			},
+			assert.NoError,
+		},
+		"cloud_auth_with_es_auth": {
+			common.MapStr{
+				"cloud.id":               "test:bG9jYWxob3N0JGVzY2x1c3RlciRiMGE1N2RhMTkwNzg0MzZmODcwZmQzNTgwZTRhNjE4ZQ==",
+				"cloud.auth":             "elastic:changeme",
+				"elasticsearch.username": "foo",
+				"elasticsearch.password": "bar",
+			},
+			common.MapStr{
+				"elasticsearch.hosts":    []string{"https://escluster.localhost:443"},
+				"elasticsearch.username": "elastic",
+				"elasticsearch.password": "changeme",
+			},
+			assert.NoError,
+		},
+		"cloud_auth_no_id": {
+			common.MapStr{
+				"cloud.auth": "elastic:changeme",
+			},
+			common.MapStr{
+				"cloud.auth": "elastic:changeme",
+			},
+			func(t assert.TestingT, err error, _ ...interface{}) bool {
+				return assert.EqualError(t, errCloudCfgIncomplete, errw.Cause(err).Error())
+			},
+		}}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := common.MustNewConfigFrom(test.in)
+			expected := common.MustNewConfigFrom(test.out)
+
+			err := OverrideWithCloudSettings(cfg)
+
+			test.errAssertionFunc(t, err)
+			assert.EqualValues(t, expected, cfg)
+		})
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make cloud.id work for monitoring Elasticsearch reporter  (#15254)