### PR TITLE
Cherry-pick #14876 to 7.x: Add monitoring information about functions to Functionbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -140,6 +140,16 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- New options to configure roles and VPC. {pull}11779[11779]
+- Export automation templates used to create functions. {pull}11923[11923]
+- Configurable Amazon endpoint. {pull}12369[12369]
+- Add timeout option to reference configuration. {pull}13351[13351]
+- Configurable tags for Lambda functions. {pull}13352[13352]
+- Add input for Cloudwatch logs through Kinesis. {pull}13317[13317]
+- Enable Logstash output. {pull}13345[13345]
+- Make `bulk_max_size` configurable in outputs. {pull}13493[13493]
+- Add `index` option to all functions to directly set a per-function index value. {issue}15064[15064] {pull}15101[15101]
+- Add monitoring info about triggered functions. {pull}14876[14876]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/function/beater/functionbeat.go
+++ b/x-pack/functionbeat/function/beater/functionbeat.go
@@ -16,10 +16,12 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/x-pack/functionbeat/config"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
 	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 	"github.com/elastic/beats/x-pack/libbeat/licenser"
 )
 
@@ -42,11 +44,12 @@ var (
 // - Run on a read only filesystem
 // - More execution constraints based on speed and memory usage.
 type Functionbeat struct {
-	ctx      context.Context
-	log      *logp.Logger
-	cancel   context.CancelFunc
-	Provider provider.Provider
-	Config   *config.Config
+	ctx       context.Context
+	log       *logp.Logger
+	cancel    context.CancelFunc
+	telemetry telemetry.T
+	Provider  provider.Provider
+	Config    *config.Config
 }
 
 // New creates an instance of functionbeat.
@@ -62,12 +65,15 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 
+	telemetryReg := monitoring.GetNamespace("state").GetRegistry().NewRegistry("functionbeat")
+
 	bt := &Functionbeat{
-		ctx:      ctx,
-		cancel:   cancel,
-		log:      logp.NewLogger("functionbeat"),
-		Provider: provider,
-		Config:   c,
+		ctx:       ctx,
+		log:       logp.NewLogger("functionbeat"),
+		cancel:    cancel,
+		telemetry: telemetry.New(telemetryReg),
+		Provider:  provider,
+		Config:    c,
 	}
 	return bt, nil
 }
@@ -120,7 +126,7 @@ func (bt *Functionbeat) Run(b *beat.Beat) error {
 	// When an error reach the coordinator we assume that we cannot recover from it and we initiate
 	// a shutdown and return an aggregated errors.
 	coordinator := core.NewCoordinator(logp.NewLogger("coordinator"), functions...)
-	err = coordinator.Run(bt.ctx)
+	err = coordinator.Run(bt.ctx, bt.telemetry)
 	if err != nil {
 		return err
 	}

--- a/x-pack/functionbeat/function/provider/provider.go
+++ b/x-pack/functionbeat/function/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 )
 
 // Create a new pipeline client based on the function configuration.
@@ -21,7 +22,7 @@ type clientFactory func(*common.Config) (core.Client, error)
 
 // Function is temporary
 type Function interface {
-	Run(context.Context, core.Client) error
+	Run(context.Context, core.Client, telemetry.T) error
 	Name() string
 }
 
@@ -46,13 +47,13 @@ type Runnable struct {
 
 // Run call the the function's Run method, the method is a specific goroutine, it will block until
 // beats shutdown or an error happen.
-func (r *Runnable) Run(ctx context.Context) error {
+func (r *Runnable) Run(ctx context.Context, t telemetry.T) error {
 	client, err := r.makeClient(r.config)
 	if err != nil {
 		return errors.Wrap(err, "could not create a client for the function")
 	}
 	defer client.Close()
-	return r.function.Run(ctx, client)
+	return r.function.Run(ctx, client, t)
 }
 
 func (r *Runnable) String() string {

--- a/x-pack/functionbeat/function/provider/provider_test.go
+++ b/x-pack/functionbeat/function/provider/provider_test.go
@@ -15,13 +15,14 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 )
 
 type simpleFunction struct {
 	err error
 }
 
-func (s *simpleFunction) Run(ctx context.Context, client core.Client) error {
+func (s *simpleFunction) Run(ctx context.Context, client core.Client, _ telemetry.T) error {
 	return s.err
 }
 
@@ -45,7 +46,7 @@ func TestRunnable(t *testing.T) {
 			function:   &simpleFunction{err: nil},
 		}
 
-		errReceived := runnable.Run(context.Background())
+		errReceived := runnable.Run(context.Background(), telemetry.Ignored())
 		assert.Equal(t, err, e.Cause(errReceived))
 	})
 
@@ -57,7 +58,7 @@ func TestRunnable(t *testing.T) {
 			function:   &simpleFunction{err: err},
 		}
 
-		errReceived := runnable.Run(context.Background())
+		errReceived := runnable.Run(context.Background(), telemetry.Ignored())
 		assert.Equal(t, err, e.Cause(errReceived))
 	})
 
@@ -68,7 +69,7 @@ func TestRunnable(t *testing.T) {
 			function:   &simpleFunction{err: nil},
 		}
 
-		errReceived := runnable.Run(context.Background())
+		errReceived := runnable.Run(context.Background(), telemetry.Ignored())
 		assert.NoError(t, errReceived)
 	})
 }

