### PR TITLE
Cherry-pick #15422 to 7.x: Introduce CLI flag -environment

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -60,8 +60,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix spooling to disk blocking infinitely if the lock file can not be acquired. {pull}15338[15338]
 - Fix `metricbeat test output` with an ipv6 ES host in the output.hosts. {pull}15368[15368]
 - Fix `convert` processor conversion of string to integer with leading zeros. {issue}15513[15513] {pull}15557[15557]
-- TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
-- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over TLS, or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
 - Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix missing output in dockerlogbeat {pull}15719[15719]
 - Fix logging target settings being ignored when Beats are started via systemd or docker. {issue}12024[12024] {pull}15422[15442]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -60,8 +60,11 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix spooling to disk blocking infinitely if the lock file can not be acquired. {pull}15338[15338]
 - Fix `metricbeat test output` with an ipv6 ES host in the output.hosts. {pull}15368[15368]
 - Fix `convert` processor conversion of string to integer with leading zeros. {issue}15513[15513] {pull}15557[15557]
+- TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
+- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over TLS, or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
 - Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix missing output in dockerlogbeat {pull}15719[15719]
+- Fix logging target settings being ignored when Beats are started via systemd or docker. {issue}12024[12024] {pull}15422[15442]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl
+++ b/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl
@@ -2,23 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Label</key>
+    <key>Label</key>
         <string>{{.identifier}}</string>
-	<key>ProgramArguments</key>
-	<array>
-            <string>{{.install_path}}/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}</string>
-            <string>-c</string>
-            <string>/etc/{{.BeatName}}/{{.BeatName}}.yml</string>
-            <string>--path.home</string>
-            <string>{{.install_path}}/{{.BeatVendor}}/{{.BeatName}}</string>
-            <string>--path.config</string>
-            <string>/etc/{{.BeatName}}</string>
-            <string>--path.data</string>
-            <string>/var/lib/{{.BeatName}}</string>
-            <string>--path.logs</string>
-            <string>/var/log/{{.BeatName}}</string>
-        </array>
-	<key>RunAtLoad</key>
-        <true/>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{.install_path}}/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}</string>
+        <string>-environment</string>
+        <string>macOS_service</string>
+        <string>-c</string>
+        <string>/etc/{{.BeatName}}/{{.BeatName}}.yml</string>
+        <string>--path.home</string>
+        <string>{{.install_path}}/{{.BeatVendor}}/{{.BeatName}}</string>
+        <string>--path.config</string>
+        <string>/etc/{{.BeatName}}</string>
+        <string>--path.data</string>
+        <string>/var/lib/{{.BeatName}}</string>
+        <string>--path.logs</string>
+        <string>/var/log/{{.BeatName}}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
 </dict>
 </plist>

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -50,4 +50,4 @@ EXPOSE {{ $port }}
 
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
-CMD ["-e"]
+CMD ["-environment", "container"]

--- a/dev-tools/packaging/templates/linux/systemd.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/systemd.unit.tmpl
@@ -9,10 +9,10 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
-Environment="BEAT_LOG_OPTS=-e"
+Environment="BEAT_LOG_OPTS="
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 Environment="BEAT_PATH_OPTS=-path.home /usr/share/{{.BeatName}} -path.config /etc/{{.BeatName}} -path.data /var/lib/{{.BeatName}} -path.logs /var/log/{{.BeatName}}"
-ExecStart=/usr/share/{{.BeatName}}/bin/{{.BeatName}} $BEAT_LOG_OPTS $BEAT_CONFIG_OPTS $BEAT_PATH_OPTS
+ExecStart=/usr/share/{{.BeatName}}/bin/{{.BeatName}} -environment systemd $BEAT_LOG_OPTS $BEAT_CONFIG_OPTS $BEAT_PATH_OPTS
 Restart=always
 
 [Install]

--- a/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
@@ -11,7 +11,7 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # Create the new service.
 New-Service -name {{.BeatName}} `
   -displayName {{.BeatName | title}} `
