### PR TITLE
AWS Lambda: downgrade Kibana dashboard

### DIFF
--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -71,7 +71,7 @@ class Test(BaseTest):
         )
         exit_code = self.run_beat(extra_args=["setup", "--dashboards"])
 
-        assert exit_code == 0
+        assert exit_code == 0, 'Error output: ' + self.get_log()
         assert self.log_contains("Kibana dashboards successfully loaded.")
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "89dccfe8-a25e-44ea-afdb-ff01ab1f05d6",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "26670498-b079-4447-bbc8-e4ca8215898c",
             "panelRefName": "panel_1",
             "title": "Estimated Billing Chart",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "221aab02-2747-4d84-9dde-028ccd51bdce",
             "panelRefName": "panel_2",
             "title": "Total Estimated Charges",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "21e91e6b-0ff0-42ba-9132-6f30c5c6bbb7",
             "panelRefName": "panel_3",
             "title": "Top 5 Estimated Billing Per Service Name",
-            "version": "7.5.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -480,5 +480,5 @@
       "version": "WzU2LDFd"
     }
   ],
-  "version": "7.5.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "89dccfe8-a25e-44ea-afdb-ff01ab1f05d6",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "26670498-b079-4447-bbc8-e4ca8215898c",
             "panelRefName": "panel_1",
             "title": "Estimated Billing Chart",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "221aab02-2747-4d84-9dde-028ccd51bdce",
             "panelRefName": "panel_2",
             "title": "Total Estimated Charges",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "21e91e6b-0ff0-42ba-9132-6f30c5c6bbb7",
             "panelRefName": "panel_3",
             "title": "Top 5 Estimated Billing Per Service Name",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -480,5 +480,5 @@
       "version": "WzU2LDFd"
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-dynamodb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-dynamodb-overview.json
@@ -29,7 +29,7 @@
             },
             "panelIndex": "9642fcd0-464b-46ea-815c-cd2d9efc056d",
             "panelRefName": "panel_0",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -42,7 +42,7 @@
             },
             "panelIndex": "03807c37-c9dc-4b41-80ce-e28a13eb66e2",
             "panelRefName": "panel_1",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -55,7 +55,7 @@
             },
             "panelIndex": "18810035-5e91-409a-98d7-c03166e1f9b3",
             "panelRefName": "panel_2",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -68,7 +68,7 @@
             },
             "panelIndex": "60e6e6e4-3237-430e-80fc-63fe9b718a7e",
             "panelRefName": "panel_3",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -81,7 +81,7 @@
             },
             "panelIndex": "5e5d6509-2889-4383-bef4-9c2da0e759c6",
             "panelRefName": "panel_4",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -94,7 +94,7 @@
             },
             "panelIndex": "2db371a7-20c5-460a-a2f7-06b5b03d7b34",
             "panelRefName": "panel_5",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -107,7 +107,7 @@
             },
             "panelIndex": "1cd72292-ecba-4008-bb3c-e76c7fb6b4f4",
             "panelRefName": "panel_6",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -120,7 +120,7 @@
             },
             "panelIndex": "cea56791-2602-4079-977b-7d088727872c",
             "panelRefName": "panel_7",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -133,7 +133,7 @@
             },
             "panelIndex": "fe509a4d-700b-4092-9aae-ce14e8de103e",
             "panelRefName": "panel_8",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -146,7 +146,7 @@
             },
             "panelIndex": "3d6b1fa0-746f-40ed-8fcc-ae89013f632b",
             "panelRefName": "panel_9",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -159,7 +159,7 @@
             },
             "panelIndex": "0f9a5223-3c63-405c-a5c4-ea15416bad4a",
             "panelRefName": "panel_10",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -1852,5 +1852,5 @@
       "version": "WzUxMzMsMV0="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
