### PR TITLE
Do not load dashboards where not available

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix missing output in dockerlogbeat {pull}15719[15719]
 - Fix logging target settings being ignored when Beats are started via systemd or docker. {issue}12024[12024] {pull}15422[15442]
+- Do not load dashboards where not available. {pull}15802[15802]
 
 *Auditbeat*
 

--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -47,6 +47,11 @@ func init() {
 		),
 	)
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithSettings(create, instance.Settings{RunFlags: runFlags, Name: Name})
+	settings := instance.Settings{
+		RunFlags:      runFlags,
+		Name:          Name,
+		HasDashboards: true,
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(create, settings)
 	RootCmd.AddCommand(ShowCmd)
 }

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -42,7 +42,12 @@ func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
-	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{RunFlags: runFlags, Name: Name})
+	settings := instance.Settings{
+		RunFlags:      runFlags,
+		Name:          Name,
+		HasDashboards: true,
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
 	RootCmd.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	RootCmd.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -38,8 +38,9 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	settings := instance.Settings{
-		Name:       Name,
-		Processing: processing.MakeDefaultSupport(true, processing.WithECS, processing.WithBeatMeta("agent")),
+		Name:          Name,
+		Processing:    processing.MakeDefaultSupport(true, processing.WithECS, processing.WithBeatMeta("agent")),
+		HasDashboards: false,
 	}
 	RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
 

--- a/journalbeat/cmd/root.go
+++ b/journalbeat/cmd/root.go
@@ -32,4 +32,4 @@ import (
 var Name = "journalbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name, HasDashboards: false})

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -518,7 +518,7 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 			fmt.Println("Index setup finished.")
 		}
 
-		if setup.Dashboard {
+		if setup.Dashboard && settings.HasDashboards {
 			fmt.Println("Loading dashboards (Kibana must be running and reachable)")
 			err = b.loadDashboards(context.Background(), true)
 

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -32,6 +32,7 @@ type Settings struct {
 	Name            string
 	IndexPrefix     string
 	Version         string
+	HasDashboards   bool
 	Monitoring      report.Settings
 	RunFlags        *pflag.FlagSet
 	ConfigOverrides []cfgfile.ConditionalOverride

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -31,7 +31,7 @@ import (
 var Version = "9.9.9"
 var Name = "mockbeat"
 
-var Settings = instance.Settings{Name: Name, Version: Version}
+var Settings = instance.Settings{Name: Name, Version: Version, HasDashboards: true}
 
 type Mockbeat struct {
 	done chan struct{}

--- a/magefile.go
+++ b/magefile.go
@@ -38,7 +38,6 @@ var (
 	// BeatsWithDashboards is a list of Beats to collect dashboards from.
 	BeatsWithDashboards = []string{
 		"heartbeat",
-		"journalbeat",
 		"packetbeat",
 		"winlogbeat",
 		"x-pack/auditbeat",

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -44,7 +44,12 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
-	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), instance.Settings{RunFlags: runFlags, Name: Name})
+	settings := instance.Settings{
+		RunFlags:      runFlags,
+		Name:          Name,
+		HasDashboards: true,
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), settings)
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", BuildModulesManager))
 	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
 }

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -44,6 +44,11 @@ func init() {
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("l"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))
 
-	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{RunFlags: runFlags, Name: Name})
+	settings := instance.Settings{
+		RunFlags:      runFlags,
+		Name:          Name,
+		HasDashboards: true,
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
 	RootCmd.AddCommand(genDevicesCommand())
 }

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -35,4 +35,4 @@ import (
 var Name = "winlogbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name, HasDashboards: true})

--- a/x-pack/functionbeat/manager/cmd/root.go
+++ b/x-pack/functionbeat/manager/cmd/root.go
@@ -24,6 +24,7 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
 		Name:            Name,
+		HasDashboards:   false,
 		ConfigOverrides: config.Overrides,
 	})
 

--- a/x-pack/metricbeat/cmd/root.go
+++ b/x-pack/metricbeat/cmd/root.go
@@ -33,7 +33,12 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
-	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), instance.Settings{RunFlags: runFlags, Name: Name})
+	settings := instance.Settings{
+		RunFlags:      runFlags,
+		Name:          Name,
+		HasDashboards: true,
+	}
+	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), settings)
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", mbcmd.BuildModulesManager))
 	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
 	xpackcmd.AddXPack(RootCmd, Name)


### PR DESCRIPTION
## What does this PR do?

This PR adds a new setting to Beat to indicate if it has a dashboard or not. If the Beat lacks dashboards, running `setup` does not attempt to load those.

## Why is it important?

Running the command `setup` fails if the Beat does not have dashboards in the appropriate folder.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made the corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Both Journalbeat and Functionbeat are affected. So both Beats can/should be tested.

```sh
./functionbeat setup
```

## Related issues

Closes #13276
Closes #11751 