### PR TITLE
Libbeat test fixes for Python 3

### DIFF
--- a/libbeat/tests/system/keystore.py
+++ b/libbeat/tests/system/keystore.py
@@ -26,7 +26,7 @@ class KeystoreBase(BaseTest):
 
         proc = Proc(args, os.path.join(self.working_dir, "mockbeat.log"))
 
-        os.write(proc.stdin_write, value)
+        os.write(proc.stdin_write, value.encode("utf8"))
         os.close(proc.stdin_write)
 
         return proc.start().wait()

--- a/libbeat/tests/system/test_cmd_setup_index_management.py
+++ b/libbeat/tests/system/test_cmd_setup_index_management.py
@@ -77,7 +77,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.alias_name, self.policy_name, self.alias_name)
         self.idxmgmt.assert_index_template_index_pattern(self.index_name, [self.index_name + "-*"])
-        self.idxmgmt.assert_docs_written_to_alias(self.alias_name)
         self.idxmgmt.assert_alias_created(self.alias_name)
         self.idxmgmt.assert_policy_created(self.policy_name)
         # try deleting policy needs to raise an error as it is in use
@@ -191,7 +190,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.custom_alias, self.policy_name, self.custom_alias)
         self.idxmgmt.assert_index_template_index_pattern(self.custom_alias, [self.custom_alias + "-*"])
-        self.idxmgmt.assert_docs_written_to_alias(self.custom_alias)
         self.idxmgmt.assert_alias_created(self.custom_alias)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -211,7 +209,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.custom_alias, self.policy_name, self.custom_alias)
         self.idxmgmt.assert_index_template_index_pattern(self.custom_alias, [self.custom_alias + "-*"])
-        self.idxmgmt.assert_docs_written_to_alias(self.custom_alias)
         self.idxmgmt.assert_alias_created(self.custom_alias)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -229,7 +226,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.alias_name, self.policy_name, self.alias_name)
         self.idxmgmt.assert_index_template_index_pattern(self.alias_name, [self.alias_name + "-*"])
-        self.idxmgmt.assert_docs_written_to_alias(self.alias_name)
         self.idxmgmt.assert_alias_created(self.alias_name)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -361,8 +361,8 @@ class Test(BaseTest):
         url = "http://" + self.get_kibana_host() + ":" + self.get_kibana_port() + \
             "/api/spaces/space"
         data = {
-            "id": "foo-bar",
-            "name": "Foo bar space"
+            "id": "libbeat-system-tests",
+            "name": "Libbeat System Tests"
         }
 
         headers = {
@@ -370,7 +370,8 @@ class Test(BaseTest):
         }
 
         r = requests.post(url, json=data, headers=headers)
-        assert r.status_code == 200
+        if r.status_code != 200 and r.status_code != 409:
+            self.fail('Bad Kibana status code when creating space: {}'.format(r.status_code))
 
     def get_version(self):
         url = "http://" + self.get_kibana_host() + ":" + self.get_kibana_port() + \

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -161,7 +161,7 @@ class TestCommandSetupILMPolicy(BaseTest):
     def setUp(self):
         super(TestCommandSetupILMPolicy, self).setUp()
 
-        self.setupCmd = "--ilm-policy"
+        self.setupCmd = "--index-management"
 
         self.alias_name = self.index_name = self.beat_name + "-9.9.9"
         self.policy_name = self.beat_name
@@ -194,12 +194,12 @@ class TestCommandSetupILMPolicy(BaseTest):
         """
         self.render_config()
 
+        # NOTE: --template is deprecated for 8.0.0./
         exit_code = self.run_beat(logging_args=["-v", "-d", "*"],
                                   extra_args=["setup", self.setupCmd, "--template"])
 
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.alias_name, self.policy_name, self.alias_name)
-        self.idxmgmt.assert_docs_written_to_alias(self.alias_name)
         self.idxmgmt.assert_alias_created(self.alias_name)
         self.idxmgmt.assert_policy_created(self.policy_name)
 
@@ -217,7 +217,6 @@ class TestCommandSetupILMPolicy(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.alias_name, self.policy_name, self.alias_name)
         self.idxmgmt.assert_index_template_index_pattern(self.alias_name, [self.alias_name + "-*"])
-        self.idxmgmt.assert_docs_written_to_alias(self.alias_name)
         self.idxmgmt.assert_alias_created(self.alias_name)
         self.idxmgmt.assert_policy_created(self.policy_name)
 
@@ -268,7 +267,6 @@ class TestCommandSetupILMPolicy(BaseTest):
 
         assert exit_code == 0
         self.idxmgmt.assert_ilm_template_loaded(self.custom_alias, self.policy_name, self.custom_alias)
-        self.idxmgmt.assert_docs_written_to_alias(self.custom_alias)
         self.idxmgmt.assert_alias_created(self.custom_alias)
 
 

--- a/libbeat/tests/system/test_meta.py
+++ b/libbeat/tests/system/test_meta.py
@@ -33,5 +33,5 @@ class TestMetaFile(BaseTest):
         """
         Test that the meta file has correct permissions
         """
-        perms = oct(stat.S_IMODE(os.lstat(self.meta_file_path).st_mode))
-        self.assertEqual(perms, "0600")
+        perms = stat.S_IMODE(os.lstat(self.meta_file_path).st_mode)
+        self.assertEqual(perms, 0o600)


### PR DESCRIPTION
This has a few fixes to python system tests under libbeat/tests/system.

assert_docs_written_to_alias had an invalid assertion ever since Elasticsearch
changed the format of the hits count to allow for track_total_hits false. Many
tests were using this assertion even when not indexing any events so the hit
count would always be zero so I removed the assertion from those tests.

In other tests I was getting spurious failures because _search was being called
before the index was refreshed to allow the documents to be search able. So I
added an explicit /_refresh to fix the issue.

I changed create_kibana_space to allow a 409 response code so you can run the
tests more than once against a Kibana instance.

I fixed an assertion on the mode bits of a file since the format of octal numbers is
always prefixed with '0o' now.

And I fixed the libbeat keystore tests by encoding the secret string to binary
before calling os.write. This fixed this error:

```
======================================================================
ERROR: Add a secret to the store using stdin
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/akroh/go/src/github.com/elastic/beats/libbeat/tests/system/test_cmd_keystore.py", line 130, in test_keystore_add_secret_from_stdin
    exit_code = self.add_secret("willnotdelete")
  File "/Users/akroh/go/src/github.com/elastic/beats/libbeat/tests/system/keystore.py", line 29, in add_secret
    os.write(proc.stdin_write, value)
TypeError: a bytes-like object is required, not 'str'
```
