### PR TITLE
Cherry-pick #15252 to 7.x: [Filebeat] Check content type when reading s3 files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -210,6 +210,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a problem in Filebeat input httpjson where interval is not used as time.Duration. {pull}14728[14728]
 - Update Logstash module's Grok patterns to support Logstash 7.4 logs. {pull}14743[14743]
 - Fix SSL config in input.yml for Filebeat httpjson input in the MISP module. {pull}14767[14767]
+- Check content-type when creating new reader in s3 input. {pull}15252[15252] {issue}15225[15225]
 - Fix session reset detection and a crash in Netflow input. {pull}14904[14904]
 
 *Heartbeat*


### PR DESCRIPTION
Cherry-pick of PR #15252 to 7.x branch. Original message: 

When file name has `.gz` suffix but with text/plain content type, `newS3BucketReader` function will fail when using s3 input in Filebeat. Instead of simply checking file name, check the actual content type from the response and then decide how to build the new reader. 

## How to test it:
Upload file to an S3 bucket and change the file metadata property to test this PR:
<img width="1245" alt="Screen Shot 2020-01-07 at 7 48 59 AM" src="https://user-images.githubusercontent.com/14081635/71904079-af6c9780-3122-11ea-8cdf-c0c019fdd5fe.png">

Upload a test1.txt.gz file and change content type to `text/plain`, s3 input should still be able to read the file.

closes https://github.com/elastic/beats/issues/15225