### PR TITLE
Cherry-pick #15649 to 7.6: [metricbeat] Add divide by zero check to docker/diskio

### DIFF
--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -174,5 +174,11 @@ func calculatePerSecond(duration time.Duration, old uint64, new uint64) float64 
 	if value < 0 {
 		value = 0
 	}
-	return value / duration.Seconds()
+
+	timeSec := duration.Seconds()
+	if timeSec == 0 {
+		return 0
+	}
+
+	return value / timeSec
 }


### PR DESCRIPTION
Cherry-pick of PR #15649 to 7.6 branch. Original message: 

Currently dealing with #15549, which involves a handful of NaN errors. I'm hoping this is one of the NaN cases. If we get invalid data from upstream, it's possible for this to be 0.