### PR TITLE
[Metricbeat] Memcached: add support for Unix socket

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -97,6 +97,7 @@ TLS or Beats that accept connections over TLS and validate client certificates. 
 - Add a `system/network_summary` metricset {pull}15196[15196]
 - Add mesh metricset for Istio Metricbeat module{pull}15535[15535]
 - Make the `system/cpu` metricset collect normalized CPU metrics by default. {issue}15618[15618] {pull}15729[15729]
+- Add support for Unix socket in Memcached metricbeat module. {issue}13685[13685] {pull}15822[15822]
 
 *Packetbeat*
 


### PR DESCRIPTION
This PR adds support for Unix socket in the Memcached Metricbeat module.

Issue: https://github.com/elastic/beats/issues/13685