### PR TITLE
Cherry-pick #14904 to 7.x: Netflow input: Improve session reset detection and allow disabling

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -209,6 +209,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a problem in Filebeat input httpjson where interval is not used as time.Duration. {pull}14728[14728]
 - Update Logstash module's Grok patterns to support Logstash 7.4 logs. {pull}14743[14743]
 - Fix SSL config in input.yml for Filebeat httpjson input in the MISP module. {pull}14767[14767]
+- Fix session reset detection and a crash in Netflow input. {pull}14904[14904]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -68,6 +68,10 @@ These allow to update the NetFlow/IPFIX fields with vendor extensions and to
 override existing fields. See <<filebeat-input-netflow,netflow input>> for
 details.
 
+`var.detect_sequence_reset`:: Flag controlling whether {beatname_uc} should
+monitor sequence numbers in the Netflow packets to detect an Exporting Process
+reset. See <<filebeat-input-netflow,netflow input>> for details.
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -29,6 +29,7 @@ Example configuration:
   queue_size: 8192
   custom_definitions:
   - path/to/fields.yml
+  detect_sequence_reset: true
 ----
 
 
@@ -106,6 +107,18 @@ IPFIX PEN zero are equivalent to changes to NetFlow fields.
 [WARNING]
 Overriding the names and/or types of standard fields can prevent
 mapping of ECS fields to function properly.
+
+[float]
+[[detect_sequence_reset]]
+==== `detect_sequence_reset`
+
+Flag controlling whether {beatname_uc} should monitor sequence numbers in the
+Netflow packets to detect an Exporting Process reset. When this condition is
+detected, record templates for the given exporter will be dropped. This will
+cause flow loss until the exporter provides new templates. If set to `false`,
+{beatname_uc} will ignore sequence numbers, which can cause some invalid flows
+if the exporter process is reset. This option is only applicable to Netflow V9
+and IPFIX. Default is `true`.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/input/netflow/config.go
+++ b/x-pack/filebeat/input/netflow/config.go
@@ -20,6 +20,7 @@ type config struct {
 	ExpirationTimeout         time.Duration `config:"expiration_timeout"`
 	PacketQueueSize           int           `config:"queue_size"`
 	CustomDefinitions         []string      `config:"custom_definitions"`
+	DetectSequenceReset       bool          `config:"detect_sequence_reset"`
 }
 
 var defaultConfig = config{
@@ -31,7 +32,8 @@ var defaultConfig = config{
 	ForwarderConfig: harvester.ForwarderConfig{
 		Type: inputName,
 	},
-	Protocols:         []string{"v5", "v9", "ipfix"},
-	ExpirationTimeout: time.Minute * 30,
-	PacketQueueSize:   8192,
+	Protocols:           []string{"v5", "v9", "ipfix"},
+	ExpirationTimeout:   time.Minute * 30,
+	PacketQueueSize:     8192,
+	DetectSequenceReset: true,
 }

--- a/x-pack/filebeat/input/netflow/decoder/v9/session.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/session.go
@@ -101,14 +101,19 @@ func (s *SessionState) ExpireTemplates() (alive int, removed int) {
 
 // CheckReset returns if the session must be reset after the receipt of the
 // given sequence number.
-func (s *SessionState) CheckReset(seqNum uint32) (reset bool) {
+func (s *SessionState) CheckReset(seqNum uint32) (prev uint32, reset bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	if reset = seqNum < s.lastSequence && seqNum-s.lastSequence > MaxSequenceDifference; reset {
+	prev = s.lastSequence
+	if reset = !isValidSequence(prev, seqNum); reset {
 		s.Templates = make(map[TemplateKey]*TemplateWrapper)
 	}
 	s.lastSequence = seqNum
 	return
+}
+
+func isValidSequence(current, next uint32) bool {
+	return next-current < MaxSequenceDifference || current-next < MaxSequenceDifference
 }
 
 // SessionMap manages all the sessions for a collector.

--- a/x-pack/filebeat/input/netflow/decoder/v9/v9.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/v9.go
@@ -21,7 +21,7 @@ const (
 	ProtocolName                 = "v9"
 	LogPrefix                    = "[netflow-v9] "
 	ProtocolID            uint16 = 9
-	MaxSequenceDifference        = 100
+	MaxSequenceDifference        = 1000
 )
 
 type NetflowV9Protocol struct {
@@ -83,8 +83,10 @@ func (p *NetflowV9Protocol) OnPacket(buf *bytes.Buffer, source net.Addr) (flows 
 	remote := source.String()
 
 	p.logger.Printf("Packet from:%s src:%d seq:%d", remote, header.SourceID, header.SequenceNo)
-	if p.detectReset && session.CheckReset(header.SequenceNo) {
-		p.logger.Printf("Session %s reset (sequence=%d last=%d)", remote, header.SequenceNo, session.lastSequence)
+	if p.detectReset {
+		if prev, reset := session.CheckReset(header.SequenceNo); reset {
+			p.logger.Printf("Session %s reset (sequence=%d last=%d)", remote, header.SequenceNo, prev)
+		}
 	}
 
 	for ; numFlowSets > 0; numFlowSets-- {

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -63,6 +63,10 @@ These allow to update the NetFlow/IPFIX fields with vendor extensions and to
 override existing fields. See <<filebeat-input-netflow,netflow input>> for
 details.
 
+`var.detect_sequence_reset`:: Flag controlling whether {beatname_uc} should
+monitor sequence numbers in the Netflow packets to detect an Exporting Process
+reset. See <<filebeat-input-netflow,netflow input>> for details.
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -19,3 +19,7 @@ custom_definitions:
 - '{{ . }}'
 {{end}}
 {{end}}
+
+{{ if .detect_sequence_reset}}
+detect_sequence_reset: {{.detect_sequence_reset}}
+{{end}}

--- a/x-pack/filebeat/module/netflow/log/manifest.yml
+++ b/x-pack/filebeat/module/netflow/log/manifest.yml
@@ -14,7 +14,7 @@ var:
   - name: read_buffer
   - name: timeout
   - name: custom_definitions
-
+  - name: detect_sequence_reset
 ingest_pipeline: ingest/pipeline.yml
 input: config/netflow.yml
 


### PR DESCRIPTION
Cherry-pick of PR #14904 to 7.x branch. Original message: 

This adds a few fixes to Netflow input:

- Session reset detection was too sensitive and not resilient against out-of-order UDP packets.
- Fixes logging (was not thread-safe).

Also this adds a new config option `check_sequence_reset` to allow disable reset detection completely.

