### PR TITLE
Metricbeat `logstash` module: accept override cluster UUID from Logstash

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for processors in light modules. {issue}14740[14740] {pull}15923[15923]
 - Add collecting AuroraDB metrics in rds metricset. {issue}14142[14142] {pull}16004[16004]
 - Reuse connections in SQL module. {pull}16001[16001]
+- Teach the `logstash` module (when `xpack.enabled` is set to `true`) to use the override `cluster_uuid` returned by Logstash APIs. {issue}15772[15772] {pull}15795[15795]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,7 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for processors in light modules. {issue}14740[14740] {pull}15923[15923]
 - Add collecting AuroraDB metrics in rds metricset. {issue}14142[14142] {pull}16004[16004]
 - Reuse connections in SQL module. {pull}16001[16001]
-- Teach the `logstash` module (when `xpack.enabled` is set to `true`) to use the override `cluster_uuid` returned by Logstash APIs. {issue}15772[15772] {pull}15795[15795]
+- Improve the `logstash` module (when `xpack.enabled` is set to `true`) to use the override `cluster_uuid` returned by Logstash APIs. {issue}15772[15772] {pull}15795[15795]
 
 *Packetbeat*
 

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -213,3 +213,21 @@ func fetchPath(httpHelper *helper.HTTP, path string, query string) ([]byte, erro
 	httpHelper.SetURI(u.String())
 	return httpHelper.FetchContent()
 }
+
+func GetVertexClusterUUID(vertex map[string]interface{}, overrideClusterUUID string) string {
+	c, ok := vertex["cluster_uuid"]
+	if !ok {
+		return overrideClusterUUID
+	}
+
+	clusterUUID, ok := c.(string)
+	if !ok {
+		return overrideClusterUUID
+	}
+
+	if clusterUUID == "" {
+		return overrideClusterUUID
+	}
+
+	return clusterUUID
+}

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -181,6 +181,27 @@ func (m *MetricSet) CheckPipelineGraphAPIsAvailable() error {
 	return nil
 }
 
+// GetVertexClusterUUID returns the correct cluster UUID value for the given Elasticsearch
+// vertex from a Logstash pipeline. If the vertex has no cluster UUID associated with it,
+// the given override cluster UUID is returned.
+func GetVertexClusterUUID(vertex map[string]interface{}, overrideClusterUUID string) string {
+	c, ok := vertex["cluster_uuid"]
+	if !ok {
+		return overrideClusterUUID
+	}
+
+	clusterUUID, ok := c.(string)
+	if !ok {
+		return overrideClusterUUID
+	}
+
+	if clusterUUID == "" {
+		return overrideClusterUUID
+	}
+
+	return clusterUUID
+}
+
 func (m *MetricSet) getVersion() (*common.Version, error) {
 	const rootPath = "/"
 	content, err := fetchPath(m.HTTP, rootPath, "")
@@ -212,22 +233,4 @@ func fetchPath(httpHelper *helper.HTTP, path string, query string) ([]byte, erro
 	// Http helper includes the HostData with username and password
 	httpHelper.SetURI(u.String())
 	return httpHelper.FetchContent()
-}
-
-func GetVertexClusterUUID(vertex map[string]interface{}, overrideClusterUUID string) string {
-	c, ok := vertex["cluster_uuid"]
-	if !ok {
-		return overrideClusterUUID
-	}
-
-	clusterUUID, ok := c.(string)
-	if !ok {
-		return overrideClusterUUID
-	}
-
-	if clusterUUID == "" {
-		return overrideClusterUUID
-	}
-
-	return clusterUUID
 }

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logstash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVertexClusterUUID(t *testing.T) {
+	tests := map[string]struct {
+		vertex              map[string]interface{}
+		overrideClusterUUID string
+		expectedClusterUUID string
+	}{
+		"vertex_and_override": {
+			map[string]interface{}{
+				"cluster_uuid": "v",
+			},
+			"o",
+			"v",
+		},
+		"vertex_only": {
+			vertex: map[string]interface{}{
+				"cluster_uuid": "v",
+			},
+			expectedClusterUUID: "v",
+		},
+		"override_only": {
+			overrideClusterUUID: "o",
+			expectedClusterUUID: "o",
+		},
+		"none": {
+			expectedClusterUUID: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedClusterUUID, GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
+		})
+	}
+}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -26,9 +26,9 @@ import (
 	"github.com/elastic/beats/metricbeat/module/logstash"
 )
 