@@ -30,7 +30,7 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Volume Write Ops",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -44,7 +44,7 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "Volume Read Ops",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -58,7 +58,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Volume Write Bytes",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -72,7 +72,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Volume Read Bytes",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -86,7 +86,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Volume Queue Length",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -100,7 +100,7 @@
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Volume Total Write Time",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -114,7 +114,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Volume Total Read Time",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -128,7 +128,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_7",
             "title": "Volume Idle Time",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -142,7 +142,7 @@
             "panelIndex": "9",
             "panelRefName": "panel_8",
             "title": "EBS Volume ID Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -155,7 +155,7 @@
             },
             "panelIndex": "10",
             "panelRefName": "panel_9",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -916,5 +916,5 @@
       "version": "WzU2NTQsN10="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -30,7 +30,7 @@
             "panelIndex": "2",
             "panelRefName": "panel_0",
             "title": "HTTP 5XX Errors",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -44,7 +44,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_1",
             "title": "Request Count",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -58,7 +58,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_2",
             "title": "Unhealthy Host Count",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -72,7 +72,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_3",
             "title": "Healthy Host Count",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -86,7 +86,7 @@
             "panelIndex": "6",
             "panelRefName": "panel_4",
             "title": "Latency in Seconds",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -100,7 +100,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_5",
             "title": "HTTP Backend 4XX Errors",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -114,7 +114,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_6",
             "title": "Backend Connection Errors",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -127,7 +127,7 @@
             },
             "panelIndex": "9",
             "panelRefName": "panel_7",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -141,7 +141,7 @@
             "panelIndex": "10",
             "panelRefName": "panel_8",
             "title": "HTTP Backend 2XX",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -1006,5 +1006,5 @@
       "version": "WzI0MTIsN10="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "8f2d1b8f-fef3-4a9a-9cc8-7f0e2c65e35a",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "443a9699-3451-44f7-8415-99a16c3f45b3",
             "panelRefName": "panel_1",
             "title": "Top Errors",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "60a16bf0-2979-467a-b30e-05ea29547b41",
             "panelRefName": "panel_2",
             "title": "AWS Region Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "349ef0d1-fea1-4b91-b95d-7a668914e10b",
             "panelRefName": "panel_3",
             "title": "Lambda Function Duration in Milliseconds",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -96,7 +96,7 @@
             "panelIndex": "048b1577-5aed-48e5-8f90-147aa3d56c1a",
             "panelRefName": "panel_4",
             "title": "Top Invoked Lambda Functions",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -112,7 +112,7 @@
             "panelIndex": "4c8e471c-45da-47be-a866-c5bfc6d28a05",
             "panelRefName": "panel_5",
             "title": "Top Throttled Lambda Functions",
-            "version": "7.5.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -650,5 +650,5 @@
       "version": "WzI2OTIsM10="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "8f2d1b8f-fef3-4a9a-9cc8-7f0e2c65e35a",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "443a9699-3451-44f7-8415-99a16c3f45b3",
             "panelRefName": "panel_1",
             "title": "Top Errors",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "60a16bf0-2979-467a-b30e-05ea29547b41",
             "panelRefName": "panel_2",
             "title": "AWS Region Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "349ef0d1-fea1-4b91-b95d-7a668914e10b",
             "panelRefName": "panel_3",
             "title": "Lambda Function Duration in Milliseconds",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -96,7 +96,7 @@
             "panelIndex": "048b1577-5aed-48e5-8f90-147aa3d56c1a",
             "panelRefName": "panel_4",
             "title": "Top Invoked Lambda Functions",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -112,7 +112,7 @@
             "panelIndex": "4c8e471c-45da-47be-a866-c5bfc6d28a05",
             "panelRefName": "panel_5",
             "title": "Top Throttled Lambda Functions",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -204,7 +204,7 @@
       },
       "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [
         {
@@ -310,7 +310,7 @@
       },
       "id": "4bf0a740-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -362,7 +362,7 @@
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [
         {
@@ -450,7 +450,7 @@
       },
       "id": "39dfc8d0-28cf-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -542,7 +542,7 @@
       },
       "id": "1f3f00c0-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -642,7 +642,7 @@
       },
       "id": "915bcd50-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.0"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -650,5 +650,5 @@
       "version": "WzI2OTIsM10="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json
@@ -204,7 +204,7 @@
       },
       "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [
         {
@@ -310,7 +310,7 @@
       },
       "id": "4bf0a740-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [],
       "type": "visualization",