-  -binaryPathName "`"$workdir\{{.BeatName}}.exe`" -c `"$workdir\{{.BeatName}}.yml`" -path.home `"$workdir`" -path.data `"C:\ProgramData\{{.BeatName}}`" -path.logs `"C:\ProgramData\{{.BeatName}}\logs`" -E logging.files.redirect_stderr=true"
+  -binaryPathName "`"$workdir\{{.BeatName}}.exe`" -environment=windows_service -c `"$workdir\{{.BeatName}}.yml`" -path.home `"$workdir`" -path.data `"C:\ProgramData\{{.BeatName}}`" -path.logs `"C:\ProgramData\{{.BeatName}}\logs`" -E logging.files.redirect_stderr=true"
 
 # Attempt to set the service to delayed start using sc config.
 Try {

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -88,6 +88,7 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("d"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))
+	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("environment"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.config"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.data"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -918,6 +918,13 @@ messages.
 *`-e, --e`*::
 Logs to stderr and disables syslog/file output.
 
+*`-environment`*::
+For logging purposes, specifies the environment that {beatname_uc} is running in.
+This setting is used to select a default log output when no log output is configured.
+Supported values are: `systemd`, `container`, `macos_service`, and `windows_service`.
+If `systemd` or `container` is specified, {beatname_uc} will log to stdout and stderr
+by default.
+
 *`--path.config`*::
 Sets the path for configuration files. See the <<directory-layout>> section for
 details.

--- a/libbeat/docs/shared-systemd.asciidoc
+++ b/libbeat/docs/shared-systemd.asciidoc
@@ -49,10 +49,6 @@ Logs are stored by default in journald. To view the Logs, use `journalctl`:
 journalctl -u {beatname_lc}.service
 ------------------------------------------------
 
-NOTE: The unit file included in the packages sets the `-e` flag by default.
-This flag makes {beatname_uc} log to stderr and disables other log outputs.
-Systemd stores all output sent to stderr in journald.
-
 [float]
 === Customize systemd unit for {beatname_uc}
 
@@ -62,7 +58,7 @@ override to change the default options.
 [cols="<h,<,<m",options="header",]
 |=======================================
 | Variable | Description | Default value
-| BEAT_LOG_OPTS | Log options | `-e`
+| BEAT_LOG_OPTS | Log options |
 | BEAT_CONFIG_OPTS | Flags for configuration file path | +-c /etc/{beatname_lc}/{beatname_lc}.yml+
 | BEAT_PATH_OPTS | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
 |=======================================
@@ -77,16 +73,7 @@ would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
 ["source", "systemd", subs="attributes"]
 ------------------------------------------------
 [Service]
-Environment="BEAT_LOG_OPTS=-e -d elasticsearch"
-------------------------------------------------
-
-To change the logging output from the {beatname_uc} configuration file, empty
-the environment variable. For example:
-
-["source", "systemd", subs="attributes"]
-------------------------------------------------
-[Service]
-Environment="BEAT_LOG_OPTS="
+Environment="BEAT_LOG_OPTS=-d elasticsearch"
 ------------------------------------------------
 
 To apply your changes, reload the systemd configuration and restart

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -17,7 +17,9 @@
 
 package logp
 
-import "time"
+import (
+	"time"
+)
 
 // Config contains the configuration options for the logger. To create a Config
 // from a common.Config use logp/config.Build.
@@ -52,20 +54,39 @@ type FileConfig struct {
 	RedirectStderr  bool          `config:"redirect_stderr"`
 }
 
-var defaultConfig = Config{
-	Level:   InfoLevel,
-	ToFiles: true,
-	Files: FileConfig{
-		MaxSize:         10 * 1024 * 1024,
-		MaxBackups:      7,
-		Permissions:     0600,
-		Interval:        0,
-		RotateOnStartup: true,
-	},
-	addCaller: true,
+// DefaultConfig returns the default config options for a given environment the
+// Beat is supposed to be run within.
+func DefaultConfig(environment Environment) Config {
+	switch environment {
+	case SystemdEnvironment, ContainerEnvironment:
+		return defaultToStderrConfig()
+
+	case MacOSServiceEnvironment, WindowsServiceEnvironment:
+		fallthrough
+	default:
+		return defaultToFileConfig()
+	}
 }
 
-// DefaultConfig returns the default config options.
-func DefaultConfig() Config {
-	return defaultConfig
+func defaultToStderrConfig() Config {
+	return Config{
+		Level:     InfoLevel,
+		ToStderr:  true,
+		addCaller: true,
+	}
+}
+
+func defaultToFileConfig() Config {
+	return Config{
+		Level:   InfoLevel,
+		ToFiles: true,
+		Files: FileConfig{
+			MaxSize:         10 * 1024 * 1024,
+			MaxBackups:      7,
+			Permissions:     0600,
+			Interval:        0,
+			RotateOnStartup: true,
+		},
+		addCaller: true,
+	}
 }

--- a/libbeat/logp/configure/logging.go
+++ b/libbeat/logp/configure/logging.go
@@ -19,6 +19,7 @@ package configure
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -30,18 +31,22 @@ var (
 	verbose        bool
 	toStderr       bool
 	debugSelectors []string
+	environment    logp.Environment
 )
+
+type environmentVar logp.Environment
 
 func init() {
 	flag.BoolVar(&verbose, "v", false, "Log at INFO level")
 	flag.BoolVar(&toStderr, "e", false, "Log to stderr and disable syslog/file output")
 	common.StringArrVarFlag(nil, &debugSelectors, "d", "Enable certain debug selectors")
+	flag.Var((*environmentVar)(&environment), "environment", "set environment the Beat is run in")
 }
 
 // Logging builds a logp.Config based on the given common.Config and the specified
 // CLI flags.
 func Logging(beatName string, cfg *common.Config) error {
-	config := logp.DefaultConfig()
+	config := logp.DefaultConfig(environment)
 	config.Beat = beatName
 	if cfg != nil {
 		if err := cfg.Unpack(&config); err != nil {
@@ -68,4 +73,18 @@ func applyFlags(cfg *logp.Config) {
 	if len(debugSelectors) > 0 {
 		cfg.Level = logp.DebugLevel
 	}
+}
+
+func (v *environmentVar) Set(in string) error {
+	env := logp.ParseEnvironment(in)
+	if env == logp.InvalidEnvironment {
+		return fmt.Errorf("'%v' is not supported", in)
+	}
+
+	*(*logp.Environment)(v) = env
+	return nil
+}
+
+func (v *environmentVar) String() string {
+	return (*logp.Environment)(v).String()
 }

--- a/libbeat/logp/environment.go
+++ b/libbeat/logp/environment.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logp
+
+import "strings"
+
+// Environment indicates the environment the logger is supped to be run in.
+// The default logger configuration may be different for different environments.
+type Environment int
+
+const (
+	// DefaultEnvironment is used if the environment the process runs in is not known.
+	DefaultEnvironment Environment = iota
+
+	// SystemdEnvironment indicates that the process is started and managed by systemd.
+	SystemdEnvironment
+
+	// ContainerEnvironment indicates that the process is running within a container (docker, k8s, rkt, ...).
+	ContainerEnvironment
+
+	// MacOSServiceEnvironment indicates that the process is running as a daemon on macOS (e.g. managed via launchctl).
+	MacOSServiceEnvironment
+
+	// WindowsServiceEnvironment indicates the the process is run as a windows service.
+	WindowsServiceEnvironment
+
+	// InvalidEnvironment indicates that the environment name given is unknown or invalid.
+	InvalidEnvironment
+)
+
+// String returns the string representation the configured environment
+func (v Environment) String() string {
+	switch v {
+	case DefaultEnvironment:
+		return "default"
+	case SystemdEnvironment:
+		return "systemd"
+	case ContainerEnvironment:
+		return "container"
+	case MacOSServiceEnvironment:
+		return "macOS_service"
+	case WindowsServiceEnvironment:
+		return "windows_service"
+	default:
+		return "<invalid>"
+	}
+}
+
+// ParseEnvironment returns the environment type by name.
+// The parse is case insensitive.
+// InvalidEnvironment is returned if the environment type is unknown.
+func ParseEnvironment(in string) Environment {
+	switch strings.ToLower(in) {
+	case "default":
+		return DefaultEnvironment
+	case "systemd":
+		return SystemdEnvironment
+	case "container":
+		return ContainerEnvironment
+	case "macos_service":
+		return MacOSServiceEnvironment
+	case "windows_service":
+		return WindowsServiceEnvironment
+	default:
+		return InvalidEnvironment
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#15422 to 7.x branch. Original message: 

## Type of change

- [x] Bug fix

## What does this PR do?

Introduce CLI flags -environment to control the default logging settings
the Beat should use if no logging is configured. The behavior of -e does
not change. By replacing `-e` with `-environment system` in the system
unit file we continue to log to stdout/stderr by default, but users are
still able to overwrite settings.

For now (I'm targeting 7.x) I tried to not introduce any breaking changes one way or the other on the config file or CLI level. So the idea is to replace the `-e` flag with the `-environment` flag in the systemd unit file. If `-environment systemd` is given the default log output is stdout/stderr, while we keep file based logging as default for other environments.

## Why is it important?

If beats are started via systemd unit files the `-e` CLI flag is added to the list of CLI arguments. This was introduced in https://github.com/elastic/beats/pull/8942. The `-e` flag its purpose is to disable the configured logging output and always log to stdout/stderr. By to enforcing the `-e` flag the users logging configurations is not honored (for example see the reports in https://github.com/elastic/beats/issues/12024).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply.
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The PR changes how beats are started as Windows Service, macOS service (installed via launchctl), docker container, and via systemd (deb/rpm). For testing Beats must be installed in a few different environment types to check if logs are correctly written to the default target and if log settings can be overwritten.

### Running beat locally via command line:
- Running a beat (e.g. metricbeat with system module) locally without configuring logging output should log to stdout/stderr if `-environment systemd` is given on the command line
- Running beat without `-environment` flag, without logging configured should create log files as usual

### Running a beat via systemd:
- The Beat should log to journald by default
- Logs should be written to `/var/log/<beatname>` when setting `logging.to_stderr: false` and `logging.to_file: true`

### Running beat using old init scripts:
- Install Beat on system still using init scripts
- Logs should be written to `/var/log/<beatname>` by default

### Running as container:
- The Beat should log to stdout/stderr by default. Check via `docker log` is this is really the case.
- Configure to_file in the config file and log to a mounted directory. Check the Beat now writes logs to the configured path.

### Running on windows

- Install the windows package zip file on windows:
  - check the service is correctly installed
  - check the service can be started
  - check the service writes logs to the configured files

### Running as service on macOS

- Install the packaged Beat on macOS. Including launchd files and preference pane:
  - check the service is correctly installed and can be restarted
  - check the service writes logs to the configured files

## Related issues

- Closes: elastic/beats#12024
- Closes: elastic/beats#12667