### PR TITLE
[docs] Add early draft of Elastic Log Driver docs

### DIFF
--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -1,4 +1,5 @@
 [[log-driver-configuration]]
+[role="xpack"]
 == {log-driver} configuration options
 
 ++++
@@ -9,350 +10,283 @@ experimental[]
 
 Use the following options to configure the {log-driver-long}. You can
 pass these options with the `--log-opt` flag when you start a container, or
-you can set them in the `daemon.json` file for all containers. For detailed
-examples, see <<log-driver-usage-examples>>.
+you can set them in the `daemon.json` file for all containers. 
 
-// I've included most of the options that are documented for outputs +
-// logging. I've shortened and edited the descriptions because they were a bit
-// unwieldy. Whichever options we decide to keep should get reviewed.
-
-// Not sure yet if we want to provide usage examples inline in
-// this topic or in a separate topic. Depends on how many options we decide to
-// document. The installation section already shows the basic syntax.
+* <<cloud-options>>
+* <<es-output-options>>
+* <<ls-output-options>>
+* <<kafka-output-options>>
+* <<redis-output-options>>
 
 [float]
-=== {ecloud} options
+=== Usage examples
 
-// Do the cloud options work? It seems that we should be able to specify these
-// options without having to also specify hosts, but that doesn't work.
+To set configuration options when you start a container:
+
+include::install.asciidoc[tag=log-driver-run]
+
+To set configuration options for all containers in the `daemon.json` file:
+
+include::install.asciidoc[tag=log-driver-daemon]
+
+For more examples, see <<log-driver-usage-examples>>.
+
+[float]
+[[cloud-options]]
+=== {ecloud} options
  
 [options="header"]
 |=====
-|Option  | Description | Default
+|Option  | Description
 
 |`cloud.id`
 |The Cloud ID found in the Elastic Cloud web console. This ID is
 used to resolve the {stack} URLs when connecting to {ess} on {ecloud}.
-|
 
 |`cloud.auth`
 |The username and password combination for connecting to {ess} on {ecloud}. The
 format is `"username:password"`.
-|
 |=====
 
 [float]
+[[es-output-options]]
 === {es} output options
 
-// QUESTION: Does the Elastic Log Driver support these options?
-// `output.logstash.indices
+// TODO: Add the following settings. Not sure how to represent them as commands
+// or in the daemon file:
+// `output.elasticsearch.indices
 // `output.elasticsearch.pipelines`
-// `output.elasticsearch.max_retries`
-
-// QUESTION: Which SSL options do we want to document?
-
-// TODO: Add SSL options. 
-
 
 [options="header"]
 |=====
-|Option  | Description | Default
+|Option  |Default |Description
 
 |`output.elasticsearch.hosts`
+|`"localhost:9200"`
 |The list of {es} nodes to connect to. Specify each node as a `URL` or
 `IP:PORT`. For example: `http://192.0.2.0`, `https://myhost:9230` or
 `192.0.2.0:9300`. If no port is specified, the default is `9200`.
-|`"localhost:9200"`
 
 |`output.elasticsearch.protocol`
+|`http` 
 |The protocol (`http` or `https`) that {es} is reachable on. If you specify a
 URL for `hosts`, the value of `protocol` is overridden by whatever scheme you
 specify in the URL.
-|`http` 
 
 |`output.elasticsearch.username`
-|The basic authentication username for connecting to {es}. 
 |
+|The basic authentication username for connecting to {es}. 
 
 |`output.elasticsearch.password`
-|The basic authentication password for connecting to {es}.
 |
+|The basic authentication password for connecting to {es}.
 
 |`output.elasticsearch.index`
+|
 |A {beats-ref}/config-file-format-type.html#_format_string_sprintf[format string]
 value that specifies the index to write events to when you're using daily
 indices. For example: +"dockerlogs-%{+yyyy.MM.dd}"+. 
-|?????
 
 3+|*Advanced:*
 
 |`output.elasticsearch.backoff.init`
+|`1s`
 |The number of seconds to wait before trying to reconnect to {es} after
 a network error. After waiting `backoff.init` seconds, the {log-driver}
 tries to reconnect. If the attempt fails, the backoff timer is increased
 exponentially up to `backoff.max`. After a successful connection, the backoff
 timer is reset.
-|1s
 
 |`output.elasticsearch.backoff.max`
+|`60s`
 |The maximum number of seconds to wait before attempting to connect to
 {es} after a network error.
-|60s
 
 |`output.elasticsearch.bulk_max_size`
+|`50`
 |The maximum number of events to bulk in a single {es} bulk API index request.
 Specify 0 to allow the queue to determine the batch size.
-|50
 
 |`output.elasticsearch.compression_level`
+|`0`
 |The gzip compression level. Valid compression levels range from 1 (best speed)
 to 9 (best compression). Specify 0 to disable compression.  Higher compression
 levels reduce network usage, but increase CPU usage.
-|0
 
 |`output.elasticsearch.escape_html`
-|Whether to escape HTML in strings.
 |`false`
+|Whether to escape HTML in strings.
 
 |`output.elasticsearch.headers`
+|
 |Custom HTTP headers to add to each request created by the {es} output. Specify
 multiple header values for the same header name by separating them with a comma.
-|
 
 |`output.elasticsearch.loadbalance`
+|`false`
 |Whether to load balance when sending events to multiple hosts. The load
 balancer also supports multiple workers per host (see
 `output.elasticsearch.worker`.)
-|`false`
+
+|`output.elasticsearch.max_retries`
+|`3`
+|The number of times to retry publishing an event after a publishing failure.
+After the specified number of retries, the events are typically dropped. Specify
+0 to retry indefinitely.
 
 |`output.elasticsearch.parameters`
+|
 | A dictionary of HTTP parameters to pass within the URL with index operations.
