### PR TITLE
CISCO IOS Improvements

### DIFF
--- a/x-pack/filebeat/module/cisco/ios/config/pipeline.js
+++ b/x-pack/filebeat/module/cisco/ios/config/pipeline.js
@@ -289,12 +289,14 @@ var ciscoIOS = (function() {
                         switch (evt.Get('event.code')) {
                             case "PS_FAIL":
                                 setCategorization(evt,"alert","host","change","failure");
+                                break;
                             case "PS_STATUS":
                                 if (evt.Get('cisco.ios.power_supply.status') == "OK") {
                                     setCategorization(evt,"event","host","info","success");
                                 } else {
                                     setCategorization(evt,"event","host","info","failure");
                                 }
+                                break;
                         }
                         return;
                     }

--- a/x-pack/filebeat/module/cisco/ios/config/pipeline.js
+++ b/x-pack/filebeat/module/cisco/ios/config/pipeline.js
@@ -180,9 +180,11 @@ var ciscoIOS = (function() {
 
             setLogSource(evt);
 
+            var dissect = "";
+
             switch (facility) {
                 case "SEC":
-                    var dissect = accessListMessagePatterns[eventCode];
+                    dissect = accessListMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         coerceNumbers(evt);
@@ -202,9 +204,9 @@ var ciscoIOS = (function() {
                         }
                         return;
                     }
-
+                    break;
                 case "LINK":
-                    var dissect = linkMessagePatterns[eventCode];
+                    dissect = linkMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         setInterfaceProperties(evt);
@@ -217,8 +219,9 @@ var ciscoIOS = (function() {
                         normalizeEventAction(evt);
                         return;
                     }
+                    break;
                 case "LINEPROTO":
-                    var dissect = lineProtoMessagePatterns[eventCode];
+                    dissect = lineProtoMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         setInterfaceProperties(evt);
@@ -231,8 +234,9 @@ var ciscoIOS = (function() {
                         normalizeEventAction(evt);
                         return;
                     }
+                    break;
                 case "ILPOWER":
-                    var dissect = ilPowerMessagePatterns[eventCode];
+                    dissect = ilPowerMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         setInterfaceProperties(evt);
@@ -246,8 +250,9 @@ var ciscoIOS = (function() {
                         normalizeEventAction(evt);
                         return;
                     }
+                    break;
                 case "PORT_SECURITY":
-                    var dissect = portSecurityMessagePatterns[eventCode];
+                    dissect = portSecurityMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         normalizeInterfaceName(evt);
@@ -257,8 +262,9 @@ var ciscoIOS = (function() {
                         normalizeEventAction(evt);
                         return;
                     }
+                    break;
                 case "PM":
-                    var dissect = pmMessagePatterns[eventCode];
+                    dissect = pmMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         normalizeInterfaceName(evt);
@@ -272,8 +278,9 @@ var ciscoIOS = (function() {
                         normalizeEventAction(evt);
                         return;
                     }
+                    break;
                 case "PLATFORM":
-                    var dissect = platformMessagePatterns[eventCode];
+                    dissect = platformMessagePatterns[eventCode];
                     if (dissect) {
                         dissect(evt);
                         setCategorization(evt,"event","host","info","unknown");
@@ -291,6 +298,7 @@ var ciscoIOS = (function() {
                         }
                         return;
                     }
+                    break;
             }
         })
         .CommunityID()
@@ -320,7 +328,7 @@ var ciscoIOS = (function() {
 
     var normalizeInterfaceName = function(evt) {
         var ifName = evt.Get("interface.name");
-        var ifName = ifName.split('.').join('');
+        ifName = ifName.split('.').join('');
         var iSpace = ifName.indexOf(' ');
         if (iSpace > 0) {
             ifName = ifName.substring(0,iSpace);
@@ -335,18 +343,12 @@ var ciscoIOS = (function() {
         }
 
         var iCut = action.indexOf(' (');
-        if (iCut > 0) {
-            evt.Put("eventAction", action.substring(0,iCut));
-        }
-    };
-
-    var normalizeEventAction = function(evt) {
-        var action = evt.Get("event.action");
-        if (!action) {
-            return;
-        }
 
         switch (true) {
+            case (iCut > 0):
+                evt.Put("eventAction", action.substring(0,iCut));
+                break;
+
             case (action.search("Power granted") == 0):
                 evt.Put("event.action", "Power granted");
                 break;
@@ -387,7 +389,7 @@ var ciscoIOS = (function() {
             evt.Put("log.source.ip", source_address[0]);
             evt.Put("log.source.port", source_address[1]);
         }
-    }
+    };
 
     var setRelatedIP = function(event) {
         event.AppendTo("related.ip", event.Get("source.ip"));

--- a/x-pack/filebeat/module/cisco/ios/config/pipeline.js
+++ b/x-pack/filebeat/module/cisco/ios/config/pipeline.js
@@ -14,23 +14,23 @@ var ciscoIOS = (function() {
     };
 
     var accessListMessagePatterns = {
-        "IPACCESSLOGP": newDissect("list %{cisco.ios.access_list} %{event.outcome} " +
+        "IPACCESSLOGP": newDissect("list %{cisco.ios.access_list} %{event.action} " +
             "%{network.transport} %{source.address}(%{source.port}) -> " +
             "%{destination.address}(%{destination.port}), %{source.packets} packet"),
 
-        "IPACCESSLOGDP": newDissect("list %{cisco.ios.access_list} %{event.outcome} " +
+        "IPACCESSLOGDP": newDissect("list %{cisco.ios.access_list} %{event.action} " +
             "%{network.transport} %{source.address} -> " +
             "%{destination.address} (%{icmp.type}/%{icmp.code}), %{source.packets} packet"),
 
-        "IPACCESSLOGRP": newDissect("list %{cisco.ios.access_list} %{event.outcome} " +
+        "IPACCESSLOGRP": newDissect("list %{cisco.ios.access_list} %{event.action} " +
             "%{network.transport} %{source.address} -> " +
             "%{destination.address}, %{source.packets} packet"),
 
-        "IPACCESSLOGSP": newDissect("list %{cisco.ios.access_list} %{event.outcome} " +
+        "IPACCESSLOGSP": newDissect("list %{cisco.ios.access_list} %{event.action} " +
             "%{network.transport} %{source.address} -> " +
             "%{destination.address} (%{igmp.type}), %{source.packets} packet"),
 
-        "IPACCESSLOGNP": newDissect("list %{cisco.ios.access_list} %{event.outcome} " +
+        "IPACCESSLOGNP": newDissect("list %{cisco.ios.access_list} %{event.action} " +
             "%{network.iana_number} %{source.address} -> " +
             "%{destination.address}, %{source.packets} packet"),
     };
@@ -39,6 +39,33 @@ var ciscoIOS = (function() {
     accessListMessagePatterns.ACCESSLOGSP = accessListMessagePatterns.IPACCESSLOGSP;
     accessListMessagePatterns.ACCESSLOGDP = accessListMessagePatterns.IPACCESSLOGDP;
     accessListMessagePatterns.ACCESSLOGNP = accessListMessagePatterns.IPACCESSLOGNP;
+
+    var linkMessagePatterns = {
+        "UPDOWN": newDissect("Interface %{interface.name}, %{event.action} to %{interface.status}")
+    };
+
+    var lineProtoMessagePatterns = {
+        "UPDOWN": newDissect("Line protocol on Interface %{interface.name}, %{event.action} to %{interface.status}")
+    };
+
+    var ilPowerMessagePatterns = {
+        "POWER_GRANTED": newDissect("Interface %{interface.name}: %{event.action}"),
+        "IEEE_DISCONNECT": newDissect("Interface %{interface.name}: %{event.action}")
+    };
+
+    var portSecurityMessagePatterns = {
+        "PSECURE_VIOLATION": newDissect("%{event.action} occurred, caused by MAC address %{source.mac} on port %{interface.name}")
+    };
+
+    var pmMessagePatterns = {
+        "ERR_DISABLE": newDissect("%{event.action} on %{interface.name}, putting Gi2/0/12 in %{interface.state} status"),
+        "ERR_RECOVER": newDissect("Attempting to %{event.action} on %{interface.name}")
+    };
+
+    var platformMessagePatterns = {
+        "PS_FAIL": newDissect("Power supply %{cisco.ios.power_supply.number} %{event.action} (Serial number %{cisco.ios.power_supply.serialnumber})"),
+        "PS_STATUS": newDissect("PowerSupply %{cisco.ios.power_supply.number} current-status is PS_%{cisco.ios.power_supply.status}")
+    };
 
     var setLogLevel = function(evt) {
         var severity = evt.Get("event.severity");
@@ -137,23 +164,133 @@ var ciscoIOS = (function() {
             ],
         })
         .Add(setLogLevel)
-        // Use a specific dissect pattern based on the event.code.
+        // Use a specific dissect pattern based on the cisco.event.facility and event.code.
         .Add(function(evt) {
+            var facility = evt.Get("cisco.ios.facility");
+            if (!facility) {
+                return;
+            }
+
+            evt.Put("event.provider", facility);
+
             var eventCode = evt.Get("event.code");
             if (!eventCode) {
                 return;
             }
 
-            var dissect = accessListMessagePatterns[eventCode];
-            if (dissect) {
-                dissect(evt);
-                coerceNumbers(evt);
-                normalizeEventOutcome(evt);
-                setNetworkType(evt);
-                setRelatedIP(evt);
-                evt.Put("event.category", "network_traffic");
-                evt.Put("event.type", "firewall");
-                return;
+            setLogSource(evt);
+
+            switch (facility) {
+                case "SEC":
+                    var dissect = accessListMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        setNetworkType(evt);
+                        setRelatedIP(evt);
+                        switch (evt.Get('event.action')) {
+                            case "permitted":
+                                setCategorization(evt,"event","process","access","success");
+                                break;
+                            case "denied":
+                                setCategorization(evt,"event","process","access","failure");
+                                break;
+                            default:
+                                setCategorization(evt,"event","process","access","unknown");
+                                break;
+                        }
+                        return;
+                    }
+
+                case "LINK":
+                    var dissect = linkMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        setInterfaceProperties(evt);
+                        if (evt.Get('interface.status') == "up") {
+                            setCategorization(evt,"event","driver","access","success");
+                        } else {
+                            setCategorization(evt,"event","driver","change","failure");
+                        }
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        return;
+                    }
+                case "LINEPROTO":
+                    var dissect = lineProtoMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        setInterfaceProperties(evt);
+                        if (evt.Get('interface.status') == "up") {
+                            setCategorization(evt,"event","driver","change","success");
+                        } else {
+                            setCategorization(evt,"event","driver","change","failure");
+                        }
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        return;
+                    }
+                case "ILPOWER":
+                    var dissect = ilPowerMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        setInterfaceProperties(evt);
+                        normalizeEventAction(evt);
+                        if (evt.Get('event.code') == "POWER_GRANTED") {
+                            setCategorization(evt,"event","driver","change","success");
+                        } else {
+                            setCategorization(evt,"event","driver","change","unknown");
+                        }
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        return;
+                    }
+                case "PORT_SECURITY":
+                    var dissect = portSecurityMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        normalizeInterfaceName(evt);
+                        setInterfaceProperties(evt);
+                        setCategorization(evt,"event","intrusion_detection","info","failure");
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        return;
+                    }
+                case "PM":
+                    var dissect = pmMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        normalizeInterfaceName(evt);
+                        setInterfaceProperties(evt);
+                        if (evt.Get('event.code') == "ERR_RECOVER") {
+                            setCategorization(evt,"event","intrusion_detection","info","success");
+                        } else {
+                            setCategorization(evt,"event","intrusion_detection","info","failure");
+                        }
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        return;
+                    }
+                case "PLATFORM":
+                    var dissect = platformMessagePatterns[eventCode];
+                    if (dissect) {
+                        dissect(evt);
+                        setCategorization(evt,"event","host","info","unknown");
+                        coerceNumbers(evt);
+                        normalizeEventAction(evt);
+                        switch (evt.Get('event.code')) {
+                            case "PS_FAIL":
+                                setCategorization(evt,"alert","host","change","failure");
+                            case "PS_STATUS":
+                                if (evt.Get('cisco.ios.power_supply.status') == "OK") {
+                                    setCategorization(evt,"event","host","info","success");
+                                } else {
+                                    setCategorization(evt,"event","host","info","failure");
+                                }
+                        }
+                        return;
+                    }
             }
         })
         .CommunityID()
@@ -170,19 +307,64 @@ var ciscoIOS = (function() {
             {from: "icmp.type", type: "long"},
             {from: "icmp.code", type: "long"},
             {from: "igmp.type", type: "long"},
+            {from: "vlan.id", type: "integer"},
+            {from: "interface.slot", type: "integer"},
+            {from: "interface.subslot", type: "integer"},
+            {from: "interface.port", type: "integer"},
+            {from: "log.source.ip", type: "ip"},
+            {from: "log.source.port", type: "integer"},
+
         ],
         ignore_missing: true,
     }).Run;
 
-    var normalizeEventOutcome = function(evt) {
-        var outcome = evt.Get("event.outcome");
-        switch (outcome) {
-            case "denied":
-                evt.Put("event.outcome", "deny");
+    var normalizeInterfaceName = function(evt) {
+        var ifName = evt.Get("interface.name");
+        var ifName = ifName.split('.').join('');
+        var iSpace = ifName.indexOf(' ');
+        if (iSpace > 0) {
+            ifName = ifName.substring(0,iSpace);
+        }
+        evt.Put("interface.name", ifName);
+    };
+
+    var normalizeEventAction = function(evt) {
+        var action = evt.Get("event.action");
+        if (!action) {
+            return;
+        }
+
+        var iCut = action.indexOf(' (');
+        if (iCut > 0) {
+            evt.Put("eventAction", action.substring(0,iCut));
+        }
+    };
+
+    var normalizeEventAction = function(evt) {
+        var action = evt.Get("event.action");
+        if (!action) {
+            return;
+        }
+
+        switch (true) {
+            case (action.search("Power granted") == 0):
+                evt.Put("event.action", "Power granted");
                 break;
-            case "permitted":
-                evt.Put("event.outcome", "allow");
-                break;
+        }
+    };
+
+    var setCategorization = function(evt, kind, category, type, outcome) {
+        if (kind) {
+            evt.Put("event.kind", kind);
+        }
+        if (category) {
+            evt.Put("event.category", category);
+        }
+        if (type) {
+            evt.Put("event.type", type);
+        }
+        if (outcome) {
+            evt.Put("event.outcome", outcome);
         }
     };
 
@@ -199,9 +381,63 @@ var ciscoIOS = (function() {
         }
     };
 
+    var setLogSource = function(evt) {
+        var source_address = evt.Get('log.source.address').split(':');
+        if (source_address.length == 2 ) {
+            evt.Put("log.source.ip", source_address[0]);
+            evt.Put("log.source.port", source_address[1]);
+        }
+    }
+
     var setRelatedIP = function(event) {
         event.AppendTo("related.ip", event.Get("source.ip"));
         event.AppendTo("related.ip", event.Get("destination.ip"));
+    };
+
+    var setInterfaceProperties = function(event) {
+        var ifName = event.Get("interface.name");
+        if (!ifName) {
+            return;
+        }
+
+        switch (true) {
+            case (ifName.search(/Gi\d/) == 0):
+                ifName = ifName.replace("Gi","GigabitEthernet");
+                event.Put("interface.name", ifName);
+                break;
+        }
+
+        var iFirstDigit = ifName.search(/\d/);
+        var ifType = ifName.substring(0,iFirstDigit);
+        var ifNumbers = ifName.substring(iFirstDigit).split('/');
+
+        switch (true) {
+            case (ifType == "Vlan"):
+                event.Put("interface.type", "vlan");
+                event.Put("vlan.id", ifNumbers[0]);
+                break;
+
+            default:
+                event.Put("interface.type", ifType);
+                break;
+        }
+
+        switch (ifNumbers.length) {
+            case 1:
+                event.Put("interface.port", ifNumbers[0]);
+                break;
+
+            case 2:
+                event.Put("interface.slot", ifNumbers[0]);
+                event.Put("interface.port", ifNumbers[1]);
+                break;
+
+            case 3:
+                event.Put("interface.slot", ifNumbers[0]);
+                event.Put("interface.subslot", ifNumbers[1]);
+                event.Put("interface.port", ifNumbers[2]);
+                break;
+        }
     };
 
     return {


### PR DESCRIPTION
The current implementation of the CISCO IOS dataset is limited to firewall access-list logs.
I have started add support for the most common (catalyst) switch logs as well.
Since I am new to beats development and there are plenty of open questions I just send this pull request to start discussion.

Main questions:

ECS categorization fields: Current version 1.4 has very strict limitation of e.kind, e.category, e.type and e.outcome. E.G. outcome ist limited to success, failure, unknown. Since the existing implementation does not follow these rules, I have adapted them to my best knowledge.
Feedback and suggestions welcome.

Interface fields:

Switch ports often contain some slot/subslot/port naming. I have therefore created these fields for easier filtering and search purposes. Please let me know what you think about it in general and if you suggest other naming.
There is some work in progress to create an interface main field in ECS. I therefore used this field for all interface related information. Please let me know if this can be used already.
Module fields:
Some logs contain info about modules like Power-Supply. In addition I could think of fans, SFPs etc. which are often seen in network devices. As far as I have seen there is no ECS field available for modules kind of infos and it would make sense to add it somehow. Please let me know your opinion.

Looking forward for your response

Regards
Bernhard