### PR TITLE
[Agent] Send meta with every checkin request

### DIFF
--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -9,13 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"runtime"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/agent/kibana"
-	"github.com/elastic/beats/agent/release"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/application/info"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/errors"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/storage"
@@ -169,19 +166,6 @@ func (c *EnrollCmd) Execute() error {
 	}
 
 	return nil
-}
-
-func metadata() (map[string]interface{}, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]interface{}{
-		"platform": runtime.GOOS,
-		"version":  release.Version(),
-		"host":     hostname,
-	}, nil
 }
 
 func yamlToReader(in interface{}) (io.Reader, error) {

--- a/x-pack/agent/pkg/agent/application/fleet_acker.go
+++ b/x-pack/agent/pkg/agent/application/fleet_acker.go
@@ -37,7 +37,7 @@ func newActionAcker(
 
 func (f *actionAcker) Ack(action fleetapi.Action) error {
 	// checkin
-	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, nil)
+	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
 		Events: []fleetapi.SerializableEvent{
 			fleetapi.Ack(action),

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -166,8 +166,13 @@ func (f *fleetGateway) execute() (*fleetapi.CheckinResponse, error) {
 	// get events
 	ee, ack := f.reporter.Events()
 
+	var metaData map[string]interface{}
+	if m, err := metadata(); err == nil {
+		metaData = m
+	}
+
 	// checkin
-	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, metadata)
+	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, metaData)
 	req := &fleetapi.CheckinRequest{
 		Events: ee,
 	}

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -167,7 +167,7 @@ func (f *fleetGateway) execute() (*fleetapi.CheckinResponse, error) {
 	ee, ack := f.reporter.Events()
 
 	// checkin
-	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
+	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, metadata)
 	req := &fleetapi.CheckinRequest{
 		Events: ee,
 	}

--- a/x-pack/agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/agent/pkg/agent/application/fleet_gateway.go
@@ -172,9 +172,10 @@ func (f *fleetGateway) execute() (*fleetapi.CheckinResponse, error) {
 	}
 
 	// checkin
-	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, metaData)
+	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
-		Events: ee,
+		Events:   ee,
+		Metadata: metaData,
 	}
 
 	resp, err := cmd.Execute(req)

--- a/x-pack/agent/pkg/agent/application/local_meta.go
+++ b/x-pack/agent/pkg/agent/application/local_meta.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/elastic/beats/agent/release"
+)
+
+func metadata() (map[string]interface{}, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"platform": runtime.GOOS,
+		"version":  release.Version(),
+		"host":     hostname,
+	}, nil
+}

--- a/x-pack/agent/pkg/fleetapi/checkin_cmd.go
+++ b/x-pack/agent/pkg/fleetapi/checkin_cmd.go
@@ -58,21 +58,19 @@ func (e *CheckinResponse) Validate() error {
 type CheckinCmd struct {
 	client clienter
 	info   agentInfo
-	metaFn metadataFunc
+	meta   map[string]interface{}
 }
 
 type agentInfo interface {
 	AgentID() string
 }
 
-type metadataFunc func() (map[string]interface{}, error)
-
 // NewCheckinCmd creates a new api command.
-func NewCheckinCmd(info agentInfo, client clienter, metaFn metadataFunc) *CheckinCmd {
+func NewCheckinCmd(info agentInfo, client clienter, metadata map[string]interface{}) *CheckinCmd {
 	return &CheckinCmd{
 		client: client,
 		info:   info,
-		metaFn: metaFn,
+		meta:   metadata,
 	}
 }
 
@@ -124,15 +122,10 @@ func (e *CheckinCmd) Execute(r *CheckinRequest) (*CheckinResponse, error) {
 }
 
 func (e *CheckinCmd) injectMetadata(r *CheckinRequest) error {
-	if e.metaFn == nil {
+	if e.meta == nil || len(e.meta) == 0 {
 		return nil
 	}
 
-	meta, err := e.metaFn()
-	if err != nil {
-		return err
-	}
-
-	r.Metadata = meta
+	r.Metadata = e.meta
 	return nil
 }

--- a/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
@@ -78,7 +78,7 @@ func TestCheckin(t *testing.T) {
 				},
 			}
 
-			cmd := NewCheckinCmd(&agentinfo{}, client, nil)
+			cmd := NewCheckinCmd(&agentinfo{}, client)
 
 			request := CheckinRequest{
 				Events: []SerializableEvent{
@@ -109,7 +109,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client, nil)
+			cmd := NewCheckinCmd(agentInfo, client)
 
 			request := CheckinRequest{}
 
@@ -160,7 +160,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client, nil)
+			cmd := NewCheckinCmd(agentInfo, client)
 
 			request := CheckinRequest{}
 
@@ -222,7 +222,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client, nil)
+			cmd := NewCheckinCmd(agentInfo, client)
 
 			request := CheckinRequest{}
 
@@ -260,7 +260,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client, nil)
+			cmd := NewCheckinCmd(agentInfo, client)
 
 			request := CheckinRequest{}
 
