### PR TITLE
Remove docs build from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,12 +170,6 @@ jobs:
       go: $TRAVIS_GO_VERSION
       stage: test
 
-    # Docs
-    - os: linux
-      env: TARGETS="docs"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-
     # Kubernetes
     - os: linux
       install: deploy/kubernetes/.travis/setup.sh


### PR DESCRIPTION
It is failing with python 3 and we have another more complete build to
test this in Jenkins.