### PR TITLE
Cherry-pick #15686 to 7.6: Remove datasource option from SQL module and add tests

### DIFF
--- a/metricbeat/docs/modules/sql.asciidoc
+++ b/metricbeat/docs/modules/sql.asciidoc
@@ -8,7 +8,7 @@ This file is generated! See scripts/mage/docs_collector.go
 
 beta[]
 
-This is the sql module that fetches metrics from a SQL database. You can define driver, datasource and SQL query.
+This is the sql module that fetches metrics from a SQL database. You can define driver and SQL query.
 
 
 
@@ -26,10 +26,9 @@ metricbeat.modules:
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 
 ----

--- a/metricbeat/mb/testing/fetcher.go
+++ b/metricbeat/mb/testing/fetcher.go
@@ -20,6 +20,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 )
@@ -32,6 +33,7 @@ type Fetcher interface {
 	FetchEvents() ([]mb.Event, []error)
 	WriteEvents(testing.TB, string)
 	WriteEventsCond(testing.TB, string, func(common.MapStr) bool)
+	StandardizeEvent(mb.Event, ...mb.EventModifier) beat.Event
 }
 
 // NewFetcher returns a test fetcher from a Metricset configuration
@@ -73,6 +75,10 @@ func (f *reportingMetricSetV2Fetcher) WriteEventsCond(t testing.TB, path string,
 	}
 }
 
+func (f *reportingMetricSetV2Fetcher) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
+}
+
 type reportingMetricSetV2FetcherError struct {
 	mb.ReportingMetricSetV2Error
 }
@@ -96,6 +102,10 @@ func (f *reportingMetricSetV2FetcherError) WriteEventsCond(t testing.TB, path st
 	}
 }
 
+func (f *reportingMetricSetV2FetcherError) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
+}
+
 type reportingMetricSetV2FetcherWithContext struct {
 	mb.ReportingMetricSetV2WithContext
 }
@@ -117,4 +127,8 @@ func (f *reportingMetricSetV2FetcherWithContext) WriteEventsCond(t testing.TB, p
 	if err != nil {
 		t.Fatal("writing events", err)
 	}
+}
+
+func (f *reportingMetricSetV2FetcherWithContext) StandardizeEvent(event mb.Event, modifiers ...mb.EventModifier) beat.Event {
+	return StandardizeEvent(f, event, modifiers...)
 }

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -935,10 +935,9 @@ metricbeat.modules:
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 
 

--- a/x-pack/metricbeat/module/sql/_meta/config.yml
+++ b/x-pack/metricbeat/module/sql/_meta/config.yml
@@ -2,9 +2,8 @@
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 

--- a/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-This is the sql module that fetches metrics from a SQL database. You can define driver, datasource and SQL query.
+This is the sql module that fetches metrics from a SQL database. You can define driver and SQL query.
 
 

--- a/x-pack/metricbeat/module/sql/docker-compose.yml
+++ b/x-pack/metricbeat/module/sql/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2.3'
+
+services:
+  mysql:
+    extends:
+      file: ../../../../metricbeat/module/mysql/docker-compose.yml
+      service: mysql
+
+  postgresql:
+    extends:
+      file: ../../../../metricbeat/module/postgresql/docker-compose.yml
+      service: postgresql

