### PR TITLE
[metricbeat] Add divide by zero check to docker/diskio

### DIFF
--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
@@ -178,8 +177,7 @@ func calculatePerSecond(duration time.Duration, old uint64, new uint64) float64 
 
 	timeSec := duration.Seconds()
 	if timeSec == 0 {
-		logp.Err("duration is zero when calculating per-second values")
-		return -1
+		return 0
 	}
 
 	return value / timeSec

--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
@@ -174,5 +175,12 @@ func calculatePerSecond(duration time.Duration, old uint64, new uint64) float64 
 	if value < 0 {
 		value = 0
 	}
-	return value / duration.Seconds()
+
+	timeSec := duration.Seconds()
+	if timeSec == 0 {
+		logp.Err("duration is zero when calculating per-second values")
+		return -1
+	}
+
+	return value / timeSec
 }


### PR DESCRIPTION
Currently dealing with #15549, which involves a handful of NaN errors. I'm hoping this is one of the NaN cases. If we get invalid data from upstream, it's possible for this to be 0.