### PR TITLE
Cherry-pick #15305 to 7.5: Fix ocasional panic in UTF16ToStringArray when processing unicode strings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed bug with `elasticsearch/cluster_stats` metricset not recording license ID in the correct field. {pull}14592[14592]
 - Fix `docker.container.size` fields values {issue}14979[14979] {pull}15224[15224]
 - Make `kibana` module more resilient to Kibana unavailability. {issue}15258[15258] {pull}15270[15270]
+- Fix panic exception with some unicode strings in perfmon metricset. {issue}15264[15264]
 - Make `logstash` module more resilient to Logstash unavailability. {issue}15276[15276] {pull}15306[15306]
 
 *Packetbeat*

--- a/metricbeat/module/windows/perfmon/pdh_query_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_query_windows.go
@@ -274,7 +274,7 @@ func UTF16ToStringArray(buf []uint16) []string {
 	stringLine := UTF16PtrToString(&buf[0])
 	for stringLine != "" {
 		strings = append(strings, stringLine)
-		nextLineStart += len(stringLine) + 1
+		nextLineStart += len([]rune(stringLine)) + 1
 		remainingBuf := buf[nextLineStart:]
 		stringLine = UTF16PtrToString(&remainingBuf[0])
 	}

--- a/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_query_windows_test.go
@@ -18,6 +18,7 @@
 package perfmon
 
 import (
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,5 +113,21 @@ func TestObjectNameRegexp(t *testing.T) {
 		if assert.Len(t, matches, 2, "regular expression did not return any matches") {
 			assert.Equal(t, matches[1], "Web Service Cache")
 		}
+	}
+}
+
+func TestUTF16ToStringArray(t *testing.T) {
+	var array = []string{"\\\\DESKTOP-RFOOE09\\Physikalischer Datenträger(0 C:)\\Schreibvorgänge/s", "\\\\DESKTOP-RFOOE09\\Physikalischer Datenträger(_Total)\\Schreibvorgänge/s", ""}
+	var unicode []uint16
+	for _, i := range array {
+		uni, err := syscall.UTF16FromString(i)
+		assert.NoError(t, err)
+		unicode = append(unicode, uni...)
+	}
+	response := UTF16ToStringArray(unicode)
+	assert.NotNil(t, response)
+	assert.Equal(t, len(response), 2)
+	for _, res := range response {
+		assert.Contains(t, array, res)
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#15305 to 7.5 branch. Original message:

Should also fix #15264.
Reproducing steps based on the original issue:

system language set to german
config for perfmon should contain:
    - instance_label: physical_disk.name
      measurement_label: physical_disk.write.time.pct
      query: '\PhysicalDisk(*)\% Disk Write Time'
the UTF16ToStringArray will not be able to read the next line start.