-| 
 
 |`output.elasticsearch.path`
+|
 |An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
 cases where {es} listens behind an HTTP reverse proxy that exports the API under
 a custom prefix.
-|
 
 |`output.elasticsearch.pipeline`
-|A {beats-ref}/config-file-format-type.html#_format_string_sprintf[format strings]
+|
+|A {beats-ref}/config-file-format-type.html#_format_string_sprintf[format string]
 value that specifies the {ref}/ingest.html[ingest node pipeline] to write events
 to.
-|
 
 |`output.elasticsearch.proxy_url`
+|
 |The URL of the proxy to use when connecting to the {es} servers. Specify a
 `URL` or `IP:PORT`.
-|
 
 |`output.elasticsearch.timeout`
+|`90`
 |The HTTP request timeout in seconds for the {es} request.
-|90
 
 |`output.elasticsearch.worker`
+|`1`
 |The number of workers per configured host publishing events to {es}. Use with
 load balancing mode (`output.elasticsearch.loadbalance`) set to `true`. Example:
 If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
 host).
-|1
 
 |=====
 
 
 [float]
+[[ls-output-options]]
 === {ls} output options
 
 [options="header"]
 |=====
-|Option  | Description | Default
+|Option  | Default | Description
 
 |`output.logstash.hosts`
+|`"localhost:5044"` 
 |The list of known {ls} servers to connect to. If load balancing is
 disabled, but multiple hosts are configured, one host is selected randomly
 (there is no precedence). If one host becomes unreachable, another one is
 selected randomly. If no port is specified, the default is `5044`.
-|`"localhost:5044"` 
 
 |`output.logstash.index`
+|
 |The index root name to write events to. For example +"dockerlogs"+ generates
-+"dockerlogs-{version}-YYYY.MM.DD"+ indices (for example,
-  +"dockerlogs-{version}-{docyear}.04.26"+).. 
-|?????
++"dockerlogs-{version}"+ indices. 
 
 3+|*Advanced:*
 
 |`output.logstash.backoff.init`
+|`1s`
 |The number of seconds to wait before trying to reconnect to {ls} after
 a network error. After waiting `backoff.init` seconds, the {log-driver}
 tries to reconnect. If the attempt fails, the backoff timer is increased
 exponentially up to `backoff.max`. After a successful connection, the backoff
 timer is reset.
-|1s
 
 |`output.logstash.backoff.max`
+|`60s`
 |The maximum number of seconds to wait before attempting to connect to
 {ls} after a network error.
-|60s
 
 |`output.logstash.bulk_max_size`
+|`2048`
 |The maximum number of events to bulk in a single {ls} request. Specify 0 to
 allow the queue to determine the batch size. 
-|2048
 
 |`output.logstash.compression_level`
+|`0`
 |The gzip compression level. Valid compression levels range from 1 (best speed)
 to 9 (best compression). Specify 0 to disable compression.  Higher compression
 levels reduce network usage, but increase CPU usage.
-|0
 
 |`output.logstash.escape_html`
-|Whether to escape HTML in strings.
 |`false`
+|Whether to escape HTML in strings.
 
 |`output.logstash.loadbalance`
+|`false`
 |Whether to load balance when sending events to multiple {ls} hosts. If set to
 `false`, the driver sends all events to only one host (determined at random) and
 switches to another host if the selected one becomes unresponsive.
-|`false`
 
 |`output.logstash.pipelining`
+|`2`
 |The number of batches to send asynchronously to {ls} while waiting for an ACK
 from {ls}. Specify 0 to disable pipelining.
-|2
 
 |`output.logstash.proxy_url`
+|
 |The URL of the SOCKS5 proxy to use when connecting to the {ls} servers. The
-value must be a URL with a scheme of `socks5://``. You can embed a
+value must be a URL with a scheme of `socks5://`. You can embed a
 username and password in the URL (for example,
 `socks5://user:password@socks5-proxy:2233`).
-|
 
 |`output.logstash.proxy_use_local_resolver`
+|`false`
 |Whether to resolve {ls} hostnames locally when using a proxy. If `false`,
 name resolution occurs on the proxy server.
-|`false`
 
 |`output.logstash.slow_start`
+|`false`
 |When enabled, only a subset of events in a batch are transferred per
 transaction. If there are no errors, the number of events per transaction
 is increased up to the bulk max size (see `output.logstash.bulk_max_size`).
 On error, the number of events per transaction is reduced again.
-|`false`
 
 |`output.logstash.timeout`
+|`30`
 |The number of seconds to wait for responses from the {ls} server before
 timing out. 
-|30
 
 |`output.logstash.ttl`
+|`0`
 |Time to live for a connection to {ls} after which the connection will be
 re-established. Useful when {ls} hosts represent load balancers. Because
 connections to {ls} hosts are sticky, operating behind load balancers can lead
 to uneven load distribution across instances. Specify a TTL on the connection
 to distribute connections across instances. Specify 0 to disable this feature.
 This option is not supported if `output.logstash.pipelining` is set.
-|0
 
 |`output.logstash.worker`
+|`1`
 |The number of workers per configured host publishing events to {ls}. Use with
 load balancing mode (`output.logstash.loadbalance`) set to `true`. Example:
 If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
 host).
-|1
 
 |=====
-
 
 [float]
-=== Logging options
+[[kafka-output-options]]
+=== Kafka output options
 
-//Did not include logging.files.redirect_stderr because it's experimental.
+// TODO: Add kafka output options here.
 
-[options="header"]
-|=====
-|Option  | Description | Default
+// NOTE: The following annotation renders as: "Coming in a future update. This
+// documentation is a work in progress."
 
-|`logging.level`
-|Minimum log level. One of `debug`, `info`, `warning`, or `error`.
-|`info`
+coming[a future update. This documentation is a work in progress]
 
