### PR TITLE
Mask password discovered via module autodiscover hint

### DIFF
--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -66,18 +66,6 @@ const (
 	selectorConfigWithPassword = "config-with-passwords"
 )
 
-var debugBlacklist = MakeStringSet(
-	"password",
-	"passphrase",
-	"key_passphrase",
-	"pass",
-	"proxy_url",
-	"url",
-	"urls",
-	"host",
-	"hosts",
-)
-
 // make hasSelector and configDebugf available for unit testing
 var hasSelector = logp.HasSelector
 var configDebugf = logp.Debug
@@ -390,30 +378,6 @@ func DebugString(c *Config, filterPrivate bool) string {
 		return ""
 	}
 	return strings.Join(bufs, "\n")
-}
-
-func filterDebugObject(c interface{}) {
-	switch cfg := c.(type) {
-	case map[string]interface{}:
-		for k, v := range cfg {
-			if debugBlacklist.Has(k) {
-				if arr, ok := v.([]interface{}); ok {
-					for i := range arr {
-						arr[i] = "xxxxx"
-					}
-				} else {
-					cfg[k] = "xxxxx"
-				}
-			} else {
-				filterDebugObject(v)
-			}
-		}
-
-	case []interface{}:
-		for _, elem := range cfg {
-			filterDebugObject(elem)
-		}
-	}
 }
 
 // OwnerHasExclusiveWritePerms asserts that the current user or root is the

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -357,7 +357,7 @@ func DebugString(c *Config, filterPrivate bool) string {
 			return fmt.Sprintf("<config error> %v", err)
 		}
 		if filterPrivate {
-			filterDebugObject(content)
+			applyLoggingMask(content)
 		}
 		j, _ := json.MarshalIndent(content, "", "  ")
 		bufs = append(bufs, string(j))
@@ -368,7 +368,7 @@ func DebugString(c *Config, filterPrivate bool) string {
 			return fmt.Sprintf("<config error> %v", err)
 		}
 		if filterPrivate {
-			filterDebugObject(content)
+			applyLoggingMask(content)
 		}
 		j, _ := json.MarshalIndent(content, "", "  ")
 		bufs = append(bufs, string(j))

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -1,6 +1,6 @@
 package common
 
