### PR TITLE
Add cost warning messages to azure get metric values calls

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -571,6 +571,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add overview dashboard for AWS SNS module {pull}14977[14977]
 - Add `index` option to all modules to specify a module-specific output index. {pull}15100[15100]
 - Add a `system/service` metricset for systemd data. {pull}14206[14206]
+- Add cost warnings for the azure module. {pull}15356[15356]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/azure/monitor_service.go
+++ b/x-pack/metricbeat/module/azure/monitor_service.go
@@ -7,6 +7,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"github.com/elastic/beats/libbeat/logp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
@@ -21,6 +22,7 @@ type MonitorService struct {
 	metricNamespaceClient  *insights.MetricNamespacesClient
 	resourceClient         *resources.Client
 	context                context.Context
+	log                    *logp.Logger
 }
 
 const metricNameLimit = 20
@@ -46,6 +48,7 @@ func NewService(clientID string, clientSecret string, tenantID string, subscript
 		metricNamespaceClient:  &metricNamespaceClient,
 		resourceClient:         &resourceClient,
 		context:                context.Background(),
+		log:                    logp.NewLogger("azure monitor service"),
 	}
 	return service, nil
 }
@@ -100,6 +103,11 @@ func (service *MonitorService) GetMetricValues(resourceID string, namespace stri
 		}
 		resp, err := service.metricsClient.List(service.context, resourceID, timespan, tg, strings.Join(metricNames[i:end], ","),
 			aggregations, nil, "", filter, insights.Data, namespace)
+		
+		// check for applied charges before returning any errors
+		if resp.Cost != nil && *resp.Cost != 0 {
+			service.log.Warnf("Charges amounted to %v are being applied while retrieving the metric values from the resource %s ", *resp.Cost, resourceID)
+		}
 		if err != nil {
 			return metrics, err
 		}

--- a/x-pack/metricbeat/module/azure/monitor_service.go
+++ b/x-pack/metricbeat/module/azure/monitor_service.go
@@ -7,8 +7,9 @@ package azure
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/beats/libbeat/logp"
 	"strings"
+
+	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-03-01/resources"
@@ -103,7 +104,7 @@ func (service *MonitorService) GetMetricValues(resourceID string, namespace stri
 		}
 		resp, err := service.metricsClient.List(service.context, resourceID, timespan, tg, strings.Join(metricNames[i:end], ","),
 			aggregations, nil, "", filter, insights.Data, namespace)
-		
+
 		// check for applied charges before returning any errors
 		if resp.Cost != nil && *resp.Cost != 0 {
 			service.log.Warnf("Charges amounted to %v are being applied while retrieving the metric values from the resource %s ", *resp.Cost, resourceID)


### PR DESCRIPTION
Add cost warning messages to azure get metric values calls.
The azure response object contains the cost value for each api call, if not 0 we will log a warning message.