### PR TITLE
Use 'python3 -m venv' instead of virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
     - MACOSX_DEPLOYMENT_TARGET=10.15
-    # Migration to Python 3
-    - PYTHON_EXE=python3
 
 jobs:
   include:
@@ -203,7 +201,7 @@ jobs:
             retries: true
           update: true
           packages:
-            - python-virtualenv
+            - python3-venv
             - libpcap-dev
             - xsltproc
             - libxml2-utils
@@ -223,7 +221,7 @@ addons:
       retries: true
     update: true
     packages:
-      - python-virtualenv
+      - python3-venv
       - libpcap-dev
       - xsltproc
       - libxml2-utils
@@ -232,6 +230,7 @@ addons:
 
 before_install:
   - python --version
+  - python3 --version
   - umask 022
   - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Docker-compose installation

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ PROJECTS=libbeat $(BEATS)
 PROJECTS_ENV=libbeat filebeat metricbeat
 PYTHON_ENV?=$(BUILD_DIR)/python-env
 PYTHON_EXE?=python3
-VIRTUALENV_PARAMS?=
+PYTHON_ENV_EXE=${PYTHON_ENV}/bin/$(notdir ${PYTHON_EXE})
+VENV_PARAMS?=
 FIND=find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
 GOLINT=golint
 GOLINT_REPO=golang.org/x/lint/golint
@@ -137,12 +138,12 @@ docs:
 .PHONY: notice
 notice: python-env
 	@echo "Generating NOTICE"
-	@$(PYTHON_ENV)/bin/python dev-tools/generate_notice.py .
+	@${PYTHON_ENV_EXE} dev-tools/generate_notice.py .
 
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env:
-	@test -d $(PYTHON_ENV) || virtualenv -p $(PYTHON_EXE) $(VIRTUALENV_PARAMS) $(PYTHON_ENV)
+	@test -d $(PYTHON_ENV) || ${PYTHON_EXE} -m venv $(VENV_PARAMS) $(PYTHON_ENV)
 	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8==1.3.5 pylint==1.9.5 future==0.18.2
 	@# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,7 +129,7 @@ def linuxGvmProvision(arch="amd64")
   return <<SCRIPT
 mkdir -p ~/bin
 if [ ! -e "~/bin/gvm" ]; then
-  curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.1.0/gvm-linux-#{arch}
+  curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.2.1/gvm-linux-#{arch}
   chmod +x ~/bin/gvm
   ~/bin/gvm #{GO_VERSION}
   echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
@@ -145,7 +145,7 @@ def linuxDebianProvision()
 #!/usr/bin/env bash
 set -eio pipefail
 apt-get update
-apt-get install -y make gcc python-pip python-virtualenv git
+apt-get install -y make gcc python3 python3-pip python3-venv git
 SCRIPT
 end
 
@@ -245,7 +245,8 @@ Vagrant.configure(2) do |config|
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
-    c.vm.provision "shell", inline: "yum install -y make gcc python-pip python-virtualenv git rpm-devel"
+    c.vm.provision "shell", inline: "yum install -y make gcc git rpm-devel epel-release"
+    c.vm.provision "shell", inline: "yum install -y python34 python34-pip"
   end
 
   config.vm.define "centos7", primary: true do |c|
@@ -254,25 +255,16 @@ Vagrant.configure(2) do |config|
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
-    c.vm.provision "shell", inline: "yum install -y make gcc python-pip python-virtualenv git rpm-devel"
+    c.vm.provision "shell", inline: "yum install -y make gcc python3 python3-pip git rpm-devel"
   end
 
-  config.vm.define "fedora29", primary: true do |c|
-    c.vm.box = "bento/fedora-29"
+  config.vm.define "fedora31", primary: true do |c|
+    c.vm.box = "bento/fedora-31"
     c.vm.network :forwarded_port, guest: 22, host: 2231, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
-    c.vm.provision "shell", inline: "dnf install -y make gcc python-pip python-virtualenv git rpm-devel"
-  end
-
-  config.vm.define "sles12", primary: true do |c|
-    c.vm.box = "elastic/sles-12-x86_64"
-    c.vm.network :forwarded_port, guest: 22, host: 2232, id: "ssh", auto_correct: true
-
-    c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
-    c.vm.provision "shell", inline: "pip install virtualenv"
+    c.vm.provision "shell", inline: "dnf install -y make gcc python3 python3-pip git rpm-devel"
   end
 
   config.vm.define "archlinux", primary: true do |c|
