### PR TITLE
Scheduler close ordering

### DIFF
--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -185,13 +185,16 @@ func (f *fleetGateway) execute() (*fleetapi.CheckinResponse, error) {
 func (f *fleetGateway) Start() {
 	f.wg.Add(1)
 	go func(wg *sync.WaitGroup) {
+		defer f.log.Info("Fleet gateway is stopped")
 		defer wg.Done()
+
 		f.worker()
 	}(&f.wg)
 }
 
 func (f *fleetGateway) Stop() {
+	f.log.Info("Fleet gateway is stopping")
+	defer f.scheduler.Stop()
 	close(f.done)
-	f.scheduler.Stop()
 	f.wg.Wait()
 }


### PR DESCRIPTION
Fix an issue when stopping the gateway and the scheduler needed to be
done in order so we don't hit a closed channel.

So now we get out of the worker loop, when the worker is closed we can
close the scheduler.