### PR TITLE
Cherry-pick #15336 to 7.x: Fix/filebeat docker events 15096

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Add a friendly log message when a request to docker has exceeded the deadline. {pull}15336[15336]
 - Decouple Debug logging from fail_on_error logic for rename, copy, truncate processors {pull}12451[12451]
 - Allow a beat to ship monitoring data directly to an Elasticsearch monitoring cluster. {pull}9260[9260]
 - Updated go-seccomp-bpf library to v1.1.0 which updates syscall lists for Linux v5.0. {pull}11394[11394]

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -308,13 +308,18 @@ func (w *watcher) watch() {
 
 			case err := <-errors:
 				// Restart watch call
-				logp.Err("Error watching for docker events: %v", err)
+				if err == context.DeadlineExceeded {
+					logp.Info("Context deadline exceeded for docker request, restarting watch call")
+				} else {
+					logp.Err("Error watching for docker events: %v", err)
+				}
+
 				time.Sleep(1 * time.Second)
 				break WATCH
 
 			case <-tickChan.C:
 				if time.Since(w.lastWatchReceivedEventTime) > dockerEventsWatchPityTimerTimeout {
-					logp.Info("No events received withing %s, restarting watch call", dockerEventsWatchPityTimerTimeout)
+					logp.Info("No events received within %s, restarting watch call", dockerEventsWatchPityTimerTimeout)
 					time.Sleep(1 * time.Second)
 					break WATCH
 				}


### PR DESCRIPTION
Cherry-pick of PR #15336 to 7.x branch. Original message: 

This should fix elastic/beats#15096 by adding a friendly log message when a request to docker has exceeded the deadline.