### PR TITLE
[7.x] Remove OneOfOne xxhash in favor of cespare (#15518)

### DIFF
--- a/libbeat/processors/fingerprint/hash.go
+++ b/libbeat/processors/fingerprint/hash.go
@@ -24,6 +24,8 @@ import (
 	"crypto/sha512"
 	"hash"
 	"strings"
+
+	"github.com/cespare/xxhash"
 )
 
 type hashMethod func() hash.Hash
@@ -34,6 +36,7 @@ var hashes = map[string]hashMethod{
 	"sha256": sha256.New,
 	"sha384": sha512.New384,
 	"sha512": sha512.New,
+	"xxhash": newXxHash,
 }
 
 // Unpack creates the hashMethod from the given string
@@ -47,4 +50,9 @@ func (f *hashMethod) Unpack(str string) error {
 
 	*f = m
 	return nil
+}
+
+// newXxHash returns a hash.Hash instead of the *Digest which implements the same
+func newXxHash() hash.Hash {
+	return xxhash.New()
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove OneOfOne xxhash in favor of cespare  (#15518)