### PR TITLE
Python3 Windows and Winlogbeat updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,8 +24,8 @@
 # freebsd and openbsd
 # -------------------
 #   - Use gmake instead of make.
-#   - Folder syncing doesn't work well. Consider copying the files into the box or
-#     cloning the project inside the box.
+#   - Folder syncing doesn't work well. Consider copying the files into the box
+#     or cloning the project inside the box.
 ###
 
 # Read the branch's Go version from the .go-version file.
@@ -82,27 +82,14 @@ if (-Not (Get-Command "choco" -ErrorAction SilentlyContinue)) {
 choco feature disable -n=showDownloadProgress
 
 if (-Not (Get-Command "python" -ErrorAction SilentlyContinue)) {
-    echo "Installing python2"
-    choco install python2 -y -r
+    echo "Installing python 3"
+    choco install python -y -r --version 3.8.1.20200110
     refreshenv
-    $env:PATH = "$env:PATH;C:\\Python27;C:\\Python27\\Scripts"
+    $env:PATH = "$env:PATH;C:\\Python38;C:\\Python38\\Scripts"
 }
 
-if (-Not (Get-Command "pip" -ErrorAction SilentlyContinue)) {
-    echo "Installing pip"
-    Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-    python get-pip.py -U --force-reinstall 2>&1 | %{ "$_" }
-    rm get-pip.py
-    Invoke-WebRequest
-} else {
-    echo "Updating pip"
-    python -m pip install --upgrade pip 2>&1 | %{ "$_" }
-}
-
-if (-Not (Get-Command "virtualenv" -ErrorAction SilentlyContinue)) {
-    echo "Installing virtualenv"
-    python -m pip install virtualenv 2>&1 | %{ "$_" }
-}
+echo "Updating pip"
+python -m pip install --upgrade pip 2>&1 | %{ "$_" }
 
 if (-Not (Get-Command "git" -ErrorAction SilentlyContinue)) {
     echo "Installing git"
@@ -113,6 +100,9 @@ if (-Not (Get-Command "gcc" -ErrorAction SilentlyContinue)) {
     echo "Installing mingw (gcc)"
     choco install mingw -y -r
 }
+
+echo "Setting PYTHON_ENV in VM to point to C:\\beats-python-env."
+[System.Environment]::SetEnvironmentVariable("PYTHON_ENV", "C:\\beats-python-env", [System.EnvironmentVariableTarget]::Machine)
 SCRIPT
 
 # Provisioning for Unix/Linux

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -32,7 +32,6 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-
 // WINDOWS USERS:
 // The python installer does not create a python3 alias like it does on other
 // platforms. So do verify the version with python.exe --version.

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -32,16 +32,20 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
+
+// WINDOWS USERS:
+// The python installer does not create a python3 alias like it does on other
+// platforms. So do verify the version with python.exe --version.
+//
+// Setting up a python virtual environment on a network drive does not work
+// well. So if this applies to your development environment set PYTHON_EXE
+// to point to somewhere on C:\.
+
 const (
 	libbeatRequirements = "{{ elastic_beats_dir}}/libbeat/tests/system/requirements.txt"
 )
 
 var (
-	// pythonExe points to the python executable to use. It defaults to python3
-	// so this must be on the PATH. The PYTHON_EXE environment can be used to
-	// modify the executable used.
-	pythonExe = EnvOr("PYTHON_EXE", "python3")
-
 	// VirtualenvReqs specifies a list of virtualenv requirements files to be
 	// used when calling PythonVirtualenv(). It defaults to the libbeat
 	// requirements.txt file.
@@ -58,7 +62,20 @@ var (
 		"module/*/test_*.py",
 		"module/*/*/test_*.py",
 	}
+
+	// pythonExe points to the python executable to use. The PYTHON_EXE
+	// environment can be used to modify the executable used.
+	// On Windows this defaults to python and on all other platforms this
+	// defaults to python3.
+	pythonExe = EnvOr("PYTHON_EXE", "python3")
 )
+
+func init() {
+	// The python installer for Windows does not setup a python3 alias.
+	if runtime.GOOS == "windows" {
+		pythonExe = EnvOr("PYTHON_EXE", "python")
+	}
+}
 
 // PythonTestArgs are the arguments used for the "python*Test" targets and they
 // define how "nosetests" is invoked.

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -244,7 +244,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         output_path = os.path.join(self.working_dir, output)
         with open(output_path, "wb") as f:
             os.chmod(output_path, 0o600)
-            f.write(output_str.encode('utf8'))
+            f.write(output_str.encode('utf_8'))
 
     # Returns output as JSON object with flattened fields (. notation)
     def read_output(self,
@@ -256,7 +256,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             output_file = "output/" + self.beat_name
 
         jsons = []
-        with open(os.path.join(self.working_dir, output_file), "r") as f:
+        with open(os.path.join(self.working_dir, output_file), "r", encoding="utf_8") as f:
             for line in f:
                 if len(line) == 0 or line[len(line) - 1] != "\n":
                     # hit EOF
@@ -280,7 +280,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             output_file = "output/" + self.beat_name
 
         jsons = []
-        with open(os.path.join(self.working_dir, output_file), "r") as f:
+        with open(os.path.join(self.working_dir, output_file), "r", encoding="utf_8") as f:
             for line in f:
                 if len(line) == 0 or line[len(line) - 1] != "\n":
                     # hit EOF
@@ -359,7 +359,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if logfile is None:
             logfile = self.beat_name + ".log"
 
-        with open(os.path.join(self.working_dir, logfile), 'r') as f:
+        with open(os.path.join(self.working_dir, logfile), 'r', encoding="utf_8") as f:
             data = f.read()
 
         return data
@@ -371,7 +371,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if logfile is None:
             logfile = self.beat_name + ".log"
 
-        with open(os.path.join(self.working_dir, logfile), 'r') as f:
+        with open(os.path.join(self.working_dir, logfile), 'r', encoding="utf_8") as f:
             data = f.readlines()
 
         return data
@@ -409,7 +409,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             logfile = self.beat_name + ".log"
 
         try:
-            with open(os.path.join(self.working_dir, logfile), "r") as f:
+            with open(os.path.join(self.working_dir, logfile), "r", encoding="utf_8") as f:
                 for line in f:
                     if is_regexp:
                         if msg.search(line) is not None:
@@ -434,7 +434,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             logfile = self.beat_name + ".log"
 
         try:
-            with open(os.path.join(self.working_dir, logfile), "r") as f:
+            with open(os.path.join(self.working_dir, logfile), "r", encoding="utf_8") as f:
                 for line in f:
                     res = pattern.search(line)
                     if res is not None:
@@ -454,7 +454,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             output_file = "output/" + self.beat_name
 
         try:
-            with open(os.path.join(self.working_dir, output_file), "r") as f:
+            with open(os.path.join(self.working_dir, output_file), "r", encoding="utf_8") as f:
                 return sum([1 for line in f])
         except IOError:
             return 0
@@ -469,7 +469,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             output_file = "output/" + self.beat_name
 
         try:
-            with open(os.path.join(self.working_dir, output_file), "r") as f:
+            with open(os.path.join(self.working_dir, output_file, ), "r", encoding="utf_8") as f:
                 return len([1 for line in f]) == lines
         except IOError:
             return False
@@ -629,7 +629,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             output_file = "output/" + self.beat_name
 
         try:
-            with open(os.path.join(self.working_dir, output_file), "r") as f:
+            with open(os.path.join(self.working_dir, output_file), "r", encoding="utf_8") as f:
                 return pred(len([1 for line in f]))
         except IOError:
             return False

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -3,8 +3,8 @@ backports.ssl-match-hostname==3.5.0.1
 cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
-docker==3.7.0
-docker-compose==1.25.0
+docker==4.1.0
+docker-compose==1.25.3
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
@@ -20,7 +20,7 @@ nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==4.2b1
-Pillow==5.4.1
+Pillow==7.0.0
 redis==2.10.6
 requests==2.20.0
 six==1.11.0

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import sys
 import time
@@ -257,4 +258,4 @@ Logon Process Name:  IKE"""
         self.assertNotIn("event.original", evts[0], msg=evts[0])
         self.assertIn("message", evts[0], msg=evts[0])
         self.assertNotIn("\\u000a", evts[0]["message"], msg=evts[0])
-        self.assertEqual(str(msg), evts[0]["message"].decode('unicode-escape'), msg=evts[0])
+        self.assertEqual(str(msg), codecs.decode(evts[0]["message"], "unicode_escape"), msg=evts[0])

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import sys
 import time
@@ -411,4 +412,5 @@ Logon Process Name:  IKE"""
         self.assertNotIn("event.original", evts[0], msg=evts[0])
         self.assertIn("message", evts[0], msg=evts[0])
         self.assertNotIn("\\u000a", evts[0]["message"], msg=evts[0])
-        self.assertEqual(str(msg), evts[0]["message"].decode('unicode-escape'), msg=evts[0])
+        self.assertEqual(str(msg), codecs.decode(evts[0]["message"], "unicode_escape"), msg=evts[0])
+

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -413,4 +413,3 @@ Logon Process Name:  IKE"""
         self.assertIn("message", evts[0], msg=evts[0])
         self.assertNotIn("\\u000a", evts[0]["message"], msg=evts[0])
         self.assertEqual(str(msg), codecs.decode(evts[0]["message"], "unicode_escape"), msg=evts[0])
-

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -43,7 +43,7 @@ class WriteReadTest(BaseTest):
 
         # Every test will use its own event log and application names to ensure
         # isolation.
-        self.testSuffix = "_" + hashlib.sha256(self.api + self._testMethodName).hexdigest()[:5]
+        self.testSuffix = "_" + hashlib.sha256(str(self.api + self._testMethodName).encode('utf_8')).hexdigest()[:5]
         self.providerName = PROVIDER + self.testSuffix
         self.applicationName = APP_NAME + self.testSuffix
         self.otherAppName = OTHER_APP_NAME + self.testSuffix
@@ -70,18 +70,18 @@ class WriteReadTest(BaseTest):
 
     def write_event_log(self, message, eventID=10, sid=None,
                         level=None, source=None):
-        if sid == None:
+        if sid is None:
             sid = self.get_sid()
-        if source == None:
+        if source is None:
             source = self.applicationName
-        if level == None:
+        if level is None:
             level = win32evtlog.EVENTLOG_INFORMATION_TYPE
 
         win32evtlogutil.ReportEvent(source, eventID,
                                     eventType=level, strings=[message], sid=sid)
 
     def get_sid(self):
-        if self.sid == None:
+        if self.sid is None:
             ph = win32api.GetCurrentProcess()
             th = win32security.OpenProcessToken(ph, win32con.TOKEN_READ)
             self.sid = win32security.GetTokenInformation(
@@ -90,13 +90,13 @@ class WriteReadTest(BaseTest):
         return self.sid
 
     def get_sid_string(self):
-        if self.sidString == None:
+        if self.sidString is None:
             self.sidString = win32security.ConvertSidToStringSid(self.get_sid())
 
         return self.sidString
 
     def read_events(self, config=None, expected_events=1):
-        if config == None:
+        if config is None:
             config = {
                 "event_logs": [
                     {"name": self.providerName, "api": self.api}
@@ -141,13 +141,13 @@ class WriteReadTest(BaseTest):
             "winlog.api": self.api,
         }, evt)
 
-        if msg == None:
+        if msg is None:
             assert "message" not in evt
         else:
             self.assertEqual(evt["message"], msg)
             self.assertDictContainsSubset({"winlog.event_data.param1": msg}, evt)
 
-        if sid == None:
+        if sid is None:
             self.assertEqual(evt["winlog.user.identifier"], self.get_sid_string())
             self.assertEqual(evt["winlog.user.name"].lower(),
                              win32api.GetUserName().lower())
@@ -158,7 +158,7 @@ class WriteReadTest(BaseTest):
             assert "winlog.user.name" not in evt
             assert "winlog.user.type" not in evt
 
-        if extra != None:
+        if extra is not None:
             self.assertDictContainsSubset(extra, evt)
 
 


### PR DESCRIPTION
This updates the Vagrantfile and addresses a few issues. I installed Python3 on Windows
via chocolotey and the python MSI and neither provided a `python3` command so I adjusted
the build tooling to use `python` on Windows.

Another issue I hit was that under Vagrant with the shared filesystem, `pip` would not
install into the virtual environment. It only will install when moving the PYTHON_ENV
off of the shared filesystem. So when provisining the Vagrant VM it will now put
PYTHON_ENV in C:\beats-python-env. Remember this if you need need to do a completely
clean build on Windows+Vagrant.

There were some encoding issues I found while reading output files containing unicode.
So I modified the libbeat's beat.py to specify `utf_8` encoding when opening output files.
I was seeing errors like:

```
======================================================================
ERROR: eventlogging - UTF-16 characters
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Gopath\src\github.com\elastic\beats\winlogbeat\tests\system\test_eventlogging.py", line 187, in test_utf16_characters
    evts = self.read_events(config={
  File "C:\Gopath\src\github.com\elastic\beats\winlogbeat\tests\system\winlogbeat.py", line 110, in read_events
    return self.read_output()
  File "C:\Gopath\src\github.com\elastic\beats\winlogbeat\tests\system\../../../libbeat/tests/system\beat\beat.py", line 260, in read_output
    for line in f:
  File "C:\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 277: character maps to <undefined>
```