### PR TITLE
Cherry-pick #15178 to 7.x: Change metricbeat image tags to use integrations-ci

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   # Used by base tests
   elasticsearch:
-    image: docker.elastic.co/observability-ci/beats-integration-elasticsearch:${ELASTICSEARCH_VERSION:-7.4.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.4.0}-1
     build:
       context: ./module/elasticsearch/_meta
       args:
@@ -37,7 +37,7 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.4.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.4.0}-1
     build:
       context: ./module/kibana/_meta
       args:
@@ -49,7 +49,7 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/observability-ci/beats-integration-metricbeat:${BEAT_VERSION:-7.3.0}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.3.0}-1
     build:
       context: ./module/beat/_meta
       args:

--- a/metricbeat/module/aerospike/docker-compose.yml
+++ b/metricbeat/module/aerospike/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   aerospike:
-    image: docker.elastic.co/observability-ci/beats-integration-aerospike:${AEROSPIKE_VERSION:-3.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-aerospike:${AEROSPIKE_VERSION:-3.9.0}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/apache/docker-compose.yml
+++ b/metricbeat/module/apache/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   apache:
-    image: docker.elastic.co/observability-ci/beats-integration-apache:${APACHE_VERSION:-2.4.20}-1
+    image: docker.elastic.co/integrations-ci/beats-apache:${APACHE_VERSION:-2.4.20}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/ceph/docker-compose.yml
+++ b/metricbeat/module/ceph/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   ceph:
-    image: docker.elastic.co/observability-ci/beats-integration-ceph:${CEPH_VERSION:-master-6373c6a-jewel-centos-7-x86_64}-1
+    image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-6373c6a-jewel-centos-7-x86_64}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/consul/docker-compose.yml
+++ b/metricbeat/module/consul/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   consul:
-    image: docker.elastic.co/observability-ci/beats-integration-consul:${CONSUL_VERSION:-1.4.2}-1
+    image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.4.2}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/couchbase/docker-compose.yml
+++ b/metricbeat/module/couchbase/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   couchbase:
-    image: docker.elastic.co/observability-ci/beats-integration-couchbase:${COUCHBASE_VERSION:-4.5.1}-1
+    image: docker.elastic.co/integrations-ci/beats-couchbase:${COUCHBASE_VERSION:-4.5.1}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/couchdb/docker-compose.yml
+++ b/metricbeat/module/couchdb/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   couchdb:
-    image: docker.elastic.co/observability-ci/beats-integration-couchdb:${COUCHDB_VERSION:-1.7}-1
+    image: docker.elastic.co/integrations-ci/beats-couchdb:${COUCHDB_VERSION:-1.7}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/dropwizard/docker-compose.yml
+++ b/metricbeat/module/dropwizard/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   dropwizard:
-    image: docker.elastic.co/observability-ci/beats-integration-dropwizard:${MAVEN_VERSION:-3.3-jdk-8}-1
+    image: docker.elastic.co/integrations-ci/beats-dropwizard:${MAVEN_VERSION:-3.3-jdk-8}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/envoyproxy/docker-compose.yml
+++ b/metricbeat/module/envoyproxy/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   envoyproxy:
-    image: docker.elastic.co/observability-ci/beats-integration-envoyproxy:v${ENVOYPROXY_VERSION:-1.7.0}-1
+    image: docker.elastic.co/integrations-ci/beats-envoyproxy:v${ENVOYPROXY_VERSION:-1.7.0}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/etcd/docker-compose.yml
+++ b/metricbeat/module/etcd/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   etcd:
-    image: docker.elastic.co/observability-ci/beats-integration-etcd:${ETCD_VERSION:-3.3.10}-1
+    image: docker.elastic.co/integrations-ci/beats-etcd:${ETCD_VERSION:-3.3.10}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/golang/docker-compose.yml
+++ b/metricbeat/module/golang/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   golang:
-    image: docker.elastic.co/observability-ci/beats-integration-golang:1
+    image: docker.elastic.co/integrations-ci/beats-golang:1
     build:
       context: ./_meta
     ports:

--- a/metricbeat/module/haproxy/docker-compose.yml
+++ b/metricbeat/module/haproxy/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   haproxy:
-    image: docker.elastic.co/observability-ci/beats-integration-haproxy:${HAPROXY_VERSION:-1.8.22}-1
+    image: docker.elastic.co/integrations-ci/beats-haproxy:${HAPROXY_VERSION:-1.8.22}-1
     build: 
       context: ./_meta
       args:

--- a/metricbeat/module/http/docker-compose.yml
+++ b/metricbeat/module/http/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   http:
-    image: docker.elastic.co/observability-ci/beats-integration-http:1
+    image: docker.elastic.co/integrations-ci/beats-http:1
     build:
       context: ./_meta
     ports:

