### PR TITLE
Persist the last good ActionPolicyChange on disk

### DIFF
--- a/x-pack/agent/pkg/agent/application/action_dispatcher.go
+++ b/x-pack/agent/pkg/agent/application/action_dispatcher.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/errors"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
+	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
 )
 
-type action interface{}
+type action = fleetapi.Action
 
 type actionHandler interface {
 	Handle(a action, acker fleetAcker) error

--- a/x-pack/agent/pkg/agent/application/action_dispatcher_test.go
+++ b/x-pack/agent/pkg/agent/application/action_dispatcher_test.go
@@ -23,8 +23,22 @@ func (h *mockHandler) Handle(a action, acker fleetAcker) error {
 }
 
 type mockAction struct{}
+
+func (m *mockAction) ID() string     { return "mockAction" }
+func (m *mockAction) Type() string   { return "mockAction" }
+func (m *mockAction) String() string { return "mockAction" }
+
 type mockActionUnknown struct{}
+
+func (m *mockActionUnknown) ID() string     { return "mockActionUnknown" }
+func (m *mockActionUnknown) Type() string   { return "mockActionUnknown" }
+func (m *mockActionUnknown) String() string { return "mockActionUnknown" }
+
 type mockActionOther struct{}
+
+func (m *mockActionOther) ID() string     { return "mockActionOther" }
+func (m *mockActionOther) Type() string   { return "mockActionOther" }
+func (m *mockActionOther) String() string { return "mockActionOther" }
 
 func TestActionDispatcher(t *testing.T) {
 	ack := newNoopAcker()
@@ -62,20 +76,11 @@ func TestActionDispatcher(t *testing.T) {
 		d, err := newActionDispatcher(nil, def)
 		require.NoError(t, err)
 
-		success := &mockHandler{}
-		d.Dispatch(ack, mockAction{}, success)
-
 		action := &mockActionUnknown{}
 		err = d.Dispatch(ack, action)
 
-		require.NoError(t, err)
-		require.False(t, success.called)
-
 		require.True(t, def.called)
 		require.Equal(t, action, def.received)
-
-		require.False(t, success.called)
-		require.Nil(t, success.received)
 	})
 
 	t.Run("Could not register two handlers on the same action", func(t *testing.T) {

--- a/x-pack/agent/pkg/agent/application/action_store.go
+++ b/x-pack/agent/pkg/agent/application/action_store.go
@@ -57,10 +57,8 @@ func (s *actionStore) Add(a action) {
 	switch v := a.(type) {
 	case *fleetapi.ActionPolicyChange:
 		// Only persist the action if the action is different.
-		if s.action != nil {
-			if s.action.ID() == v.ID() {
-				return
-			}
+		if s.action != nil && s.action.ID() == v.ID() {
+			return
 		}
 		s.dirty = true
 		s.action = a
@@ -134,14 +132,11 @@ func (a *actionStoreAcker) Ack(action fleetapi.Action) error {
 		return err
 	}
 	a.store.Add(action)
-	return nil
+	return a.store.Save()
 }
 
 func (a *actionStoreAcker) Commit() error {
-	if err := a.acker.Commit(); err != nil {
-		return err
-	}
-	return a.store.Save()
+	return nil
 }
 
 func newActionStoreAcker(acker fleetAcker, store *actionStore) *actionStoreAcker {

--- a/x-pack/agent/pkg/agent/application/action_store.go
+++ b/x-pack/agent/pkg/agent/application/action_store.go
@@ -9,7 +9,6 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/elastic/beats/x-pack/agent/pkg/agent/storage"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
 )
@@ -20,14 +19,12 @@ import (
 // Fleet. The store is not threadsafe.
 type actionStore struct {
 	log    *logger.Logger
-	store  store
+	store  storeLoad
 	dirty  bool
 	action action
 }
 
-func newActionStore(log *logger.Logger, file string) (*actionStore, error) {
-	store := storage.NewDiskStore(file)
-
+func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
 	// If the store exists we will read it, if any errors is returned we assume we do not have anything
 	// persisted and we return an empty store.
 	reader, err := store.Load()

--- a/x-pack/agent/pkg/agent/application/action_store.go
+++ b/x-pack/agent/pkg/agent/application/action_store.go
@@ -1,0 +1,158 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/elastic/beats/x-pack/agent/pkg/agent/storage"
+	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
+	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
+)
+
+// actionStore receives multiples actions to persist to disk, the implementation of the store only
+// take care of action policy change every other action are discarded. The store will only keep the
+// last good action on disk, we assume that the action is added to the store after it was ACK with
+// Fleet. The store is not threadsafe.
+type actionStore struct {
+	log    *logger.Logger
+	store  store
+	dirty  bool
+	action action
+}
+
+func newActionStore(log *logger.Logger, file string) (*actionStore, error) {
+	store := storage.NewDiskStore(file)
+
+	// If the store exists we will read it, if any errors is returned we assume we do not have anything
+	// persisted and we return an empty store.
+	reader, err := store.Load()
+	if err != nil {
+		return &actionStore{log: log, store: store}, nil
+	}
+
+	var action actionPolicyChangeSerializer
+
+	dec := yaml.NewDecoder(reader)
+	if err := dec.Decode(&action); err != nil {
+		return nil, err
+	}
+
+	apc := fleetapi.ActionPolicyChange(action)
+
+	return &actionStore{
+		log:    log,
+		store:  store,
+		action: &apc,
+	}, nil
+}
+
+// Add is only taking care of ActionPolicyChange for now and will only keep the last one it receive,
+// any other type of action will be silently ignored.
+func (s *actionStore) Add(a action) {
+	switch a.(type) {
+	case *fleetapi.ActionPolicyChange:
+		s.dirty = true
+		s.action = a
+	}
+}
+
+func (s *actionStore) Save() error {
+	defer func() { s.dirty = false }()
+	if !s.dirty {
+		return nil
+	}
+
+	apc, ok := s.action.(*fleetapi.ActionPolicyChange)
+	if !ok {
+		return fmt.Errorf("incompatible type, expected ActionPolicyChange and received %T", s.action)
+	}
+
+	serialize := actionPolicyChangeSerializer(*apc)
+
+	reader, err := yamlToReader(&serialize)
+	if err != nil {
+		return err
+	}
+
+	if err := s.store.Save(reader); err != nil {
+		return err
+	}
+	s.log.Debugf("save on disk action policy change: %+v", s.action)
+	return nil
+}
+
+// Actions returns a slice of action to execute in order, currently only a action policy change is
+// persisted.
+func (s *actionStore) Actions() []action {
+	if s.action == nil {
+		return []action{}
+	}
+
+	return []action{s.action}
+}
+
+// actionPolicyChangeSerializer is a struct that add YAML serialization, I don't think serialization
+// is a concern of the fleetapi package. I went this route so I don't have to do much refactoring.
+//
+// There are four ways to achieve the same results:
+// 1. We create a second struct that map the existing field.
+// 2. We add the serialization in the fleetapi.
+// 3. We move the actual action type outside of the actual fleetapi package.
+// 4. We have two sets of type.
+//
+// This could be done in a refactoring.
+type actionPolicyChangeSerializer struct {
+	ActionID   string                 `yaml:"action_id"`
+	ActionType string                 `yaml:"action_type"`
+	Policy     map[string]interface{} `yaml:"policy"`
+}
+
+// Add a guards between the serializer structs and the original struct.
+var _ actionPolicyChangeSerializer = actionPolicyChangeSerializer(fleetapi.ActionPolicyChange{})
+
+// actionStoreAcker wraps an existing acker and will send any acked event to the action store,
+// its up to the action store to decide if we need to persist the event for future replay or just
+// discard the event.
+type actionStoreAcker struct {
+	acker fleetAcker
+	store *actionStore
+}
+
+func (a *actionStoreAcker) Ack(action fleetapi.Action) error {
+	if err := a.acker.Ack(action); err != nil {
+		return err
+	}
+	a.store.Add(action)
+	return nil
+}
+
+func (a *actionStoreAcker) Commit() error {
+	if err := a.acker.Commit(); err != nil {
+		return err
+	}
+	return a.store.Save()
+}
+
+func newActionStoreAcker(acker fleetAcker, store *actionStore) *actionStoreAcker {
+	return &actionStoreAcker{acker: acker, store: store}
+}
+
+func replayActions(
+	log *logger.Logger,
+	dispatcher dispatcher,
+	acker fleetAcker,
+	actions ...action,
+) error {
+	log.Info("restoring current policy from disk")
+
+	if err := dispatcher.Dispatch(acker, actions...); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x-pack/agent/pkg/agent/application/action_store.go
+++ b/x-pack/agent/pkg/agent/application/action_store.go
@@ -54,8 +54,14 @@ func newActionStore(log *logger.Logger, file string) (*actionStore, error) {
 // Add is only taking care of ActionPolicyChange for now and will only keep the last one it receive,
 // any other type of action will be silently ignored.
 func (s *actionStore) Add(a action) {
-	switch a.(type) {
+	switch v := a.(type) {
 	case *fleetapi.ActionPolicyChange:
+		// Only persist the action if the action is different.
+		if s.action != nil {
+			if s.action.ID() == v.ID() {
+				return
+			}
+		}
 		s.dirty = true
 		s.action = a
 	}

--- a/x-pack/agent/pkg/agent/application/action_store_test.go
+++ b/x-pack/agent/pkg/agent/application/action_store_test.go
@@ -78,4 +78,20 @@ func TestActionStore(t *testing.T) {
 
 			require.Equal(t, actionPolicyChange, actions[0])
 		}))
+
+	t.Run("when we ACK we save to disk",
+		withFile(func(t *testing.T, file string) {
+			actionPolicyChange := &fleetapi.ActionPolicyChange{
+				ActionID: "abc123",
+			}
+
+			store, err := newActionStore(log, file)
+			require.NoError(t, err)
+
+			acker := newActionStoreAcker(&testAcker{}, store)
+			require.Equal(t, 0, len(store.Actions()))
+
+			require.NoError(t, acker.Ack(actionPolicyChange))
+			require.Equal(t, 1, len(store.Actions()))
+		}))
 }

--- a/x-pack/agent/pkg/agent/application/action_store_test.go
+++ b/x-pack/agent/pkg/agent/application/action_store_test.go
@@ -1,0 +1,81 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
+	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
+)
+
+func TestActionStore(t *testing.T) {
+	log, _ := logger.New()
+	withFile := func(fn func(t *testing.T, file string)) func(*testing.T) {
+		return func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "action-store")
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+			file := filepath.Join(dir, "config.yml")
+			fn(t, file)
+		}
+	}
+
+	t.Run("action returns empty when no action is saved on disk",
+		withFile(func(t *testing.T, file string) {
+			store, err := newActionStore(log, file)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(store.Actions()))
+		}))
+
+	t.Run("will discard silently unknown action",
+		withFile(func(t *testing.T, file string) {
+			actionPolicyChange := &fleetapi.ActionUnknown{
+				ActionID: "abc123",
+			}
+
+			store, err := newActionStore(log, file)
+			require.NoError(t, err)
+
+			require.Equal(t, 0, len(store.Actions()))
+			store.Add(actionPolicyChange)
+			err = store.Save()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(store.Actions()))
+		}))
+
+	t.Run("can save to disk known action type",
+		withFile(func(t *testing.T, file string) {
+			actionPolicyChange := &fleetapi.ActionPolicyChange{
+				ActionID:   "abc123",
+				ActionType: "POLICY_CHANGE",
+				Policy: map[string]interface{}{
+					"hello": "world",
+				},
+			}
+
+			store, err := newActionStore(log, file)
+			require.NoError(t, err)
+
+			require.Equal(t, 0, len(store.Actions()))
+			store.Add(actionPolicyChange)
+			err = store.Save()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(store.Actions()))
+
+			store1, err := newActionStore(log, file)
+			require.NoError(t, err)
+
+			actions := store1.Actions()
+			require.Equal(t, 1, len(actions))
+
+			require.Equal(t, actionPolicyChange, actions[0])
+		}))
+}

--- a/x-pack/agent/pkg/agent/application/action_store_test.go
+++ b/x-pack/agent/pkg/agent/application/action_store_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/x-pack/agent/pkg/agent/storage"
 	"github.com/elastic/beats/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/x-pack/agent/pkg/fleetapi"
 )
