### PR TITLE
Cherry-pick #15806 to 7.6: Do not collect Google Cloud metadata

### DIFF
--- a/metricbeat/docs/modules/googlecloud.asciidoc
+++ b/metricbeat/docs/modules/googlecloud.asciidoc
@@ -59,7 +59,7 @@ You can play in IAM pretty much with your service accounts and Instance level ac
 
 Google Cloud Platform offers the https://cloud.google.com/monitoring/api/metrics_gcp[Stackdriver Monitoring API] to fetch metrics from its services. *Those metrics are retrieved one by one*.
 
-If you also want to *extract service metadata and labels* (by setting `exclude_labels` to false, which is the default state). You also make a new API check on the corresponding service. Service labels requires a new API call to extract those metrics. In the worst case the number of API calls will be doubled. In the best case, all metrics come from the same GCP entity and 100% of the required information is included in the first API call (which is cached for subsequent calls).
+If you also want to *extract service labels* (by setting `exclude_labels` to false, which is the default state). You also make a new API check on the corresponding service. Service labels requires a new API call to extract those metrics. In the worst case the number of API calls will be doubled. In the best case, all metrics come from the same GCP entity and 100% of the required information is included in the first API call (which is cached for subsequent calls).
 
 A recommended `period` value between fetches is between 5 and 10 minutes, depending on how granular you want your metrics. GCP restricts information for less than 5 minutes.
 

--- a/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
@@ -49,7 +49,7 @@ You can play in IAM pretty much with your service accounts and Instance level ac
 
 Google Cloud Platform offers the https://cloud.google.com/monitoring/api/metrics_gcp[Stackdriver Monitoring API] to fetch metrics from its services. *Those metrics are retrieved one by one*.
 
-If you also want to *extract service metadata and labels* (by setting `exclude_labels` to false, which is the default state). You also make a new API check on the corresponding service. Service labels requires a new API call to extract those metrics. In the worst case the number of API calls will be doubled. In the best case, all metrics come from the same GCP entity and 100% of the required information is included in the first API call (which is cached for subsequent calls).
+If you also want to *extract service labels* (by setting `exclude_labels` to false, which is the default state). You also make a new API check on the corresponding service. Service labels requires a new API call to extract those metrics. In the worst case the number of API calls will be doubled. In the best case, all metrics come from the same GCP entity and 100% of the required information is included in the first API call (which is cached for subsequent calls).
 
 A recommended `period` value between fetches is between 5 and 10 minutes, depending on how granular you want your metrics. GCP restricts information for less than 5 minutes.
 

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/compute/metadata.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/compute/metadata.go
@@ -90,9 +90,13 @@ func (s *metadataCollector) Metadata(ctx context.Context, resp *monitoringpb.Tim
 		metadataCollectorData.Labels[googlecloud.LabelUser] = s.computeMetadata.User
 	}
 
-	if s.computeMetadata.Metadata != nil {
-		metadataCollectorData.Labels[googlecloud.LabelMetadata] = s.computeMetadata.Metadata
-	}
+	/*
+		Do not collect meta for now, as it can contain sensitive info
+		TODO revisit this and make meta available through whitelisting
+		if s.computeMetadata.Metadata != nil {
+			metadataCollectorData.Labels[googlecloud.LabelMetadata] = s.computeMetadata.Metadata
+		}
+	*/
 
 	return metadataCollectorData, nil
 }


### PR DESCRIPTION
Cherry-pick of PR #15806 to 7.6 branch. Original message: 

## What does this PR do?

Compute instances metadata may contain sensitive info, so we should not
collect them.

In the future we can enable this again with some kind of whitelisting,
to only report the metadata we want.

## Why is it important?

We should avoid collecting sensitive info

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

Configure Metricbeat against a GCloud project that has Compute VMs with metadata, check that we are not collecting it.

## Related issues

- Closes #15782