-var debugMasklist = MakeStringSet(
+var maskList = MakeStringSet(
 	"password",
 	"passphrase",
 	"key_passphrase",
@@ -12,11 +12,11 @@ var debugMasklist = MakeStringSet(
 	"hosts",
 )
 
-func filterDebugObject(c interface{}) {
+func applyLoggingMask(c interface{}) {
 	switch cfg := c.(type) {
 	case map[string]interface{}:
 		for k, v := range cfg {
-			if debugMasklist.Has(k) {
+			if maskList.Has(k) {
 				if arr, ok := v.([]interface{}); ok {
 					for i := range arr {
 						arr[i] = "xxxxx"
@@ -25,13 +25,13 @@ func filterDebugObject(c interface{}) {
 					cfg[k] = "xxxxx"
 				}
 			} else {
-				filterDebugObject(v)
+				applyLoggingMask(v)
 			}
 		}
 
 	case []interface{}:
 		for _, elem := range cfg {
-			filterDebugObject(elem)
+			applyLoggingMask(elem)
 		}
 	}
 }

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -1,0 +1,37 @@
+package common
+
+var debugBlacklist = MakeStringSet(
+	"password",
+	"passphrase",
+	"key_passphrase",
+	"pass",
+	"proxy_url",
+	"url",
+	"urls",
+	"host",
+	"hosts",
+)
+
+func filterDebugObject(c interface{}) {
+	switch cfg := c.(type) {
+	case map[string]interface{}:
+		for k, v := range cfg {
+			if debugBlacklist.Has(k) {
+				if arr, ok := v.([]interface{}); ok {
+					for i := range arr {
+						arr[i] = "xxxxx"
+					}
+				} else {
+					cfg[k] = "xxxxx"
+				}
+			} else {
+				filterDebugObject(v)
+			}
+		}
+
+	case []interface{}:
+		for _, elem := range cfg {
+			filterDebugObject(elem)
+		}
+	}
+}

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -1,6 +1,6 @@
 package common
 
-var debugBlacklist = MakeStringSet(
+var debugMasklist = MakeStringSet(
 	"password",
 	"passphrase",
 	"key_passphrase",
@@ -16,7 +16,7 @@ func filterDebugObject(c interface{}) {
 	switch cfg := c.(type) {
 	case map[string]interface{}:
 		for k, v := range cfg {
-			if debugBlacklist.Has(k) {
+			if debugMasklist.Has(k) {
 				if arr, ok := v.([]interface{}); ok {
 					for i := range arr {
 						arr[i] = "xxxxx"

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package common
 
 var maskList = MakeStringSet(

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -20,6 +20,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -232,6 +233,19 @@ func (m MapStr) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		zap.Any(k, v).AddTo(enc)
 	}
 	return nil
+}
+
+// Format implements fmt.Formatter
+func (m MapStr) Format(f fmt.State, c rune) {
+	if f.Flag('+') || f.Flag('#') {
+		io.WriteString(f, m.String())
+		return
+	}
+
+	debugM := m.Clone()
+	filterDebugObject(map[string]interface{}(debugM))
+
+	io.WriteString(f, debugM.String())
 }
 
 // Flatten flattens the given MapStr and returns a flat MapStr.

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -220,7 +220,7 @@ func (m MapStr) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 
 	debugM := m.Clone()
-	filterDebugObject(map[string]interface{}(debugM))
+	applyLoggingMask(map[string]interface{}(debugM))
 
 	keys := make([]string, 0, len(debugM))
 	for k := range debugM {
@@ -246,7 +246,7 @@ func (m MapStr) Format(f fmt.State, c rune) {
 	}
 
 	debugM := m.Clone()
-	filterDebugObject(map[string]interface{}(debugM))
+	applyLoggingMask(map[string]interface{}(debugM))
 
 	io.WriteString(f, debugM.String())
 }

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -219,13 +219,16 @@ func (m MapStr) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 
-	keys := make([]string, 0, len(m))
-	for k := range m {
+	debugM := m.Clone()
+	filterDebugObject(map[string]interface{}(debugM))
+
+	keys := make([]string, 0, len(debugM))
+	for k := range debugM {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		v := m[k]
+		v := debugM[k]
 		if inner, ok := tryToMapStr(v); ok {
 			enc.AddObject(k, inner)
 			continue

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -1002,3 +1002,26 @@ func BenchmarkWalkMap(b *testing.B) {
 		}
 	})
 }
+
+func TestFormat(t *testing.T) {
+	input := MapStr{
+		"foo":      "bar",
+		"password": "SUPER_SECURE",
+	}
+
+	tests := map[string]string{
+		"%v":  `{"foo":"bar","password":"xxxxx"}`,
+		"%+v": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%#v": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%s":  `{"foo":"bar","password":"xxxxx"}`,
+		"%+s": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%#s": `{"foo":"bar","password":"SUPER_SECURE"}`,
+	}
+
+	for verb, expected := range tests {
+		t.Run(verb, func(t *testing.T) {
+			actual := fmt.Sprintf(verb, input)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -141,6 +141,8 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		moduleConfig["password"] = password
 	}
 
+	logp.Debug("hints.builder", "generated config: %v", moduleConfig)
+
 	// Create config object
 	cfg, err := common.NewConfigFrom(moduleConfig)
 	if err != nil {

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -47,8 +47,6 @@ const (
 	username    = "username"
 	password    = "password"
 
-	mcfgPassword = "password"
-
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
 )
@@ -140,7 +138,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		moduleConfig["username"] = username
 	}
 	if password != "" {
-		moduleConfig[mcfgPassword] = password
+		moduleConfig["password"] = password
 	}
 
 	// Create config object

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -58,13 +58,6 @@ type metricHints struct {
 	Registry *mb.Register
 }
 
-type moduleCfg common.MapStr
-
-func (mcfg *moduleCfg) SecureString() string {
-	cfg := common.MustNewConfigFrom(mcfg)
-	return common.DebugString(cfg, true)
-}
-
 // NewMetricHints builds a new metrics builder based on hints
 func NewMetricHints(cfg *common.Config) (autodiscover.Builder, error) {
 	config := defaultConfig()
@@ -126,7 +119,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 	username := m.getUsername(hints)
 	password := m.getPassword(hints)
 
-	moduleConfig := moduleCfg{
+	moduleConfig := common.MapStr{
 		"module":     mod,
 		"metricsets": msets,
 		"hosts":      hosts,
@@ -150,14 +143,12 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		moduleConfig[mcfgPassword] = password
 	}
 
-	logp.Debug("hints.builder", "generated config: %v", moduleConfig.SecureString())
-
 	// Create config object
 	cfg, err := common.NewConfigFrom(moduleConfig)
 	if err != nil {
 		logp.Debug("hints.builder", "config merge failed with error: %v", err)
 	}
-	logp.Debug("hints.builder", "generated config: +%v", *cfg)
+	logp.Debug("hints.builder", "generated config: +%v", common.DebugString(cfg, true))
 	config = append(config, cfg)
 
 	// Apply information in event to the template to generate the final config

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -47,6 +47,8 @@ const (
 	username    = "username"
 	password    = "password"
 
+	mcfgPassword = "password"
+
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
 )
@@ -60,8 +62,8 @@ type moduleCfg common.MapStr
 
 func (mcfg *moduleCfg) SecureString() string {
 	mcfgCopy := common.MapStr(*mcfg).Clone()
-	if exists, _ := mcfgCopy.HasKey("password"); exists {
-		mcfgCopy.Put("password", "******")
+	if exists, _ := mcfgCopy.HasKey(mcfgPassword); exists {
+		mcfgCopy.Put(mcfgPassword, "******")
 	}
 
 	return mcfgCopy.String()
@@ -149,7 +151,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		moduleConfig["username"] = username
 	}
 	if password != "" {
-		moduleConfig["password"] = password
+		moduleConfig[mcfgPassword] = password
 	}
 
 	logp.Debug("hints.builder", "generated config: %v", moduleConfig.SecureString())

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -58,7 +58,7 @@ type metricHints struct {
 
 type moduleCfg common.MapStr
 
-func (mcfg *moduleCfg) String() string {
+func (mcfg *moduleCfg) SecureString() string {
 	mcfgCopy := common.MapStr(*mcfg).Clone()
 	if exists, _ := mcfgCopy.HasKey("password"); exists {
 		mcfgCopy.Put("password", "******")
@@ -152,7 +152,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		moduleConfig["password"] = password
 	}
 
-	logp.Debug("hints.builder", "generated config: %v", moduleConfig.String())
+	logp.Debug("hints.builder", "generated config: %v", moduleConfig.SecureString())
 
 	// Create config object
 	cfg, err := common.NewConfigFrom(moduleConfig)

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -56,6 +56,17 @@ type metricHints struct {
 	Registry *mb.Register
 }
 
+type moduleCfg common.MapStr
+
+func (mcfg *moduleCfg) String() string {
+	mcfgCopy := common.MapStr(*mcfg).Clone()
+	if exists, _ := mcfgCopy.HasKey("password"); exists {
+		mcfgCopy.Put("password", "******")
+	}
+
+	return mcfgCopy.String()
+}
+
 // NewMetricHints builds a new metrics builder based on hints
 func NewMetricHints(cfg *common.Config) (autodiscover.Builder, error) {
 	config := defaultConfig()
@@ -117,7 +128,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 	username := m.getUsername(hints)
 	password := m.getPassword(hints)
 
-	moduleConfig := common.MapStr{
+	moduleConfig := moduleCfg{
 		"module":     mod,
 		"metricsets": msets,
 		"hosts":      hosts,

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -148,7 +148,7 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 	if err != nil {
 		logp.Debug("hints.builder", "config merge failed with error: %v", err)
 	}
-	logp.Debug("hints.builder", "generated config: +%v", common.DebugString(cfg, true))
+	logp.Debug("hints.builder", "generated config: %+v", common.DebugString(cfg, true))
 	config = append(config, cfg)
 
 	// Apply information in event to the template to generate the final config

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -61,12 +61,8 @@ type metricHints struct {
 type moduleCfg common.MapStr
 
 func (mcfg *moduleCfg) SecureString() string {
-	mcfgCopy := common.MapStr(*mcfg).Clone()
-	if exists, _ := mcfgCopy.HasKey(mcfgPassword); exists {
-		mcfgCopy.Put(mcfgPassword, "******")
-	}
-
-	return mcfgCopy.String()
+	cfg := common.MustNewConfigFrom(mcfg)
+	return common.DebugString(cfg, true)
 }
 
 // NewMetricHints builds a new metrics builder based on hints

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -324,6 +324,16 @@ func TestGenerateHints(t *testing.T) {
 	}
 }
 
+func TestModuleCfg_SecureString(t *testing.T) {
+	testModuleCfg := moduleCfg{
+		"username": "foo",
+		"password": "SUPER_SECURE",
+	}
+	assert.Contains(t, testModuleCfg.SecureString(), `"username":"foo"`)
+	assert.Contains(t, testModuleCfg.SecureString(), `"password":"`)
+	assert.NotContains(t, testModuleCfg.SecureString(), "SUPER_SECURE")
+}
+
 type MockMetricSet struct {
 	mb.BaseMetricSet
 }

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -324,16 +324,6 @@ func TestGenerateHints(t *testing.T) {
 	}
 }
 
-func TestModuleCfg_SecureString(t *testing.T) {
-	testModuleCfg := moduleCfg{
-		"username": "foo",
-		"password": "SUPER_SECURE",
-	}
-	assert.Contains(t, testModuleCfg.SecureString(), `"username": "foo"`)
-	assert.Contains(t, testModuleCfg.SecureString(), `"password": "`)
-	assert.NotContains(t, testModuleCfg.SecureString(), "SUPER_SECURE")
-}
-
 type MockMetricSet struct {
 	mb.BaseMetricSet
 }

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -329,8 +329,8 @@ func TestModuleCfg_SecureString(t *testing.T) {
 		"username": "foo",
 		"password": "SUPER_SECURE",
 	}
-	assert.Contains(t, testModuleCfg.SecureString(), `"username":"foo"`)
-	assert.Contains(t, testModuleCfg.SecureString(), `"password":"`)
+	assert.Contains(t, testModuleCfg.SecureString(), `"username": "foo"`)
+	assert.Contains(t, testModuleCfg.SecureString(), `"password": "`)
 	assert.NotContains(t, testModuleCfg.SecureString(), "SUPER_SECURE")
 }
 


### PR DESCRIPTION
Follow up to #15349.

With this PR any string representations of a Metricbeat module configuration constructed by autodiscovery will mask the password. For instance, this will prevent the password from being output verbatim in Metricbeat logs.

### Manual Testing
1. Enable autodiscover in metricbeat.yml
```
metricbeat:
  autodiscover.providers:
    - type: docker
      hints.enabled: true
```
2. Start metricbeat with log enabled: `./metricbeat -e -d "hints.builder" `
3. `docker run -l co.elastic.metrics/module=nats -l co.elastic.metrics/username=user42 -l co.elastic.metrics/password=SUPERSECRET --name nats nats`
4. Check in Metricbeat logs for : 
   ```
   2019-12-16T15:53:18.712+0200	DEBUG	[hints.builder]	hints/metrics.go:144	generated config: {"enabled":true,"hosts":"xxxxx","metricsets":["connections","routes","stats","subscriptions"],"module":"nats","password":"xxxxx","period":"1m","processors":null,"ssl":{},"timeout":"3s","username":"user42"}
   ``` 

   Specifically make sure the `password` field is masked in the generated config that's emitted in the log.