### PR TITLE
Functionbeat providers compilation with specific GOOS and GOARCH

### DIFF
--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -45,10 +45,12 @@ func Build() error {
 
 	// Building functions to deploy
 	for _, provider := range functionbeat.SelectedProviders {
-		inputFiles := filepath.Join("provider", provider, "main.go")
+		inputFiles := filepath.Join("provider", provider.Name, "main.go")
 		params.InputFiles = []string{inputFiles}
-		params.Name = devtools.BeatName + "-" + provider
-		params.OutputDir = filepath.Join("provider", provider)
+		params.Name = devtools.BeatName + "-" + provider.Name
+		params.OutputDir = filepath.Join("provider", provider.Name)
+		params.Env = map[string]string{"GOOS": provider.GOOS, "GOARCH": provider.GOARCH}
+
 		err := devtools.Build(params)
 		if err != nil {
 			return err
@@ -78,7 +80,7 @@ func CrossBuild() error {
 
 	// Building functions to deploy
 	for _, provider := range functionbeat.SelectedProviders {
-		err := devtools.CrossBuild(devtools.AddPlatforms("linux/amd64"), devtools.InDir("x-pack", "functionbeat", "provider", provider))
+		err := devtools.CrossBuild(devtools.AddPlatforms("linux/amd64"), devtools.InDir("x-pack", "functionbeat", "provider", provider.Name))
 		if err != nil {
 			return err
 		}
@@ -138,10 +140,10 @@ func BuildSystemTestBinary() error {
 
 	params := devtools.DefaultTestBinaryArgs()
 	for _, provider := range functionbeat.SelectedProviders {
-		params.Name = filepath.Join("provider", provider, devtools.BeatName+"-"+provider)
+		params.Name = filepath.Join("provider", provider.Name, devtools.BeatName+"-"+provider.Name)
 		inputFiles := make([]string, 0)
 		for _, inputFileName := range []string{"main.go", "main_test.go"} {
-			inputFiles = append(inputFiles, filepath.Join("provider", provider, inputFileName))
+			inputFiles = append(inputFiles, filepath.Join("provider", provider.Name, inputFileName))
 		}
 		params.InputFiles = inputFiles
 		err := devtools.BuildSystemTestGoBinary(params)

--- a/x-pack/functionbeat/scripts/mage/providers.go
+++ b/x-pack/functionbeat/scripts/mage/providers.go
@@ -31,10 +31,12 @@ func getConfiguredProviders() []functionbeatProvider {
 	}
 
 	providers := make([]functionbeatProvider, 0)
+
 	for _, name := range strings.Split(providersList, ",") {
 		for _, provider := range availableProviders {
 			if provider.Name == name {
 				providers = append(providers, provider)
+				break
 			}
 		}
 	}

--- a/x-pack/functionbeat/scripts/mage/providers.go
+++ b/x-pack/functionbeat/scripts/mage/providers.go
@@ -4,7 +4,7 @@
 
 package mage
 
-type FunctionbeatProvider struct {
+type functionbeatProvider struct {
 	Name   string
 	GOOS   string
 	GOARCH string
@@ -12,7 +12,7 @@ type FunctionbeatProvider struct {
 
 var (
 	// SelectedProviders is the list of selected providers
-	SelectedProviders = []FunctionbeatProvider{
+	SelectedProviders = []functionbeatProvider{
 		{Name: "aws", GOOS: "darwin", GOARCH: "amd64"},
 	}
 )

--- a/x-pack/functionbeat/scripts/mage/providers.go
+++ b/x-pack/functionbeat/scripts/mage/providers.go
@@ -4,6 +4,11 @@
 
 package mage
 
+import (
+	"os"
+	"strings"
+)
+
 type functionbeatProvider struct {
 	Name   string
 	GOOS   string
@@ -12,7 +17,27 @@ type functionbeatProvider struct {
 
 var (
 	// SelectedProviders is the list of selected providers
-	SelectedProviders = []functionbeatProvider{
-		{Name: "aws", GOOS: "darwin", GOARCH: "amd64"},
+	SelectedProviders = getConfiguredProviders()
+
+	availableProviders = []functionbeatProvider{
+		{Name: "aws", GOOS: "linux", GOARCH: "amd64"},
 	}
 )
+
+func getConfiguredProviders() []functionbeatProvider {
+	providersList := os.Getenv("PROVIDERS")
+	if len(providersList) == 0 {
+		return availableProviders
+	}
+
+	providers := make([]functionbeatProvider, 0)
+	for _, name := range strings.Split(providersList, ",") {
+		for _, provider := range availableProviders {
+			if provider.Name == name {
+				providers = append(providers, provider)
+			}
+		}
+	}
+
+	return providers
+}

--- a/x-pack/functionbeat/scripts/mage/providers.go
+++ b/x-pack/functionbeat/scripts/mage/providers.go
@@ -4,26 +4,15 @@
 
 package mage
 
-import (
-	"os"
-	"strings"
-)
+type FunctionbeatProvider struct {
+	Name   string
+	GOOS   string
+	GOARCH string
+}
 
 var (
 	// SelectedProviders is the list of selected providers
-	// Can be configured by setting PROVIDERS enviroment variable.
-	SelectedProviders = getConfiguredProviders()
-
-	availableProviders = []string{
-		"aws",
+	SelectedProviders = []FunctionbeatProvider{
+		{Name: "aws", GOOS: "darwin", GOARCH: "amd64"},
 	}
 )
-
-func getConfiguredProviders() []string {
-	providers := os.Getenv("PROVIDERS")
-	if len(providers) == 0 {
-		return availableProviders
-	}
-
-	return strings.Split(providers, ",")
-}


### PR DESCRIPTION
This is a proposal to fix the issue #15132, which describes the problem when generating the functionbeat for providers (currently only aws).

#### How this works

Now the `SelectedProviders` is a slice of objects containing the required info of the provider:

```go
type FunctionbeatProvider struct {
	Name   string
	GOOS   string
	GOARCH string
}
```

So when building the providers, the `params.Env ` is written with that information so now we can build the beat for a required os/arch.