### PR TITLE
Cherry-pick #14789 to 7.6: Cisco: Add warning about script compilations to docs

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -23,6 +23,17 @@ Cisco ASA devices also support exporting flow records using NetFlow, which is
 supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 {beatname_uc}.
 
+[WARNING]
+=======================================
+Some filesets in this module make extensive use of ingest pipeline scripts.
+This can cause their ingest pipelines to fail loading due to exceeding the
+default compilation limits:
+
+`[script] Too many dynamic script compilations within, max: [75/5m]`
+
+Check the <<dynamic-script-compilations>> section for more information.
+=======================================
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/running-modules.asciidoc[]
@@ -279,6 +290,22 @@ include::../include/timezone-support.asciidoc[]
 :has-dashboards!:
 
 :fileset_ex!:
+
+[float]
+[[dynamic-script-compilations]]
+=== Dynamic Script Compilations
+
+The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
+use of script processors and painless conditions. This can cause the pipelines
+to fail loading the first time the module is used, due to exceeding the maximum
+script compilation limits. It is recommended to tune the following parameters
+on your cluster:
+
+- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
+  Increase to at least `100/5m`.
+
+- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
+  Increase to at least `200` if using both filesets or other script-heavy modules.
 
 :modulename!:
 

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -18,6 +18,17 @@ Cisco ASA devices also support exporting flow records using NetFlow, which is
 supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 {beatname_uc}.
 
+[WARNING]
+=======================================
+Some filesets in this module make extensive use of ingest pipeline scripts.
+This can cause their ingest pipelines to fail loading due to exceeding the
+default compilation limits:
+
+`[script] Too many dynamic script compilations within, max: [75/5m]`
+
+Check the <<dynamic-script-compilations>> section for more information.
+=======================================
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/running-modules.asciidoc[]
@@ -274,5 +285,21 @@ include::../include/timezone-support.asciidoc[]
 :has-dashboards!:
 
 :fileset_ex!:
+
+[float]
+[[dynamic-script-compilations]]
+=== Dynamic Script Compilations
+
+The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
+use of script processors and painless conditions. This can cause the pipelines
+to fail loading the first time the module is used, due to exceeding the maximum
+script compilation limits. It is recommended to tune the following parameters
+on your cluster:
+
+- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
+  Increase to at least `100/5m`.
+
+- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
+  Increase to at least `200` if using both filesets or other script-heavy modules.
 
 :modulename!:


### PR DESCRIPTION
Cherry-pick of PR #14789 to 7.6 branch. Original message: 

The cisco/asa and cisco/ftd filesets can cause problems with the default script compilation settings in Elasticsearch. This PR adds a warning about it to the docs and some workarounds.
