### PR TITLE
Cherry-pick #15803 to 7.6: Add azure input documentation for inputs

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -54,6 +54,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-s3>>
 * <<{beatname_lc}-input-netflow>>
 * <<{beatname_lc}-input-google-pubsub>>
+* <<{beatname_lc}-input-azure-eventhub>>
 
 
 include::inputs/input-log.asciidoc[]
@@ -79,3 +80,5 @@ include::../../x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc[]
 include::../../x-pack/filebeat/docs/inputs/input-netflow.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-google-pubsub.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc[]


### PR DESCRIPTION
Cherry-pick of PR #15803 to 7.6 branch. Original message:

Should fix #15801