### PR TITLE
Cherry-pick #15700 to 7.x: Split global and normal logger tests

### DIFF
--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -20,7 +20,6 @@ package logp
 import (
 	"io/ioutil"
 	golog "log"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,8 +28,6 @@ import (
 
 func TestLogger(t *testing.T) {
 	exerciseLogger := func() {
-		Info("unnamed global logger")
-
 		log := NewLogger("example")
 		log.Info("some message")
 		log.Infof("some message with parameter x=%v, y=%v", 1, 2)
@@ -53,78 +50,6 @@ func TestLogger(t *testing.T) {
 	exerciseLogger()
 	TestingSetup(AsJSON())
 	exerciseLogger()
-}
-
-func TestLoggerSelectors(t *testing.T) {
-	if err := DevelopmentSetup(WithSelectors("good", " padded "), ToObserverOutput()); err != nil {
-		t.Fatal(err)
-	}
-
-	assert.True(t, HasSelector("padded"))
-
-	good := NewLogger("good")
-	bad := NewLogger("bad")
-
-	good.Debug("is logged")
-	logs := ObserverLogs().TakeAll()
-	assert.Len(t, logs, 1)
-
-	// Selectors only apply to debug level logs.
-	bad.Debug("not logged")
-	logs = ObserverLogs().TakeAll()
-	assert.Len(t, logs, 0)
-
-	bad.Info("is also logged")
-	logs = ObserverLogs().TakeAll()
-	assert.Len(t, logs, 1)
-}
-
-func TestGlobalLoggerLevel(t *testing.T) {
-	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
-		t.Fatal(err)
-	}
-
-	const loggerName = "tester"
-
-	Debug(loggerName, "debug")
-	logs := ObserverLogs().TakeAll()
-	if assert.Len(t, logs, 1) {
-		assert.Equal(t, zap.DebugLevel, logs[0].Level)
-		assert.Equal(t, loggerName, logs[0].LoggerName)
-		assert.Equal(t, "debug", logs[0].Message)
-	}
-
-	Info("info")
-	logs = ObserverLogs().TakeAll()
-	if assert.Len(t, logs, 1) {
-		assert.Equal(t, zap.InfoLevel, logs[0].Level)
-		assert.Equal(t, "", logs[0].LoggerName)
-		assert.Equal(t, "info", logs[0].Message)
-	}
-
-	Warn("warning")
-	logs = ObserverLogs().TakeAll()
-	if assert.Len(t, logs, 1) {
-		assert.Equal(t, zap.WarnLevel, logs[0].Level)
-		assert.Equal(t, "", logs[0].LoggerName)
-		assert.Equal(t, "warning", logs[0].Message)
-	}
-
-	Err("error")
-	logs = ObserverLogs().TakeAll()
-	if assert.Len(t, logs, 1) {
-		assert.Equal(t, zap.ErrorLevel, logs[0].Level)
-		assert.Equal(t, "", logs[0].LoggerName)
-		assert.Equal(t, "error", logs[0].Message)
-	}
-
-	Critical("critical")
-	logs = ObserverLogs().TakeAll()
-	if assert.Len(t, logs, 1) {
-		assert.Equal(t, zap.ErrorLevel, logs[0].Level)
-		assert.Equal(t, "", logs[0].LoggerName)
-		assert.Equal(t, "critical", logs[0].Message)
-	}
 }
 
 func TestLoggerLevel(t *testing.T) {
@@ -166,47 +91,6 @@ func TestLoggerLevel(t *testing.T) {
 		assert.Equal(t, loggerName, logs[0].LoggerName)
 		assert.Equal(t, "error", logs[0].Message)
 	}
-}
-
-func TestRecover(t *testing.T) {
-	const recoveryExplanation = "Something went wrong"
-	const cause = "unexpected condition"
-
-	DevelopmentSetup(ToObserverOutput())
-
-	defer func() {
-		logs := ObserverLogs().TakeAll()
-		if assert.Len(t, logs, 1) {
-			log := logs[0]
-			assert.Equal(t, zap.ErrorLevel, log.Level)
-			assert.Equal(t, "logp/core_test.go",
-				strings.Split(log.Caller.TrimmedPath(), ":")[0])
-			assert.Contains(t, log.Message, recoveryExplanation+
-				". Recovering, but please report this.")
-			assert.Contains(t, log.ContextMap(), "panic")
-		}
-	}()
-
-	defer Recover(recoveryExplanation)
-	panic(cause)
-}
-
-func TestHasSelector(t *testing.T) {
-	DevelopmentSetup(WithSelectors("*", "config"))
-	assert.True(t, HasSelector("config"))
-	assert.False(t, HasSelector("publish"))
-}
-
-func TestIsDebug(t *testing.T) {
-	DevelopmentSetup()
-	assert.True(t, IsDebug("all"))
-
-	DevelopmentSetup(WithSelectors("*"))
-	assert.True(t, IsDebug("all"))
-
-	DevelopmentSetup(WithSelectors("only_this"))
-	assert.False(t, IsDebug("all"))
-	assert.True(t, IsDebug("only_this"))
 }
 
 func TestL(t *testing.T) {

--- a/libbeat/logp/global.go
+++ b/libbeat/logp/global.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//+build !nologpglobal
+
 package logp
 
 import (
@@ -29,12 +31,6 @@ func MakeDebug(selector string) func(string, ...interface{}) {
 	return func(format string, v ...interface{}) {
 		globalLogger().Named(selector).Debug(fmt.Sprintf(format, v...))
 	}
-}
-
-// HasSelector returns true if the given selector was explicitly set.
-func HasSelector(selector string) bool {
-	_, found := loadLogger().selectors[selector]
-	return found
 }
 
 // IsDebug returns true if the given selector would be logged.

--- a/libbeat/logp/global_test.go
+++ b/libbeat/logp/global_test.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//+build !nologpglobal
+
+package logp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestGlobalLoggerLevel(t *testing.T) {
+	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
+		t.Fatal(err)
+	}
+
+	const loggerName = "tester"
+
+	Debug(loggerName, "debug")
+	logs := ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.DebugLevel, logs[0].Level)
+		assert.Equal(t, loggerName, logs[0].LoggerName)
+		assert.Equal(t, "debug", logs[0].Message)
+	}
+
+	Info("info")
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.InfoLevel, logs[0].Level)
+		assert.Equal(t, "", logs[0].LoggerName)
+		assert.Equal(t, "info", logs[0].Message)
+	}
+
+	Warn("warning")
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.WarnLevel, logs[0].Level)
+		assert.Equal(t, "", logs[0].LoggerName)
+		assert.Equal(t, "warning", logs[0].Message)
+	}
+
+	Err("error")
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.ErrorLevel, logs[0].Level)
+		assert.Equal(t, "", logs[0].LoggerName)
+		assert.Equal(t, "error", logs[0].Message)
+	}
+
+	Critical("critical")
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.ErrorLevel, logs[0].Level)
+		assert.Equal(t, "", logs[0].LoggerName)
+		assert.Equal(t, "critical", logs[0].Message)
+	}
+}
+
+func TestRecover(t *testing.T) {
+	const recoveryExplanation = "Something went wrong"
+	const cause = "unexpected condition"
+
+	DevelopmentSetup(ToObserverOutput())
+
+	defer func() {
+		logs := ObserverLogs().TakeAll()
+		if assert.Len(t, logs, 1) {
+			log := logs[0]
+			assert.Equal(t, zap.ErrorLevel, log.Level)
+			assert.Equal(t, "logp/global_test.go",
+				strings.Split(log.Caller.TrimmedPath(), ":")[0])
+			assert.Contains(t, log.Message, recoveryExplanation+
+				". Recovering, but please report this.")
+			assert.Contains(t, log.ContextMap(), "panic")
+		}
+	}()
+
+	defer Recover(recoveryExplanation)
+	panic(cause)
+}
+
+func TestIsDebug(t *testing.T) {
+	DevelopmentSetup()
+	assert.True(t, IsDebug("all"))
+
+	DevelopmentSetup(WithSelectors("*"))
+	assert.True(t, IsDebug("all"))
+
+	DevelopmentSetup(WithSelectors("only_this"))
+	assert.False(t, IsDebug("all"))
+	assert.True(t, IsDebug("only_this"))
+}

