### PR TITLE
Read hits.total.value to get number of hits

### DIFF
--- a/x-pack/libbeat/tests/system/test_management.py
+++ b/x-pack/libbeat/tests/system/test_management.py
@@ -282,7 +282,7 @@ class TestManagement(BaseTest):
     def check_document_count(self, index, count):
         try:
             self.es.indices.refresh(index=index)
-            return self.es.search(index=index, body={"query": {"match_all": {}}})['hits']['total'] >= count
+            return self.es.search(index=index, body={"query": {"match_all": {}}})['hits']['total']['value'] >= count
         except:
             return False
 


### PR DESCRIPTION
This should fix test_management.py under Python3. An object was being returned but
the test was expecting to get a number. The format of the Elasticsearch response changed
for the "track_total_hits" enhancement, but this wasn't updated.