@@ -362,7 +362,7 @@
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [
         {
@@ -450,7 +450,7 @@
       },
       "id": "39dfc8d0-28cf-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [],
       "type": "visualization",
@@ -542,7 +542,7 @@
       },
       "id": "1f3f00c0-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [],
       "type": "visualization",
@@ -642,7 +642,7 @@
       },
       "id": "915bcd50-28d1-11ea-ba6c-49a884eb104f",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.4.0"
       },
       "references": [],
       "type": "visualization",

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-rds-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-rds-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Database Connections",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_1",
             "title": "Insert Latency in Milliseconds",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_2",
             "title": "Select Latency in Milliseconds",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_3",
             "title": "Transaction Blocked",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -93,7 +93,7 @@
             },
             "panelIndex": "6",
             "panelRefName": "panel_4",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -109,7 +109,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_5",
             "title": "Insert Throughput in Count/Second",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -125,7 +125,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_6",
             "title": "Select Throughput in Count/Second",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -141,7 +141,7 @@
             "panelIndex": "132653bc-2669-4e8c-b536-06c680e9acf0",
             "panelRefName": "panel_7",
             "title": "Disk Queue Depth",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -843,5 +843,5 @@
       "version": "WzExNTk1LDhd"
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-s3-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-s3-overview.json
@@ -29,7 +29,7 @@
             },
             "panelIndex": "1",
             "panelRefName": "panel_0",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -42,7 +42,7 @@
             },
             "panelIndex": "2",
             "panelRefName": "panel_1",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -55,7 +55,7 @@
             },
             "panelIndex": "3",
             "panelRefName": "panel_2",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -68,7 +68,7 @@
             },
             "panelIndex": "4",
             "panelRefName": "panel_3",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -81,7 +81,7 @@
             },
             "panelIndex": "5",
             "panelRefName": "panel_4",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -94,7 +94,7 @@
             },
             "panelIndex": "6",
             "panelRefName": "panel_5",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -107,7 +107,7 @@
             },
             "panelIndex": "7",
             "panelRefName": "panel_6",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -713,5 +713,5 @@
       "version": "Wzc0NDAsN10="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-sns-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-sns-overview.json
@@ -55,7 +55,7 @@
             },
             "panelIndex": "3b9b0cee-b175-4268-8c5b-4ce869a09caf",
             "panelRefName": "panel_0",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -71,7 +71,7 @@
             "panelIndex": "5f0d72c5-0f28-449f-9c93-3b4074f068f7",
             "panelRefName": "panel_1",
             "title": "SNS Messages and Notifications",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {},
@@ -84,7 +84,7 @@
             },
             "panelIndex": "5a9d5f2f-b075-4892-8188-c6e808a1163d",
             "panelRefName": "panel_2",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -100,7 +100,7 @@
             "panelIndex": "c6d5a54d-61a4-470b-8769-c5b6d6ab6c0f",
             "panelRefName": "panel_3",
             "title": "SNS Publish Size",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -116,7 +116,7 @@
             "panelIndex": "0684c25d-34e8-425e-9069-dd8364e6325b",
             "panelRefName": "panel_4",
             "title": "SNS Notifications Filtered Out",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -132,7 +132,7 @@
             "panelIndex": "72e987da-9a49-4dd4-99c4-4acbc49a0e0b",
             "panelRefName": "panel_5",
             "title": "SNS Notifications Filtered Out Invalid Attributes",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -148,7 +148,7 @@
             "panelIndex": "923bd4cd-d8fe-47b5-afcf-577bf2c5987c",
             "panelRefName": "panel_6",
             "title": "SNS Notifications Filtered Out No Message Attributes",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -164,7 +164,7 @@
             "panelIndex": "f176153f-4588-42f9-a7bb-3015909d5610",
             "panelRefName": "panel_7",
             "title": "SNS Notifications Failed to Redrive to DLQ",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -180,7 +180,7 @@
             "panelIndex": "f3c5915b-6848-4950-afca-53653d13d6af",
             "panelRefName": "panel_8",
             "title": "SNS SMS Success Rate",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -196,7 +196,7 @@
             "panelIndex": "3b3cc747-b57c-44e0-a18c-77155072bee4",
             "panelRefName": "panel_9",
             "title": "SNS Notifications Redriven To DLQ",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -212,7 +212,7 @@
             "panelIndex": "ee130150-c1de-465b-8a8e-013f466528bf",
             "panelRefName": "panel_10",
             "title": "SNS SMS Month To Date Spent USD",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -1122,5 +1122,5 @@
       "version": "WzU1MywxXQ=="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-usage-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-usage-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "2ea7bd59-d748-4e4a-889d-f7e2ca1cfe36",
             "panelRefName": "panel_0",
             "title": "Region Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "00c2b1f6-3367-4b6f-ac01-7e48b76c262a",
             "panelRefName": "panel_1",
             "title": "Usage Resource Count",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "fecfe5d4-ef1c-4f38-954a-a2506d72bc5b",
             "panelRefName": "panel_2",
             "title": "Usage API Call Count",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "69ce7461-36ad-4e7c-b541-c6a1601bf089",
             "panelRefName": "panel_3",
             "title": "AWS Account Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -96,7 +96,7 @@
             "panelIndex": "62e86407-6ae3-47d3-9136-dd61bdf3267a",
             "panelRefName": "panel_4",
             "title": "AWS Service Filter",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -112,7 +112,7 @@
             "panelIndex": "196a044c-5c20-4417-8aa0-f60fc502e46c",
             "panelRefName": "panel_5",
             "title": "Usage Resource Count Per Service",
