### PR TITLE
docs: update README with GitOps commands

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -99,9 +99,9 @@ pipeline {
       }
     }
   }
-  post {
-    cleanup {
-      notifyBuildResult()
-    }
-  }
+  // post {
+  //   cleanup {
+  //     notifyBuildResult()
+  //   }
+  // }
 }

--- a/README.md
+++ b/README.md
@@ -85,3 +85,18 @@ your dev environment to build Beats from the source.
 ## Snapshots
 
 For testing purposes, we generate snapshot builds that you can find [here](https://beats-ci.elastic.co/job/elastic+beats+master+multijob-package-linux/lastSuccessfulBuild/gcsObjects/). Please be aware that these are built on top of master and are not meant for production.
+
+## CI
+
+It is possible to trigger some jobs by putting a comment on a GitHub PR,
+this service is only available for Elastic users.
+
+* [beats][]
+  * `jenkins run the tests please`
+  * `jenkins run tests`
+* [apm-beats-update][]
+  * `/run apm-beats-update`
+
+
+[beats]: https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/
+[apm-beats-update]: https://beats-ci.elastic.co/job/Beats/job/apm-beats-update/

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ For testing purposes, we generate snapshot builds that you can find [here](https
 
 ## CI
 
-It is possible to trigger some jobs by putting a comment on a GitHub PR,
-this service is only available for Elastic users.
+It is possible to trigger some jobs by putting a comment on a GitHub PR.
+(This service is only available for users affiliated with Elastic and not for open-source contributors.)
 
 * [beats][]
   * `jenkins run the tests please`


### PR DESCRIPTION
Update the README with information about how to trigger builds with comments in GitHub. 

NOTE:  [beats pipeline](https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/)  is not  activate for PRs because is not listening PRs