### PR TITLE
[Elastic Logging Plugin] Fix tarball file name in dockerlogbeat build

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -147,10 +146,13 @@ func Package() {
 // Release builds a "release" tarball that can be used later with `docker plugin create`
 func Release() error {
 	mg.Deps(Build)
-	name, err := getPluginName()
+
+	version, err := mage.BeatQualifiedVersion()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error getting beats version")
 	}
+
+	tarballName := fmt.Sprintf("%s-%s-%s.tar.gz", name, version, "docker-build-context")
 
 	bashScript := `#!/bin/bash
 docker plugin create %s
@@ -162,7 +164,7 @@ docker plugin enable %s
 		return errors.Wrap(err, "error writing script")
 	}
 
-	outpath := filepath.Join(packageEndDir, fmt.Sprintf("%s.gz", strings.Replace(name, "/", "-", -1)))
+	outpath := filepath.Join(packageEndDir, tarballName)
 
 	sh.RunV("tar", "zcf", outpath,
 		filepath.Join(packageStagingDir, "rootfs"),

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -152,7 +152,7 @@ func Release() error {
 		return errors.Wrap(err, "error getting beats version")
 	}
 
-	tarballName := fmt.Sprintf("%s-%s-%s.tar.gz", name, version, "docker-build-context")
+	tarballName := fmt.Sprintf("%s-%s-%s.tar.gz", name, version, "docker-plugin")
 
 	bashScript := `#!/bin/bash
 docker plugin create %s


### PR DESCRIPTION
This PR just makes the artifact name consistent with the rest of the beats. 