### PR TITLE
Revert changes in travis for the migration to python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ jobs:
     - os: linux
       env: TARGETS="check"
       go: $TRAVIS_GO_VERSION
-      # XXX: Change back to stage: check when migration to Python 3 is finished
-      # stage: check
-      stage: test
+      stage: check
 
     # Filebeat
     - os: linux


### PR DESCRIPTION
Move back `make check` to the `check` stage.