@@ -30,7 +31,8 @@ func TestActionStore(t *testing.T) {
 
 	t.Run("action returns empty when no action is saved on disk",
 		withFile(func(t *testing.T, file string) {
-			store, err := newActionStore(log, file)
+			s := storage.NewDiskStore(file)
+			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 			require.Equal(t, 0, len(store.Actions()))
 		}))
@@ -41,7 +43,8 @@ func TestActionStore(t *testing.T) {
 				ActionID: "abc123",
 			}
 
-			store, err := newActionStore(log, file)
+			s := storage.NewDiskStore(file)
+			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 
 			require.Equal(t, 0, len(store.Actions()))
@@ -61,7 +64,8 @@ func TestActionStore(t *testing.T) {
 				},
 			}
 
-			store, err := newActionStore(log, file)
+			s := storage.NewDiskStore(file)
+			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 
 			require.Equal(t, 0, len(store.Actions()))
@@ -70,7 +74,8 @@ func TestActionStore(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(store.Actions()))
 
-			store1, err := newActionStore(log, file)
+			s = storage.NewDiskStore(file)
+			store1, err := newActionStore(log, s)
 			require.NoError(t, err)
 
 			actions := store1.Actions()
@@ -85,7 +90,8 @@ func TestActionStore(t *testing.T) {
 				ActionID: "abc123",
 			}
 
