### PR TITLE
Fix the tick than wait strategy for the PeriodicJitter

### DIFF
--- a/x-pack/agent/pkg/scheduler/scheduler.go
+++ b/x-pack/agent/pkg/scheduler/scheduler.go
@@ -108,6 +108,7 @@ func (p *PeriodicJitter) WaitTick() <-chan time.Time {
 			p.C <- time.Now()
 			close(p.C)
 		}
+		p.ran = true
 		return p.C
 	}
 

--- a/x-pack/agent/pkg/scheduler/scheduler_test.go
+++ b/x-pack/agent/pkg/scheduler/scheduler_test.go
@@ -110,7 +110,7 @@ func testPeriodic(t *testing.T) {
 
 func testPeriodicJitter(t *testing.T) {
 	t.Run("tick than wait", func(t *testing.T) {
-		duration := 1 * time.Minute
+		duration := 5 * time.Second
 		variance := 2 * time.Second
 		scheduler := NewPeriodicJitter(duration, variance)
 		defer scheduler.Stop()
@@ -122,7 +122,19 @@ func testPeriodicJitter(t *testing.T) {
 
 		nE := <-recorder.recorder
 
-		require.True(t, nE.at.Sub(startedAt) <= variance)
+		diff := nE.at.Sub(startedAt)
+		require.True(
+			t,
+			diff <= variance,
+		)
+
+		startedAt = time.Now()
+		nE = <-recorder.recorder
+		diff = nE.at.Sub(startedAt)
+		require.True(
+			t,
+			diff >= duration,
+		)
 	})
 
 	t.Run("multiple ticks", func(t *testing.T) {

--- a/x-pack/agent/pkg/scheduler/scheduler_test.go
+++ b/x-pack/agent/pkg/scheduler/scheduler_test.go
@@ -125,7 +125,7 @@ func testPeriodicJitter(t *testing.T) {
 		diff := nE.at.Sub(startedAt)
 		require.True(
 			t,
-			diff <= variance,
+			diff < duration,
 		)
 
 		startedAt = time.Now()


### PR DESCRIPTION
There was a bug where the wait was incorrectly calculated after the
first tick.

Related to error:

```
-- FAIL: TestScheduler/PeriodicJitter_scheduler (4.98s)
        --- FAIL: TestScheduler/PeriodicJitter_scheduler/tick_than_wait (2.09s)
            require.go:1159: 
                	Error Trace:	scheduler_test.go:125
                	Error:      	Should be true
                	Test:       	TestScheduler/PeriodicJitter_scheduler/tick_than_wait