### PR TITLE
Fix test output with ipv6 addresses

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,6 +144,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `proxy_url` option in Elasticsearch output. {pull}14950[14950]
 - Fix bug with potential concurrent reads and writes from event.Meta map by Kafka output. {issue}14542[14542] {pull}14568[14568]
 - Fix spooling to disk blocking infinitely if the lock file can not be acquired. {pull}15338[15338]
+- Fix `metricbeat test output` with an ipv6 ES host in the output.hosts. {pull}15368[15368]
 
 *Auditbeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -668,10 +668,8 @@ func (client *Client) Test(d testing.Driver) {
 		u, err := url.Parse(client.URL)
 		d.Fatal("parse url", err)
 
-		address := u.Hostname()
-		if u.Port() != "" {
-			address += ":" + u.Port()
-		}
+		address := u.Host
+
 		d.Run("connection", func(d testing.Driver) {
 			netDialer := transport.TestNetDialer(d, client.timeout)
 			_, err = netDialer.Dial("tcp", address)


### PR DESCRIPTION
Fixes #15078 

Using `u.Host` would not break anything, as far as I can tell