### PR TITLE
Cherry-pick #15640 to 7.x: [Metricbeat] Update KQL to get estimated cost without dimension ServiceName

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
@@ -56,12 +56,12 @@
             },
             "gridData": {
               "h": 11,
-              "i": "04159643-33c0-4f01-80f1-fb8d212ed959",
+              "i": "221aab02-2747-4d84-9dde-028ccd51bdce",
               "w": 16,
               "x": 0,
               "y": 5
             },
-            "panelIndex": "04159643-33c0-4f01-80f1-fb8d212ed959",
+            "panelIndex": "221aab02-2747-4d84-9dde-028ccd51bdce",
             "panelRefName": "panel_2",
             "title": "Total Estimated Charges",
             "version": "7.5.0"
@@ -114,8 +114,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-12-02T18:54:47.255Z",
-      "version": "WzU1NywyXQ=="
+      "updated_at": "2020-01-17T15:11:20.337Z",
+      "version": "WzY2MiwxXQ=="
     },
     {
       "attributes": {
@@ -140,7 +140,7 @@
                 "fieldName": "cloud.account.name",
                 "id": "1549397251041",
                 "indexPatternRefName": "control_0_index_pattern",
-                "label": "AWS account",
+                "label": "account name",
                 "options": {
                   "dynamicOptions": true,
                   "multiselect": true,
@@ -172,8 +172,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-12-02T18:50:52.450Z",
-      "version": "WzU1MywyXQ=="
+      "updated_at": "2020-01-17T14:43:10.917Z",
+      "version": "WzE1NywxXQ=="
     },
     {
       "attributes": {
@@ -295,8 +295,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-12-02T18:53:50.818Z",
-      "version": "WzU1NSwyXQ=="
+      "updated_at": "2020-01-17T14:43:00.631Z",
+      "version": "WzU0LDFd"
     },
     {
       "attributes": {
@@ -329,7 +329,7 @@
                 "id": "ebb52700-1531-11ea-961e-c1db9cc6166e"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 1,
             "gauge_color_rules": [
@@ -352,7 +352,7 @@
                 "fill": 0.5,
                 "filter": {
                   "language": "kuery",
-                  "query": "aws.dimensions.ServiceName :* "
+                  "query": "not aws.dimensions.ServiceName : * "
                 },
                 "formatter": "number",
                 "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -365,16 +365,20 @@
                     "type": "sum"
                   }
                 ],
+                "override_index_pattern": 1,
                 "point_size": 1,
                 "separate_axis": 0,
+                "series_drop_last_bucket": 0,
+                "series_interval": "12h",
                 "split_mode": "filter",
                 "stacked": "none",
+                "time_range_mode": "entire_time_range",
                 "value_template": "${{value}}"
               }
             ],
             "show_grid": 1,
             "show_legend": 1,
-            "time_field": null,
+            "time_field": "@timestamp",
             "type": "metric"
           },
           "title": "Total Estimated Charges [Metricbeat AWS]",
@@ -387,8 +391,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-12-02T18:35:29.434Z",
-      "version": "WzU0NywyXQ=="
+      "updated_at": "2020-01-17T15:10:12.013Z",
+      "version": "WzY1OSwxXQ=="
     },
     {
       "attributes": {
@@ -472,8 +476,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-12-02T18:49:11.978Z",
-      "version": "WzU1MSwyXQ=="
+      "updated_at": "2020-01-17T14:43:00.631Z",
+      "version": "WzU2LDFd"
     }
   ],
   "version": "7.5.0"


### PR DESCRIPTION
Cherry-pick of PR #15640 to 7.x branch. Original message: 

## What does this PR do?
This PR is to fix Total Estimated Cost visualization for billing metricset in aws module.

## Why is it important?
In Total Estimated Cost visulization, `aws.dimensions.ServiceName : *` query of Total Estimated Charges is wrong. It's returning total charges with any service name instead of returning total charges from all service names. Total charges from all service name does not have a ServiceName as dimension. So the KQL should be `not aws.dimensions.ServiceName : *` instead.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally
Download this PR locally and build metricbeat with `mage update; mage build`.
Enable aws module: `./metricbeat modules enable aws`
Load dashboards:  `./metricbeat setup --dashboards -E setup.dashboards.directory=build/kibana`
Change metricbeat aws.yml to:
```
- module: aws
  period: 12h
  credential_profile_name: elastic-beats
  metricsets:
    - billing
  regions:
    - us-east-1
```
Start Metricbeat: `./metricbeat -e`
Make sure you have billing metrics show up in ES before checking the dashboard.

## Related issues
- Relates https://github.com/elastic/beats/pull/14801

## Screenshots
<img width="1454" alt="Screen Shot 2020-01-17 at 8 33 25 AM" src="https://user-images.githubusercontent.com/14081635/72624376-113bb700-3904-11ea-96c3-9a4239b8a73c.png">

From this screenshot you can see the metric value without ServiceName is $7.74, which matches the value showed in the screenshot below:
<img width="1455" alt="Screen Shot 2020-01-17 at 8 32 49 AM" src="https://user-images.githubusercontent.com/14081635/72624428-316b7600-3904-11ea-8a71-4f1b5b3a96a8.png">
