### PR TITLE
Cherry-pick #15847 to 7.x: Use RFC3339 format for timestamps in SQL module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Make `logstash` module more resilient to Logstash unavailability. {issue}15276[15276] {pull}15306[15306]
 - Add username/password in Metricbeat autodiscover hints {pull}15349[15349]
 - Fix CPU count in docker/cpu in cases where no `online_cpus` are reported {pull}15070[15070]
+- Use RFC3339 format for timestamps collected using the SQL module. {pull}15847[15847]
+
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
+++ b/x-pack/metricbeat/module/sql/query/_meta/data_postgres.json
@@ -10,7 +10,7 @@
         "period": 10000
     },
     "service": {
-        "address": "172.22.0.2:5432",
+        "address": "192.168.0.3:5432",
         "type": "sql"
     },
     "sql": {
@@ -19,8 +19,8 @@
             "numeric": {
                 "blk_read_time": 0,
                 "blk_write_time": 0,
-                "blks_hit": 1923,
-                "blks_read": 111,
+                "blks_hit": 948,
+                "blks_read": 96,
                 "conflicts": 0,
                 "datid": 12379,
                 "deadlocks": 0,
@@ -28,18 +28,18 @@
                 "temp_bytes": 0,
                 "temp_files": 0,
                 "tup_deleted": 0,
-                "tup_fetched": 1249,
+                "tup_fetched": 616,
                 "tup_inserted": 0,
-                "tup_returned": 1356,
+                "tup_returned": 717,
                 "tup_updated": 0,
-                "xact_commit": 18,
+                "xact_commit": 3,
                 "xact_rollback": 0
             },
             "string": {
                 "datname": "postgres",
-                "stats_reset": "2020-01-21 11:23:56.53"
+                "stats_reset": "2020-01-25T18:21:44.869405Z"
             }
         },
-        "query": "select * from pg_stat_database"
+        "query": "select * from pg_stat_database where datname='postgres'"
     }
 }

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -150,7 +150,7 @@ func getValue(pval *interface{}) string {
 	case []byte:
 		return string(v)
 	case time.Time:
-		return v.Format("2006-01-02 15:04:05.999")
+		return v.Format(time.RFC3339Nano)
 	default:
 		return fmt.Sprint(v)
 	}

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -73,7 +73,7 @@ func TestPostgreSQL(t *testing.T) {
 
 	config = testFetchConfig{
 		Driver:    "postgres",
-		Query:     "select * from pg_stat_database",
+		Query:     "select * from pg_stat_database where datname='postgres'",
 		Host:      fmt.Sprintf("postgres://%s:%s@%s:%s/?sslmode=disable", user, password, host, port),
 		Assertion: assertFieldNotContains("service.address", ":"+password+"@"),
 	}


### PR DESCRIPTION
Cherry-pick of PR #15847 to 7.x branch. Original message: 

## What does this PR do?

Format timestamps collected with the SQL module using the RFC3339 Nano format,
that includes the timezone and is a more precise representation.

## Why is it important?

So timezone information and precission is not lost when formatting the timestamps
for the final event.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works