### PR TITLE
Cherry-pick #15680 to 7.x: Add keep-backport-label in cherry_pick script

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -66,6 +66,8 @@ def main():
                         help="Which remote to push the backport branch to")
     parser.add_argument("--zube-team", default="",
                         help="Team the PR belongs to")
+    parser.add_argument("--keep-backport-label", action="store_true",
+                        help="Preserve label needs_backport in original PR")
     args = parser.parse_args()
 
     print(args)
@@ -167,8 +169,9 @@ def main():
         session.post(
             base + "/issues/{}/labels".format(new_pr["number"]), json=labels)
 
-        # remove needs backport label from the original PR
-        session.delete(base + "/issues/{}/labels/needs_backport".format(args.pr_number))
+        if not args.keep_backport_label:
+            # remove needs backport label from the original PR
+            session.delete(base + "/issues/{}/labels/needs_backport".format(args.pr_number))
 
         # get version and set a version label on the original PR
         version = get_version(os.getcwd())


### PR DESCRIPTION
Cherry-pick of PR #15680 to 7.x branch. Original message: 

## What does this PR do?

This PR adds a `keep-backport-label` in cherry_pick script. If this flag is set then the label `needs_backport` of the original PR will be preserved.

## Why is it important?

In many cases we want to backport to more than one branches so removing the label by default for any backporting action may remove label even if the backports are not completed yet.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

I tested this manually with https://github.com/elastic/beats/pull/15535 and it works.

@jsoriano @kvch what do you think about this?