@@ -281,6 +273,6 @@ Vagrant.configure(2) do |config|
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
-    c.vm.provision "shell", inline: "pacman -Sy && pacman -S --noconfirm make gcc python-pip python-virtualenv git"
+    c.vm.provision "shell", inline: "pacman -Sy && pacman -S --noconfirm make gcc python python-pip git"
   end
 end

--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -3,14 +3,14 @@ FROM golang:1.13.6
 RUN \
     apt-get update \
       && apt-get install -y --no-install-recommends \
-         python-pip \
-         virtualenv \
          python3 \
+         python3-pip \
+         python3-venv \
          librpm-dev \
       && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
-RUN pip install --upgrade docker-compose==1.23.2
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2

--- a/dev-tools/mage/docs.go
+++ b/dev-tools/mage/docs.go
@@ -75,7 +75,7 @@ func (docsBuilder) FieldDocs(fieldsYML string) error {
 		return err
 	}
 
-	python, err := LookVirtualenvPath(ve, "python")
+	python, err := LookVirtualenvPath(ve, pythonExe)
 	if err != nil {
 		return err
 	}

--- a/dev-tools/mage/kibana.go
+++ b/dev-tools/mage/kibana.go
@@ -67,7 +67,7 @@ func KibanaDashboards(moduleDirs ...string) error {
 	}
 
 	// Convert 7.x dashboards to strings.