@@ -310,9 +310,9 @@ Something went wrong
 				"key": "value",
 			}
 
-			cmd := NewCheckinCmd(agentInfo, client, meta)
+			cmd := NewCheckinCmd(agentInfo, client)
 
-			request := CheckinRequest{}
+			request := CheckinRequest{Metadata: meta}
 
 			r, err := cmd.Execute(&request)
 			require.NoError(t, err)
@@ -348,7 +348,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client, nil)
+			cmd := NewCheckinCmd(agentInfo, client)
 
 			request := CheckinRequest{}
 

--- a/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
@@ -7,10 +7,12 @@ package fleetapi
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,7 +78,7 @@ func TestCheckin(t *testing.T) {
 				},
 			}
 
-			cmd := NewCheckinCmd(&agentinfo{}, client)
+			cmd := NewCheckinCmd(&agentinfo{}, client, nil)
 
 			request := CheckinRequest{
 				Events: []SerializableEvent{
@@ -107,7 +109,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client)
+			cmd := NewCheckinCmd(agentInfo, client, nil)
 
 			request := CheckinRequest{}
 
@@ -158,7 +160,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client)
+			cmd := NewCheckinCmd(agentInfo, client, nil)
 
 			request := CheckinRequest{}
 
@@ -220,7 +222,7 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client)
+			cmd := NewCheckinCmd(agentInfo, client, nil)
 
 			request := CheckinRequest{}
 
@@ -258,7 +260,59 @@ Something went wrong
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
-			cmd := NewCheckinCmd(agentInfo, client)
+			cmd := NewCheckinCmd(agentInfo, client, nil)
+
+			request := CheckinRequest{}
+
+			r, err := cmd.Execute(&request)
+			require.NoError(t, err)
+			require.True(t, r.Success)
+
+			require.Equal(t, 0, len(r.Actions))
+		},
+	))
+
+	key, value := "key", "val"
+	t.Run("Meta are sent", withServerWithAuthClient(
+		func(t *testing.T) *http.ServeMux {
+			raw := `
+{
+  "actions": [],
+	"success": true
+}
+`
+			mux := http.NewServeMux()
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
+			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
+				type Request struct {
+					Metadata map[string]interface{} `json:"local_metadata"`
+				}
+				req := &Request{}
+
+				content, err := ioutil.ReadAll(r.Body)
+				assert.NoError(t, err)
+				assert.NoError(t, json.Unmarshal(content, &req))
+
+				assert.Equal(t, 1, len(req.Metadata))
+				v, found := req.Metadata[key]
+				assert.True(t, found)
+
+				intV, ok := v.(string)
+				assert.True(t, ok)
+				assert.Equal(t, value, intV)
+
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, raw)
+			}, withAPIKey))
+			return mux
+		}, withAPIKey,
+		func(t *testing.T, client clienter) {
+			metaFn := func() (map[string]interface{}, error) {
+				return map[string]interface{}{
+					key: value,
+				}, nil
+			}
+			cmd := NewCheckinCmd(agentInfo, client, metaFn)
 
 			request := CheckinRequest{}
 


### PR DESCRIPTION
Checking API endpoint allows to update local metadata.

This PR inject metadata to each checking request.

Based on #15496 