### PR TITLE
Fix python3 sys.platform check for Linux

### DIFF
--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -24,7 +24,7 @@ class Test(AuditbeatXPackTest):
 
         self.check_metricset("system", "host", COMMON_FIELDS + fields)
 
-    @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
+    @unittest.skipUnless(sys.platform.startswith('linux'), "Only implemented for Linux")
     @unittest.skipIf(sys.byteorder != "little", "Test only implemented for little-endian systems")
     def test_metricset_login(self):
         """
@@ -43,7 +43,7 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "login", COMMON_FIELDS + fields, config, warnings_allowed=True)
 
     @unittest.skipIf(sys.platform == "win32", "Not implemented for Windows")
-    @unittest.skipIf(sys.platform == "linux2" and not (os.path.isdir("/var/lib/dpkg") or os.path.isdir("/var/lib/rpm")),
+    @unittest.skipIf(sys.platform.startswith('linux') and not (os.path.isdir("/var/lib/dpkg") or os.path.isdir("/var/lib/rpm")),
                      "Only implemented for dpkg and rpm")
     def test_metricset_package(self):
         """
@@ -74,7 +74,7 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "process", COMMON_FIELDS + fields, {"process.hash.max_file_size": 1},
                              errors_allowed=True, warnings_allowed=True)
 
-    @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
+    @unittest.skipUnless(sys.platform.startswith('linux'), "Only implemented for Linux")
     def test_metricset_user(self):
         """
         user metricset collects information about users on a server.


### PR DESCRIPTION
On Linux, sys.platform doesn’t contain the major version anymore. It is now always ‘linux’, instead of ‘linux2’ or ‘linux3’ depending on the Linux version used to build Python. Replace sys.platform == ‘linux2’ with sys.platform.startswith(‘linux’), or directly sys.platform == ‘linux’ if you don’t need to support older Python versions.

Ref: https://docs.python.org/3.3/whatsnew/3.3.html#porting-python-code