### PR TITLE
Remove datasource option from SQL module and add tests

### DIFF
--- a/metricbeat/docs/modules/sql.asciidoc
+++ b/metricbeat/docs/modules/sql.asciidoc
@@ -8,7 +8,7 @@ This file is generated! See scripts/mage/docs_collector.go
 
 beta[]
 
-This is the sql module that fetches metrics from a SQL database. You can define driver, datasource and SQL query.
+This is the sql module that fetches metrics from a SQL database. You can define driver and SQL query.
 
 
 
@@ -26,10 +26,9 @@ metricbeat.modules:
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 
 ----

--- a/metricbeat/mb/testing/fetcher.go
+++ b/metricbeat/mb/testing/fetcher.go
@@ -20,17 +20,20 @@ package testing
 import (
 	"testing"
 
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
 // Fetcher is an interface implemented by all fetchers for testing purpouses
 type Fetcher interface {
-	mb.MetricSet
+	Module() mb.Module
+	Name() string
 
 	FetchEvents() ([]mb.Event, []error)
 	WriteEvents(testing.TB, string)
 	WriteEventsCond(testing.TB, string, func(common.MapStr) bool)
+	StandardizeEvent(mb.Event, ...mb.EventModifier) beat.Event
 }
 
 // NewFetcher returns a test fetcher from a Metricset configuration
@@ -72,6 +75,10 @@ func (f *reportingMetricSetV2Fetcher) WriteEventsCond(t testing.TB, path string,
 	}
 }
 
+func (f *reportingMetricSetV2Fetcher) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
+}
+
 type reportingMetricSetV2FetcherError struct {
 	mb.ReportingMetricSetV2Error
 }
@@ -95,6 +102,10 @@ func (f *reportingMetricSetV2FetcherError) WriteEventsCond(t testing.TB, path st
 	}
 }
 
+func (f *reportingMetricSetV2FetcherError) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
+}
+
 type reportingMetricSetV2FetcherWithContext struct {
 	mb.ReportingMetricSetV2WithContext
 }
@@ -116,4 +127,8 @@ func (f *reportingMetricSetV2FetcherWithContext) WriteEventsCond(t testing.TB, p
 	if err != nil {
 		t.Fatal("writing events", err)
 	}
+}
+
+func (f *reportingMetricSetV2FetcherWithContext) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
 }