-	err = sh.Run("python",
+	err = sh.Run(pythonExe,
 		filepath.Join(esBeatsDir, "libbeat/scripts/unpack_dashboards.py"),
 		"--glob="+filepath.Join(kibanaBuildDir, "7/dashboard/*.json"))
 	if err != nil {

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -4,15 +4,15 @@ RUN \
     apt-get update \
       && apt-get install -y --no-install-recommends \
          netcat \
-         python-pip \
          rsync \
-         virtualenv \
          python3 \
+         python3-pip \
+         python3-venv \
          libpcap-dev \
       && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
-RUN pip install --upgrade docker-compose==1.23.2
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2

--- a/filebeat/tests/load/Makefile
+++ b/filebeat/tests/load/Makefile
@@ -1,5 +1,5 @@
 run:
-	python load.py
+	python3 load.py
 
 clean:
 	rm -r logs

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -1,17 +1,19 @@
 FROM golang:1.13.6
-MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-         netcat python-pip virtualenv python3 && \
-    apt-get clean
+RUN \
+    apt-get update \
+      && apt-get install -y --no-install-recommends \
+         netcat \
+         python3 \
+         python3-pip \
+         python3-venv \
+      && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
-RUN pip install --upgrade docker-compose==1.23.2
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment
 ENV HEARTBEAT_PATH /go/src/github.com/elastic/beats/heartbeat

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -1,15 +1,21 @@
 FROM golang:1.13.6
-MAINTAINER Noémi Ványi <noemi.vanyi@elastic.co>
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      python-pip virtualenv python3 libsystemd-dev libc6-dev-i386 gcc-arm-linux-gnueabi && \
-    apt-get clean
+RUN \
+    apt-get update \
+      && apt-get install -y --no-install-recommends \
+         libsystemd-dev \
+         libc6-dev-i386 \
+         gcc-arm-linux-gnueabi \
+         python3 \
+         python3-pip \
+         python3-venv \
+      && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade setuptools
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment
 ENV JOURNALBEAT_PATH /go/src/github.com/elastic/beats/journalbeat

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -1,21 +1,20 @@
-# Beats dockerfile used for testing
 FROM golang:1.13.6
-MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-         netcat python-pip virtualenv python3 libpcap-dev && \
-    apt-get clean
+RUN \
+    apt-get update \
+      && apt-get install -y --no-install-recommends \
+         netcat \
+         libpcap-dev \
+         python3 \
+         python3-pip \
+         python3-venv \
+      && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN test -d ${PYTHON_ENV} || virtualenv -p python3 ${PYTHON_ENV}
-COPY ./tests/system/requirements.txt /tmp/requirements.txt
-
-# Upgrade pip to make sure to have the most recent version
-RUN . ${PYTHON_ENV}/bin/activate && pip install -U pip
-RUN . ${PYTHON_ENV}/bin/activate && pip install -Ur /tmp/requirements.txt
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Libbeat specific
 RUN mkdir -p /etc/pki/tls/certs

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -23,7 +23,6 @@ SECCOMP_BLACKLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-blacklist
 SECCOMP_ALLOWLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-allow.txt
 MAGE_PRESENT := $(shell command -v mage 2> /dev/null)
 MAGE_IMPORT_PATH?=github.com/elastic/beats/vendor/github.com/magefile/mage
-PYTHON_EXE?=python3
 export MAGE_IMPORT_PATH
 
 space:=$() #
@@ -90,7 +89,9 @@ DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${BEAT_VERSION
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
+PYTHON_EXE?=python3
 PYTHON_ENV?=${BUILD_DIR}/python-env
+PYTHON_ENV_EXE=${PYTHON_ENV}/bin/$(notdir ${PYTHON_EXE})
 PIP_INSTALL_PARAMS?=
 BUILDID?=$(shell git rev-parse HEAD) ## @Building The build ID
 VENV_PARAMS?=
@@ -215,7 +216,7 @@ integration-tests-environment: prepare-tests build-image
 system-tests: ## @testing Runs the system tests
 system-tests: prepare-tests ${BEAT_NAME}.test python-env
 	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} nosetests ${PYTHON_TEST_FILES} ${NOSETESTS_OPTIONS}
-	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ${BUILD_DIR}/system-tests/run
+	${PYTHON_ENV_EXE} ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ${BUILD_DIR}/system-tests/run
 
 # Runs the system tests
 .PHONY: system-tests-environment
@@ -308,8 +309,8 @@ testsuite: clean update
 
 # Generates a coverage report from the existing coverage files
 .PHONY: coverage-report
-coverage-report:
-	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/full.cov ${COVERAGE_DIR}
+coverage-report: python-env
+	${PYTHON_ENV_EXE} ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/full.cov ${COVERAGE_DIR}
 	go tool cover -html=${COVERAGE_DIR}/full.cov -o ${COVERAGE_DIR}/full.html
 	test ! -s ${COVERAGE_DIR}/integration.cov   || go tool cover -html=${COVERAGE_DIR}/integration.cov   -o ${COVERAGE_DIR}/integration.html
 	test ! -s ${COVERAGE_DIR}/system.cov || go tool cover -html=${COVERAGE_DIR}/system.cov -o ${COVERAGE_DIR}/system.html
@@ -337,7 +338,7 @@ endif
 ifneq ($(shell [[ $(BEAT_NAME) == libbeat || $(BEAT_NAME) == metricbeat ]] && echo true ),true)
 	@# Update docs
 	@mkdir -p docs
-	@${PYTHON_ENV}/bin/python ${ES_BEATS}/libbeat/scripts/generate_fields_docs.py $(PWD)/fields.yml ${BEAT_TITLE} ${ES_BEATS}
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/libbeat/scripts/generate_fields_docs.py $(PWD)/fields.yml ${BEAT_TITLE} ${ES_BEATS}
 endif
 
 	@mkdir -p $(PWD)/_meta/kibana.generated
@@ -346,7 +347,7 @@ endif
 		cp -pr $(PWD)/_meta/kibana/* $(PWD)/_meta/kibana.generated ; \
 	fi
 	@# Convert all dashboards to string
-	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana.generated/7/dashboard/*.json"
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana.generated/7/dashboard/*.json"
 endif
 
 .PHONY: docs
@@ -423,10 +424,10 @@ get_version: ## @packaging get the version of the beat.
 	@${ES_BEATS}/dev-tools/get_version
 
 help: ## @help Show this help.
-	@python ${ES_BEATS}/libbeat/scripts/generate_makefile_doc.py $(MAKEFILE_LIST)
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/libbeat/scripts/generate_makefile_doc.py $(MAKEFILE_LIST)
 
 help_variables: ## @help Show Makefile customizable variables.
-	@python ${ES_BEATS}/libbeat/scripts/generate_makefile_doc.py --variables $(MAKEFILE_LIST)
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/libbeat/scripts/generate_makefile_doc.py --variables $(MAKEFILE_LIST)
 
 # Generates a seccomp whitelist policy for the binary pointed to by
 # SECCOMP_BINARY.

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -93,7 +93,7 @@ GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 PYTHON_ENV?=${BUILD_DIR}/python-env
 PIP_INSTALL_PARAMS?=
 BUILDID?=$(shell git rev-parse HEAD) ## @Building The build ID
-VIRTUALENV_PARAMS?=
+VENV_PARAMS?=
 INTEGRATION_TESTS?=
 FIND?=. ${PYTHON_ENV}/bin/activate; find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
 PERM_EXEC?=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
@@ -250,7 +250,7 @@ load-tests: ## @testing Runs load tests
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
-	@test -e ${PYTHON_ENV}/bin/activate || virtualenv $(if ${PYTHON_EXE},-p ${PYTHON_EXE}) ${VIRTUALENV_PARAMS} ${PYTHON_ENV}
+	@test -e ${PYTHON_ENV}/bin/activate || ${PYTHON_EXE} -m venv ${VENV_PARAMS} ${PYTHON_ENV}
 	@. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -q --upgrade pip ; \
 	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
 		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -4,16 +4,16 @@ RUN \
     apt-get update \
       && apt-get install -y --no-install-recommends \
          netcat \
-         python-pip \
-         virtualenv \
          python3 \
+         python3-pip \
+         python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
-RUN pip install --upgrade docker-compose==1.23.2
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Add healthcheck for the docker/healthcheck metricset to check during testing.
 HEALTHCHECK CMD exit 0

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -32,7 +32,7 @@ configs: python-env
 	@cp ${ES_BEATS}/metricbeat/_meta/common.yml _meta/beat.yml
 	@cat ${ES_BEATS}/metricbeat/_meta/setup.yml >> _meta/beat.yml
 	@cat ${ES_BEATS}/metricbeat/_meta/common.reference.yml > _meta/beat.reference.yml
-	@${PYTHON_ENV}/bin/python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.reference.yml
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.reference.yml
 	@rm -rf modules.d
 	mage config
 	@chmod go-w modules.d/*
@@ -52,7 +52,7 @@ collect: assets collect-docs configs kibana imports
 # Creates a new metricset. Requires the params MODULE and METRICSET
 .PHONY: create-metricset
 create-metricset: python-env
-	@${PYTHON_ENV}/bin/python ${ES_BEATS}/metricbeat/scripts/create_metricset.py --path=$(PWD) --es_beats=$(ES_BEATS) --module=$(MODULE) --metricset=$(METRICSET)
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/metricbeat/scripts/create_metricset.py --path=$(PWD) --es_beats=$(ES_BEATS) --module=$(MODULE) --metricset=$(METRICSET)
 
 # Generates the data.json example documents
 .PHONY: generate-json

--- a/packetbeat/Makefile
+++ b/packetbeat/Makefile
@@ -17,4 +17,4 @@ benchmark:
 
 .PHONY: create-tcp-protocol
 create-tcp-protocol: python-env
-	@${PYTHON_ENV}/bin/python ${ES_BEATS}/packetbeat/scripts/create_tcp_protocol.py
+	@${PYTHON_ENV_EXE} ${ES_BEATS}/packetbeat/scripts/create_tcp_protocol.py

--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -1,15 +1,20 @@
 FROM golang:1.13.6
-MAINTAINER Pier-Hugues Pellerin <ph@elastic.co>
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-         netcat python-pip rsync virtualenv python3 && \
-    apt-get clean
+RUN \
+    apt-get update \
+      && apt-get install -y --no-install-recommends \
+         netcat \
+         rsync \
+         python3 \
+         python3-pip \
+         python3-venv \
+      && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade setuptools
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment
 ENV FUNCTIONBEAT_PATH /go/src/github.com/elastic/beats/x-pack/functionbeat

--- a/x-pack/libbeat/Dockerfile
+++ b/x-pack/libbeat/Dockerfile
@@ -1,14 +1,20 @@
 FROM golang:1.13.6
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-         netcat python-pip rsync virtualenv python3 && \
-    apt-get clean
+RUN \
+    apt-get update \
+      && apt-get install -y --no-install-recommends \
+         netcat \
+         rsync \
+         python3 \
+         python3-pip \
+         python3-venv \
+      && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip install --upgrade setuptools
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment
 ENV LIBBEAT_PATH /go/src/github.com/elastic/beats/x-pack/libbeat


### PR DESCRIPTION
Switch over to `python3 -m venv` instead of `virtualenv`. It's the recommended way to create virtual Python environments in 3.4 and above.

https://docs.python.org/3/library/venv.html