-|`logging.to_stderr`
-|When `true`, writes all logging output to standard error output. 
-|`false`
+[float]
+[[redis-output-options]]
+=== Redis output options
 
-|`logging.to_syslog`
-|When `true`, writes all logging output to the syslog. Not supported on Windows.
-|`false`
+// TODO: Add Redis output options here. 
 
-|`logging.to_eventlog`
-|When `true`, writes all logging output to the Windows Event Log.
-|`false`
-
-|`logging.to_files`
-|When `true`, writes all logging output to files. The log files are automatically
-rotated when the log file size limit is reached.
-|`true`
-
-|`logging.selectors`
-|A list of debugging-only selector tags. Use `*` to enable debug output for all
-components. For example, add `publish` to display all the debug messages related
-to event publishing.
-|
-
-|`logging.files.path`
-|The directory that log files are written to.
-|????
-
-|`logging.files.name`
-|The name of the file that logs are written to.
-|`docker.*`
-
-|`logging.json`
-|When `true`, logs messages in JSON format.
-|`false`
-
-3+|*Advanced:*
-
-|`logging.metrics.enabled`
-|If `true`, the {log-driver} periodically logs internal metrics that have
-changed in the last period. For each metric that changed, the delta from the
-value at the beginning of the period is logged. Also, the total values for all
-non-zero internal metrics are logged on shutdown.
-|`true`
-
-|`logging.files.interval`
-|Enable log file rotation on time intervals in addition to size-based rotation.
-Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
-are boundary-aligned with minutes, hours, days, weeks, months, and years as
-reported by the local system clock. All other intervals are calculated from the
-unix epoch.
-|0
-
-|`logging.files.keepfiles`
-|The number of most recent rotated log files to keep on disk. Older files are
-deleted during log rotation. Valid range is 2 to 1024 files.
-|7
-
-|`logging.files.permissions`
-|The permissions mask to apply when rotating log files. The default value is
-0600. The `permissions` option must be a valid Unix-style file permissions mask
-expressed in octal notation. In Go, numbers in octal notation must start with
-'0'.
-|
-
-|`logging.metrics.period`
-|The period after which to log the internal metrics.
-|30s
-
-|`logging.files.rotateeverybytes`
-|The maximum size of a log file. If the limit is reached, a new log file is
-generated.
-|10485760 (10 MB).
-
-|`logging.files.rotateonstartup`
-|When `true`, rotates existing logs on startup rather than appending to the
-existing file.
-|`true`
-
-|=====
+coming[a future update. This documentation is a work in progress]

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -52,7 +52,7 @@ format is `"username:password"`.
 [[es-output-options]]
 === {es} output options
 
