### PR TITLE
Fix filebeat to perseve log.level in event from json reader

### DIFF
--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -29,10 +29,12 @@ import (
 // WriteJSONKeys writes the json keys to the given event based on the overwriteKeys option and the addErrKey
 func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys bool, addErrKey bool) {
 	if !overwriteKeys {
-		for k, v := range keys {
-			if _, exists := event.Fields[k]; !exists && k != "@timestamp" && k != "@metadata" {
-				event.Fields[k] = v
-			}
+		if keys != nil {
+			// DeepUpdate the event fields over the keys from the JSON. Ensures that the predefined
+			// event keys are not overwritten, but any nesting of map values is still added to the event.
+			fields := common.MapStr(keys)
+			fields.DeepUpdate(event.Fields)
+			event.Fields.Update(fields)
 		}
 		return
 	}

--- a/libbeat/common/jsontransform/jsonhelper_test.go
+++ b/libbeat/common/jsontransform/jsonhelper_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package jsontransform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestWriteJSONKeys_NoOverwriteMerges(t *testing.T) {
+	evt := beat.Event{
+		Fields: common.MapStr{
+			"log": common.MapStr{
+				"offset": 0,
+				"file": common.MapStr{
+					"path": "/var/log/log.json",
+				},
+			},
+		},
+	}
+	keys := common.MapStr{
+		"log": common.MapStr{
+			"level":  "debug",
+			"offset": 10, // not written to event
+			"file": common.MapStr{
+				"path":   "/var/log/other.json", // not written to event
+				"nested": "written",
+			},
+		},
+	}
+
+	WriteJSONKeys(&evt, keys, false, false)
+
+	expected := beat.Event{
+		Fields: common.MapStr{
+			"log": common.MapStr{
+				"level":  "debug",
+				"offset": 0,
+				"file": common.MapStr{
+					"path":   "/var/log/log.json",
+					"nested": "written",
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, evt)
+}


### PR DESCRIPTION
Fix filebeat to perserve log.level in event from json reader.

Closes elastic/beats#12040 