### PR TITLE
Cherry-pick #15394 to 7.x: Use source blocks in asciidocs instead of backquotes

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -131,11 +131,14 @@ Kafka fetch settings:
 
 If the fileset using this input expects to receive multiple messages bundled under a specific field then the config option `expand_event_list_from_field` value can be assigned the name of the field.
 For example in the case of azure filesets the events are found under the json object "records".
-```
+
+["source","json"]
+----
 {
 "records": [ {event1}, {event2}]
 }
-```
+----
+
 This setting will be able to split the messages under the group value ('records') into separate events.
 
 ===== `rebalance`

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -44,7 +44,8 @@ image::./images/filebeat-azure-overview.png[]
 [float]
 === Module configuration
 
-```
+["source","yaml"]
+----
 - module: azure
   activitylogs:
     enabled: true
@@ -68,8 +69,7 @@ image::./images/filebeat-azure-overview.png[]
        eventhub: ["insights-logs-signinlogs"]
        consumer_group: "$Default"
        connection_string: ""
-
-```
+----
 
 
 A side by side kafka/event hubs notation, we will follow Azure notations in this case.

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -68,9 +68,10 @@ Process execution data (state, memory, cpu, cmdline) should be available for an 
 If the beats process is running as less privileged user, it may not be able to read process data belonging to
 other users. The issue should be reported in application logs:
 
-```
+["source"]
+----
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
-```
+----
 
 [float]
 ==== process_summary
@@ -118,9 +119,10 @@ Systemd service data (memory, tasks, states) should be available for an authoriz
 If the beats process is running as less privileged user, it may not be able to read process data belonging to
 other users. The issue should be reported in application logs:
 
-```
+["source"]
+----
 2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
-```
+----
 
 [float]
 ==== filesystem

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -61,9 +61,10 @@ Process execution data (state, memory, cpu, cmdline) should be available for an 
 If the beats process is running as less privileged user, it may not be able to read process data belonging to
 other users. The issue should be reported in application logs:
 
-```
+["source"]
+----
 2019-12-23T13:32:06.457+0100    DEBUG   [processes]     process/process.go:475  Skip process pid=235: error getting process state for pid=235: Could not read process info for pid 23
-```
+----
 
 [float]
 ==== process_summary
@@ -111,9 +112,10 @@ Systemd service data (memory, tasks, states) should be available for an authoriz
 If the beats process is running as less privileged user, it may not be able to read process data belonging to
 other users. The issue should be reported in application logs:
 
-```
+["source"]
+----
 2020-01-02T08:19:50.635Z	INFO	module/wrapper.go:252	Error fetching data for metricset system.service: error getting list of running units: Rejected send message, 2 matched rules; type="method_call", sender=":1.35" (uid=1000 pid=4429 comm="./metricbeat -d * -e ") interface="org.freedesktop.systemd1.Manager" member="ListUnitsByPatterns" error name="(unset)" requested_reply="0" destination="org.freedesktop.systemd1" (uid=0 pid=1 comm="/usr/lib/systemd/systemd --switched-root --system ")
-```
+----
 
 [float]
 ==== filesystem

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -39,7 +39,8 @@ image::./images/filebeat-azure-overview.png[]
 [float]
 === Module configuration
 
-```
+["source","yaml"]
+----
 - module: azure
   activitylogs:
     enabled: true
@@ -63,8 +64,7 @@ image::./images/filebeat-azure-overview.png[]
        eventhub: ["insights-logs-signinlogs"]
        consumer_group: "$Default"
        connection_string: ""
-
-```
+----
 
 
 A side by side kafka/event hubs notation, we will follow Azure notations in this case.

--- a/x-pack/metricbeat/module/azure/monitor/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/monitor/_meta/docs.asciidoc
@@ -51,11 +51,13 @@ Metrics with dimensions are exported as flattened single dimensional metrics, ag
 `value`:: Dimension value. (Users can select * to return metric values for each dimension)
 
 Users can select the options to retrieve all metrics from a specific namespace using the following:
-```
+
+["source","yaml"]
+----
  metrics:
  - name: ["*"]
    namespace: "Microsoft.Storage/storageAccounts"
-```
+----
 
 If no aggregations are entered under a metric level the metricset will retrieve the primary aggregation assigned for this metric.
 


### PR DESCRIPTION
Cherry-pick of PR #15394 to 7.x branch. Original message: 

In general we use source blocks in asciidocs for blocks of code,
in some places we were using backquotes, and formatting is not
consistent. Change backquotes with source blocks.