-// TODO: Add the following settings. Syntax is a little differnt so we might
+// TODO: Add the following settings. Syntax is a little different so we might
 // need to add deameon examples that show how to specify these settings:
 // `output.elasticsearch.indices
 // `output.elasticsearch.pipelines`

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -1,0 +1,358 @@
+[[log-driver-configuration]]
+== {log-driver} configuration options
+
+++++
+<titleabbrev>Configuration options</titleabbrev>
+++++
+
+experimental[]
+
+Use the following options to configure the {log-driver-long}. You can
+pass these options with the `--log-opt` flag when you start a container, or
+you can set them in the `daemon.json` file for all containers. For detailed
+examples, see <<log-driver-usage-examples>>.
+
+// I've included most of the options that are documented for outputs +
+// logging. I've shortened and edited the descriptions because they were a bit
+// unwieldy. Whichever options we decide to keep should get reviewed.
+
+// Not sure yet if we want to provide usage examples inline in
+// this topic or in a separate topic. Depends on how many options we decide to
+// document. The installation section already shows the basic syntax.
+
+[float]
+=== {ecloud} options
+
+// Do the cloud options work? It seems that we should be able to specify these
+// options without having to also specify hosts, but that doesn't work.
+ 
+[options="header"]
+|=====
+|Option  | Description | Default
+
+|`cloud.id`
+|The Cloud ID found in the Elastic Cloud web console. This ID is
+used to resolve the {stack} URLs when connecting to {ess} on {ecloud}.
+|
+
+|`cloud.auth`
+|The username and password combination for connecting to {ess} on {ecloud}. The
+format is `"username:password"`.
+|
+|=====
+
+[float]
+=== {es} output options
+
+// QUESTION: Does the Elastic Log Driver support these options?
+// `output.logstash.indices
+// `output.elasticsearch.pipelines`
+// `output.elasticsearch.max_retries`
+
+// QUESTION: Which SSL options do we want to document?
+
+// TODO: Add SSL options. 
+
+
+[options="header"]
+|=====
+|Option  | Description | Default
+
+|`output.elasticsearch.hosts`
+|The list of {es} nodes to connect to. Specify each node as a `URL` or
+`IP:PORT`. For example: `http://192.0.2.0`, `https://myhost:9230` or
+`192.0.2.0:9300`. If no port is specified, the default is `9200`.
+|`"localhost:9200"`
+
+|`output.elasticsearch.protocol`
+|The protocol (`http` or `https`) that {es} is reachable on. If you specify a
+URL for `hosts`, the value of `protocol` is overridden by whatever scheme you
+specify in the URL.
+|`http` 
+
+|`output.elasticsearch.username`
+|The basic authentication username for connecting to {es}. 
+|
+
+|`output.elasticsearch.password`
+|The basic authentication password for connecting to {es}.
+|
+
+|`output.elasticsearch.index`
+|A {beats-ref}/config-file-format-type.html#_format_string_sprintf[format string]
+value that specifies the index to write events to when you're using daily
+indices. For example: +"dockerlogs-%{+yyyy.MM.dd}"+. 
+|?????
+
+3+|*Advanced:*
+
+|`output.elasticsearch.backoff.init`
+|The number of seconds to wait before trying to reconnect to {es} after
+a network error. After waiting `backoff.init` seconds, the {log-driver}
+tries to reconnect. If the attempt fails, the backoff timer is increased
+exponentially up to `backoff.max`. After a successful connection, the backoff
+timer is reset.
+|1s
+
+|`output.elasticsearch.backoff.max`
+|The maximum number of seconds to wait before attempting to connect to
+{es} after a network error.
+|60s
+
+|`output.elasticsearch.bulk_max_size`
+|The maximum number of events to bulk in a single {es} bulk API index request.
+Specify 0 to allow the queue to determine the batch size.
+|50
+
+|`output.elasticsearch.compression_level`
+|The gzip compression level. Valid compression levels range from 1 (best speed)
+to 9 (best compression). Specify 0 to disable compression.  Higher compression
+levels reduce network usage, but increase CPU usage.
+|0
+
+|`output.elasticsearch.escape_html`
+|Whether to escape HTML in strings.
+|`false`
+
+|`output.elasticsearch.headers`
+|Custom HTTP headers to add to each request created by the {es} output. Specify
+multiple header values for the same header name by separating them with a comma.
+|
+
+|`output.elasticsearch.loadbalance`
+|Whether to load balance when sending events to multiple hosts. The load
+balancer also supports multiple workers per host (see
+`output.elasticsearch.worker`.)
+|`false`
+
+|`output.elasticsearch.parameters`
+| A dictionary of HTTP parameters to pass within the URL with index operations.
+| 
+
+|`output.elasticsearch.path`
+|An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
+cases where {es} listens behind an HTTP reverse proxy that exports the API under
+a custom prefix.
+|
+
+|`output.elasticsearch.pipeline`
+|A {beats-ref}/config-file-format-type.html#_format_string_sprintf[format strings]
+value that specifies the {ref}/ingest.html[ingest node pipeline] to write events
+to.
+|
+
+|`output.elasticsearch.proxy_url`
+|The URL of the proxy to use when connecting to the {es} servers. Specify a
+`URL` or `IP:PORT`.
+|
+
+|`output.elasticsearch.timeout`
+|The HTTP request timeout in seconds for the {es} request.
+|90
+
+|`output.elasticsearch.worker`
+|The number of workers per configured host publishing events to {es}. Use with
+load balancing mode (`output.elasticsearch.loadbalance`) set to `true`. Example:
+If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
+host).
+|1
+
+|=====
+
+
+[float]
+=== {ls} output options
+
+[options="header"]
+|=====
+|Option  | Description | Default
+
+|`output.logstash.hosts`
+|The list of known {ls} servers to connect to. If load balancing is
+disabled, but multiple hosts are configured, one host is selected randomly
+(there is no precedence). If one host becomes unreachable, another one is
+selected randomly. If no port is specified, the default is `5044`.
+|`"localhost:5044"` 
+
+|`output.logstash.index`
+|The index root name to write events to. For example +"dockerlogs"+ generates
++"dockerlogs-{version}-YYYY.MM.DD"+ indices (for example,
+  +"dockerlogs-{version}-{docyear}.04.26"+).. 
+|?????
+
+3+|*Advanced:*
+
+|`output.logstash.backoff.init`
+|The number of seconds to wait before trying to reconnect to {ls} after
+a network error. After waiting `backoff.init` seconds, the {log-driver}
+tries to reconnect. If the attempt fails, the backoff timer is increased
+exponentially up to `backoff.max`. After a successful connection, the backoff
+timer is reset.
+|1s
+
+|`output.logstash.backoff.max`
+|The maximum number of seconds to wait before attempting to connect to
+{ls} after a network error.
+|60s
+
+|`output.logstash.bulk_max_size`
+|The maximum number of events to bulk in a single {ls} request. Specify 0 to
+allow the queue to determine the batch size. 
+|2048
+
+|`output.logstash.compression_level`
+|The gzip compression level. Valid compression levels range from 1 (best speed)
+to 9 (best compression). Specify 0 to disable compression.  Higher compression
+levels reduce network usage, but increase CPU usage.
+|0
+
+|`output.logstash.escape_html`
+|Whether to escape HTML in strings.
+|`false`
+
+|`output.logstash.loadbalance`
+|Whether to load balance when sending events to multiple {ls} hosts. If set to
+`false`, the driver sends all events to only one host (determined at random) and
+switches to another host if the selected one becomes unresponsive.
+|`false`
+
+|`output.logstash.pipelining`
+|The number of batches to send asynchronously to {ls} while waiting for an ACK
+from {ls}. Specify 0 to disable pipelining.
+|2
+
+|`output.logstash.proxy_url`
+|The URL of the SOCKS5 proxy to use when connecting to the {ls} servers. The
+value must be a URL with a scheme of `socks5://``. You can embed a
+username and password in the URL (for example,
+`socks5://user:password@socks5-proxy:2233`).
+|
+
+|`output.logstash.proxy_use_local_resolver`
+|Whether to resolve {ls} hostnames locally when using a proxy. If `false`,
+name resolution occurs on the proxy server.
+|`false`
+
+|`output.logstash.slow_start`
+|When enabled, only a subset of events in a batch are transferred per
+transaction. If there are no errors, the number of events per transaction
+is increased up to the bulk max size (see `output.logstash.bulk_max_size`).
+On error, the number of events per transaction is reduced again.
+|`false`
+
+|`output.logstash.timeout`
+|The number of seconds to wait for responses from the {ls} server before
+timing out. 
+|30
+
+|`output.logstash.ttl`
+|Time to live for a connection to {ls} after which the connection will be
+re-established. Useful when {ls} hosts represent load balancers. Because
+connections to {ls} hosts are sticky, operating behind load balancers can lead
+to uneven load distribution across instances. Specify a TTL on the connection
+to distribute connections across instances. Specify 0 to disable this feature.
+This option is not supported if `output.logstash.pipelining` is set.
+|0
+
+|`output.logstash.worker`
+|The number of workers per configured host publishing events to {ls}. Use with
+load balancing mode (`output.logstash.loadbalance`) set to `true`. Example:
+If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
+host).
+|1
+
+|=====
+
+
+[float]
+=== Logging options
+
+//Did not include logging.files.redirect_stderr because it's experimental.
+
+[options="header"]
+|=====
+|Option  | Description | Default
+
+|`logging.level`
+|Minimum log level. One of `debug`, `info`, `warning`, or `error`.
+|`info`
+
+|`logging.to_stderr`
+|When `true`, writes all logging output to standard error output. 
+|`false`
+
+|`logging.to_syslog`
+|When `true`, writes all logging output to the syslog. Not supported on Windows.
+|`false`
+
+|`logging.to_eventlog`
+|When `true`, writes all logging output to the Windows Event Log.
+|`false`
+
+|`logging.to_files`
+|When `true`, writes all logging output to files. The log files are automatically
+rotated when the log file size limit is reached.
+|`true`
+
+|`logging.selectors`
+|A list of debugging-only selector tags. Use `*` to enable debug output for all
+components. For example, add `publish` to display all the debug messages related
+to event publishing.
+|
+
+|`logging.files.path`
+|The directory that log files are written to.
+|????
+
+|`logging.files.name`
+|The name of the file that logs are written to.
+|`docker.*`
+
+|`logging.json`
+|When `true`, logs messages in JSON format.
+|`false`
+
+3+|*Advanced:*
+
+|`logging.metrics.enabled`
+|If `true`, the {log-driver} periodically logs internal metrics that have
+changed in the last period. For each metric that changed, the delta from the
+value at the beginning of the period is logged. Also, the total values for all
+non-zero internal metrics are logged on shutdown.
+|`true`
+
+|`logging.files.interval`
+|Enable log file rotation on time intervals in addition to size-based rotation.
+Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+are boundary-aligned with minutes, hours, days, weeks, months, and years as
+reported by the local system clock. All other intervals are calculated from the
+unix epoch.
+|0
+
+|`logging.files.keepfiles`
+|The number of most recent rotated log files to keep on disk. Older files are
+deleted during log rotation. Valid range is 2 to 1024 files.
+|7
+
+|`logging.files.permissions`
+|The permissions mask to apply when rotating log files. The default value is
+0600. The `permissions` option must be a valid Unix-style file permissions mask
+expressed in octal notation. In Go, numbers in octal notation must start with
+'0'.
+|
+
+|`logging.metrics.period`
+|The period after which to log the internal metrics.
+|30s
+
+|`logging.files.rotateeverybytes`
+|The maximum size of a log file. If the limit is reached, a new log file is
+generated.
+|10485760 (10 MB).
+
+|`logging.files.rotateonstartup`
+|When `true`, rotates existing logs on startup rather than appending to the
+existing file.
+|`true`
+
+|=====

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -52,8 +52,8 @@ format is `"username:password"`.
 [[es-output-options]]
 === {es} output options
 
