### PR TITLE
[7.x] Building functionbeat providers with specific GOOS and GOARCH (#15586)

### DIFF
--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -59,6 +59,14 @@ func Build() error {
 		params.InputFiles = []string{inputFiles}
 		params.Name = devtools.BeatName + "-" + provider.Name
 		params.OutputDir = filepath.Join("provider", provider.Name)
+		params.CGO = false
+		params.Env = make(map[string]string)
+		if provider.GOOS != "" {
+			params.Env["GOOS"] = provider.GOOS
+		}
+		if provider.GOARCH != "" {
+			params.Env["GOARCH"] = provider.GOARCH
+		}
 		err := devtools.Build(params)
 		if err != nil {
 			return err

--- a/x-pack/functionbeat/scripts/mage/providers.go
+++ b/x-pack/functionbeat/scripts/mage/providers.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	availableProviders = []ProviderDetails{
-		{Name: "aws", Buildable: true},
+		{Name: "aws", Buildable: true, GOOS: "linux", GOARCH: "amd64"},
 		{Name: "gcp", Buildable: false},
 	}
 )
@@ -21,6 +21,8 @@ var (
 type ProviderDetails struct {
 	Name      string
 	Buildable bool
+	GOOS      string
+	GOARCH    string
 }
 
 // SelectedProviders is the list of selected providers


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Building functionbeat providers with specific GOOS and GOARCH  (#15586)