### PR TITLE
[Agent] Fix panic on backoff Retry

### DIFF
--- a/x-pack/agent/pkg/agent/operation/operator.go
+++ b/x-pack/agent/pkg/agent/operation/operator.go
@@ -102,7 +102,7 @@ func defaultOperatorConfig() *operatorCfg.Config {
 			Enabled:      false,
 			RetriesCount: 0,
 			Delay:        30 * time.Second,
-			MaxDelay:     300 * time.Second,
+			MaxDelay:     5 * time.Minute,
 			Exponential:  false,
 		},
 	}

--- a/x-pack/agent/pkg/agent/operation/operator.go
+++ b/x-pack/agent/pkg/agent/operation/operator.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/configrequest"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/errors"
@@ -21,6 +22,7 @@ import (
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/plugin/app"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/plugin/app/monitoring"
+	"github.com/elastic/beats/x-pack/agent/pkg/core/plugin/retry"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/plugin/state"
 	rconfig "github.com/elastic/beats/x-pack/agent/pkg/core/remoteconfig/grpc"
 )
@@ -58,20 +60,13 @@ func NewOperator(
 	stateResolver *stateresolver.StateResolver,
 	eventProcessor callbackHooks) (*Operator, error) {
 
-	operatorConfig := &operatorCfg.Config{}
+	operatorConfig := defaultOperatorConfig()
 	if err := config.Unpack(&operatorConfig); err != nil {
 		return nil, err
 	}
 
 	if operatorConfig.DownloadConfig == nil {
 		return nil, fmt.Errorf("artifacts configuration not provided")
-	}
-
-	if operatorConfig.MonitoringConfig == nil {
-		operatorConfig.MonitoringConfig = &monitoring.Config{
-			MonitorLogs:    false,
-			MonitorMetrics: false,
-		}
 	}
 
 	if eventProcessor == nil {
@@ -95,6 +90,22 @@ func NewOperator(
 	os.MkdirAll(operatorConfig.DownloadConfig.InstallPath, 0755)
 
 	return operator, nil
+}
+
+func defaultOperatorConfig() *operatorCfg.Config {
+	return &operatorCfg.Config{
+		MonitoringConfig: &monitoring.Config{
+			MonitorLogs:    false,
+			MonitorMetrics: false,
+		},
+		RetryConfig: &retry.Config{
+			Enabled:      false,
+			RetriesCount: 0,
+			Delay:        30 * time.Second,
+			MaxDelay:     300 * time.Second,
+			Exponential:  false,
+		},
+	}
 }
 
 // State describes the current state of the system.

--- a/x-pack/agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/agent/pkg/agent/operation/operator_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/elastic/beats/x-pack/agent/pkg/core/plugin/state"
 )
 
-var installPath string = "tests/scripts"
+var installPath = "tests/scripts"
 
 func TestMain(m *testing.M) {
 	// init supported with test cases

--- a/x-pack/agent/pkg/core/remoteconfig/grpc/noop_backoff.go
+++ b/x-pack/agent/pkg/core/remoteconfig/grpc/noop_backoff.go
@@ -12,7 +12,7 @@ import (
 // Used when no backoff is configured.
 type NoopBackoff struct{}
 
-// NewEqualJitterBackoff returns a new EqualJitter object.
+// NewNoopBackoff returns a new EqualJitter object.
 func NewNoopBackoff() backoff.Backoff {
 	return &NoopBackoff{}
 }

--- a/x-pack/agent/pkg/core/remoteconfig/grpc/noop_backoff.go
+++ b/x-pack/agent/pkg/core/remoteconfig/grpc/noop_backoff.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package grpc
+
+import (
+	"github.com/elastic/beats/libbeat/common/backoff"
+)
+
+// NoopBackoff implements a backoff interface without any wait.
+// Used when no backoff is configured.
+type NoopBackoff struct{}
+
+// NewEqualJitterBackoff returns a new EqualJitter object.
+func NewNoopBackoff() backoff.Backoff {
+	return &NoopBackoff{}
+}
+
+// Reset resets the duration of the backoff.
+func (b *NoopBackoff) Reset() {}
+
+// Wait block until either the timer is completed or channel is done.
+func (b *NoopBackoff) Wait() bool {
+	return true
+}

--- a/x-pack/agent/pkg/scheduler/scheduler.go
+++ b/x-pack/agent/pkg/scheduler/scheduler.go
@@ -16,7 +16,7 @@ type Scheduler interface {
 	Stop()
 }
 
-// Stepper is a scheduler where each Tick is manully triggered, this is useful in scenario
+// Stepper is a scheduler where each Tick is manually triggered, this is useful in scenario
 // when you want to test the behavior of asynchronous code in a synchronous way.
 type Stepper struct {
 	C chan time.Time

--- a/x-pack/agent/pkg/scheduler/scheduler_test.go
+++ b/x-pack/agent/pkg/scheduler/scheduler_test.go
@@ -106,6 +106,7 @@ func testPeriodic(t *testing.T) {
 		nE = <-recorder.recorder
 		require.Equal(t, 3, nE.count)
 	})
+
 }
 
 func testPeriodicJitter(t *testing.T) {

--- a/x-pack/agent/pkg/scheduler/scheduler_test.go
+++ b/x-pack/agent/pkg/scheduler/scheduler_test.go
@@ -106,7 +106,6 @@ func testPeriodic(t *testing.T) {
 		nE = <-recorder.recorder
 		require.Equal(t, 3, nE.count)
 	})
-
 }
 
 func testPeriodicJitter(t *testing.T) {


### PR DESCRIPTION
Issue is when retry is disabled and delay/maxDelay are not part of the config, zero values which are 0 are passed into `backoff.New()`

When backoff tries to rand on 0 it panics. 

Fix is on 2 places;
- operator config unpack unpacks into prepopulated structure which contains default values for delay and maxDelay, with retry disabled. 
- if somehow delay or maxdelay are 0 then operator creates NoopBackoff which does nothing instead of EqualJitterBackoff (other option would be to default to 30s but then client would wait 30s for no reason after error) 

cc @ph #15474