-// TODO: Add the following settings. Not sure how to represent them as commands
-// or in the daemon file:
+// TODO: Add the following settings. Syntax is a little differnt so we might
+// need to add deameon examples that show how to specify these settings:
 // `output.elasticsearch.indices
 // `output.elasticsearch.pipelines`
 
@@ -283,6 +283,11 @@ host).
 
 coming[a future update. This documentation is a work in progress]
 
+Need the docs now? See the
+{filebeat-ref}/kafka-output.html[Kafka output docs] for {filebeat}.
+The {log-driver} supports most of the same options, just make sure you use
+the fully qualified setting names.
+
 [float]
 [[redis-output-options]]
 === Redis output options
@@ -290,3 +295,8 @@ coming[a future update. This documentation is a work in progress]
 // TODO: Add Redis output options here. 
 
 coming[a future update. This documentation is a work in progress]
+
+Need the docs now? See the
+{filebeat-ref}/redis-output.html[Redis output docs] for {filebeat}.
+The {log-driver} supports most of the same options, just make sure you use
+the fully qualified setting names.

--- a/x-pack/dockerlogbeat/docs/index.asciidoc
+++ b/x-pack/dockerlogbeat/docs/index.asciidoc
@@ -1,0 +1,21 @@
+= Elastic Log Driver for Docker
+
+:libbeat-dir: {docdir}/../../../libbeat/docs
+:log-driver: Elastic Log Driver
+:log-driver-long: Elastic Log Driver for Docker
+:log-driver-alias: elastic-logging-plugin
+:docker-version: ???
+
+include::{libbeat-dir}/version.asciidoc[]
+
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+include::overview.asciidoc[]
+
+include::install.asciidoc[]
+
+include::configuration.asciidoc[]
+
+include::usage.asciidoc[]

--- a/x-pack/dockerlogbeat/docs/index.asciidoc
+++ b/x-pack/dockerlogbeat/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :log-driver: Elastic Log Driver
 :log-driver-long: Elastic Log Driver for Docker
 :log-driver-alias: elastic-logging-plugin
-:docker-version: ???
+:docker-version: Engine API 1.25
 
 include::{libbeat-dir}/version.asciidoc[]
 
@@ -19,3 +19,7 @@ include::install.asciidoc[]
 include::configuration.asciidoc[]
 
 include::usage.asciidoc[]
+
+include::troubleshooting.asciidoc[]
+
+include::limitations.asciidoc[]

--- a/x-pack/dockerlogbeat/docs/index.asciidoc
+++ b/x-pack/dockerlogbeat/docs/index.asciidoc
@@ -1,10 +1,10 @@
-= Elastic Log Driver for Docker
-
 :libbeat-dir: {docdir}/../../../libbeat/docs
