### PR TITLE
Add layouts to the String method of the timestamp processor

### DIFF
--- a/libbeat/processors/timestamp/timestamp.go
+++ b/libbeat/processors/timestamp/timestamp.go
@@ -100,8 +100,8 @@ func loadLocation(timezone string) (*time.Location, error) {
 }
 
 func (p *processor) String() string {
-	return fmt.Sprintf("timestamp=[field=%s, target_field=%v, timezone=%v]",
-		p.Field, p.TargetField, p.tz)
+	return fmt.Sprintf("timestamp=[field=%s, target_field=%v, timezone=%v, layouts=%v]",
+		p.Field, p.TargetField, p.tz, p.Layouts)
 }
 
 func (p *processor) Run(event *beat.Event) (*beat.Event, error) {


### PR DESCRIPTION
When dealing with autodiscover & hints, especially, that generate new configurations depending on the discovered workloads, having the `layouts` as part of the debug message is quite useful for checking what the timestamp processor is trying to match against the target field.