### PR TITLE
Cherry-pick #15882 to 7.x: [Metricbeat] Fix total estimated charges visualization to report last value

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-billing-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "89dccfe8-a25e-44ea-afdb-ff01ab1f05d6",
             "panelRefName": "panel_0",
             "title": "AWS Account Filter",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -40,15 +40,15 @@
             },
             "gridData": {
               "h": 16,
-              "i": "26670498-b079-4447-bbc8-e4ca8215898c",
+              "i": "632595ea-b8bb-401d-9d69-a21e009cb07c",
               "w": 32,
               "x": 16,
               "y": 0
             },
-            "panelIndex": "26670498-b079-4447-bbc8-e4ca8215898c",
+            "panelIndex": "632595ea-b8bb-401d-9d69-a21e009cb07c",
             "panelRefName": "panel_1",
             "title": "Estimated Billing Chart",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "221aab02-2747-4d84-9dde-028ccd51bdce",
             "panelRefName": "panel_2",
             "title": "Total Estimated Charges",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "21e91e6b-0ff0-42ba-9132-6f30c5c6bbb7",
             "panelRefName": "panel_3",
             "title": "Top 5 Estimated Billing Per Service Name",
-            "version": "7.3.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -98,7 +98,7 @@
           "type": "visualization"
         },
         {
-          "id": "749cd470-1530-11ea-841c-01bf20a6c8ba",
+          "id": "35934980-4122-11ea-93eb-13c5950b2c9e",
           "name": "panel_1",
           "type": "visualization"
         },
@@ -114,8 +114,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-17T15:11:20.337Z",
-      "version": "WzY2MiwxXQ=="
+      "updated_at": "2020-01-27T20:51:32.061Z",
+      "version": "WzM4NjAsMV0="
     },
     {
       "attributes": {
@@ -172,8 +172,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:10.917Z",
-      "version": "WzE1NywxXQ=="
+      "updated_at": "2020-01-27T19:32:04.671Z",
+      "version": "WzMzODUsMV0="
     },
     {
       "attributes": {
@@ -189,18 +189,7 @@
           }
         },
         "title": "Estimated Billing Pie Chart [Metricbeat AWS]",
-        "uiStateJSON": {
-          "vis": {
-            "colors": {
-              "16": "#629E51",
-              "272": "#DEDAF7",
-              "80": "#E24D42",
-              "running": "#7EB26D",
-              "stopped": "#E24D42"
-            },
-            "legendOpen": true
-          }
-        },
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
           "aggs": [
@@ -208,7 +197,6 @@
               "enabled": true,
               "id": "1",
               "params": {
-                "customLabel": "",
                 "field": "aws.billing.metrics.EstimatedCharges.max"
               },
               "schema": "metric",
@@ -218,21 +206,11 @@
               "enabled": true,
               "id": "2",
               "params": {
-                "customLabel": "",
                 "field": "aws.dimensions.ServiceName",
                 "missingBucket": false,
                 "missingBucketLabel": "Missing",
                 "order": "desc",
-                "orderAgg": {
-                  "enabled": true,
-                  "id": "2-orderAgg",
-                  "params": {
-                    "field": "aws.billing.metrics.EstimatedCharges.max"
-                  },
-                  "schema": "orderAgg",
-                  "type": "avg"
-                },
-                "orderBy": "custom",
+                "orderBy": "1",
                 "otherBucket": true,
                 "otherBucketLabel": "Other",
                 "size": 10
@@ -283,7 +261,7 @@
           "type": "pie"
         }
       },
-      "id": "749cd470-1530-11ea-841c-01bf20a6c8ba",
+      "id": "35934980-4122-11ea-93eb-13c5950b2c9e",
       "migrationVersion": {
         "visualization": "7.3.1"
       },
@@ -295,8 +273,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:00.631Z",
-      "version": "WzU0LDFd"
+      "updated_at": "2020-01-27T19:31:53.402Z",
+      "version": "WzMyNzUsMV0="
     },
     {
       "attributes": {
@@ -331,7 +309,7 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 1,
+            "drop_last_bucket": 0,
             "gauge_color_rules": [
               {
                 "id": "e8a045e0-1531-11ea-961e-c1db9cc6166e"
@@ -362,23 +340,24 @@
                   {
                     "field": "aws.billing.metrics.EstimatedCharges.max",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "sum"
+                    "type": "max"
                   }
                 ],
-                "override_index_pattern": 1,
+                "override_index_pattern": 0,
                 "point_size": 1,
                 "separate_axis": 0,
                 "series_drop_last_bucket": 0,
                 "series_interval": "12h",
                 "split_mode": "filter",
                 "stacked": "none",
-                "time_range_mode": "entire_time_range",
+                "time_range_mode": "last_value",
                 "value_template": "${{value}}"
               }
             ],
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "time_range_mode": "last_value",
             "type": "metric"
           },
           "title": "Total Estimated Charges [Metricbeat AWS]",
@@ -391,8 +370,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-17T15:10:12.013Z",
-      "version": "WzY1OSwxXQ=="
+      "updated_at": "2020-01-27T20:51:25.785Z",
+      "version": "WzM4NTksMV0="
     },
     {
       "attributes": {
@@ -476,9 +455,9 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-17T14:43:00.631Z",
-      "version": "WzU2LDFd"
+      "updated_at": "2020-01-27T19:31:53.402Z",
+      "version": "WzMyNzcsMV0="
     }
   ],
-  "version": "7.3.0"
+  "version": "7.4.0"
 }


### PR DESCRIPTION
Cherry-pick of PR #15882 to 7.x branch. Original message: 

Bug: Total Estimated Charges is showing a sum of all charges during the time range of the dashboard. 
From Kibana Discover we can see, there are two sets of estimated charges. `aws.billing.metrics.EstimatedCharges.max` should only be the latest values not all values combined.
<img width="829" alt="Screen Shot 2020-01-27 at 2 35 38 PM" src="https://user-images.githubusercontent.com/14081635/73216229-d5c69700-4112-11ea-8e5f-2cfad2bfbb75.png">

<img width="815" alt="Screen Shot 2020-01-27 at 2 35 51 PM" src="https://user-images.githubusercontent.com/14081635/73215971-5cc73f80-4112-11ea-8690-da6dc57e28fe.png">

Fix: instead of `sum` aggregation of `aws.billing.metrics.EstimatedCharges.max`, `max` should be used.

Fixed:
<img width="1626" alt="Screen Shot 2020-01-27 at 2 23 23 PM" src="https://user-images.githubusercontent.com/14081635/73215631-aa8f7800-4111-11ea-94b1-63371d7802af.png">
