### PR TITLE
Cherry-pick #15368 to 7.x: Fix test output with ipv6 addresses

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
 - Fix spooling to disk blocking infinitely if the lock file can not be acquired. {pull}15338[15338]
+- Fix `metricbeat test output` with an ipv6 ES host in the output.hosts. {pull}15368[15368]
 
 *Auditbeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -668,10 +668,8 @@ func (client *Client) Test(d testing.Driver) {
 		u, err := url.Parse(client.URL)
 		d.Fatal("parse url", err)
 
-		address := u.Hostname()
-		if u.Port() != "" {
-			address += ":" + u.Port()
-		}
+		address := u.Host
+
 		d.Run("connection", func(d testing.Driver) {
 			netDialer := transport.TestNetDialer(d, client.timeout)
 			_, err = netDialer.Dial("tcp", address)


### PR DESCRIPTION
Cherry-pick of PR #15368 to 7.x branch. Original message: 

Fixes #15078 

Using `u.Host` would not break anything, as far as I can tell