### PR TITLE
Exclude TLS1.3 support if older go version is used

### DIFF
--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -131,8 +131,8 @@ func TestApplyEmptyConfig(t *testing.T) {
 	}
 
 	cfg := tmp.BuildModuleConfig("")
-	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
+	assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
+	assert.Equal(t, int(TLSVersionDefaultMax), int(cfg.MaxVersion))
 	assert.Len(t, cfg.Certificates, 0)
 	assert.Nil(t, cfg.RootCAs)
 	assert.Equal(t, false, cfg.InsecureSkipVerify)
@@ -163,8 +163,8 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.NotNil(t, cfg.RootCAs)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
-	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
+	assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
+	assert.Equal(t, int(TLSVersionDefaultMax), int(cfg.MaxVersion))
 	assert.Len(t, cfg.CurvePreferences, 1)
 	assert.Equal(t, tls.RenegotiateOnceAsClient, cfg.Renegotiation)
 }
@@ -188,8 +188,8 @@ func TestServerConfigDefaults(t *testing.T) {
 		assert.Len(t, cfg.CurvePreferences, 0)
 		// values set by default
 		assert.Equal(t, false, cfg.InsecureSkipVerify)
-		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-		assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
+		assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
+		assert.Equal(t, int(TLSVersionDefaultMax), int(cfg.MaxVersion))
 		assert.Equal(t, tls.NoClientCert, cfg.ClientAuth)
 	})
 	t.Run("when CA is explicitly set", func(t *testing.T) {
@@ -214,8 +214,8 @@ func TestServerConfigDefaults(t *testing.T) {
 		assert.Len(t, cfg.CurvePreferences, 0)
 		// values set by default
 		assert.Equal(t, false, cfg.InsecureSkipVerify)
-		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-		assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
+		assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
+		assert.Equal(t, int(TLSVersionDefaultMax), int(cfg.MaxVersion))
 		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
 	})
 }
