### PR TITLE
Cherry-pick #15834 to 7.5: Add the Elasticsearch License in the log

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v7.5.0...v7.5.1[View commits]
 
 - Fix `proxy_url` option in Elasticsearch output. {pull}14950[14950]
 - Fix bug with potential concurrent reads and writes from event.Meta map by Kafka output. {issue}14542[14542] {pull}14568[14568]
+- Fix license detection, when a beats successfully connect to Elasticsearch the detected license will be show in the log at info level. {pull}15834[15834]
 
 *Filebeat*
 

--- a/x-pack/functionbeat/function/beater/functionbeat.go
+++ b/x-pack/functionbeat/function/beater/functionbeat.go
@@ -96,7 +96,7 @@ func (bt *Functionbeat) Run(b *beat.Beat) error {
 	}
 
 	if outputName == "elasticsearch" {
-		licenser.Enforce(logp.NewLogger("license"), b.Info.Name, licenser.BasicAndAboveOrTrial)
+		licenser.Enforce(b.Info.Name, licenser.BasicAndAboveOrTrial)
 	}
 
 	bt.log.Info("Functionbeat is running")

--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"github.com/elastic/beats/libbeat/cmd"
-	"github.com/elastic/beats/libbeat/logp"
 
 	// register central management
 	"github.com/elastic/beats/x-pack/libbeat/licenser"
@@ -16,10 +15,8 @@ import (
 	_ "github.com/elastic/beats/x-pack/libbeat/autodiscover/providers/aws/elb"
 )
 
-const licenseDebugK = "license"
-
 // AddXPack extends the given root folder with XPack features
 func AddXPack(root *cmd.BeatsRootCmd, name string) {
-	licenser.Enforce(logp.NewLogger(licenseDebugK), name, licenser.BasicAndAboveOrTrial)
+	licenser.Enforce(name, licenser.BasicAndAboveOrTrial)
 	root.AddCommand(genEnrollCmd(name, ""))
 }

--- a/x-pack/libbeat/licenser/es_callback.go
+++ b/x-pack/libbeat/licenser/es_callback.go
@@ -14,12 +14,17 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
+const licenseDebugK = "license"
+
 // Enforce setups the corresponding callbacks in libbeat to verify the license on the
 // remote elasticsearch cluster.
-func Enforce(log *logp.Logger, name string, checks ...CheckFunc) {
+func Enforce(name string, checks ...CheckFunc) {
 	name = strings.Title(name)
 
 	cb := func(client *elasticsearch.Client) error {
+		// Logger created earlier than this place are at risk of discarding any log statement.
+		log := logp.NewLogger(licenseDebugK)
+
 		fetcher := NewElasticFetcher(client)
 		license, err := fetcher.Fetch()
 
@@ -41,6 +46,8 @@ func Enforce(log *logp.Logger, name string, checks ...CheckFunc) {
 				license.Get(),
 			)
 		}
+
+		log.Infof("Elasticsearch license: %s", license.Get())
 
 		return nil
 	}


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#15834 to 7.5 branch. Original message: 


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

When the license callback is executed the license will be show in
the log at info level

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

X-pack licensed beats require to have at least a basic license on the remote Elasticsearch cluster, this make it clear which license the beat has detected.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Run any beats agaisn't a non oss version of Elasticsearch.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- [ ] Run any beats agaisn't a non oss version of Elasticsearch.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->
- Relates https://github.com/elastic/beats/pull/14249

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
