### PR TITLE
Cherry-pick #15140 to 7.5: Fix mage package on generated beats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,11 +142,11 @@ jobs:
 
     # Generators
     - os: linux
-      env: TARGETS="-C generator/metricbeat test"
+      env: TARGETS="-C generator/metricbeat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C generator/beat test"
+      env: TARGETS="-C generator/beat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
 

--- a/generator/beat/{beat}/magefile.go
+++ b/generator/beat/{beat}/magefile.go
@@ -77,3 +77,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -24,6 +24,12 @@ test: prepare-test
 	$(MAKE) || exit 1 ; \
 	$(MAKE) unit
 
+.PHONY: test-package
+test-package: test
+	cd ${BEAT_PATH} ; \
+	export PATH=$${GOPATH}/bin:$${PATH}; \
+	mage package
+
 .PHONY: prepare-test
 prepare-test:: python-env
 	# Makes sure to use current version of beats for testing

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -27,6 +27,7 @@ test: prepare-test
 .PHONY: test-package
 test-package: test
 	cd ${BEAT_PATH} ; \
+	export GOPATH=${PWD}/build ; \
 	export PATH=$${GOPATH}/bin:$${PATH}; \
 	mage package
 

--- a/generator/metricbeat/{beat}/magefile.go
+++ b/generator/metricbeat/{beat}/magefile.go
@@ -112,3 +112,14 @@ func Build() error {
 func CrossBuild() error {
 	return build.CrossBuild()
 }
+
+// BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
+func BuildGoDaemon() error {
+	return build.BuildGoDaemon()
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+	return build.GolangCrossBuild()
+}


### PR DESCRIPTION
Cherry-pick of PR #15140 to 7.5 branch. Original message: 

Mage package calls some targets by name (instead of by reference), and
then these targets need to be defined in the main magefile.

Add mage package to the test suite so we earlier detect these issues.

This is probably broken since https://github.com/elastic/beats/pull/14162

Fix https://github.com/elastic/beats/issues/15122