### PR TITLE
[Agent] Fix empty policy handler

### DIFF
--- a/x-pack/agent/pkg/agent/application/stream.go
+++ b/x-pack/agent/pkg/agent/application/stream.go
@@ -45,7 +45,7 @@ type operatorStream struct {
 }
 
 func (b *operatorStream) Close() error {
-	return nil
+	return b.configHandler.HandleConfig(&configRequest{})
 }
 
 func (b *operatorStream) Execute(cfg *configRequest) error {

--- a/x-pack/agent/pkg/core/plugin/process/process.go
+++ b/x-pack/agent/pkg/core/plugin/process/process.go
@@ -198,6 +198,7 @@ func pushCredentials(w io.Writer, c *Creds) error {
 
 	// this gives beat with grpc a bit of time to spin up a goroutine and start a server.
 	// should be ok until we come up with more clever solution.
+	// Issue: https://github.com/elastic/beats/issues/15634
 	<-time.After(1500 * time.Millisecond)
 	return err
 }

--- a/x-pack/agent/pkg/core/plugin/process/process.go
+++ b/x-pack/agent/pkg/core/plugin/process/process.go
@@ -194,7 +194,10 @@ func pushCredentials(w io.Writer, c *Creds) error {
 		return err
 	}
 
-	<-time.After(1500 * time.Millisecond)
 	_, err = w.Write(credbytes)
+
+	// this gives beat with grpc a bit of time to spin up a goroutine and start a server.
+	// should be ok until we come up with more clever solution.
+	<-time.After(1500 * time.Millisecond)
 	return err
 }

--- a/x-pack/agent/pkg/core/plugin/process/process.go
+++ b/x-pack/agent/pkg/core/plugin/process/process.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	mrand "math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -154,6 +155,12 @@ func getGrpcTCPAddress(minPort, maxPort int) (string, error) {
 		maxPort = DefaultMaxPort
 	}
 
+	jitter := (maxPort - minPort) / 3
+	if jitter > 0 {
+		mrand.Seed(time.Now().UnixNano())
+		minPort += mrand.Intn(jitter)
+	}
+
 	for port := minPort; port <= maxPort; port++ {
 		desiredAddress := fmt.Sprintf("127.0.0.1:%d", port)
 		listener, _ := net.Listen("tcp", desiredAddress)
@@ -187,6 +194,7 @@ func pushCredentials(w io.Writer, c *Creds) error {
 		return err
 	}
 
+	<-time.After(1500 * time.Millisecond)
 	_, err = w.Write(credbytes)
 	return err
 }

--- a/x-pack/agent/pkg/reporter/reporter.go
+++ b/x-pack/agent/pkg/reporter/reporter.go
@@ -86,9 +86,10 @@ func (r *Reporter) OnFailing(application string, err error) {
 
 // OnStopping reports application stopped event.
 func (r *Reporter) OnStopping(application string) {
-	msg := fmt.Sprintf("Application: %s[%s]: State change: STOPPING", application, r.info.AgentID())
-	rec := generateRecord(EventTypeState, EventSubTypeStopping, msg)
-	r.report(rec)
+	// TODO: [michal] re-enable when https://github.com/elastic/kibana/issues/55155 is fixed
+	// msg := fmt.Sprintf("Application: %s[%s]: State change: STOPPING", application, r.info.AgentID())
+	// rec := generateRecord(EventTypeState, EventSubTypeStopping, msg)
+	// r.report(rec)
 }
 
 // OnStopped reports application stopped event.

--- a/x-pack/agent/pkg/reporter/reporter_test.go
+++ b/x-pack/agent/pkg/reporter/reporter_test.go
@@ -46,14 +46,15 @@ func TestTypes(t *testing.T) {
 	}
 
 	// test stopping
-	rep.OnStopping("a3")
-	if r := result.Type(); r != EventTypeState {
-		t.Errorf("OnStopping: expected record type '%v', got '%v'", EventTypeState, r)
-	}
+	// TODO: [michal] re-enable when https://github.com/elastic/kibana/issues/55155 is fixed
+	// rep.OnStopping("a3")
+	// if r := result.Type(); r != EventTypeState {
+	// 	t.Errorf("OnStopping: expected record type '%v', got '%v'", EventTypeState, r)
+	// }
 
-	if r := result.SubType(); r != EventSubTypeStopping {
-		t.Errorf("OnStopping: expected event type '%v', got '%v'", EventSubTypeStarting, r)
-	}
+	// if r := result.SubType(); r != EventSubTypeStopping {
+	// 	t.Errorf("OnStopping: expected event type '%v', got '%v'", EventSubTypeStarting, r)
+	// }
 
 	// test stopped
 	rep.OnStopped("a4")


### PR DESCRIPTION
This PR solves 3 things:

First small thing is a small randomization of port allocations. Instead of just starting to start looking from static port (== minPort) it pick random port from first third of the range and starts from there

Second one is a small sleep when pushing credentials. This reduces a chance of retry when agent tries to call `Config` on a grpc server which is not up yet and then waits 30s to retry.

Last change is correctly handle stream close. When empty configuration comes from fleet, resolver will Close stream instead of stopping all programs. Solution is to push empty config for resolution to a stream before removing it.

Also this PR removes implementation of OnStopping event until https://github.com/elastic/kibana/issues/55155 is fixes

Fixes: elastic/beats#15615