### PR TITLE
Extend documentation of max_depth option of decode_json_fields processor

### DIFF
--- a/libbeat/processors/actions/docs/decode_json_fields.asciidoc
+++ b/libbeat/processors/actions/docs/decode_json_fields.asciidoc
@@ -21,7 +21,9 @@ The `decode_json_fields` processor has the following configuration settings:
 `fields`:: The fields containing JSON strings to decode.
 `process_array`:: (Optional) A boolean that specifies whether to process
 arrays. The default is false.
-`max_depth`:: (Optional) The maximum parsing depth. The default is 1.
+`max_depth`:: (Optional) The maximum parsing depth. A value of 1 will decode the
+JSON objects in fields indicated in `fields`, a value of 2 will also decode the
+objects embedded in the fields of these parsed documents. The default is 1.
 `target`:: (Optional) The field under which the decoded JSON will be written. By
 default the decoded JSON object replaces the string field from which it was
 read. To merge the decoded JSON fields into the root of the event, specify
@@ -33,4 +35,4 @@ default value is false.
 `add_error_key`:: (Optional) If it set to true, in case of error while decoding json keys
 `error` field is going to be part of event with error message. If it set to false, there
 will not be any error in event's field. Even error occurs while decoding json keys. The
-default value is false
+default value is false.


### PR DESCRIPTION
## What does this PR do?

Try to clarify what parsing depth means.

## Why is it important?

`max_depth` is also understood sometimes as the maximum level of fields decoded, instead of the maximum level of nested objects decoded.