-            "version": "7.5.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -128,7 +128,7 @@
             "panelIndex": "022941b7-01a1-4570-86e9-d03451d4e102",
             "panelRefName": "panel_6",
             "title": "Usage API Call Count Per Service",
-            "version": "7.5.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -819,5 +819,5 @@
       "version": "WzU4OSw0XQ=="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-usage-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-usage-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "2ea7bd59-d748-4e4a-889d-f7e2ca1cfe36",
             "panelRefName": "panel_0",
             "title": "Region Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "00c2b1f6-3367-4b6f-ac01-7e48b76c262a",
             "panelRefName": "panel_1",
             "title": "Usage Resource Count",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "fecfe5d4-ef1c-4f38-954a-a2506d72bc5b",
             "panelRefName": "panel_2",
             "title": "Usage API Call Count",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "69ce7461-36ad-4e7c-b541-c6a1601bf089",
             "panelRefName": "panel_3",
             "title": "AWS Account Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -96,7 +96,7 @@
             "panelIndex": "62e86407-6ae3-47d3-9136-dd61bdf3267a",
             "panelRefName": "panel_4",
             "title": "AWS Service Filter",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -112,7 +112,7 @@
             "panelIndex": "196a044c-5c20-4417-8aa0-f60fc502e46c",
             "panelRefName": "panel_5",
             "title": "Usage Resource Count Per Service",
-            "version": "7.4.0"
+            "version": "7.3.0"
           },
           {
             "embeddableConfig": {
@@ -128,7 +128,7 @@
             "panelIndex": "022941b7-01a1-4570-86e9-d03451d4e102",
             "panelRefName": "panel_6",
             "title": "Usage API Call Count Per Service",
-            "version": "7.4.0"
+            "version": "7.3.0"
           }
         ],
         "timeRestore": false,
@@ -819,5 +819,5 @@
       "version": "WzU4OSw0XQ=="
     }
   ],
-  "version": "7.4.0"
+  "version": "7.3.0"
 }


### PR DESCRIPTION
This PR downgrades required Kibana version for AWS Lambda dashboard. It fixes error:

```
$ metricbeat setup --dashboards
Loading dashboards (Kibana must be running and reachable)
Exiting: Failed to import dashboard: Failed to load directory /Users/user/go/src/github.com/elastic/beats/x-pack/metricbeat/kibana/7/dashboard:
  error loading /Users/user/go/src/github.com/elastic/beats/x-pack/metricbeat/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json: returned 422 to import file: <nil>. Response: {"statusCode":422,"error":"Unprocessable Entity","message":"Document \"deab0260-2981-11e9-86eb-a3a07a77f530\" has property \"visualization\" which belongs to a more recent version of Kibana (7.4.2)."}
```

... and fixes `test_dashboards` reported by Travis CI.