### PR TITLE
Cherry-pick #15765 to 7.6: [Filebeat] Fix typos in zeek notice fileset config file (#15765)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
+- Fix typos in zeek notice fileset config file. {issue}15764[15764] {pull}15765[15765]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -56,7 +56,7 @@ processors:
           to: "zeek.notice.file.id"
 
         - from: "zeek.notice.f.parent_id"
-          to: "dzeek.notice.file.parent_id"
+          to: "zeek.notice.file.parent_id"
 
         - from: "zeek.notice.f.source"
           to: "zeek.notice.file.source"
@@ -70,7 +70,7 @@ processors:
         - from: "zeek.notice.f.total_bytes"
           to: "zeek.notice.file.total_bytes"
 
-        - from: "zzeek.notice.file_mime_type"
+        - from: "zeek.notice.file_mime_type"
           to: "zeek.notice.file.mime_type"
 
       ignore_missing: true


### PR DESCRIPTION
Fixes #15764

(cherry picked from commit 48c17393c87f2739767e50d4afce109f54e0393b)