-func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.PipelineState) error {
+func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.PipelineState, overrideClusterUUID string) error {
 	pipelines = getUserDefinedPipelines(pipelines)
-	clusterToPipelinesMap := makeClusterToPipelinesMap(pipelines)
+	clusterToPipelinesMap := makeClusterToPipelinesMap(pipelines, overrideClusterUUID)
 	for clusterUUID, pipelines := range clusterToPipelinesMap {
 		for _, pipeline := range pipelines {
 			removeClusterUUIDsFromPipeline(pipeline)
@@ -62,9 +62,14 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 	return nil
 }
 
-func makeClusterToPipelinesMap(pipelines []logstash.PipelineState) map[string][]logstash.PipelineState {
+func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClusterUUID string) map[string][]logstash.PipelineState {
 	var clusterToPipelinesMap map[string][]logstash.PipelineState
 	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
+
+	if overrideClusterUUID != "" {
+		clusterToPipelinesMap[overrideClusterUUID] = pipelines
+		return clusterToPipelinesMap
+	}
 
 	for _, pipeline := range pipelines {
 		var clusterUUIDs []string

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -66,25 +66,13 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 	var clusterToPipelinesMap map[string][]logstash.PipelineState
 	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
 
-	if overrideClusterUUID != "" {
-		clusterToPipelinesMap[overrideClusterUUID] = pipelines
-		return clusterToPipelinesMap
-	}
-
 	for _, pipeline := range pipelines {
 		var clusterUUIDs []string
 		for _, vertex := range pipeline.Graph.Graph.Vertices {
-			c, ok := vertex["cluster_uuid"]
-			if !ok {
-				continue
+			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
+			if clusterUUID != "" {
+				clusterUUIDs = append(clusterUUIDs, clusterUUID)
 			}
-
-			clusterUUID, ok := c.(string)
-			if !ok {
-				continue
-			}
-
-			clusterUUIDs = append(clusterUUIDs, clusterUUID)
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one

--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -74,13 +74,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return eventMapping(r, content)
 	}
 
-	pipelinesContent, err := logstash.GetPipelines(m.MetricSet)
+	pipelinesContent, overrideClusterUUID, err := logstash.GetPipelines(m.MetricSet)
 	if err != nil {
 		m.Logger().Error(err)
 		return nil
 	}
 
-	err = eventMappingXPack(r, m, pipelinesContent)
+	err = eventMappingXPack(r, m, pipelinesContent, overrideClusterUUID)
 	if err != nil {
 		m.Logger().Error(err)
 	}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/elastic/beats/metricbeat/module/logstash"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -212,17 +214,10 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 	for _, pipeline := range pipelines {
 		var clusterUUIDs []string
 		for _, vertex := range pipeline.Vertices {
-			c, ok := vertex["cluster_uuid"]
-			if !ok {
-				continue
+			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
+			if clusterUUID != "" {
+				clusterUUIDs = append(clusterUUIDs, clusterUUID)
 			}
-
-			clusterUUID, ok := c.(string)
-			if !ok {
-				continue
-			}
-
-			clusterUUIDs = append(clusterUUIDs, clusterUUID)
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one


### PR DESCRIPTION
## What does this PR do?

This PR teaches the `logstash` Metricbeat module to accept an optional override `cluster_uuid` field from Logstash APIs called by the module. 

If the Logstash pipeline being monitored by this module has an Elasticsearch plugin vertex in it, the cluster UUID associated with that vertex will be used. If no such vertex is found, the override cluster UUID will be used.

## Why is it important?

See https://github.com/elastic/beats/issues/15772.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. Configure Logstash to use an override cluster_uuid for monitoring. To do this, add this line to your `config/logstash.yml`:
   ```
   monitoring.cluster_uuid: foobar
   ```

2. Start a simple pipeline in Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'
   ```

2. Enable the `logstash-xpack` module in Metricbeat. This will enable the `logstash` module with the required configuration for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. For easy inspection of generated events, disable the `elasticsearch` output and enable the `console` output in Metricbeat. To do this, edit your `metricbeat.yml` file and set `output.elasticsearch.enabled: false` and `output.console.enabled: true`.
   
3. Run Metricbeat and check that the generated Logstash Stack Monitoring events of `type:logstash_state` and `type:logstash_stats` both have a top-level field of `cluster_uuid` with the same value as set in the Logstash configuration file.
   ```
   ./metricbeat | jq -c 'select(.service.type == "logstash") | .type,.cluster_uuid'
   ```


## Related issues

- Closes #15772.
- Related to https://github.com/elastic/logstash/pull/11106.
