### PR TITLE
[Flaky] [Auditbeat] DNSTestCase: verify outbound packets only

### DIFF
--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -652,7 +652,7 @@ class DNSTestCase:
                 "event.kind": "event",
                 "event.module": "system",
                 "network.packets": net_bytes,
-                "network.direction": "inbound",
+                "network.direction": "outbound",
                 "network.packets": net_packets,
                 "network.transport": self.socket_factory.transport,
                 "network.type": self.socket_factory.network,


### PR DESCRIPTION
This PR adjusts test case verification of exchanged network packets to verify only outbound packets when communicating with fake HTTP server (serving elastic.co).

Flakiness spotted, i.e. here: https://travis-ci.org/elastic/beats/jobs/640285395?utm_medium=notification&utm_source=github_status

The DNS test case includes checking DNS IP address of the "elastic.co" and later on sending an HTTP request. As we do not test the fake server, I assume we can only verify if the packet has been sent (outbound).