### PR TITLE
Add dev tool for finding Jenkins jobs for a Beats PR

### DIFF
--- a/dev-tools/find_pr_jenkins_jobs.sh
+++ b/dev-tools/find_pr_jenkins_jobs.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Description:
+#   This script finds Jenkins jobs for a given Beats PR.
+#
+# Usage:
+#   ./find_pr_jenkins_job.sh PR_NUMBER
+#
+# Example:
+#   ./find_pr_jenkins_job.sh 15790
+#
+
+set -e
+
+NUM_JOBS_TO_SEARCH=100
+
+get_pr_from_input() {
+    pr=$1
+    if [ -z $pr ]; then
+        echo "Usage: ./find_jenkins_job.sh PR_NUMBER" >&2
+        exit 1
+    fi
+
+    echo $pr
+}
+
+find_latest_beats_pr_job() {
+    curl -s 'https://beats-ci.elastic.co/job/elastic+beats+pull-request/api/json' | jq '.builds[0].number'
+}
+
+find_job_for_pr() {
+    job=$1
+    pr=$2
+    
+    found=$(curl -s "https://beats-ci.elastic.co/job/elastic+beats+pull-request/$job/api/json" \
+                | jq -c ".actions[] | select(._class == \"org.jenkinsci.plugins.ghprb.GhprbParametersAction\").parameters[] | select(.name == \"ghprbPullId\" and .value == \"$pr\")" \
+                | wc -l)
+
+    echo $found
+}
+    
+main() {
+    pr=$(get_pr_from_input $1)
+    echo "Searching last $NUM_JOBS_TO_SEARCH Jenkins jobs for PR number: $pr..."
+
+    n=$(find_latest_beats_pr_job $pr)
+    let e=$n-$NUM_JOBS_TO_SEARCH
+    
+    while [ $n -gt $e ]; do
+        found=$(find_job_for_pr $n $pr)
+        if [ $found -gt 0 ]; then
+            echo "https://beats-ci.elastic.co/job/elastic+beats+pull-request/$n/"
+        fi
+
+        let n=$n-1
+    done
+}
+
+main $1

--- a/dev-tools/find_pr_jenkins_jobs.sh
+++ b/dev-tools/find_pr_jenkins_jobs.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 # Description:
-#   This script finds Jenkins jobs for a given Beats PR.
+#    This script finds Jenkins jobs for a given Beats PR.
 #
 # Usage:
-#   ./find_pr_jenkins_job.sh PR_NUMBER
+#    ./find_pr_jenkins_job.sh PR_NUMBER
 #
 # Example:
-#   ./find_pr_jenkins_job.sh 15790
+#    ./find_pr_jenkins_job.sh 15790
 #
+# Dependencies:
+#    curl, jq
 
 set -e
 

--- a/dev-tools/find_pr_jenkins_jobs.sh
+++ b/dev-tools/find_pr_jenkins_jobs.sh
@@ -33,21 +33,21 @@ find_latest_beats_pr_job() {
 find_job_for_pr() {
     job=$1
     pr=$2
-    
+
     found=$(curl -s "https://beats-ci.elastic.co/job/elastic+beats+pull-request/$job/api/json" \
                 | jq -c ".actions[] | select(._class == \"org.jenkinsci.plugins.ghprb.GhprbParametersAction\").parameters[] | select(.name == \"ghprbPullId\" and .value == \"$pr\")" \
                 | wc -l)
 
     echo $found
 }
-    
+
 main() {
     pr=$(get_pr_from_input $1)
     echo "Searching last $NUM_JOBS_TO_SEARCH Jenkins jobs for PR number: $pr..."
 
     n=$(find_latest_beats_pr_job $pr)
     let e=$n-$NUM_JOBS_TO_SEARCH
-    
+
     while [ $n -gt $e ]; do
         found=$(find_job_for_pr $n $pr)
         if [ $found -gt 0 ]; then


### PR DESCRIPTION
## What does this PR do?

Adds a developer tool script, `find_pr_jenkins_jobs.sh`. This script will find and list out Jenkins CI jobs for a given Beats PR. 

### Sample usage

```
$ ./find_pr_jenkins_jobs.sh 15790
Searching last 100 Jenkins jobs for PR number: 15790...
https://beats-ci.elastic.co/job/elastic+beats+pull-request/8216/
https://beats-ci.elastic.co/job/elastic+beats+pull-request/8176/
```

## Why is it important?

Could be useful when trying to find all old Jenkins CI builds for a PR, particularly if CI has been re-run repeatedly on that PR with a `jenkins, test this` command. This often happens on PRs that are testing solutions to flaky tests (e.g. #15790). 


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