-			store, err := newActionStore(log, file)
+			s := storage.NewDiskStore(file)
+			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 
 			acker := newActionStoreAcker(&testAcker{}, store)

--- a/x-pack/agent/pkg/agent/application/config.go
+++ b/x-pack/agent/pkg/agent/application/config.go
@@ -21,6 +21,11 @@ func fleetAgentConfigPath() string {
 	return info.AgentConfigFile
 }
 
+// TODO(ph) correctly setup with global path.
+func fleetActionStoreFile() string {
+	return info.AgentActionStoreFile
+}
+
 // Config define the configuration of the Agent.
 type Config struct {
 	Management *config.Config `config:"management"`

--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -24,6 +24,11 @@ type store interface {
 	Save(io.Reader) error
 }
 
+type storeLoad interface {
+	store
+	Load() (io.ReadCloser, error)
+}
+
 type clienter interface {
 	Send(
 		method string,

--- a/x-pack/agent/pkg/agent/application/fleet_acker_test.go
+++ b/x-pack/agent/pkg/agent/application/fleet_acker_test.go
@@ -35,7 +35,7 @@ func TestAcker(t *testing.T) {
 	}
 
 	testID := "ack-test-action-id"
-	testAction := &fleetapi.ActionUnknown{ActionBase: &fleetapi.ActionBase{ActionID: testID}}
+	testAction := &fleetapi.ActionUnknown{ActionID: testID}
 
 	ch := client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
 		content, err := ioutil.ReadAll(body)

--- a/x-pack/agent/pkg/agent/application/handler_action_policy_change.go
+++ b/x-pack/agent/pkg/agent/application/handler_action_policy_change.go
@@ -30,12 +30,10 @@ func (h *handlerPolicyChange) Handle(a action, acker fleetAcker) error {
 		return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
 	}
 
-	h.log.Debug("HandlerPolicyChange: emit configuration")
-
-	// ACK config
-	if err := acker.Ack(action); err != nil {
+	h.log.Debugf("HandlerPolicyChange: emit configuration for action %+v", a)
+	if err := h.emitter(c); err != nil {
 		return err
 	}
 
-	return h.emitter(c)
+	return acker.Ack(action)
 }

--- a/x-pack/agent/pkg/agent/application/handler_action_policy_change_test.go
+++ b/x-pack/agent/pkg/agent/application/handler_action_policy_change_test.go
@@ -36,7 +36,8 @@ func TestPolicyChange(t *testing.T) {
 
 		policy := map[string]interface{}{"hello": "world"}
 		action := &fleetapi.ActionPolicyChange{
-			ActionBase: &fleetapi.ActionBase{ActionID: "abc123", ActionType: "POLICY_CHANGE"},
+			ActionID:   "abc123",
+			ActionType: "POLICY_CHANGE",
 			Policy:     policy,
 		}
 
@@ -53,7 +54,8 @@ func TestPolicyChange(t *testing.T) {
 
 		policy := map[string]interface{}{"hello": "world"}
 		action := &fleetapi.ActionPolicyChange{
-			ActionBase: &fleetapi.ActionBase{ActionID: "abc123", ActionType: "POLICY_CHANGE"},
+			ActionID:   "abc123",
+			ActionType: "POLICY_CHANGE",
 			Policy:     policy,
 		}
 
@@ -66,7 +68,7 @@ func TestPolicyChange(t *testing.T) {
 
 func TestPolicyAcked(t *testing.T) {
 	log, _ := logger.New()
-	t.Run("Policy change acked", func(t *testing.T) {
+	t.Run("Policy change should not ACK on error", func(t *testing.T) {
 		tacker := &testAcker{}
 
 		mockErr := errors.New("error returned")
@@ -75,7 +77,8 @@ func TestPolicyAcked(t *testing.T) {
 		policy := map[string]interface{}{"hello": "world"}
 		actionID := "abc123"
 		action := &fleetapi.ActionPolicyChange{
-			ActionBase: &fleetapi.ActionBase{ActionID: actionID, ActionType: "POLICY_CHANGE"},
+			ActionID:   actionID,
+			ActionType: "POLICY_CHANGE",
 			Policy:     policy,
 		}
 
@@ -85,8 +88,30 @@ func TestPolicyAcked(t *testing.T) {
 		require.Error(t, err)
 
 		actions := tacker.Items()
+		assert.EqualValues(t, 0, len(actions))
+	})
+
+	t.Run("Policy change should ACK", func(t *testing.T) {
+		tacker := &testAcker{}
+
+		emitter := &mockEmitter{}
+
+		policy := map[string]interface{}{"hello": "world"}
+		actionID := "abc123"
+		action := &fleetapi.ActionPolicyChange{
+			ActionID:   actionID,
+			ActionType: "POLICY_CHANGE",
+			Policy:     policy,
+		}
+
+		handler := &handlerPolicyChange{log: log, emitter: emitter.Emitter}
+
+		err := handler.Handle(action, tacker)
+		require.NoError(t, err)
+
+		actions := tacker.Items()
 		assert.EqualValues(t, 1, len(actions))
-		assert.EqualValues(t, actionID, actions[0])
+		assert.Equal(t, actionID, actions[0])
 	})
 }
 

--- a/x-pack/agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/agent/pkg/agent/application/info/agent_id.go
@@ -21,6 +21,9 @@ import (
 const AgentConfigFile = "fleet.yml"
 const agentInfoKey = "agent_info"
 
+// AgentActionStoreFile is the file that will contains the action that can be replayed after restart.
+const AgentActionStoreFile = "action_store.yml"
+
 type persistentAgentInfo struct {
 	ID string `json:"ID" yaml:"ID" config:"ID"`
 }

--- a/x-pack/agent/pkg/agent/application/lazy_acker_test.go
+++ b/x-pack/agent/pkg/agent/application/lazy_acker_test.go
@@ -40,9 +40,9 @@ func TestLazyAcker(t *testing.T) {
 	testID1 := "ack-test-action-id"
 	testID2 := testID1 + "2"
 	testID3 := testID1 + "3"
-	testAction1 := &fleetapi.ActionUnknown{ActionBase: &fleetapi.ActionBase{ActionID: testID1}}
-	testAction2 := &actionImmediate{ActionBase: &fleetapi.ActionBase{ActionID: testID2}}
-	testAction3 := &fleetapi.ActionUnknown{ActionBase: &fleetapi.ActionBase{ActionID: testID3}}
+	testAction1 := &fleetapi.ActionUnknown{ActionID: testID1}
+	testAction2 := &actionImmediate{ActionID: testID2}
+	testAction3 := &fleetapi.ActionUnknown{ActionID: testID3}
 
 	ch := client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
 		content, err := ioutil.ReadAll(body)
@@ -88,13 +88,18 @@ func TestLazyAcker(t *testing.T) {
 }
 
 type actionImmediate struct {
-	*fleetapi.ActionBase
+	ActionID     string
+	ActionType   string
 	originalType string
 }
 
 // Type returns the type of the Action.
 func (a *actionImmediate) Type() string {
 	return "IMMEDIATE"
+}
+
+func (a *actionImmediate) ID() string {
+	return a.ActionID
 }
 
 func (a *actionImmediate) ForceAck() {}

--- a/x-pack/agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/agent/pkg/agent/application/managed_mode.go
@@ -126,7 +126,7 @@ func newManaged(
 	batchedAcker := newLazyAcker(acker)
 
 	// Create the action store that will persist the last good policy change on disk.
-	actionStore, err := newActionStore(log, fleetActionStoreFile())
+	actionStore, err := newActionStore(log, storage.NewDiskStore(fleetActionStoreFile()))
 	if err != nil {
 		return nil, errors.New(err, fmt.Sprintf("fail to read action store '%s'", fleetActionStoreFile()))
 	}

--- a/x-pack/agent/pkg/fleetapi/ack_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/ack_cmd_test.go
@@ -51,10 +51,8 @@ func TestAck(t *testing.T) {
 		}, withAPIKey,
 		func(t *testing.T, client clienter) {
 			action := &ActionPolicyChange{
-				ActionBase: &ActionBase{
-					ActionID:   "my-id",
-					ActionType: "POLICY_CHANGE",
-				},
+				ActionID:   "my-id",
+				ActionType: "POLICY_CHANGE",
 				Policy: map[string]interface{}{
 					"id": "policy_id",
 				},

--- a/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,74 @@ func (*agentinfo) AgentID() string { return "id" }
 func TestCheckin(t *testing.T) {
 	const withAPIKey = "secret"
 	agentInfo := &agentinfo{}
+
+	t.Run("Send back status of actions", withServerWithAuthClient(
+		func(t *testing.T) *http.ServeMux {
+			raw := `
+{
+    "actions": [],
+    "success": true
+}
+`
+			mux := http.NewServeMux()
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
+			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+
+				type E struct {
+					ActionID  string    `json:"action_id"`
+					Type      string    `json:"type"`
+					SubType   string    `json:"subtype"`
+					Message   string    `json:"message"`
+					Timestamp time.Time `json:"timestamp"`
+				}
+
+				responses := struct {
+					Events []E `json:"events"`
+				}{}
+
+				decoder := json.NewDecoder(r.Body)
+				defer r.Body.Close()
+
+				err := decoder.Decode(&responses)
+				require.NoError(t, err)
+
+				require.Equal(t, 1, len(responses.Events))
+
+				e := responses.Events[0]
+				require.Equal(t, "my-id", e.ActionID)
+				require.Equal(t, "ACTION", e.Type)
+				require.Equal(t, "ACKNOWLEDGED", e.SubType)
+				require.Equal(t, "Acknowledge action my-id", e.Message)
+
+				fmt.Fprintf(w, raw)
+			}, withAPIKey))
+			return mux
+		}, withAPIKey,
+		func(t *testing.T, client clienter) {
+			action := &ActionPolicyChange{
+				ActionID:   "my-id",
+				ActionType: "POLICY_CHANGE",
+				Policy: map[string]interface{}{
+					"id": "policy_id",
+				},
+			}
+
+			cmd := NewCheckinCmd(&agentinfo{}, client)
+
+			request := CheckinRequest{
+				Events: []SerializableEvent{
+					Ack(action),
+				},
+			}
+
+			r, err := cmd.Execute(&request)
+			require.NoError(t, err)
+			require.True(t, r.Success)
+
+			require.Equal(t, 0, len(r.Actions))
+		},
+	))
 
 	t.Run("Propagate any errors from the server", withServerWithAuthClient(
 		func(t *testing.T) *http.ServeMux {

--- a/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
+++ b/x-pack/agent/pkg/fleetapi/checkin_cmd_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,74 +22,6 @@ func (*agentinfo) AgentID() string { return "id" }
 func TestCheckin(t *testing.T) {
 	const withAPIKey = "secret"
 	agentInfo := &agentinfo{}
-
-	t.Run("Send back status of actions", withServerWithAuthClient(
-		func(t *testing.T) *http.ServeMux {
-			raw := `
-{
-    "actions": [],
-    "success": true
-}
-`
-			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
-			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-
-				type E struct {
-					ActionID  string    `json:"action_id"`
-					Type      string    `json:"type"`
-					SubType   string    `json:"subtype"`
-					Message   string    `json:"message"`
-					Timestamp time.Time `json:"timestamp"`
-				}
-
-				responses := struct {
-					Events []E `json:"events"`
-				}{}
-
-				decoder := json.NewDecoder(r.Body)
-				defer r.Body.Close()
-
-				err := decoder.Decode(&responses)
-				require.NoError(t, err)
-
-				require.Equal(t, 1, len(responses.Events))
-
-				e := responses.Events[0]
-				require.Equal(t, "my-id", e.ActionID)
-				require.Equal(t, "ACTION", e.Type)
-				require.Equal(t, "ACKNOWLEDGED", e.SubType)
-				require.Equal(t, "Acknowledge action my-id", e.Message)
-
-				fmt.Fprintf(w, raw)
-			}, withAPIKey))
-			return mux
-		}, withAPIKey,
-		func(t *testing.T, client clienter) {
-			action := &ActionPolicyChange{
-				ActionID:   "my-id",
-				ActionType: "POLICY_CHANGE",
-				Policy: map[string]interface{}{
-					"id": "policy_id",
-				},
-			}
-
-			cmd := NewCheckinCmd(&agentinfo{}, client)
-
-			request := CheckinRequest{
-				Events: []SerializableEvent{
-					Ack(action),
-				},
-			}
-
-			r, err := cmd.Execute(&request)
-			require.NoError(t, err)
-			require.True(t, r.Success)
-
-			require.Equal(t, 0, len(r.Actions))
-		},
-	))
 
 	t.Run("Propagate any errors from the server", withServerWithAuthClient(
 		func(t *testing.T) *http.ServeMux {


### PR DESCRIPTION
This is initial PR will followed by a few more. Details on the
implementation, first I've limited what can be persisted to disk to only
action policy change but I've keep the code in a more generic approach
to other type of events. I've selected the action policy change only
because the invalidation of the action is the most problematic part and
since we don't have anything else to persit for now we can skip it.

How it work?

- Agent starts the FleetGateway
- Agent receives an ActionPolicyChange
- Agent dispatch the ActionPolicyChange to the dispatcher.
- Agent applies the configuration.
- Agent ACKs to the fleet the ActionPolicyChange
- Agent ACKs locally the ActionPolicyChange
- Agent persited the ActionPolicyChange on disk

On reboot

- Agent looks the action store if any events are present.
- When events are present we dispatch them to the action dispatcher.
- We log on error.
- We start the FleetGateway.
- Polling loops happens.

Now, there is a catch let's say that we have an invalid persisted
policy, yes theses are possible because configuration are
permissive. The Agent will try to applies the policy and will fails, we
will logs this event. After the FleetGateway will start and will not
receive any configuration from Fleet, because all previous police are
ACKed. I am thinking maybe we should have a way for the Agent to try to
"sync" the policy if an error occurred when we were trying to restore
the state.

Fixes: elastic/beats#15507