### PR TITLE
[Elastic Log Driver] Remove the clean step from build for now

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -53,7 +53,6 @@ func getPluginName() (string, error) {
 
 // Build builds docker rootfs container root
 func Build() error {
-	mg.Deps(CleanDocker)
 	mage.CreateDir(packageStagingDir)
 	mage.CreateDir(packageEndDir)
 


### PR DESCRIPTION
It turns out, this breaks the release manager. Clean should be run  as a separate step, and not part of a build.