### PR TITLE
Cherry-pick #15233 to 7.x: Fix: expect more output lines / Test the addition of a dynamic config

### DIFF
--- a/heartbeat/tests/system/test_reload.py
+++ b/heartbeat/tests/system/test_reload.py
@@ -80,7 +80,7 @@ class Test(BaseTest):
             self.wait_until(lambda: self.log_contains(
                 "Starting reload procedure, current runners: 1"))
 
-            self.wait_until(lambda: self.output_has(lines=1))
+            self.wait_until(lambda: self.output_lines() > 0)
 
             self.proc.check_kill_and_wait()
         finally:


### PR DESCRIPTION
Cherry-pick of PR #15233 to 7.x branch. Original message: 

This PR adjusts system tests for heartbeat.

The system test verifies if the application works after changing configuration, but more output lines can be produced.

Issue: https://github.com/elastic/beats/issues/15202