### PR TITLE
Try to fix flakiness of appsearch system tests

### DIFF
--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -160,7 +160,7 @@ func PythonNoseTest(params PythonTestArgs) error {
 	}
 
 	defer fmt.Println(">> python test:", params.TestName, "Testing Complete")
-	_, err := sh.Exec(nosetestsEnv, os.Stdout, os.Stderr, nosetestsPath, append(nosetestsOptions, testFiles...)...)
+	_, err = sh.Exec(nosetestsEnv, os.Stdout, os.Stderr, nosetestsPath, append(nosetestsOptions, testFiles...)...)
 	return err
 
 	// TODO: Aggregate all the individual code coverage reports and generate

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -160,7 +160,8 @@ func PythonNoseTest(params PythonTestArgs) error {
 	}
 
 	defer fmt.Println(">> python test:", params.TestName, "Testing Complete")
-	return sh.RunWith(nosetestsEnv, nosetestsPath, append(nosetestsOptions, testFiles...)...)
+	_, err := sh.Exec(nosetestsEnv, os.Stdout, os.Stderr, nosetestsPath, append(nosetestsOptions, testFiles...)...)
+	return err
 
 	// TODO: Aggregate all the individual code coverage reports and generate
 	// and HTML report.

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -33,9 +33,6 @@ func init() {
 
 	devtools.BeatDescription = "Metricbeat is a lightweight shipper for metrics."
 	devtools.BeatLicense = "Elastic License"
-
-	// XXX: Remove this
-	os.Setenv("MAGEFILE_VERBOSE", "true")
 }
 
 // Aliases provides compatibility with CI while we transition all Beats

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -33,6 +33,9 @@ func init() {
 
 	devtools.BeatDescription = "Metricbeat is a lightweight shipper for metrics."
 	devtools.BeatLicense = "Elastic License"
+
+	// XXX: Remove this
+	os.Setenv("MAGEFILE_VERBOSE", "true")
 }
 
 // Aliases provides compatibility with CI while we transition all Beats

--- a/x-pack/metricbeat/module/appsearch/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/appsearch/_meta/Dockerfile
@@ -1,6 +1,7 @@
-FROM docker.elastic.co/app-search/app-search:7.5.0
+ARG APPSEARCH_VERSION
+FROM docker.elastic.co/app-search/app-search:${APPSEARCH_VERSION}
 
 COPY docker-entrypoint-dependencies.sh /usr/local/bin/
 ENTRYPOINT /usr/local/bin/docker-entrypoint-dependencies.sh
 
-HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:3002/swiftype-app-version"); data = json.loads(response.read()); exit(0);'
+HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:3002/api/as/v1/internal/health"); response.getcode() == 200 or exit(1); data = json.loads(response.read()); exit(0);'

--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - "elasticsearch.host=http://elasticsearch:9200"
       - "allow_es_settings_modification=true"
-      - "JAVA_OPTS=-Xms1g -Xmx1g"
+      - "JAVA_OPTS=-Xms2g -Xmx2g"
     ports:
       - 3002
     command: --process app-server

--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -2,14 +2,17 @@ version: '2.3'
 
 services:
   appsearch:
+    image: docker.elastic.co/integrations-ci/beats-appsearch:${APPSEARCH_VERSION:-7.5.0}-1
     build:
       context: ./_meta
+      args:
+        APPSEARCH_VERSION: ${APPSEARCH_VERSION:-7.5.0}
     depends_on:
       - elasticsearch
     environment:
       - "elasticsearch.host=http://elasticsearch:9200"
       - "allow_es_settings_modification=true"
-      - "JAVA_OPTS=-Xms2g -Xmx2g"
+      - "JAVA_OPTS=-Xms1g -Xmx1g"
     ports:
       - 3002
     command: --process app-server


### PR DESCRIPTION
This test fails quite frequently in python 3 builds in Travis #14798, and much
less frequently in other builds. Try to address this flakiness.

* Use the health check of the service for the docker health check
* Actually check the response status code
* Reduce memory allocation for JVM