### PR TITLE
Cherry-pick #15140 to 7.x: Fix mage package on generated beats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,11 +148,11 @@ jobs:
 
     # Generators
     - os: linux
-      env: TARGETS="-C generator/metricbeat test"
+      env: TARGETS="-C generator/metricbeat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C generator/beat test"
+      env: TARGETS="-C generator/beat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -88,3 +88,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -16,6 +16,12 @@ test: prepare-test
 	$(MAKE) || exit 1 ; \
 	$(MAKE) unit
 
+.PHONY: test-package
+test-package: test
+	cd ${BEAT_PATH} ; \
+	export PATH=$${GOPATH}/bin:$${PATH}; \
+	mage package
+
 .PHONY: prepare-test
 prepare-test:: ${GOPATH}/bin/mage
 	rm -fr ${BEAT_PATH}

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -124,3 +124,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}


### PR DESCRIPTION
Cherry-pick of PR #15140 to 7.x branch. Original message: 

Mage package calls some targets by name (instead of by reference), and
then these targets need to be defined in the main magefile.

Add mage package to the test suite so we earlier detect these issues.

This is probably broken since https://github.com/elastic/beats/pull/14162

Fix https://github.com/elastic/beats/issues/15122