--- a/x-pack/functionbeat/function/provider/registry_test.go
+++ b/x-pack/functionbeat/function/provider/registry_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 )
 
 type mockProvider struct {
@@ -48,8 +49,8 @@ type mockFunction struct {
 	name string
 }
 
-func (mf *mockFunction) Run(ctx context.Context, client core.Client) error { return nil }
-func (mf *mockFunction) Name() string                                      { return mf.name }
+func (mf *mockFunction) Run(ctx context.Context, client core.Client, t telemetry.T) error { return nil }
+func (mf *mockFunction) Name() string                                                     { return mf.name }
 
 func testProviderLookup(t *testing.T) {
 	name := "myprovider"

--- a/x-pack/functionbeat/function/telemetry/telemetry.go
+++ b/x-pack/functionbeat/function/telemetry/telemetry.go
@@ -1,0 +1,37 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package telemetry
+
+import (
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+// T is a telemetry instance
+type T interface {
+	AddTriggeredFunction()
+}
+
+type telemetry struct {
+	registry       *monitoring.Registry
+	countFunctions *monitoring.Int
+}
+
+// New returns a new telemetry registry.
+func New(r *monitoring.Registry) T {
+	return &telemetry{
+		registry:       r.NewRegistry("functions"),
+		countFunctions: monitoring.NewInt(r, "count"),
+	}
+}
+
+// Ignored is used when the package is not monitored.
+func Ignored() T {
+	return nil
+}
+
+// AddTriggeredFunction adds a triggered function data to the registry.
+func (t *telemetry) AddTriggeredFunction() {
+	t.countFunctions.Inc()
+}

--- a/x-pack/functionbeat/provider/aws/aws/api_gateway_proxy.go
+++ b/x-pack/functionbeat/provider/aws/aws/api_gateway_proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
 	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 	"github.com/elastic/beats/x-pack/functionbeat/provider/aws/aws/transformer"
 )
 
@@ -44,7 +45,9 @@ func APIGatewayProxyDetails() *feature.Details {
 }
 
 // Run starts the lambda function and wait for web triggers.
-func (a *APIGatewayProxy) Run(_ context.Context, client core.Client) error {
+func (a *APIGatewayProxy) Run(_ context.Context, client core.Client, telemetry telemetry.T) error {
+	telemetry.AddTriggeredFunction()
+
 	lambda.Start(a.createHandler(client))
 	return nil
 }
@@ -55,6 +58,7 @@ func (a *APIGatewayProxy) createHandler(
 	return func(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		a.log.Debugf("The handler receives a new event from the gateway (requestID: %s)", request.RequestContext.RequestID)
 		event := transformer.APIGatewayProxyRequest(request)
+
 		if err := client.Publish(event); err != nil {
 			a.log.Errorf("could not publish event to the pipeline, error: %+v", err)
 			return buildResponse(

--- a/x-pack/functionbeat/provider/aws/aws/cloudwatch_kinesis.go
+++ b/x-pack/functionbeat/provider/aws/aws/cloudwatch_kinesis.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
 	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 	"github.com/elastic/beats/x-pack/functionbeat/provider/aws/aws/transformer"
 )
 
@@ -69,7 +70,9 @@ func CloudwatchKinesisDetails() *feature.Details {
 }
 
 // Run starts the lambda function and wait for web triggers.
-func (c *CloudwatchKinesis) Run(_ context.Context, client core.Client) error {
+func (c *CloudwatchKinesis) Run(_ context.Context, client core.Client, t telemetry.T) error {
+	t.AddTriggeredFunction()
+
 	lambdarunner.Start(c.createHandler(client))
 	return nil
 }

--- a/x-pack/functionbeat/provider/aws/aws/cloudwatch_logs.go
+++ b/x-pack/functionbeat/provider/aws/aws/cloudwatch_logs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
 	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 	"github.com/elastic/beats/x-pack/functionbeat/provider/aws/aws/transformer"
 )
 
@@ -105,7 +106,9 @@ func CloudwatchLogsDetails() *feature.Details {
 }
 
 // Run start the AWS lambda handles and will transform any events received to the pipeline.
-func (c *CloudwatchLogs) Run(_ context.Context, client core.Client) error {
+func (c *CloudwatchLogs) Run(_ context.Context, client core.Client, t telemetry.T) error {
+	t.AddTriggeredFunction()
+
 	lambdarunner.Start(c.createHandler(client))
 	return nil
 }
@@ -130,6 +133,7 @@ func (c *CloudwatchLogs) createHandler(
 		)
 
 		events := transformer.CloudwatchLogs(parsedEvent)
+
 		if err := client.PublishAll(events); err != nil {
 			c.log.Errorf("Could not publish events to the pipeline, error: %+v", err)
 			return err

--- a/x-pack/functionbeat/provider/local/local/local.go
+++ b/x-pack/functionbeat/provider/local/local/local.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/x-pack/functionbeat/function/core"
 	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/function/telemetry"
 )
 
 const stdinName = "stdin"
@@ -43,7 +44,7 @@ func NewStdinFunction(
 
 // Run reads events from the STDIN and send them to the publisher pipeline, will stop reading by
 // either by an external signal to stop or by reaching EOF. When EOF is reached functionbeat will shutdown.
-func (s *StdinFunction) Run(ctx context.Context, client core.Client) error {
+func (s *StdinFunction) Run(ctx context.Context, client core.Client, _ telemetry.T) error {
 	errChan := make(chan error)
 	defer close(errChan)
 	lineChan := make(chan string)


### PR DESCRIPTION
Cherry-pick of PR #14876 to 7.x branch. Original message: 

This PR adds a new counter which returns the number of triggered functions of Functionbeat.

Example snippet of the telemetry message containing info about function:

```json
{
  "state": {
    "functionbeat": {
        "functions": {
             "count": 1,
        }
    }
}
```

Follow-up work is required on Kibana side to process the reported information correctly to get telemetry data.