### PR TITLE
[7.6] Change joda style pattern to java style (#15695)

### DIFF
--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -66,7 +66,7 @@ Date math is supported in this setting. For example:
 
 [source,yaml]
 ----
-setup.ilm.pattern: "{now/M{YYYY.MM}}-000001"
+setup.ilm.pattern: "{now/M{yyyy.MM}}-000001"
 ----
 
 For more information, see


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Change joda style pattern to java style  (#15695)