### PR TITLE
Update script shebangs to python3

### DIFF
--- a/dev-tools/aggregate_coverage.py
+++ b/dev-tools/aggregate_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script to concatenate coverage reports.
 """

--- a/dev-tools/deploy
+++ b/dev-tools/deploy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import argparse
 from subprocess import check_call

--- a/dev-tools/get_version
+++ b/dev-tools/get_version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import argparse

--- a/dev-tools/merge_pr
+++ b/dev-tools/merge_pr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import argparse
 from subprocess import check_call, call, check_output

--- a/dev-tools/open_pr
+++ b/dev-tools/open_pr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Open a PR from the current branch"""
 
 import sys

--- a/dev-tools/promote_docs
+++ b/dev-tools/promote_docs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 from subprocess import check_call
 

--- a/dev-tools/set_docs_version
+++ b/dev-tools/set_docs_version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 from subprocess import check_call
 

--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import os
 import re

--- a/filebeat/tests/system/test_input.py
+++ b/filebeat/tests/system/test_input.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from filebeat import BaseTest
 import os

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test the registrar"""
 import os
 import platform

--- a/filebeat/tests/system/test_registrar_upgrade.py
+++ b/filebeat/tests/system/test_registrar_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test the registrar with old registry file formats"""
 
 import os

--- a/filebeat/tests/system/test_stdin.py
+++ b/filebeat/tests/system/test_stdin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from filebeat import BaseTest
 import os

--- a/libbeat/scripts/generate_makefile_doc.py
+++ b/libbeat/scripts/generate_makefile_doc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This script generates and output a documentation from a list of Makefile files

--- a/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/tcp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_delete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/tcp_stats.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/udp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/udp_counter_ops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/udp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/udp_delete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/udp_multi_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_multi_store.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 

--- a/packetbeat/tests/system/gen/memcache/udp_single_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_single_store.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mc
 


### PR DESCRIPTION
Use python3 in the shebang for python scripts. python is going to be reserved for python2 in Ubuntu, and PEP394 mentions that python should be used in the shebang line only for scripts that are source compatible with both Python 2 and 3.