### PR TITLE
Cherry-pick #15208 to 7.x: Use travis_wait to extend no output timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,12 @@ before_install:
 install: true
 
 script:
+  # Replacement for travis_wait which doesn't print output in real time.
+  # Default Travis timeout is 10min, so this workaround prints timestamps every 9min to reset the counter.
+  # Using seconds (540s = 9min) instead of minutes for shell compatibility reasons.
+  - while sleep 540; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
   - make $TARGETS
+  - kill %1
 
 notifications:
   slack:


### PR DESCRIPTION
Cherry-pick of PR #15208 to 7.x branch. Original message: 

This PR adds travis_wait function to extend the no output timeout to 30 minutes.

Issue: https://github.com/elastic/beats/issues/15201