-:log-driver: Elastic Log Driver
-:log-driver-long: Elastic Log Driver for Docker
+:log-driver: Elastic Logging Plugin
+:log-driver-long: Elastic Logging Plugin for Docker
 :log-driver-alias: elastic-logging-plugin
 :docker-version: Engine API 1.25
+
+= {log-driver} for Docker
 
 include::{libbeat-dir}/version.asciidoc[]
 

--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -1,0 +1,109 @@
+[[log-driver-installation]]
+== Install and configure the {log-driver}
+
+++++
+<titleabbrev>Install and configure</titleabbrev>
+++++
+
+experimental[]
+
+[float]
+=== Before you begin
+
+Make sure your system meets the following prerequisites:
+
+* Docker: {docker-version}
+* {stack}: Version 7.6.0 and later
+
+//REVIEWERS: Are there any other prereqs?
+//REVIEWERS: Do we want to add a step for setting up a cloud trial? 
+
+[float]
+=== Step 1: Install the {log-driver} plugin
+
+// REVIEWERS: Will the plugin be available on docker hub when 7.6 ships, or will
+// users need to build from source? These instructions assume that the driver
+// will be available at the initial release. If it's not, we can add the steps
+// for building from source.
+
+// Related question: Do we want to document how to build/install from source
+// too?
+
+// The commands shown here are a guess because of course I couldn't test them.
+
+1. Install the plugin from the Docker store:
++
+["source","sh",subs="attributes"]
+----
+docker plugin install store/elastic/elastic-logging-driver:{version} --alias elastic-logging-driver
+----
+
+2. If necessary, enable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin enable elastic/elastic-logging-driver:{version}
+----
+
+3. Verify that the plugin is installed and enabled:
++
+[source,shell]
+----
+docker plugin ls
+----
++
+The output should say something like:
++
+["source","sh",subs="attributes"]
+----
+ID                  NAME                                   DESCRIPTION              ENABLED
+c2ff9d2cf090        elastic/{log-driver-alias}:{version}   A beat for docker logs   true
+----
+
+[float]
+=== Step 2: Configure the {log-driver}
+
+You can set configuration options for a single container, or for all containers
+running on the host. See <<log-driver-configuration>> for a list of
+supported configuration options.
+
+* To configure a single container, pass configuration options at run time
+when you start the container. For example:
++
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version}
+           --log-opt output.elasticsearch.hosts="192.0.2.0:9200"
+           --log-opt output.elasticsearch.username="myusername"
+           --log-opt output.elasticsearch.password="myusername"
+           --log-opt output.elasticsearch.index="myindex" -it debian /bin/bash
+----
+
+* To configure all containers running on the host, set configuration options
+in the `daemon.json` file. For example:
++
+[source,json,subs="attributes"]
+----
+{
+  "log-driver": "elastic/{log-driver-alias}:{version}",
+  "log-opts": {
+    "output.elasticsearch.hosts": "192.0.2.0:9200",
+    "output.elasticsearch.username": "myusername",
+    "output.elasticsearch.password": "mypassword",
+    "output.elasticsearch.index": "myindex"
+  }
+}
+----
++
+Then run the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version}
+           --config-file=/etc/docker/daemon.json <1>
+----
+<1> The default location of the configuration file varies by platform. To
+specify a different location, set the `--config-file` flag. For more
+information about the Docker daemon configuration file, see the
+https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file[Docker docs].
+ 

--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -1,4 +1,5 @@
 [[log-driver-installation]]
+[role="xpack"]
 == Install and configure the {log-driver}
 
 ++++
@@ -12,37 +13,41 @@ experimental[]
 
 Make sure your system meets the following prerequisites:
 
-* Docker: {docker-version}
-* {stack}: Version 7.6.0 and later
-
-//REVIEWERS: Are there any other prereqs?
-//REVIEWERS: Do we want to add a step for setting up a cloud trial? 
+* Docker: {docker-version} or later
+* {stack}: Version 7.6.0 or later
 
 [float]
 === Step 1: Install the {log-driver} plugin
 
-// REVIEWERS: Will the plugin be available on docker hub when 7.6 ships, or will
-// users need to build from source? These instructions assume that the driver
-// will be available at the initial release. If it's not, we can add the steps
-// for building from source.
+// TODO: Test the following commands when the driver is available on docker hub.
 
-// Related question: Do we want to document how to build/install from source
-// too?
-
-// The commands shown here are a guess because of course I couldn't test them.
-
-1. Install the plugin from the Docker store:
+1. Install the plugin. You can install it from the Docker store (recommended),
+or build and install the plugin from source in the
+https://github.com/elastic/beats[beats] GitHub repo.
++
+*To install from the Docker store:*
 +
 ["source","sh",subs="attributes"]
 ----
-docker plugin install store/elastic/elastic-logging-driver:{version} --alias elastic-logging-driver
+docker plugin install store/elastic/{log-driver-alias}:{version} --alias {log-driver-alias}
+----
++
+*To build and install from source:*
++
+{beats-devguide}/beats-contributing.html#setting-up-dev-environment[Set up your
+development environment] as described in the _Beats Developer Guide_ then run:
++
+[source,shell]
+----
+cd x-pack/dockerlogbeat
+mage BuildAndInstall
 ----
 
 2. If necessary, enable the plugin:
 +
 ["source","sh",subs="attributes"]
 ----
-docker plugin enable elastic/elastic-logging-driver:{version}
+docker plugin enable elastic/{log-driver-alias}:{version}
 ----
 
 3. Verify that the plugin is installed and enabled:
@@ -67,43 +72,45 @@ You can set configuration options for a single container, or for all containers
 running on the host. See <<log-driver-configuration>> for a list of
 supported configuration options.
 
