### PR TITLE
Cherry-pick #7206 to 7.x: [Metricbeat] Add /snap mountpoints to blacklist per default

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -65,7 +65,7 @@ data:
         - fsstat
       processors:
       - drop_event.when.regexp:
-          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)'
   kubernetes.yml: |-
     - module: kubernetes
       metricsets:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -65,7 +65,7 @@ data:
         - fsstat
       processors:
       - drop_event.when.regexp:
-          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)'
   kubernetes.yml: |-
     - module: kubernetes
       metricsets:

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -24,7 +24,7 @@
     - fsstat
   processors:
   - drop_event.when.regexp:
-      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)'
 
 - module: system
   period: 15m

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -27,7 +27,7 @@
     - fsstat
   processors:
   - drop_event.when.regexp:
-      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)'
 
 - module: system
   period: 15m


### PR DESCRIPTION
Cherry-pick of PR #7206 to 7.x branch. Original message: 

By design these mounts always show 100% utilization, thus the information of them being full is negligible. These changes add /snap/ to the list of mounts to be ignored