@@ -227,7 +227,6 @@ func TestApplyWithServerConfig(t *testing.T) {
     certificate_authorities: [ca_test.pem]
     verification_mode: none
     client_authentication: optional
-    supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
     cipher_suites:
       - "ECDHE-ECDSA-AES-256-CBC-SHA"
       - "ECDHE-ECDSA-AES-256-GCM-SHA384"
@@ -235,6 +234,10 @@ func TestApplyWithServerConfig(t *testing.T) {
   `
 	var c ServerConfig
 	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	for i, ver := range TLSDefaultVersions {
+		config.SetString("supported_protocols", i, ver.String())
+	}
+
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -254,8 +257,8 @@ func TestApplyWithServerConfig(t *testing.T) {
 	assert.NotNil(t, cfg.ClientCAs)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
-	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS13), int(cfg.MaxVersion))
+	assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
+	assert.Equal(t, int(TLSVersionDefaultMax), int(cfg.MaxVersion))
 	assert.Len(t, cfg.CurvePreferences, 1)
 	assert.Equal(t, tls.VerifyClientCertIfGiven, cfg.ClientAuth)
 }

--- a/libbeat/common/transport/tlscommon/types.go
+++ b/libbeat/common/transport/tlscommon/types.go
@@ -99,25 +99,6 @@ var tlsRenegotiationSupportTypes = map[string]tlsRenegotiationSupport{
 	"freely": tlsRenegotiationSupport(tls.RenegotiateFreelyAsClient),
 }
 
-// TLSVersion type for TLS version.
-type TLSVersion uint16
-
-// Define all the possible TLS version.
-const (
-	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
-	TLSVersion10    TLSVersion = tls.VersionTLS10
-	TLSVersion11    TLSVersion = tls.VersionTLS11
-	TLSVersion12    TLSVersion = tls.VersionTLS12
-	TLSVersion13    TLSVersion = tls.VersionTLS13
-)
-
-// TLSDefaultVersions list of versions of TLS we should support.
-var TLSDefaultVersions = []TLSVersion{
-	TLSVersion11,
-	TLSVersion12,
-	TLSVersion13,
-}
-
 type tlsClientAuth int
 
 const (
@@ -130,24 +111,6 @@ var tlsClientAuthTypes = map[string]tlsClientAuth{
 	"none":     tlsClientAuthNone,
 	"optional": tlsClientAuthOptional,
 	"required": tlsClientAuthRequired,
-}
-
-var tlsProtocolVersions = map[string]TLSVersion{
-	"SSLv3":   TLSVersionSSL30,
-	"SSLv3.0": TLSVersionSSL30,
-	"TLSv1":   TLSVersion10,
-	"TLSv1.0": TLSVersion10,
-	"TLSv1.1": TLSVersion11,
-	"TLSv1.2": TLSVersion12,
-	"TLSv1.3": TLSVersion13,
-}
-
-var tlsProtocolVersionsInverse = map[TLSVersion]string{
-	TLSVersionSSL30: "SSLv3",
-	TLSVersion10:    "TLSv1.0",
-	TLSVersion11:    "TLSv1.1",
-	TLSVersion12:    "TLSv1.2",
-	TLSVersion13:    "TLSv1.3",
 }
 
 // TLSVerificationMode represents the type of verification to do on the remote host,
@@ -165,24 +128,6 @@ const (
 	//       postVerifyTLSConnection
 	// VerifyCertificate
 )
-
-func (v TLSVersion) String() string {
-	if s, ok := tlsProtocolVersionsInverse[v]; ok {
-		return s
-	}
-	return "unknown"
-}
-
-//Unpack transforms the string into a constant.
-func (v *TLSVersion) Unpack(s string) error {
-	version, found := tlsProtocolVersions[s]
-	if !found {
-		return fmt.Errorf("invalid tls version '%v'", s)
-	}
-
-	*v = version
-	return nil
-}
 
 var tlsVerificationModes = map[string]TLSVerificationMode{
 	"":     VerifyFull,

--- a/libbeat/common/transport/tlscommon/versions.go
+++ b/libbeat/common/transport/tlscommon/versions.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import "fmt"
+
+// TLSVersion type for TLS version.
+type TLSVersion uint16
+
+func (v TLSVersion) String() string {
+	if s, ok := tlsProtocolVersionsInverse[v]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+//Unpack transforms the string into a constant.
+func (v *TLSVersion) Unpack(s string) error {
+	version, found := tlsProtocolVersions[s]
+	if !found {
+		return fmt.Errorf("invalid tls version '%v'", s)
+	}
+
+	*v = version
+	return nil
+}

--- a/libbeat/common/transport/tlscommon/versions_default.go
+++ b/libbeat/common/transport/tlscommon/versions_default.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.13
+
+package tlscommon
+
+import "crypto/tls"
+
+// Define all the possible TLS version.
+const (
+	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
+	TLSVersion10    TLSVersion = tls.VersionTLS10
+	TLSVersion11    TLSVersion = tls.VersionTLS11
+	TLSVersion12    TLSVersion = tls.VersionTLS12
+	TLSVersion13    TLSVersion = tls.VersionTLS13
+
+	// TLSVersionMin is the min TLS version supported.
+	TLSVersionMin = TLSVersionSSL30
+
+	// TLSVersionMax is the max TLS version supported.
+	TLSVersionMax = TLSVersion13
+
+	// TLSVersionDefaultMin is the minimal default TLS version that is
+	// enabled by default. TLSVersionDefaultMin is >= TLSVersionMin
+	TLSVersionDefaultMin = TLSVersion11
+
+	// TLSVersionDefaultMax is the max default TLS version that
+	// is enabled by default.
+	TLSVersionDefaultMax = TLSVersionMax
+)
+
+// TLSDefaultVersions list of versions of TLS we should support.
+var TLSDefaultVersions = []TLSVersion{
+	TLSVersion11,
+	TLSVersion12,
+	TLSVersion13,
+}
+
+var tlsProtocolVersions = map[string]TLSVersion{
+	"SSLv3":   TLSVersionSSL30,
+	"SSLv3.0": TLSVersionSSL30,
+	"TLSv1":   TLSVersion10,
+	"TLSv1.0": TLSVersion10,
+	"TLSv1.1": TLSVersion11,
+	"TLSv1.2": TLSVersion12,
+	"TLSv1.3": TLSVersion13,
+}
+
+var tlsProtocolVersionsInverse = map[TLSVersion]string{
+	TLSVersionSSL30: "SSLv3",
+	TLSVersion10:    "TLSv1.0",
+	TLSVersion11:    "TLSv1.1",
+	TLSVersion12:    "TLSv1.2",
+	TLSVersion13:    "TLSv1.3",
+}

--- a/libbeat/common/transport/tlscommon/versions_legacy.go
+++ b/libbeat/common/transport/tlscommon/versions_legacy.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !go1.13
+
+package tlscommon
+
+import "crypto/tls"
+
+const (
+	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
+	TLSVersion10    TLSVersion = tls.VersionTLS10
+	TLSVersion11    TLSVersion = tls.VersionTLS11
+	TLSVersion12    TLSVersion = tls.VersionTLS12
+
+	// TLSVersionMin is the min TLS version supported.
+	TLSVersionMin = TLSVersionSSL30
+
+	// TLSVersionMax is the max TLS version supported.
+	TLSVersionMax = TLSVersion12
+
+	// TLSVersionDefaultMin is the minimal default TLS version that is
+	// enabled by default. TLSVersionDefaultMin is >= TLSVersionMin
+	TLSVersionDefaultMin = TLSVersion10
+
+	// TLSVersionDefaultMax is the max default TLS version that
+	// is enabled by default.
+	TLSVersionDefaultMax = TLSVersionMax
+)
+
+// TLSDefaultVersions list of versions of TLS we should support.
+var TLSDefaultVersions = []TLSVersion{
+	TLSVersion10,
+	TLSVersion11,
+	TLSVersion12,
+}
+
+var tlsProtocolVersions = map[string]TLSVersion{
+	"SSLv3":   TLSVersionSSL30,
+	"SSLv3.0": TLSVersionSSL30,
+	"TLSv1":   TLSVersion10,
+	"TLSv1.0": TLSVersion10,
+	"TLSv1.1": TLSVersion11,
+	"TLSv1.2": TLSVersion12,
+}
+
+var tlsProtocolVersionsInverse = map[TLSVersion]string{
+	TLSVersionSSL30: "SSLv3",
+	TLSVersion10:    "TLSv1.0",
+	TLSVersion11:    "TLSv1.1",
+	TLSVersion12:    "TLSv1.2",
+}

--- a/libbeat/outputs/transport/tls.go
+++ b/libbeat/outputs/transport/tls.go
@@ -35,20 +35,6 @@ type TLSConfig = tlscommon.TLSConfig
 // TLSVersion type for TLS version.
 type TLSVersion = tlscommon.TLSVersion
 
-// Define all the possible TLS version.
-const (
-	TLSVersionSSL30 = tlscommon.TLSVersionSSL30
-	TLSVersion10    = tlscommon.TLSVersion10
-	TLSVersion11    = tlscommon.TLSVersion11
-	TLSVersion12    = tlscommon.TLSVersion12
-)
-
-// Constants of the supported verification mode.
-const (
-	VerifyFull = tlscommon.VerifyFull
-	VerifyNone = tlscommon.VerifyNone
-)
-
 func TLSDialer(forward Dialer, config *TLSConfig, timeout time.Duration) (Dialer, error) {
 	return TestTLSDialer(testing.NullDriver, forward, config, timeout)
 }


### PR DESCRIPTION
Only compile with TLS1.3 support for go1.13 or newer is used. If an
older go version is used we stick with TLS1.2 max.

The change also introduces TLSVersionMin/Max and
TLSVersionDefaultMin/Max constants, so to keep the tests intact.

Note: This change comes with a gotcha. All TLS documentation use the same contents and will mention TLS1.3. But GCP support will not have TLS1.3 support, because GCP requires go1.11. This must be reflected in our GCP Functionbeat docs as well.