### PR TITLE
[7.6][docs] Backport: Clarify privileges required for the writer role (#15604)

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -214,8 +214,9 @@ endif::serverless[]
 ==== Grant privileges and roles needed for publishing
 
 Users who publish events to {es} need to create and write to {beatname_uc}
-indices. To minimize the privileges required by the writer role, you can use the
-<<privileges-to-setup-beats,setup role>> to pre-load dependencies.
+indices. To minimize the privileges required by the writer role, use the
+<<privileges-to-setup-beats,setup role>> to pre-load dependencies. This section
+assumes that you've pre-loaded dependencies. 
 
 ifndef::no_ilm[]
 When using ILM, turn off the ILM setup check in the {beatname_uc} config file before


### PR DESCRIPTION
Backports #15604 to 7.6 branch.