--- a/metricbeat/mb/testing/fetcher.go
+++ b/metricbeat/mb/testing/fetcher.go
@@ -26,8 +26,7 @@ import (
 
 // Fetcher is an interface implemented by all fetchers for testing purpouses
 type Fetcher interface {
-	Module() mb.Module
-	Name() string
+	mb.MetricSet
 
 	FetchEvents() ([]mb.Event, []error)
 	WriteEvents(testing.TB, string)

--- a/vendor/github.com/lib/pq/go.mod
+++ b/vendor/github.com/lib/pq/go.mod
@@ -1,3 +1,1 @@
 module github.com/lib/pq
-
-go 1.13

--- a/vendor/github.com/lib/pq/go.mod
+++ b/vendor/github.com/lib/pq/go.mod
@@ -1,1 +1,3 @@
 module github.com/lib/pq
+
+go 1.13

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -965,10 +965,9 @@ metricbeat.modules:
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 
 

--- a/x-pack/metricbeat/module/sql/_meta/config.yml
+++ b/x-pack/metricbeat/module/sql/_meta/config.yml
@@ -2,9 +2,8 @@
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 

--- a/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-This is the sql module that fetches metrics from a SQL database. You can define driver, datasource and SQL query.
+This is the sql module that fetches metrics from a SQL database. You can define driver and SQL query.
 
 

--- a/x-pack/metricbeat/module/sql/docker-compose.yml
+++ b/x-pack/metricbeat/module/sql/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2.3'
+
+services:
+  mysql:
+    extends:
+      file: ../../../../metricbeat/module/mysql/docker-compose.yml
+      service: mysql
+
+  postgresql:
+    extends:
+      file: ../../../../metricbeat/module/postgresql/docker-compose.yml
+      service: postgresql

--- a/x-pack/metricbeat/module/sql/query/_meta/data.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data.json
@@ -10,7 +10,7 @@
         "period": 10000
     },
     "service": {
-        "address": "xxxxx",
+        "address": "172.22.0.3:3306",
         "type": "sql"
     },
     "sql": {

--- a/x-pack/metricbeat/module/sql/query/_meta/data.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data.json
@@ -10,7 +10,7 @@
         "period": 10000
     },
     "service": {
-        "address": "root:test@tcp(172.22.0.3:3306)/",
+        "address": "xxxxx",
         "type": "sql"
     },
     "sql": {

--- a/x-pack/metricbeat/module/sql/query/_meta/data.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data.json
@@ -1,26 +1,30 @@
 {
-    "@timestamp":"2016-05-23T08:05:34.853Z",
-    "beat":{
-        "hostname":"beathost",
-        "name":"beathost"
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "event": {
+        "dataset": "sql.query",
+        "duration": 115000,
+        "module": "sql"
     },
-    "metricset":{
-        "host":"localhost",
-        "module":"sql",
-        "name":"query",
-        "rtt":44269
+    "metricset": {
+        "name": "query",
+        "period": 10000
     },
-    "sql":{
-        "metrics":{
-           "numeric":{
-              "mynumericfield":1
-           },
-           "string":{
-              "mystringfield":"abc"
-           }
+    "service": {
+        "address": "root:test@tcp(172.22.0.3:3306)/",
+        "type": "sql"
+    },
+    "sql": {
+        "driver": "mysql",
+        "metrics": {
+            "numeric": {
+                "table_rows": 6
+            },
+            "string": {
+                "engine": "InnoDB",
+                "table_name": "sys_config",
+                "table_schema": "sys"
+            }
         },
-        "driver":"postgres",
-        "query":"select * from mytable"
-     },
-    "type":"metricsets"
+        "query": "select table_schema, table_name, engine, table_rows from information_schema.tables where table_rows \u003e 0;"
+    }
 }

--- a/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
@@ -1,0 +1,45 @@
+{
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "event": {
+        "dataset": "sql.query",
+        "duration": 115000,
+        "module": "sql"
+    },
+    "metricset": {
+        "name": "query",
+        "period": 10000
+    },
+    "service": {
+        "address": "user=postgres password=postgres sslmode=disable host=172.22.0.2 port=5432",
+        "type": "sql"
+    },
+    "sql": {
+        "driver": "postgres",
+        "metrics": {
+            "numeric": {
+                "blk_read_time": 0,
+                "blk_write_time": 0,
+                "blks_hit": 4251,
+                "blks_read": 103,
+                "conflicts": 0,
+                "datid": 12379,
+                "deadlocks": 0,
+                "numbackends": 1,
+                "temp_bytes": 0,
+                "temp_files": 0,
+                "tup_deleted": 0,
+                "tup_fetched": 2847,
+                "tup_inserted": 0,
+                "tup_returned": 4877,
+                "tup_updated": 0,
+                "xact_commit": 49,
+                "xact_rollback": 0
+            },
+            "string": {
+                "datname": "postgres",
+                "stats_reset": "2020-01-20 19:48:28.217"
+            }
+        },
+        "query": "select * from pg_stat_database"
+    }
+}

--- a/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
@@ -10,7 +10,7 @@
         "period": 10000
     },
     "service": {
-        "address": "xxxxx",
+        "address": "172.22.0.2:5432",
         "type": "sql"
     },
     "sql": {
@@ -19,8 +19,8 @@
             "numeric": {
                 "blk_read_time": 0,
                 "blk_write_time": 0,
-                "blks_hit": 2793,
-                "blks_read": 116,
+                "blks_hit": 1923,
+                "blks_read": 111,
                 "conflicts": 0,
                 "datid": 12379,
                 "deadlocks": 0,
@@ -28,16 +28,16 @@
                 "temp_bytes": 0,
                 "temp_files": 0,
                 "tup_deleted": 0,
-                "tup_fetched": 1832,
+                "tup_fetched": 1249,
                 "tup_inserted": 0,
-                "tup_returned": 2898,
+                "tup_returned": 1356,
                 "tup_updated": 0,
-                "xact_commit": 28,
+                "xact_commit": 18,
                 "xact_rollback": 0
             },
             "string": {
                 "datname": "postgres",
-                "stats_reset": "2020-01-20 21:02:53.21"
+                "stats_reset": "2020-01-21 11:23:56.53"
             }
         },
         "query": "select * from pg_stat_database"

--- a/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
@@ -10,7 +10,7 @@
         "period": 10000
     },
     "service": {
-        "address": "user=postgres password=postgres sslmode=disable host=172.22.0.2 port=5432",
+        "address": "xxxxx",
         "type": "sql"
     },
     "sql": {
@@ -19,8 +19,8 @@
             "numeric": {
                 "blk_read_time": 0,
                 "blk_write_time": 0,
-                "blks_hit": 4251,
-                "blks_read": 103,
+                "blks_hit": 2793,
+                "blks_read": 116,
                 "conflicts": 0,
                 "datid": 12379,
                 "deadlocks": 0,
@@ -28,16 +28,16 @@
                 "temp_bytes": 0,
                 "temp_files": 0,
                 "tup_deleted": 0,
-                "tup_fetched": 2847,
+                "tup_fetched": 1832,
                 "tup_inserted": 0,
-                "tup_returned": 4877,
+                "tup_returned": 2898,
                 "tup_updated": 0,
-                "xact_commit": 49,
+                "xact_commit": 28,
                 "xact_rollback": 0
             },
             "string": {
                 "datname": "postgres",
-                "stats_reset": "2020-01-20 19:48:28.217"
+                "stats_reset": "2020-01-20 21:02:53.21"
             }
         },
         "query": "select * from pg_stat_database"

--- a/x-pack/metricbeat/module/sql/query/dsn.go
+++ b/x-pack/metricbeat/module/sql/query/dsn.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package query
+
+import (
+	"net/url"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+// ParseDSN tries to parse the host
+func ParseDSN(mod mb.Module, host string) (mb.HostData, error) {
+	// TODO: Add support for `username` and `password` as module options
+
+	sanitized := sanitize(host)
+
+	return mb.HostData{
+		URI:          host,
+		SanitizedURI: sanitized,
+		Host:         sanitized,
+	}, nil
+}
+
+func sanitize(host string) string {
+	// Host is a standard URL
+	if url, err := url.Parse(host); err == nil && len(url.Host) > 0 {
+		return url.Host
+	}
+
+	// Host is a MySQL DSN
+	if config, err := mysql.ParseDSN(host); err == nil {
+		return config.Addr
+	}
+
+	// TODO: Add support for PostgreSQL connection strings and other formats
+
+	return "(redacted)"
+}

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -63,6 +63,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
+// Host returns the host string that will be stored in the events, as the
+// module is generic, the value in `hosts` can contain passwords in different
+// places, so mask the whole value.
+func (m *MetricSet) Host() string {
+	// TODO: Return something more meaningful
+	return "xxxxx"
+}
+
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/mb/parse"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -24,7 +25,9 @@ import (
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet("sql", "query", New)
+	mb.Registry.MustAddMetricSet("sql", "query", New,
+		mb.WithHostParser(parse.PassThruHostParser),
+	)
 }
 
 // MetricSet holds any configuration or state information. It must implement
@@ -33,9 +36,10 @@ func init() {
 // interface methods except for Fetch.
 type MetricSet struct {
 	mb.BaseMetricSet
-	Driver     string
-	Datasource string
-	Query      string
+	Driver string
+	Query  string
+
+	db *sqlx.DB
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -44,9 +48,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The sql query metricset is beta.")
 
 	config := struct {
-		Driver     string `config:"driver"`
-		Datasource string `config:"datasource"`
-		Query      string `config:"sql_query"`
+		Driver string `config:"driver"`
+		Query  string `config:"sql_query"`
 	}{}
 
 	if err := base.Module().UnpackConfig(&config); err != nil {
@@ -56,7 +59,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		Driver:        config.Driver,
-		Datasource:    config.Datasource,
 		Query:         config.Query,
 	}, nil
 }
@@ -65,7 +67,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
-	db, err := sqlx.Open(m.Driver, m.Datasource)
+	db, err := sqlx.Open(m.Driver, m.HostData().URI)
 	if err != nil {
 		return errors.Wrap(err, "error opening connection")
 	}

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -10,14 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/metricbeat/mb/parse"
-
-	"github.com/jmoiron/sqlx"
 )
 
 // init registers the MetricSet with the central registry as soon as the program
@@ -26,7 +24,7 @@ import (
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
 	mb.Registry.MustAddMetricSet("sql", "query", New,
-		mb.WithHostParser(parse.PassThruHostParser),
+		mb.WithHostParser(ParseDSN),
 	)
 }
 
@@ -38,8 +36,6 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	Driver string
 	Query  string
-
-	db *sqlx.DB
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -61,14 +57,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Driver:        config.Driver,
 		Query:         config.Query,
 	}, nil
-}
-
-// Host returns the host string that will be stored in the events, as the
-// module is generic, the value in `hosts` can contain passwords in different
-// places, so mask the whole value.
-func (m *MetricSet) Host() string {
-	// TODO: Return something more meaningful
-	return "xxxxx"
 }
 
 // Fetch methods implements the data gathering and data conversion to the right

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -96,7 +96,7 @@ func testFetch(t *testing.T, cfg testFetchConfig) {
 
 	if cfg.Assertion != nil {
 		for _, event := range events {
-			cfg.Assertion(t, mbtest.StandardizeEvent(m, event, mb.AddMetricSetInfo))
+			cfg.Assertion(t, m.StandardizeEvent(event, mb.AddMetricSetInfo))
 		}
 	}
 }

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -1,0 +1,75 @@
+// +build integration
+
+package query
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/tests/compose"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/mysql"
+	"github.com/elastic/beats/metricbeat/module/postgresql"
+
+	// Drivers
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+type testFetchConfig struct {
+	Driver     string
+	Query      string
+	Host       string
+	Datasource string
+}
+
+func TestFetchMySQL(t *testing.T) {
+	service := compose.EnsureUp(t, "mysql")
+	testFetch(t, testFetchConfig{
+		Driver:     "mysql",
+		Query:      "select now()",
+		Host:       service.Host(),
+		Datasource: mysql.GetMySQLEnvDSN(service.Host()),
+	})
+}
+
+func TestFetchPostgreSQL(t *testing.T) {
+	service := compose.EnsureUp(t, "postgresql")
+	host, port, err := net.SplitHostPort(service.Host())
+	require.NoError(t, err)
+
+	user := postgresql.GetEnvUsername()
+	password := postgresql.GetEnvPassword()
+
+	testFetch(t, testFetchConfig{
+		Driver:     "postgres",
+		Query:      "select now()",
+		Host:       service.Host(),
+		Datasource: fmt.Sprintf("user=%s password=%s sslmode=disable host=%s port=%s", user, password, host, port),
+	})
+}
+
+func TestData(t *testing.T) {
+}
+
+func testFetch(t *testing.T, cfg testFetchConfig) {
+	m := mbtest.NewFetcher(t, getConfig(cfg))
+	events, errs := m.FetchEvents()
+	require.Empty(t, errs)
+	require.NotEmpty(t, events)
+	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
+}
+
+func getConfig(cfg testFetchConfig) map[string]interface{} {
+	return map[string]interface{}{
+		"module":     "sql",
+		"metricsets": []string{"query"},
+		"hosts":      []string{cfg.Host},
+		"driver":     cfg.Driver,
+		"sql_query":  cfg.Query,
+		"datasource": cfg.Datasource,
+	}
+}

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 // +build integration
 
 package query

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -40,7 +40,7 @@ func TestMySQL(t *testing.T) {
 		Driver:    "mysql",
 		Query:     "select table_schema, table_name, engine, table_rows from information_schema.tables where table_rows > 0;",
 		Host:      mysql.GetMySQLEnvDSN(service.Host()),
-		Assertion: assertFieldNotContains("service.address", "root:test@"),
+		Assertion: assertFieldNotContains("service.address", ":test@"),
 	}
 
 	t.Run("fetch", func(t *testing.T) {
@@ -68,6 +68,17 @@ func TestPostgreSQL(t *testing.T) {
 	}
 
 	t.Run("fetch", func(t *testing.T) {
+		testFetch(t, config)
+	})
+
+	config = testFetchConfig{
+		Driver:    "postgres",
+		Query:     "select * from pg_stat_database",
+		Host:      fmt.Sprintf("postgres://%s:%s@%s:%s/?sslmode=disable", user, password, host, port),
+		Assertion: assertFieldNotContains("service.address", ":"+password+"@"),
+	}
+
+	t.Run("fetch with URL", func(t *testing.T) {
 		testFetch(t, config)
 	})
 

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -107,9 +107,9 @@ func getConfig(cfg testFetchConfig) map[string]interface{} {
 
 func assertFieldNotContains(field, s string) func(t *testing.T, event beat.Event) {
 	return func(t *testing.T, event beat.Event) {
-		address, err := event.GetValue(field)
+		value, err := event.GetValue(field)
 		assert.NoError(t, err)
-		require.NotEmpty(t, address.(string))
-		require.NotContains(t, address.(string), s)
+		require.NotEmpty(t, value.(string))
+		require.NotContains(t, value.(string), s)
 	}
 }

--- a/x-pack/metricbeat/modules.d/sql.yml.disabled
+++ b/x-pack/metricbeat/modules.d/sql.yml.disabled
@@ -5,9 +5,8 @@
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 


### PR DESCRIPTION
## What does this PR do?

* Remove `datasource` option from SQL module. This option was intended to set the DSN of a database connection, and we were ignoring the `hosts` setting. In other SQL modules we are using the values in `host` as DSNs, do here the same for consistency. Host is redacted when we cannot parse it as it can contain passwords.
* `StandardizeEvent` is exposed in `mbtest.Fetcher` interface so we can more easily check contents of events.
* Add integration tests of the module with MySQL and PostgreSQL.
* Add real `data.json` with data from MySQL and PostgreSQL.

## Why is it important?

* To have consistency between this new SQL module and other engine-specific SQL modules.
* To have automatic tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Continues #13257
- Solves part of #15048