--- a/x-pack/metricbeat/module/sql/query/_meta/data.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data.json
@@ -1,26 +1,30 @@
 {
-    "@timestamp":"2016-05-23T08:05:34.853Z",
-    "beat":{
-        "hostname":"beathost",
-        "name":"beathost"
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "event": {
+        "dataset": "sql.query",
+        "duration": 115000,
+        "module": "sql"
     },
-    "metricset":{
-        "host":"localhost",
-        "module":"sql",
-        "name":"query",
-        "rtt":44269
+    "metricset": {
+        "name": "query",
+        "period": 10000
     },
-    "sql":{
-        "metrics":{
-           "numeric":{
-              "mynumericfield":1
-           },
-           "string":{
-              "mystringfield":"abc"
-           }
+    "service": {
+        "address": "172.22.0.3:3306",
+        "type": "sql"
+    },
+    "sql": {
+        "driver": "mysql",
+        "metrics": {
+            "numeric": {
+                "table_rows": 6
+            },
+            "string": {
+                "engine": "InnoDB",
+                "table_name": "sys_config",
+                "table_schema": "sys"
+            }
         },
-        "driver":"postgres",
-        "query":"select * from mytable"
-     },
-    "type":"metricsets"
+        "query": "select table_schema, table_name, engine, table_rows from information_schema.tables where table_rows \u003e 0;"
+    }
 }

--- a/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
@@ -1,0 +1,45 @@
+{
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "event": {
+        "dataset": "sql.query",
+        "duration": 115000,
+        "module": "sql"
+    },
+    "metricset": {
+        "name": "query",
+        "period": 10000
+    },
+    "service": {
+        "address": "172.22.0.2:5432",
+        "type": "sql"
+    },
+    "sql": {
+        "driver": "postgres",
+        "metrics": {
+            "numeric": {
+                "blk_read_time": 0,
+                "blk_write_time": 0,
+                "blks_hit": 1923,
+                "blks_read": 111,
+                "conflicts": 0,
+                "datid": 12379,
+                "deadlocks": 0,
+                "numbackends": 1,
+                "temp_bytes": 0,
+                "temp_files": 0,
+                "tup_deleted": 0,
+                "tup_fetched": 1249,
+                "tup_inserted": 0,
+                "tup_returned": 1356,
+                "tup_updated": 0,
+                "xact_commit": 18,
+                "xact_rollback": 0
+            },
+            "string": {
+                "datname": "postgres",
+                "stats_reset": "2020-01-21 11:23:56.53"
+            }
+        },
+        "query": "select * from pg_stat_database"
+    }
+}

--- a/x-pack/metricbeat/module/sql/query/dsn.go
+++ b/x-pack/metricbeat/module/sql/query/dsn.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package query
+
+import (
+	"net/url"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+// ParseDSN tries to parse the host
+func ParseDSN(mod mb.Module, host string) (mb.HostData, error) {
+	// TODO: Add support for `username` and `password` as module options
+
+	sanitized := sanitize(host)
+
+	return mb.HostData{
+		URI:          host,
+		SanitizedURI: sanitized,
+		Host:         sanitized,
+	}, nil
+}
+
+func sanitize(host string) string {
+	// Host is a standard URL
+	if url, err := url.Parse(host); err == nil && len(url.Host) > 0 {
+		return url.Host
+	}
+
+	// Host is a MySQL DSN
+	if config, err := mysql.ParseDSN(host); err == nil {
+		return config.Addr
+	}
+
+	// TODO: Add support for PostgreSQL connection strings and other formats
+
+	return "(redacted)"
+}

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -1,0 +1,126 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package query
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Drivers
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/tests/compose"
+	"github.com/elastic/beats/metricbeat/mb"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/mysql"
+	"github.com/elastic/beats/metricbeat/module/postgresql"
+)
+
+type testFetchConfig struct {
+	Driver string
+	Query  string
+	Host   string
+
+	Assertion func(t *testing.T, event beat.Event)
+}
+
+func TestMySQL(t *testing.T) {
+	service := compose.EnsureUp(t, "mysql")
+	config := testFetchConfig{
+		Driver:    "mysql",
+		Query:     "select table_schema, table_name, engine, table_rows from information_schema.tables where table_rows > 0;",
+		Host:      mysql.GetMySQLEnvDSN(service.Host()),
+		Assertion: assertFieldNotContains("service.address", ":test@"),
+	}
+
+	t.Run("fetch", func(t *testing.T) {
+		testFetch(t, config)
+	})
+
+	t.Run("data", func(t *testing.T) {
+		testData(t, config, "")
+	})
+}
+
+func TestPostgreSQL(t *testing.T) {
+	service := compose.EnsureUp(t, "postgresql")
+	host, port, err := net.SplitHostPort(service.Host())
+	require.NoError(t, err)
+
+	user := postgresql.GetEnvUsername()
+	password := postgresql.GetEnvPassword()
+
+	config := testFetchConfig{
+		Driver:    "postgres",
+		Query:     "select * from pg_stat_database",
+		Host:      fmt.Sprintf("user=%s password=%s sslmode=disable host=%s port=%s", user, password, host, port),
+		Assertion: assertFieldNotContains("service.address", "password="+password),
+	}
+
+	t.Run("fetch", func(t *testing.T) {
+		testFetch(t, config)
+	})
+
+	config = testFetchConfig{
+		Driver:    "postgres",
+		Query:     "select * from pg_stat_database",
+		Host:      fmt.Sprintf("postgres://%s:%s@%s:%s/?sslmode=disable", user, password, host, port),
+		Assertion: assertFieldNotContains("service.address", ":"+password+"@"),
+	}
+
+	t.Run("fetch with URL", func(t *testing.T) {
+		testFetch(t, config)
+	})
+
+	t.Run("data", func(t *testing.T) {
+		testData(t, config, "./_meta/data_postgres.json")
+	})
+}
+
+func testFetch(t *testing.T, cfg testFetchConfig) {
+	m := mbtest.NewFetcher(t, getConfig(cfg))
+	events, errs := m.FetchEvents()
+	require.Empty(t, errs)
+	require.NotEmpty(t, events)
+	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
+
+	if cfg.Assertion != nil {
+		for _, event := range events {
+			cfg.Assertion(t, m.StandardizeEvent(event, mb.AddMetricSetInfo))
+		}
+	}
+}
+
+func testData(t *testing.T, cfg testFetchConfig, postfix string) {
+	m := mbtest.NewFetcher(t, getConfig(cfg))
+	m.WriteEvents(t, postfix)
+}
+
+func getConfig(cfg testFetchConfig) map[string]interface{} {
+	return map[string]interface{}{
+		"module":     "sql",
+		"metricsets": []string{"query"},
+		"hosts":      []string{cfg.Host},
+		"driver":     cfg.Driver,
+		"sql_query":  cfg.Query,
+	}
+}
+
+func assertFieldNotContains(field, s string) func(t *testing.T, event beat.Event) {
+	return func(t *testing.T, event beat.Event) {
+		value, err := event.GetValue(field)
+		assert.NoError(t, err)
+		require.NotEmpty(t, value.(string))
+		require.NotContains(t, value.(string), s)
+	}
+}

--- a/x-pack/metricbeat/modules.d/sql.yml.disabled
+++ b/x-pack/metricbeat/modules.d/sql.yml.disabled
@@ -5,9 +5,8 @@
   metricsets:
     - query
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["user=myuser password=mypassword dbname=mydb sslmode=disable"]
 
   driver: "postgres"
-  datasource: "user=myuser password=mypassword dbname=mydb sslmode=disable"
   sql_query: "select now()"
 


### PR DESCRIPTION
Cherry-pick of PR #15686 to 7.6 branch. Original message: 

## What does this PR do?

* Remove `datasource` option from SQL module. This option was intended to set the DSN of a database connection, and we were ignoring the `hosts` setting. In other SQL modules we are using the values in `host` as DSNs, do here the same for consistency. Host is redacted when we cannot parse it as it can contain passwords.
* `StandardizeEvent` is exposed in `mbtest.Fetcher` interface so we can more easily check contents of events.
* Add integration tests of the module with MySQL and PostgreSQL.
* Add real `data.json` with data from MySQL and PostgreSQL.

## Why is it important?

* To have consistency between this new SQL module and other engine-specific SQL modules.
* To have automatic tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Continues #13257
- Solves part of #15048