### PR TITLE
Cherry-pick #15419 to 7.x: [Filebeat] Add missing googlecloud.yml.disabled file

### DIFF
--- a/x-pack/filebeat/modules.d/googlecloud.yml.disabled
+++ b/x-pack/filebeat/modules.d/googlecloud.yml.disabled
@@ -1,0 +1,57 @@
+# Module: googlecloud
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-googlecloud.html
+
+- module: googlecloud
+  vpcflow:
+    enabled: true
+
+    # Google Cloud project ID.
+    var.project_id: my-gcp-project-id
+
+    # Google Pub/Sub topic containing VPC flow logs. Stackdriver must be
+    # configured to use this topic as a sink for VPC flow logs.
+    var.topic: googlecloud-vpc-flowlogs
+
+    # Google Pub/Sub subscription for the topic. Filebeat will create this
+    # subscription if it does not exist.
+    var.subscription_name: filebeat-googlecloud-vpc-flowlogs-sub
+
+    # Credentials file for the service account with authorization to read from
+    # the subscription.
+    var.credentials_file: ${path.config}/gcp-service-account-xyz.json
+
+  firewall:
+    enabled: true
+
+    # Google Cloud project ID.
+    var.project_id: my-gcp-project-id
+
+    # Google Pub/Sub topic containing firewall logs. Stackdriver must be
+    # configured to use this topic as a sink for firewall logs.
+    var.topic: googlecloud-vpc-firewall
+
+    # Google Pub/Sub subscription for the topic. Filebeat will create this
+    # subscription if it does not exist.
+    var.subscription_name: filebeat-googlecloud-firewall-sub
+
+    # Credentials file for the service account with authorization to read from
+    # the subscription.
+    var.credentials_file: ${path.config}/gcp-service-account-xyz.json
+
+  audit:
+    enabled: true
+
+    # Google Cloud project ID.
+    var.project_id: my-gcp-project-id
+
+    # Google Pub/Sub topic containing firewall logs. Stackdriver must be
+    # configured to use this topic as a sink for firewall logs.
+    var.topic: googlecloud-vpc-audit
+
+    # Google Pub/Sub subscription for the topic. Filebeat will create this
+    # subscription if it does not exist.
+    var.subscription_name: filebeat-googlecloud-audit
+
+    # Credentials file for the service account with authorization to read from
+    # the subscription.
+    var.credentials_file: ${path.config}/gcp-service-account-xyz.json

--- a/x-pack/filebeat/modules.d/googlecloud.yml.disabled
+++ b/x-pack/filebeat/modules.d/googlecloud.yml.disabled
@@ -1,5 +1,5 @@
 # Module: googlecloud
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-googlecloud.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-module-googlecloud.html
 
 - module: googlecloud
   vpcflow:
@@ -15,24 +15,6 @@
     # Google Pub/Sub subscription for the topic. Filebeat will create this
     # subscription if it does not exist.
     var.subscription_name: filebeat-googlecloud-vpc-flowlogs-sub
-
-    # Credentials file for the service account with authorization to read from
-    # the subscription.
-    var.credentials_file: ${path.config}/gcp-service-account-xyz.json
-
-  firewall:
-    enabled: true
-
-    # Google Cloud project ID.
-    var.project_id: my-gcp-project-id
-
-    # Google Pub/Sub topic containing firewall logs. Stackdriver must be
-    # configured to use this topic as a sink for firewall logs.
-    var.topic: googlecloud-vpc-firewall
-
-    # Google Pub/Sub subscription for the topic. Filebeat will create this
-    # subscription if it does not exist.
-    var.subscription_name: filebeat-googlecloud-firewall-sub
 
     # Credentials file for the service account with authorization to read from
     # the subscription.


### PR DESCRIPTION
Cherry-pick of PR #15419 to 7.x branch. Original message: 

Seems like `modules.d/googlecloud.yml.disabled` is missing. When I run `mage update; mage build`, this file gets generated.

This file exists in 7.5 branch but not in master or 7.x. Maybe it got deleted by accident?!