--- a/libbeat/logp/logger.go
+++ b/libbeat/logp/logger.go
@@ -18,6 +18,8 @@
 package logp
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -201,6 +203,14 @@ func (l *Logger) Panicw(msg string, keysAndValues ...interface{}) {
 // Field such as logp.Stringer.
 func (l *Logger) DPanicw(msg string, keysAndValues ...interface{}) {
 	l.sugar.DPanicw(msg, keysAndValues...)
+}
+
+// Recover stops a panicking goroutine and logs an Error.
+func (l *Logger) Recover(msg string) {
+	if r := recover(); r != nil {
+		msg := fmt.Sprintf("%s. Recovering, but please report this.", msg)
+		l.Error(msg, zap.Any("panic", r), zap.Stack("stack"))
+	}
 }
 
 // L returns an unnamed global logger.

--- a/libbeat/logp/selective.go
+++ b/libbeat/logp/selective.go
@@ -27,6 +27,12 @@ type selectiveCore struct {
 	core         zapcore.Core
 }
 
+// HasSelector returns true if the given selector was explicitly set.
+func HasSelector(selector string) bool {
+	_, found := loadLogger().selectors[selector]
+	return found
+}
+
 func selectiveWrapper(core zapcore.Core, selectors map[string]struct{}) zapcore.Core {
 	if len(selectors) == 0 {
 		return core

--- a/libbeat/logp/selective_test.go
+++ b/libbeat/logp/selective_test.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSelector(t *testing.T) {
+	DevelopmentSetup(WithSelectors("*", "config"))
+	assert.True(t, HasSelector("config"))
+	assert.False(t, HasSelector("publish"))
+}
+
+func TestLoggerSelectors(t *testing.T) {
+	if err := DevelopmentSetup(WithSelectors("good", " padded "), ToObserverOutput()); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, HasSelector("padded"))
+
+	good := NewLogger("good")
+	bad := NewLogger("bad")
+
+	good.Debug("is logged")
+	logs := ObserverLogs().TakeAll()
+	assert.Len(t, logs, 1)
+
+	// Selectors only apply to debug level logs.
+	bad.Debug("not logged")
+	logs = ObserverLogs().TakeAll()
+	assert.Len(t, logs, 0)
+
+	bad.Info("is also logged")
+	logs = ObserverLogs().TakeAll()
+	assert.Len(t, logs, 1)
+}


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#15700 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Move logp global functions to global.go and selective.go, plus split up
tests. The change also adds the `nologpglobal` build tag to global.go and global_test.go.
By default all global functions are available. When compiling or
running a package its test code with `-tags=nologpglobal`, then global
logp functions are not available.

## Why is it important?

In order to better support structured logging in Beats we want to remove global logging functions. See #15699     

This PR adds a build tag that can be used to check for packages that need to be cleaned up. When running `go build -tags=nologpglobal` or `go test -tags=nologpglobal` on a selected package, the compiler will fail until the package and its transitive dependencies have been cleaned up.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#15699

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
