### PR TITLE
Metricbeat system test fixes (Python3 branch)

### DIFF
--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -74,6 +74,7 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("elasticsearch", metricset, self.get_hosts(), self.FIELDS +
                              ["service"], extras={"index_recovery.active_only": "false"})
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_xpack(self):
         """
         elasticsearch-xpack module tests


### PR DESCRIPTION
0af1703 - Add missing integration_tests check to metricbeat xpack test

This Elasticsearch test was running with the unit test target and failing since ES wasn't available.

7eb1e52 - Update Kibana version used in x-pack/metricbeat

It was failing with:

```
2020-01-23T00:00:05.715Z        DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Initialize the Kibana 7.4.0 loader
2020-01-23T00:00:05.715Z        DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Kibana URL http://172.20.0.3:5601

2020-01-23T00:01:22.639Z        DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Import dashboard from /go/src/github.com/elastic/beats/x-pack/metricbeat/build/system-tests/run/test_xpack_base.Test.test_dashboards/kibana/7/dashboard/metricbeat-windows-service.json
2020-01-23T00:01:23.721Z        ERROR   instance/beat.go:921    Exiting: Failed to import dashboard: Failed to load directory /go/src/github.com/elastic/beats/x-pack/metricbeat/build/system-tests/run/test_xpack_base.Test.test_dashboards/kibana/7/dashboard:
  error loading /go/src/github.com/elastic/beats/x-pack/metricbeat/build/system-tests/run/test_xpack_base.Test.test_dashboards/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json: returned 422 to import file: <nil>. Response: {"statusCode":422,"error":"Unprocessable Entity","message":"Document \"deab0260-2981-11e9-86eb-a3a07a77f530\" has property \"visualization\" which belongs to a more recent version of Kibana (7.4.2)."}
Exiting: Failed to import dashboard: Failed to load directory /go/src/github.com/elastic/beats/x-pack/metricbeat/build/system-tests/run/test_xpack_base.Test.test_dashboards/kibana/7/dashboard:
  error loading /go/src/github.com/elastic/beats/x-pack/metricbeat/build/system-tests/run/test_xpack_base.Test.test_dashboards/kibana/7/dashboard/Metricbeat-aws-lambda-overview.json: returned 422 to import file: <nil>. Response: {"statusCode":422,"error":"Unprocessable Entity","message":"Document \"deab0260-2981-11e9-86eb-a3a07a77f530\" has property \"visualization\" which belongs to a more recent version of Kibana (7.4.2)."}
```