### PR TITLE
[Metricbeat] Fix Estimated Billing Chart visualization

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "89dccfe8-a25e-44ea-afdb-ff01ab1f05d6",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -40,15 +40,15 @@
             },
             "gridData": {
               "h": 16,
-              "i": "26670498-b079-4447-bbc8-e4ca8215898c",
+              "i": "632595ea-b8bb-401d-9d69-a21e009cb07c",
               "w": 32,
               "x": 16,
               "y": 0
             },
-            "panelIndex": "26670498-b079-4447-bbc8-e4ca8215898c",
+            "panelIndex": "632595ea-b8bb-401d-9d69-a21e009cb07c",
             "panelRefName": "panel_1",
             "title": "Estimated Billing Chart",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "221aab02-2747-4d84-9dde-028ccd51bdce",
             "panelRefName": "panel_2",
             "title": "Total Estimated Charges",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "21e91e6b-0ff0-42ba-9132-6f30c5c6bbb7",
             "panelRefName": "panel_3",
             "title": "Top 5 Estimated Billing Per Service Name",
-            "version": "7.3.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -98,7 +98,7 @@
           "type": "visualization"
         },
         {
-          "id": "749cd470-1530-11ea-841c-01bf20a6c8ba",
+          "id": "35934980-4122-11ea-93eb-13c5950b2c9e",
           "name": "panel_1",
           "type": "visualization"
         },
@@ -114,8 +114,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-17T15:11:20.337Z",
-      "version": "WzY2MiwxXQ=="
+      "updated_at": "2020-01-27T17:11:40.585Z",
+      "version": "WzYzNywxXQ=="
     },
     {
       "attributes": {
@@ -172,8 +172,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:10.917Z",
-      "version": "WzE1NywxXQ=="
+      "updated_at": "2020-01-27T16:08:35.784Z",
+      "version": "WzE2NCwxXQ=="
     },
     {
       "attributes": {
@@ -189,18 +189,7 @@
           }
         },
         "title": "Estimated Billing Pie Chart [Metricbeat AWS]",
-        "uiStateJSON": {
-          "vis": {
-            "colors": {
-              "16": "#629E51",
-              "272": "#DEDAF7",
-              "80": "#E24D42",
-              "running": "#7EB26D",
-              "stopped": "#E24D42"
-            },
-            "legendOpen": true
-          }
-        },
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
           "aggs": [
@@ -208,7 +197,6 @@
               "enabled": true,
               "id": "1",
               "params": {
-                "customLabel": "",
                 "field": "aws.billing.metrics.EstimatedCharges.max"
               },
               "schema": "metric",
@@ -218,21 +206,11 @@
               "enabled": true,
               "id": "2",
               "params": {
-                "customLabel": "",
                 "field": "aws.dimensions.ServiceName",
                 "missingBucket": false,
                 "missingBucketLabel": "Missing",
                 "order": "desc",
-                "orderAgg": {
-                  "enabled": true,
-                  "id": "2-orderAgg",
-                  "params": {
-                    "field": "aws.billing.metrics.EstimatedCharges.max"
-                  },
-                  "schema": "orderAgg",
-                  "type": "avg"
-                },
-                "orderBy": "custom",
+                "orderBy": "1",
                 "otherBucket": true,
                 "otherBucketLabel": "Other",
                 "size": 10
@@ -283,7 +261,7 @@
           "type": "pie"
         }
       },
-      "id": "749cd470-1530-11ea-841c-01bf20a6c8ba",
+      "id": "35934980-4122-11ea-93eb-13c5950b2c9e",
       "migrationVersion": {
         "visualization": "7.3.1"
       },
@@ -295,8 +273,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:00.631Z",
-      "version": "WzU0LDFd"
+      "updated_at": "2020-01-27T16:29:37.175Z",
+      "version": "WzYzNiwxXQ=="
     },
     {
       "attributes": {
@@ -391,8 +369,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-17T15:10:12.013Z",
-      "version": "WzY1OSwxXQ=="
+      "updated_at": "2020-01-27T16:08:24.435Z",
+      "version": "WzU1LDFd"
     },
     {
       "attributes": {
@@ -476,9 +454,9 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:00.631Z",
+      "updated_at": "2020-01-27T16:08:24.435Z",
       "version": "WzU2LDFd"
     }
   ],
-  "version": "7.3.0"
+  "version": "7.4.0"
 }


### PR DESCRIPTION
Problem found in testing:
<img width="1622" alt="Screen Shot 2020-01-27 at 9 17 46 AM" src="https://user-images.githubusercontent.com/14081635/73199896-f7178b00-40f2-11ea-9c4d-796f9469971e.png">

With this PR:
<img width="826" alt="Screen Shot 2020-01-27 at 10 55 45 AM" src="https://user-images.githubusercontent.com/14081635/73200220-99d00980-40f3-11ea-82cf-530b1847ff49.png">