-* To configure a single container, pass configuration options at run time
-when you start the container. For example:
-+
+*To configure a single container:*
+
+Pass configuration options at run time when you start the container. For
+example:
+
+// tag::log-driver-run[] 
 ["source","sh",subs="attributes"]
 ----
-docker run --log-driver=elastic/{log-driver-alias}:{version}
-           --log-opt output.elasticsearch.hosts="192.0.2.0:9200"
-           --log-opt output.elasticsearch.username="myusername"
-           --log-opt output.elasticsearch.password="myusername"
-           --log-opt output.elasticsearch.index="myindex" -it debian /bin/bash
+docker run --log-driver=elastic/{log-driver-alias}:{version} \
+           --log-opt output.elasticsearch.hosts="https://myhost:9200" \
+           --log-opt output.elasticsearch.username="myusername" \
+           --log-opt output.elasticsearch.password="mypassword" \
+           --log-opt output.elasticsearch.index="elastic-log-driver-%{+yyyy.MM.dd}" \
+           -it debian:jessie /bin/bash
 ----
+// end::log-driver-run[]
 
-* To configure all containers running on the host, set configuration options
-in the `daemon.json` file. For example:
-+
+*To configure all containers running on the host:*
+
+Set configuration options in the Docker `daemon.json` configuration file. For
+example:
+
+// tag::log-driver-daemon[] 
 [source,json,subs="attributes"]
 ----
 {
-  "log-driver": "elastic/{log-driver-alias}:{version}",
-  "log-opts": {
-    "output.elasticsearch.hosts": "192.0.2.0:9200",
-    "output.elasticsearch.username": "myusername",
-    "output.elasticsearch.password": "mypassword",
-    "output.elasticsearch.index": "myindex"
+  "log-driver" : "elastic/{log-driver-alias}:{version}",
+  "log-opts" : {
+    "output.elasticsearch.hosts" : "https://myhost:9200",
+    "output.elasticsearch.username" : "myusername",
+    "output.elasticsearch.password" : "mypassword",
+    "output.elasticsearch.index" : "elastic-log-driver-%{+yyyy.MM.dd}"
   }
 }
 ----
-+
-Then run the plugin:
-+
-["source","sh",subs="attributes"]
-----
-docker run --log-driver=elastic/{log-driver-alias}:{version}
-           --config-file=/etc/docker/daemon.json <1>
-----
-<1> The default location of the configuration file varies by platform. To
-specify a different location, set the `--config-file` flag. For more
-information about the Docker daemon configuration file, see the
-https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file[Docker docs].
- 
+// end::log-driver-daemon[]
+
+NOTE: The default location of the `daemon.json` file varies by platform. On
+Linux, the default location is `/etc/docker/daemon.json`. For more information,
+see the
+https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file[Docker
+docs].

--- a/x-pack/dockerlogbeat/docs/limitations.asciidoc
+++ b/x-pack/dockerlogbeat/docs/limitations.asciidoc
@@ -4,8 +4,10 @@
 
 experimental[]
 
-This release of the {log-driver} has the following problems and limitations:
+This release of the {log-driver} has the following known problems and
+limitations:
 
-coming[a future update. This documentation is a work in progress]
-
-//* Add limitations here... 
+* Spool to disk (beta) is not supported.
+* Complex config options can't be easily represented via `--log-opts`.
+* Mapping templates and other assets that are normally installed by the
+{beats} setup are not available.

--- a/x-pack/dockerlogbeat/docs/limitations.asciidoc
+++ b/x-pack/dockerlogbeat/docs/limitations.asciidoc
@@ -1,0 +1,11 @@
+[[log-driver-limitations]]
+[role="xpack"]
+== Known problems and limitations
+
+experimental[]
+
+This release of the {log-driver} has the following problems and limitations:
+
+coming[a future update. This documentation is a work in progress]
+
+//* Add limitations here... 

--- a/x-pack/dockerlogbeat/docs/overview.asciidoc
+++ b/x-pack/dockerlogbeat/docs/overview.asciidoc
@@ -1,0 +1,16 @@
+// I thought it might be useful to put the descriptions we want to use in into variables.
+
+:shortdesc: {log-driver} is a Docker logging plugin for shipping container logs to the {stack}.
+
+[[log-driver-overview]]
+== {log-driver} overview
+
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
+
+experimental[]
+
+{shortdesc}
+
+TODO: Add more detail here.

--- a/x-pack/dockerlogbeat/docs/overview.asciidoc
+++ b/x-pack/dockerlogbeat/docs/overview.asciidoc
@@ -1,8 +1,5 @@
-// I thought it might be useful to put the descriptions we want to use in into variables.
-
-:shortdesc: {log-driver} is a Docker logging plugin for shipping container logs to the {stack}.
-
 [[log-driver-overview]]
+[role="xpack"]
 == {log-driver} overview
 
 ++++
@@ -11,6 +8,12 @@
 
 experimental[]
 
-{shortdesc}
+The {log-driver} is a Docker plugin that sends container logs to the
+https://www.elastic.co/elastic-stack[{stack}], where you can search, analyze,
+and visualize the data in real time.
 
-TODO: Add more detail here.
+The {log-driver} is built on top of the https://www.elastic.co/beats[{beats}]
+platform and supports many of the features and outputs supported by the
+{beats} shippers.
+
+Beat users: see <<log-driver-limitations>>.

--- a/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
@@ -1,0 +1,7 @@
+[[log-driver-troubleshooting]]
+== Troubleshooting
+
+experimental[]
+
+
+TODO: Move content about troubleshooting from readme to this section.

--- a/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
@@ -1,7 +1,35 @@
 [[log-driver-troubleshooting]]
+[role="xpack"]
 == Troubleshooting
 
 experimental[]
 
+// TODO: Add details about locating the log files written by the Elastic Log
+// driver.
 
-TODO: Move content about troubleshooting from readme to this section.
+You can set the debug level to capture debugging output about the {log-driver}.
+To set the debug level:
+
+1. Disable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin disable elastic/{log-driver-alias}:{version}
+----
+
+2. Set the debug level:
++
+["source","sh",subs="attributes"]
+----
+docker plugin set elastic/{log-driver-alias}:{version} LOG_DRIVER_LEVEL=debug
+----
++
+Where valid settings for `LOG_DRIVER_LEVEL` are `debug`, `info`, `warning`, or
+`error`.
+
+3. Enable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin enable elastic/{log-driver-alias}:{version}
+----

--- a/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
@@ -4,9 +4,6 @@
 
 experimental[]
 
-// TODO: Add details about locating the log files written by the Elastic Log
-// driver.
-
 You can set the debug level to capture debugging output about the {log-driver}.
 To set the debug level:
 
@@ -33,3 +30,13 @@ Where valid settings for `LOG_DRIVER_LEVEL` are `debug`, `info`, `warning`, or
 ----
 docker plugin enable elastic/{log-driver-alias}:{version}
 ----
+
+To view the logs:
+
+On Linux, the {log-driver} logs are written to the same location as other
+docker logs, typically the system journal. 
+
+On MacOS, locating the logs is more complicated. For more information, see
+the
+https://github.com/elastic/beats/tree/{branch}/x-pack/dockerlogbeat#debugging-on-macos[Debugging
+on MacOS] section in the readme file.

