### PR TITLE
Collect normalized CPU percentages by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@ TLS or Beats that accept connections over TLS and validate client certificates. 
 - Release elb module as GA. {pull}15485[15485]
 - Add a `system/network_summary` metricset {pull}15196[15196]
 - Add mesh metricset for Istio Metricbeat module{pull}15535[15535]
+- Make the `system/cpu` metricset collect normalized CPU metrics by default. {issue}15618[15618] {pull}15729[15729]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -178,7 +178,7 @@ metricbeat.modules:
   processes: ['.*']
 
   # Configure the metric types that are included by these metricsets.
-  cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
+  cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
   # A list of filesystem types to ignore. The filesystem metricset will not

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -79,7 +79,7 @@ metricbeat.modules:
   processes: ['.*']
 
   # Configure the metric types that are included by these metricsets.
-  cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
+  cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
   # A list of filesystem types to ignore. The filesystem metricset will not

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -20,7 +20,7 @@
   processes: ['.*']
 
   # Configure the metric types that are included by these metricsets.
-  cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
+  cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
   # A list of filesystem types to ignore. The filesystem metricset will not

--- a/metricbeat/module/system/cpu/config.go
+++ b/metricbeat/module/system/cpu/config.go
@@ -62,5 +62,5 @@ func (c Config) Validate() error {
 }
 
 var defaultConfig = Config{
-	Metrics: []string{percentages},
+	Metrics: []string{percentages, normalizedPercentages},
 }

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -79,7 +79,7 @@ metricbeat.modules:
   processes: ['.*']
 
   # Configure the metric types that are included by these metricsets.
-  cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
+  cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
   # A list of filesystem types to ignore. The filesystem metricset will not


### PR DESCRIPTION
Resolves #15618. 

This PR enhances the `system/cpu` metricset to collect normalized CPU percentages by default. The normalised percentage takes into account the number of cores, which allows users to compare hosts with different number of cores.

## Testing this PR

1. Configure Metricbeat with the `console` output for easy inspection of generated events. In your `metricbeat.yml`, set `output.elasticsearch.enabled: false` and `output.console.enabled: true`.

2. In a separate window, make your CPU do some work.
   ```sh
   cd $GOPATH/src/github.com/elastic/beats/metricbeat/module/system/_meta/testing
   GOMAXPROCS=4 go run burn.go -cpus 4
   ```

3. Run Metricbeat with default modules enabled (i.e. just the `system` module) and check that normalized CPU percentages are collected/reported by default by the `system/cpu` metricset.
   ```sh
   ./metricbeat | jq -c 'select(.event.dataset == "system.cpu") | .system.cpu'
   ```
