### PR TITLE
Cherry-pick #15373 to 7.x: [Elastic Log Driver] Remove the clean step from build for now

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -53,7 +53,6 @@ func getPluginName() (string, error) {
 
 // Build builds docker rootfs container root
 func Build() error {
-	mg.Deps(CleanDocker)
 	mage.CreateDir(packageStagingDir)
 	mage.CreateDir(packageEndDir)
 


### PR DESCRIPTION
Cherry-pick of PR #15373 to 7.x branch. Original message: 

It turns out, this breaks the release manager. Clean should be run  as a separate step, and not part of a build.