### PR TITLE
Cherry-pick #15708 to 7.x: Fix issue where default go logger is not discarded when either * or stdout is selected.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -64,6 +64,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix missing output in dockerlogbeat {pull}15719[15719]
 - Fix logging target settings being ignored when Beats are started via systemd or docker. {issue}12024[12024] {pull}15422[15442]
 - Do not load dashboards where not available. {pull}15802[15802]
+- Fix issue where default go logger is not discarded when either * or stdout is selected. {issue}10251[10251] {pull}15708[15708]
+
 
 *Auditbeat*
 

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -37,7 +37,8 @@ import (
 )
 
 var (
-	_log unsafe.Pointer // Pointer to a coreLogger. Access via atomic.LoadPointer.
+	_log          unsafe.Pointer // Pointer to a coreLogger. Access via atomic.LoadPointer.
+	_defaultGoLog = golog.Writer()
 )
 
 func init() {
@@ -86,6 +87,10 @@ func Configure(cfg Config) error {
 		return errors.Wrap(err, "failed to build log output")
 	}
 
+	// Default logger is always discard, debug level below will
+	// possibly re-enable it.
+	golog.SetOutput(ioutil.Discard)
+
 	// Enabled selectors when debug is enabled.
 	selectors := make(map[string]struct{}, len(cfg.Selectors))
 	if cfg.Level.Enabled(DebugLevel) && len(cfg.Selectors) > 0 {
@@ -98,10 +103,12 @@ func Configure(cfg Config) error {
 			selectors["*"] = struct{}{}
 		}
 
-		if _, enabled := selectors["stdlog"]; !enabled {
-			// Disable standard logging by default (this is sometimes used by
-			// libraries and we don't want their spam).
-			golog.SetOutput(ioutil.Discard)
+		// Re-enable the default go logger output when either stdlog
+		// or all selector is enabled.
+		_, stdlogEnabled := selectors["stdlog"]
+		_, allEnabled := selectors["*"]
+		if stdlogEnabled || allEnabled {
+			golog.SetOutput(_defaultGoLog)
 		}
 
 		sink = selectiveWrapper(sink, selectors)

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -18,6 +18,8 @@
 package logp
 
 import (
+	"io/ioutil"
+	golog "log"
 	"strings"
 	"testing"
 
@@ -231,4 +233,32 @@ func TestL(t *testing.T) {
 		assert.Equal(t, loggerName, log.LoggerName)
 		assert.Equal(t, "warning 1", log.Message)
 	}
+}
+
+func TestDebugAllStdoutEnablesDefaultGoLogger(t *testing.T) {
+	DevelopmentSetup(WithSelectors("*"))
+	assert.Equal(t, _defaultGoLog, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("stdlog"))
+	assert.Equal(t, _defaultGoLog, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("*", "stdlog"))
+	assert.Equal(t, _defaultGoLog, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("other"))
+	assert.Equal(t, ioutil.Discard, golog.Writer())
+}
+
+func TestNotDebugAllStdoutDisablesDefaultGoLogger(t *testing.T) {
+	DevelopmentSetup(WithSelectors("*"), WithLevel(InfoLevel))
+	assert.Equal(t, ioutil.Discard, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("stdlog"), WithLevel(InfoLevel))
+	assert.Equal(t, ioutil.Discard, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("*", "stdlog"), WithLevel(InfoLevel))
+	assert.Equal(t, ioutil.Discard, golog.Writer())
+
+	DevelopmentSetup(WithSelectors("other"), WithLevel(InfoLevel))
+	assert.Equal(t, ioutil.Discard, golog.Writer())
 }


### PR DESCRIPTION
Cherry-pick of PR #15708 to 7.x branch. Original message: 

## What does this PR do?

Fix issue where default go logger is not discarded when either * or stdout is selected. 

## Why is it important?

Prevents other imported modules from outputting log messages.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Closes #10251 