--- a/x-pack/dockerlogbeat/docs/usage.asciidoc
+++ b/x-pack/dockerlogbeat/docs/usage.asciidoc
@@ -1,0 +1,15 @@
+[[log-driver-usage-examples]]
+== {log-driver} usage examples
+
+++++
+<titleabbrev>Usage examples</titleabbrev>
+++++
+
+experimental[]
+
+TODO: Add examples that show commands and daemon file. Some possibilities: 
+
+* ES output with SSL
+* ES output with custom HTTP headers
+* ES output with pipeline - uses format string to select pipeline?
+* LS output with proxy_url and proxy_use_local_resolver

--- a/x-pack/dockerlogbeat/docs/usage.asciidoc
+++ b/x-pack/dockerlogbeat/docs/usage.asciidoc
@@ -7,9 +7,88 @@
 
 experimental[]
 
-TODO: Add examples that show commands and daemon file. Some possibilities: 
+The following examples show common configurations for the {log-driver}.
 
-* ES output with SSL
-* ES output with custom HTTP headers
-* ES output with pipeline - uses format string to select pipeline?
-* LS output with proxy_url and proxy_use_local_resolver
+[float]
+=== Send Docker logs to {es} 
+
+*Docker run command:*
+
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version} \
+           --log-opt output.elasticsearch.hosts="myhost:9200" \
+           --log-opt output.elasticsearch.protocol="https" \
+           --log-opt output.elasticsearch.username="myusername" \
+           --log-opt output.elasticsearch.password="mypassword" \
+           --log-opt output.elasticsearch.index="elastic-log-driver-%{+yyyy.MM.dd}" \
+           -it debian:jessie /bin/bash
+----
+
+*Daemon configuration:*
+
+["source","json",subs="attributes"]
+----
+{
+  "log-driver" : "elastic/{log-driver-alias}:{version}",
+  "log-opts" : {
+    "output.elasticsearch.hosts" : "myhost:9200",
+    "output.elasticsearch.protocol" : "https",
+    "output.elasticsearch.username" : "myusername",
+    "output.elasticsearch.password" : "mypassword",
+    "output.elasticsearch.index" : "elastic-log-driver-%{+yyyy.MM.dd}"
+  }
+}
+----
+
+[float]
+=== Send Docker logs to {ess} on {ecloud}
+
+*Docker run command:*
+
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version} \
+           --log-opt cloud.id="MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5" \
+           --log-opt cloud.auth="myusername:mypassword" \
+           --log-opt output.elasticsearch.index="elastic-log-driver-%{+yyyy.MM.dd}" \
+           -it debian:jessie /bin/bash
+----
+
+*Daemon configuration:*
+
+["source","json",subs="attributes"]
+----
+{
+  "log-driver" : "elastic/{log-driver-alias}:{version}",
+  "log-opts" : {
+    "cloud.id" : "MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5",
+    "cloud.auth" : "myusername:mypassword",
+    "output.elasticsearch.index" : "elastic-log-driver-%{+yyyy.MM.dd}"
+  }
+}
+----
+
+[float]
+=== Send Docker logs to {ls}
+
+*Docker run command:*
+
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version} \
+           --log-opt output.logstash.hosts="myhost:5044" \
+           -it debian:jessie /bin/bash
+----
+
+*Daemon configuration:*
+
+["source","json",subs="attributes"]
+----
+{
+  "log-driver" : "elastic/{log-driver-alias}:{version}",
+  "log-opts" : {
+    "output.logstash.hosts" : "myhost:5044"
+  }
+}
+----


### PR DESCRIPTION
Adds early draft of Elastic Log Driver docs. 

What's left (can be done after initial merging):

- [ ] Test examples again (tested once, but I made a bunch of formatting changes and minor fixes).
- [ ] Test the step for installing from the docker store.
- [ ] Add (or decide not to add) output.elasticsearch.indices and output.elasticsearch.pipelines to the config docs.
- [ ] Remove any settings that we don't want to expose or don't work.
- [ ] Add Kafka and Redis output options to the config docs.
- [x] Add detail to the troubleshooting topic to describe how to find the logs for the log driver (maybe point to the readme? The steps are so weird that it's hard to make the steps platform agnostic).
- [x] Add a list of limitations to the topic about known problems and limitations.
- [ ] [DeDe] Merge the conf.yaml file in the docs build to get these docs publishing.https://github.com/elastic/docs/pull/1728