### PR TITLE
Listen explicitly on localhost on heartbeat TCP tests

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2019 Elasticsearch BV
+Copyright 2014-2020 Elasticsearch BV
 
 This product includes software developed by The Apache Software 
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
Some tests were requiring localhost to resolve to 127.0.0.1, but this is
not always the case. In some machines localhost resolve to other local
addresses as 127.0.1.1, or to [::1] if ipv4 is not available.

`httptest.NewServer` always binds to `127.0.0.1`, so connections to
localhost can fail if localhost resolves to a different IP.

Explicitly use `localhost` when binding and later expecting name resolution.

Issue [seen in Travis](https://travis-ci.org/elastic/beats/jobs/627818852#L486) when upgrading the Ubuntu image during the
migration to Python 3, can be reproduced by modifying `/etc/hosts` to
use an IP different to `127.0.0.1` as `localhost`.