--- a/metricbeat/module/jolokia/docker-compose.yml
+++ b/metricbeat/module/jolokia/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   jolokia:
-    image: docker.elastic.co/observability-ci/beats-integration-jolokia:${JOLOKIA_VERSION:-1.5.0}-1
+    image: docker.elastic.co/integrations-ci/beats-jolokia:${JOLOKIA_VERSION:-1.5.0}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/kafka/docker-compose.yml
+++ b/metricbeat/module/kafka/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   kafka:
-    image: docker.elastic.co/observability-ci/beats-integration-kafka:${KAFKA_VERSION:-2.1.1}-2
+    image: docker.elastic.co/integrations-ci/beats-kafka:${KAFKA_VERSION:-2.1.1}-2
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/logstash/docker-compose.yml
+++ b/metricbeat/module/logstash/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   logstash:
-    image: docker.elastic.co/observability-ci/beats-integration-logstash:${LOGSTASH_VERSION:-7.4.0}-1
+    image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.4.0}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/memcached/docker-compose.yml
+++ b/metricbeat/module/memcached/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   memcached:
-    image: docker.elastic.co/observability-ci/beats-integration-memcached:${MEMCACHED_VERSION:-1.4.35}-1
+    image: docker.elastic.co/integrations-ci/beats-memcached:${MEMCACHED_VERSION:-1.4.35}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/mongodb/docker-compose.yml
+++ b/metricbeat/module/mongodb/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   mongodb:
-    image: docker.elastic.co/observability-ci/beats-integration-mongodb:${MONGODB_VERSION:-3.4}-1
+    image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-3.4}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/munin/docker-compose.yml
+++ b/metricbeat/module/munin/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   munin:
-    image: docker.elastic.co/observability-ci/beats-integration-munin:1
+    image: docker.elastic.co/integrations-ci/beats-munin:1
     build:
       context: ./_meta
     ports:

--- a/metricbeat/module/mysql/docker-compose.yml
+++ b/metricbeat/module/mysql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   mysql:
-    image: docker.elastic.co/observability-ci/beats-integration-mysql:${MYSQL_VARIANT:-mysql}-${MYSQL_VERSION:-5.7.12}-1
+    image: docker.elastic.co/integrations-ci/beats-mysql:${MYSQL_VARIANT:-mysql}-${MYSQL_VERSION:-5.7.12}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/nats/docker-compose.yml
+++ b/metricbeat/module/nats/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   nats:
-    image: docker.elastic.co/observability-ci/beats-integration-nats:${NATS_VERSION:-2.0.4}-1
+    image: docker.elastic.co/integrations-ci/beats-nats:${NATS_VERSION:-2.0.4}-1
     build:
       context: ./_meta
       dockerfile: Dockerfile.2.0.X
@@ -12,7 +12,7 @@ services:
       - 8222
 
   nats_1_3:
-    image: docker.elastic.co/observability-ci/beats-integration-nats:${NATS_VERSION:-1.3.0}-1
+    image: docker.elastic.co/integrations-ci/beats-nats:${NATS_VERSION:-1.3.0}-1
     build:
       context: ./_meta
       dockerfile: Dockerfile.1.3

--- a/metricbeat/module/nginx/docker-compose.yml
+++ b/metricbeat/module/nginx/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   nginx:
-    image: docker.elastic.co/observability-ci/beats-integration-nginx:${NGINX_VERSION:-1.9}-1
+    image: docker.elastic.co/integrations-ci/beats-nginx:${NGINX_VERSION:-1.9}-1
     build: 
       context: ./_meta
       args:

--- a/metricbeat/module/php_fpm/docker-compose.yml
+++ b/metricbeat/module/php_fpm/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   phpfpm:
-    image: docker.elastic.co/observability-ci/beats-integration-phpfpm:${PHPFPM_VERSION:-7.1}-1
+    image: docker.elastic.co/integrations-ci/beats-phpfpm:${PHPFPM_VERSION:-7.1}-1
     build: 
       context: ./_meta
       args:

