### PR TITLE
Cherry-pick #14666 to 7.5: Restrict permissible regex for instance name in perfmon 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -67,7 +67,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. {issue}14541[14541] {pull}14591[14591]
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
 - Fix regular expression to detect instance name in perfmon metricset. {issue}14273[14273] {pull}14666[14666]
-- Vshpere module splits `virtualmachine.host` into `virtualmachine.host.id` and `virtualmachine.host.hostname`. {issue}7187[7187] {pull}7213[7213]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
 - Fix `docker.container.size` fields values {issue}14979[14979] {pull}15224[15224]
 - Make `kibana` module more resilient to Kibana unavailability. {issue}15258[15258] {pull}15270[15270]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -66,6 +66,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix checking tagsFilter using length in cloudwatch metricset. {pull}14525[14525]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. {issue}14541[14541] {pull}14591[14591]
 - Log bulk failures from bulk API requests to monitoring cluster. {issue}14303[14303] {pull}14356[14356]
+- Fix regular expression to detect instance name in perfmon metricset. {issue}14273[14273] {pull}14666[14666]
+- Vshpere module splits `virtualmachine.host` into `virtualmachine.host.id` and `virtualmachine.host.hostname`. {issue}7187[7187] {pull}7213[7213]
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
 - Fix `docker.container.size` fields values {issue}14979[14979] {pull}15224[15224]
 - Make `kibana` module more resilient to Kibana unavailability. {issue}15258[15258] {pull}15270[15270]

--- a/metricbeat/module/windows/perfmon/pdh_query_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_query_windows.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	instanceNameRegexp = regexp.MustCompile(`.*\((.*)\).*`)
+	instanceNameRegexp = regexp.MustCompile(`.*?\((.*?)\).*`)
 	objectNameRegexp   = regexp.MustCompile(`(?:^\\\\[^\\]+\\|^\\)([^\\]+)`)
 )
 

--- a/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
@@ -89,3 +89,28 @@ func TestSuccessfulQuery(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, list)
 }
+
+// TestInstanceNameRegexp tests regular expression for instance.
+func TestInstanceNameRegexp(t *testing.T) {
+	queryPaths := []string{`\SQLServer:Databases(*)\Log File(s) Used Size (KB)`, `\Search Indexer(*)\L0 Indexes (Wordlists)`,
+		`\Search Indexer(*)\L0 Merges (flushes) Now.`, `\NUMA Node Memory(*)\Free & Zero Page List MBytes`}
+	for _, path := range queryPaths {
+		matches := instanceNameRegexp.FindStringSubmatch(path)
+		if assert.Len(t, matches, 2, "regular expression did not return any matches") {
+			assert.Equal(t, matches[1], "*")
+		}
+	}
+}
+
+// TestObjectNameRegexp tests regular expression for object.
+func TestObjectNameRegexp(t *testing.T) {
+	queryPaths := []string{`\Web Service Cache\Output Cache Current Flushed Items`,
+		`\Web Service Cache\Output Cache Total Flushed Items`, `\Web Service Cache\Total Flushed Metadata`,
+		`\Web Service Cache\Kernel: Current URIs Cached`}
+	for _, path := range queryPaths {
+		matches := objectNameRegexp.FindStringSubmatch(path)
+		if assert.Len(t, matches, 2, "regular expression did not return any matches") {
+			assert.Equal(t, matches[1], "Web Service Cache")
+		}
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#14666 to 7.5 branch. Original message:

Should fix #14273.

Previous regular expression will pick up the string in the last parentheses. We restricted this to the first set instead.
Added tests for the regular expressions.