### PR TITLE
Cherry-pick #13395 to 7.x: Add more metrics to Filebeat harvesters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -122,6 +122,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `index` option to all inputs to directly set a per-input index value. {pull}14010[14010]
 - Add new fileset googlecloud/audit for ingesting Google Cloud Audit logs. {pull}15200[15200]
 - Add dashboards to the CEF module (ported from the Logstash ArcSight module). {pull}14342[14342]
+- Expose more metrics of harvesters (e.g. `read_offset`, `start_time`). {pull}13395[13395]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#13395 to 7.x branch. Original message: 

I have added a few new metrics to harvesters of Filebeat:

- `"last_event_timestamp"`: `@timestamp` of the last published event
- `"last_event_publised_time"`:  the time when the last event was published and the offset was updated
- `"size"`: file size in bytes
- `"read_offset"`: offset of the file
- `"start_time"`: harvester start time 

By reporting these metrics it is possible to create more complex checks in Kibana to help to diagnose issues in harvesters.

```
"harvester": {
    "files": {
        "0be8e828-e39f-42ba-8468-029a08451a37": {
            "last_event_timestamp": "2019-08-29T13:17:22.961Z",
            "last_event_published_time": "2019-08-29T13:17:22.961Z",
            "name": "/var/log/dpkg.log",
            "read_offset": 42417,
            "size": 42417,
            "start_time": "2019-08-29T13:17:19.908Z"
        },
        "6950906f-ef19-4d99-aff9-ca81b49e024f": {
            "last_event_timestamp": "",
            "last_event_published_time": "",
            "name": "/var/log/pm-powersave.log",
            "start_time": "2019-08-29T13:17:22.907Z"
        },
        "752bb2c3-2a61-4055-b3c6-5b8b87204f2b": {
            "last_event_timestamp": "2019-08-29T13:17:22.905Z",
            "last_event_published_time": "2019-08-29T13:17:22.905Z",
            "name": "/var/log/vbox-setup.log",
            "read_offset": 140,
            "size": 140,
            "start_time": "2019-08-29T13:17:19.908Z"
        },
        "c339d330-cfa6-41ae-8a77-83a019ca99ab": {
            "last_event_timestamp": "2019-08-29T13:17:22.924Z",
            "last_event_published_time": "2019-08-29T13:17:22.925Z",
            "name": "/var/log/fontconfig.log",
            "read_offset": 2269,
            "size": 2269,
            "start_time": "2019-08-29T13:17:22.915Z"
        },
        "edb8b270-904a-40dc-bb3b-e6ef278585a2": {
            "last_event_timestamp": "2019-08-29T13:17:22.915Z",
            "last_event_published_time": "2019-08-29T13:17:22.915Z",
            "name": "/var/log/alternatives.log",
            "read_offset": 5752,
            "size": 5752,
            "start_time": "2019-08-29T13:17:22.913Z"
        },
        "f63a4922-164b-47bb-9edd-1b446685090c": {
            "last_event_@timestamp": "",
            "last_event_published_time": "",
            "name": "/var/log/pm-suspend.log",
            "start_time": "2019-08-29T13:17:22.906Z"
        }
    },
    "open_files": 6,
    "running": 6,
    "started": 6
}
```

Closes elastic/beats#7743