### PR TITLE
Cherry-pick #15334 to 7.x: [Metricbeat] Comment out optional configurations in default aws config.yml

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -8,12 +8,12 @@
     - cloudwatch
   metrics:
     - namespace: AWS/EC2
-      name: ["CPUUtilization", "DiskWriteOps"]
+      #name: ["CPUUtilization", "DiskWriteOps"]
       tags.resource_type_filter: ec2:instance
       #dimensions:
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
-      statistic: ["Average", "Maximum"]
+      #statistic: ["Average", "Maximum"]
 - module: aws
   period: 5m
   metricsets:

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -11,12 +11,12 @@
     - cloudwatch
   metrics:
     - namespace: AWS/EC2
-      name: ["CPUUtilization", "DiskWriteOps"]
+      #name: ["CPUUtilization", "DiskWriteOps"]
       tags.resource_type_filter: ec2:instance
       #dimensions:
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a
-      statistic: ["Average", "Maximum"]
+      #statistic: ["Average", "Maximum"]
 - module: aws
   period: 5m
   metricsets:


### PR DESCRIPTION
Cherry-pick of PR #15334 to 7.x branch. Original message: 

Default config.yml for aws module should collect all metrics. Comment out name and statistic options under AWS/EC2 so the config collects all metrics from AWS/EC2 by default.