### PR TITLE
Kubernetes: update replicaset type to apps/v1

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -44,6 +44,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix missing output in dockerlogbeat {pull}15719[15719]
 - Fix logging target settings being ignored when Beats are started via systemd or docker. {issue}12024[12024] {pull}15422[15442]
 - Do not load dashboards where not available. {pull}15802[15802]
+- Update replicaset group to apps/v1 {pull}15854[15802]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -65,7 +64,7 @@ type PodContainerStatus = v1.ContainerStatus
 type Deployment = appsv1.Deployment
 
 // ReplicaSet data
-type ReplicaSet = extv1.ReplicaSet
+type ReplicaSet = appsv1.ReplicaSet
 
 // StatefulSet data
 type StatefulSet = appsv1.StatefulSet


### PR DESCRIPTION
Since kubernetes 1.16 replicasets needs to be create from apps/v1 group.
