### PR TITLE
Cherry-pick #15867 to 7.5: Use ECS fields in Kafka output examples

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -123,12 +123,12 @@ the specified string:
 ------------------------------------------------------------------------------
 output.kafka:
   hosts: ["localhost:9092"]
-  topic: "logs-%{[beat.version]}" 
+  topic: "logs-%{[agent.version]}"
   topics:
-    - topic: "critical-%{[beat.version]}"
+    - topic: "critical-%{[agent.version]}"
       when.contains:
         message: "CRITICAL"
-    - topic: "error-%{[beat.version]}"
+    - topic: "error-%{[agent.version]}"
       when.contains:
         message: "ERR"
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of PR #15867 to 7.5 branch. Original message: 

Fields used in examples for dynamic topic names don't exist since 7.0,
replace it with existing ECS fields to avoid confusion.