### PR TITLE
Cherry-pick #15511 to 7.x: Fix pull on ContainerStart wrapper used in tests

### DIFF
--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -20,6 +20,8 @@ package docker
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -41,9 +43,11 @@ func NewClient() (Client, error) {
 // ContainerStart pulls and starts the given container
 func (c Client) ContainerStart(image string, cmd []string, labels map[string]string) (string, error) {
 	ctx := context.Background()
-	if _, err := c.cli.ImagePull(ctx, image, types.ImagePullOptions{}); err != nil {
-		return "", err
+	respBody, err := c.cli.ImagePull(ctx, image, types.ImagePullOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "pullling image %s", image)
 	}
+	defer respBody.Close()
 
 	resp, err := c.cli.ContainerCreate(ctx, &container.Config{
 		Image:  image,
@@ -51,11 +55,11 @@ func (c Client) ContainerStart(image string, cmd []string, labels map[string]str
 		Labels: labels,
 	}, nil, nil, "")
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "creating container")
 	}
 
 	if err := c.cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "starting container")
 	}
 
 	return resp.ID, nil


### PR DESCRIPTION
Cherry-pick of PR #15511 to 7.x branch. Original message: 

ContainerStart wrapper used in tests was not waiting for the pull to
finish, causing flakiness, e.g. in `TestDockerStart`. Pull can be
waited to finish by calling to `Close()` in the response body. This is
also something that has to be done at some moment to avoid leaks.

Also add some more context on error messages.