--- a/metricbeat/module/postgresql/docker-compose.yml
+++ b/metricbeat/module/postgresql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   postgresql:
-    image: docker.elastic.co/observability-ci/beats-integration-postgresql:${POSTGRESQL_VERSION:-9.5.3}-1
+    image: docker.elastic.co/integrations-ci/beats-postgresql:${POSTGRESQL_VERSION:-9.5.3}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/prometheus/docker-compose.yml
+++ b/metricbeat/module/prometheus/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   prometheus:
-    image: docker.elastic.co/observability-ci/beats-integration-prometheus:${PROMETHEUS_VERSION:-2.6.0}-1
+    image: docker.elastic.co/integrations-ci/beats-prometheus:${PROMETHEUS_VERSION:-2.6.0}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/rabbitmq/docker-compose.yml
+++ b/metricbeat/module/rabbitmq/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   rabbitmq:
-    image: docker.elastic.co/observability-ci/beats-integration-rabbitmq:${RABBITMQ_VERSION:-3.7.4}-1
+    image: docker.elastic.co/integrations-ci/beats-rabbitmq:${RABBITMQ_VERSION:-3.7.4}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/redis/docker-compose.yml
+++ b/metricbeat/module/redis/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   redis:
-    image: docker.elastic.co/observability-ci/beats-integration-redis:${REDIS_VERSION:-3.2.12}-1
+    image: docker.elastic.co/integrations-ci/beats-redis:${REDIS_VERSION:-3.2.12}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/traefik/docker-compose.yml
+++ b/metricbeat/module/traefik/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   traefik:
-    image: docker.elastic.co/observability-ci/beats-integration-traefik:${TRAEFIK_VERSION:-1.6}-1
+    image: docker.elastic.co/integrations-ci/beats-traefik:${TRAEFIK_VERSION:-1.6}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/uwsgi/docker-compose.yml
+++ b/metricbeat/module/uwsgi/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   uwsgi_tcp:
-    image: docker.elastic.co/observability-ci/beats-integration-uwsgi:py${PYTHON_VERSION:-3.6}-1
+    image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
     build:
       context: ./_meta
       args:
@@ -12,7 +12,7 @@ services:
       - 9191
 
   uwsgi_http:
-    image: docker.elastic.co/observability-ci/beats-integration-uwsgi:py${PYTHON_VERSION:-3.6}-1
+    image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
     build:
       context: ./_meta
       args:

--- a/metricbeat/module/zookeeper/docker-compose.yml
+++ b/metricbeat/module/zookeeper/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   zookeeper:
-    image: docker.elastic.co/observability-ci/beats-integration-zookeeper:${ZOOKEEPER_VERSION:-3.5.5}-1
+    image: docker.elastic.co/integrations-ci/beats-zookeeper:${ZOOKEEPER_VERSION:-3.5.5}-1
     build:
       context: ./_meta
       args:

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.4.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.4.0}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:

--- a/x-pack/metricbeat/module/activemq/docker-compose.yml
+++ b/x-pack/metricbeat/module/activemq/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   activemq:
-    image: docker.elastic.co/observability-ci/beats-integration-activemq:${ACTIVEMQ_VERSION:-5.15.9}-1
+    image: docker.elastic.co/integrations-ci/beats-activemq:${ACTIVEMQ_VERSION:-5.15.9}-1
     build:
       context: ./_meta
       args:

--- a/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
+++ b/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   cockroachdb:
-    image: docker.elastic.co/observability-ci/beats-integration-cockroachdb:${COCKROACHDB_VERSION:-19.1.1}-1
+    image: docker.elastic.co/integrations-ci/beats-cockroachdb:${COCKROACHDB_VERSION:-19.1.1}-1
     build:
       context: ./_meta
       args:

--- a/x-pack/metricbeat/module/coredns/docker-compose.yml
+++ b/x-pack/metricbeat/module/coredns/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   coredns:
-    image: docker.elastic.co/observability-ci/beats-integration-coredns:${COREDNS_VERSION:-1.5.0}-1
+    image: docker.elastic.co/integrations-ci/beats-coredns:${COREDNS_VERSION:-1.5.0}-1
     build:
       context: ./_meta
       args:

--- a/x-pack/metricbeat/module/mssql/docker-compose.yml
+++ b/x-pack/metricbeat/module/mssql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   mssql:
-    image: docker.elastic.co/observability-ci/beats-integration-mssql:${MSSQL_VERSION:-2017-GA}-1
+    image: docker.elastic.co/integrations-ci/beats-mssql:${MSSQL_VERSION:-2017-GA}-1
     build:
       context: ./_meta
       args:

--- a/x-pack/metricbeat/module/stan/docker-compose.yml
+++ b/x-pack/metricbeat/module/stan/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   stan:
-    image: docker.elastic.co/observability-ci/beats-integration-stan:${STAN_VERSION:-0.15.1}-1
+    image: docker.elastic.co/integrations-ci/beats-stan:${STAN_VERSION:-0.15.1}-1
     build:
       context: ./_meta
       args:


### PR DESCRIPTION
Cherry-pick of PR #15178 to 7.x branch. Original message: 

Change tags of docker images used in metricbeat testing to use
the `integrations-ci` namespace, that is publicly available.
"`integrations`" is removed from the image name to avoid repeating,
so the names change like this:

```diff
- docker.elastic.co/observability-ci/beats-integration-<integration>:<version>
+ docker.elastic.co/integrations-ci/beats-<integration>:<version>
```

Closes elastic/beats#15035