### PR TITLE
[7.x][DOCS] Backport: Adds description for missing kafka_home parameter

### DIFF
--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -33,7 +33,7 @@ include::../include/configuring-intro.asciidoc[]
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
 file to override the default paths for logs:
 
-["source","yaml",subs="attributes"]
+[source,yaml]
 -----
 - module: kafka
   log:
@@ -48,7 +48,7 @@ file to override the default paths for logs:
 
 To specify the same settings at the command line, you use:
 
-["source","sh",subs="attributes"]
+[source,yaml]
 -----
 -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
@@ -61,6 +61,19 @@ include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
+
+*`var.kafka_home`*::
+
+The path to your Kafka installation. The default is `/opt`. For example:
++
+[source,yaml]
+----
+- module: kafka
+  log:
+    enabled: true
+    var.kafka_home: /usr/share/kafka_2.12-2.4.0
+    ...
+----
 
 include::../include/var-paths.asciidoc[]
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -28,7 +28,7 @@ include::../include/configuring-intro.asciidoc[]
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
 file to override the default paths for logs:
 
-["source","yaml",subs="attributes"]
+[source,yaml]
 -----
 - module: kafka
   log:
@@ -43,7 +43,7 @@ file to override the default paths for logs:
 
 To specify the same settings at the command line, you use:
 
-["source","sh",subs="attributes"]
+[source,yaml]
 -----
 -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
@@ -56,6 +56,19 @@ include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
+
+*`var.kafka_home`*::
+
+The path to your Kafka installation. The default is `/opt`. For example:
++
+[source,yaml]
+----
+- module: kafka
+  log:
+    enabled: true
+    var.kafka_home: /usr/share/kafka_2.12-2.4.0
+    ...
+----
 
 include::../include/var-paths.asciidoc[]
 


### PR DESCRIPTION
Backports #15371 to 7.x branch.