### PR TITLE
Retry initializing add_kubernetes_metadata processor if first attempt…

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
+- Retry initializing add_kubernetes_metadata processor if first attempt fails {issue}14164[14164]
 
 *Heartbeat*
 


### PR DESCRIPTION
… fails.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR resolves [#14164](https://github.com/elastic/beats/issues/14164) by implementing exponential backoff retry for initializing the add_kubernetes_metadata processor.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
As mentioned in the issue when filebeat is run in a cluster that uses the Istio service mesh the processor will be initialized before the Istio sidecar is fully running. This causes initial pings to Kubernetes to fail. Since this initialization was never tried again no Kubernetes metadata would ever be added to log messages that were gathered.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
I need some guidance in this area. As far as I can tell the Dockerfile that is used by the official filebeat chart published by Elastic is not publicly available. This is preventing me from deploying these changes to my local cluster for proper testing since I am not sure how to create my own Dockerfile for running filebeat in Kubernetes. I have done some hacky workarounds to verify that it is not completely broken but obviously need to do better. Any advice?

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Closes elastic/beats#14164

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
