### PR TITLE
Cherry-pick #15453 to 7.6: Include log.source.address for unparseable syslog messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -143,6 +143,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add expand_event_list_from_field support in s3 input for reading json format AWS logs. {issue}15357[15357] {pull}15370[15370]
 - Add azure-eventhub input which will use the azure eventhub go sdk. {issue}14092[14092] {pull}14882[14882]
 - Expose more metrics of harvesters (e.g. `read_offset`, `start_time`). {pull}13395[13395]
+- Include log.source.address for unparseable syslog messages. {issue}13268[13268] {pull}15453[15453]
 - Release aws elb fileset as GA. {pull}15426[15426] {issue}15380[15380]
 - Integrate the azure-eventhub with filebeat azure module (replace the kafka input). {pull}15480[15480]
 - Release aws s3access fileset to GA. {pull}15431[15431] {issue}15430[15430]

--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -49,6 +49,46 @@ class Test(BaseTest):
         self.assert_syslog(output[0])
         sock.close()
 
+    def test_syslog_with_tcp_invalid_message(self):
+        """
+        Test syslog input with invalid events from TCP.
+        """
+        host = "127.0.0.1"
+        port = 8080
+        input_raw = """
+- type: syslog
+  protocol:
+    tcp:
+        host: "{}:{}"
+"""
+
+        input_raw = input_raw.format(host, port)
+        self.render_config_template(
+            input_raw=input_raw,
+            inputs=False,
+        )
+
+        filebeat = self.start_beat()
+
+        self.wait_until(lambda: self.log_contains("Started listening for TCP connection"))
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # TCP
+        sock.connect((host, port))
+
+        for n in range(0, 2):
+            sock.send("invalid\n")
+
+        self.wait_until(lambda: self.output_count(lambda x: x >= 2))
+
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output()
+
+        assert len(output) == 2
+        assert output[0]["message"] == "invalid"
+        assert len(output[0]["log.source.address"]) > 0
+        sock.close()
+
     def test_syslog_with_udp(self):
         """
         Test syslog input with events from TCP.


### PR DESCRIPTION
Cherry-pick of PR #15453 to 7.6 branch. Original message: 

Continues with #13274, fixes #13268.

How to test:
* Start filebeat with the syslog input
* Send an invalid message to the open port
* Check that the generated event for the invalid message includes the source address

Co-authored-by: Brian Candler <b.candler@pobox.com>