### PR TITLE
New mage target: generate pkg file to test the manager

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -64,3 +64,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Added a `default_field` option to fields in fields.yml to offer a way to exclude fields from the default_field list. {issue}14262[14262] {pull}14341[14341]
 - `supported-versions.yml` can be used in metricbeat python system tests to obtain the build args for docker compose builds. {pull}14520[14520]
 - Fix dropped errors in the tests for the metricbeat Azure module. {pull}13773[13773]
+- New mage target for Functionbeat: generate pkg folder to make manager easier. {pull}15580[15880]

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -145,6 +146,34 @@ func TestPackages() error {
 // GoTestUnit is an alias for goUnitTest.
 func GoTestUnit() {
 	mg.Deps(unittest.GoUnitTest)
+}
+
+func BuildPkgForFunctions() error {
+	mg.Deps(Update, Build)
+
+	err := os.MkdirAll("pkg", 700)
+	if err != nil {
+		return err
+	}
+
+	filesToCopy := map[string]string{
+		filepath.Join("provider", "aws", "functionbeat-aws"):           filepath.Join("pkg", "functionbeat-aws"),
+		filepath.Join("provider", "gcp", "pubsub", "pubsub.go"):        filepath.Join("pkg", "pubsub", "pubsub.go"),
+		filepath.Join("provider", "gcp", "storage", "storage.go"):      filepath.Join("pkg", "storage", "storage.go"),
+		filepath.Join("provider", "gcp", "build", "pubsub", "vendor"):  filepath.Join("pkg", "pubsub", "vendor"),
+		filepath.Join("provider", "gcp", "build", "storage", "vendor"): filepath.Join("pkg", "storage", "vendor"),
+	}
+	for src, dest := range filesToCopy {
+		c := &devtools.CopyTask{
+			Source: src,
+			Dest:   dest,
+		}
+		err = c.Execute()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // BuildSystemTestBinary build a binary for testing that is instrumented for

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -148,6 +148,8 @@ func GoTestUnit() {
 	mg.Deps(unittest.GoUnitTest)
 }
 
+// BuildPkgForFunctions creates a folder named pkg and adds functions to it.
+// This makes testing the manager more comfortable.
 func BuildPkgForFunctions() error {
 	mg.Deps(Update, Build)
 


### PR DESCRIPTION
This PR adds a new mage target to Functionbeat named `buildPkgForFunction`. It generates the folder `pkg` with the functions to make testing the manager more comfortable during development.