### PR TITLE
Backport #15400 to 7.x: Revert "[Elastic Logging Plugin] add dockerlogbeat to make release (#15359)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ XPACK_SUFFIX=x-pack/
 # PROJECTS_XPACK_PKG is a list of Beats that have independent packaging support
 # in the x-pack directory (rather than having the OSS build produce both sets
 # of artifacts). This will be removed once we complete the transition.
-PROJECTS_XPACK_PKG=x-pack/auditbeat x-pack/dockerlogbeat x-pack/filebeat x-pack/metricbeat x-pack/winlogbeat
+PROJECTS_XPACK_PKG=x-pack/auditbeat x-pack/filebeat x-pack/metricbeat x-pack/winlogbeat
 # PROJECTS_XPACK_MAGE is a list of Beats whose primary build logic is based in
 # Mage. For compatibility with CI testing these projects support a subset of the
 # makefile targets. After all Beats converge to primarily using Mage we can


### PR DESCRIPTION
Backport of #15400 

This reverts commit be95f2d3743bf08a864c5f61bbd9119559fb94ee which added
the dockerlogbeat build process to the release process. It turns out that
this update prevents the x-pack artifacts built to be copied into the
`build/distributions/<project>` at the end of the build process, which
breaks the Unified Release worflow.

The team is working on a fix to integrate the Elastic Logging Plugin
artifact in the build release process without breaking the current workflow.