### PR TITLE
Fix tests for the dissect processor

### DIFF
--- a/libbeat/processors/dissect/dissect_test.go
+++ b/libbeat/processors/dissect/dissect_test.go
@@ -59,10 +59,17 @@ func init() {
 		os.Exit(1)
 	}
 
-	json.Unmarshal(content, &tests)
+	if err := json.Unmarshal(content, &tests); err != nil {
+		fmt.Printf("could not parse the content of 'dissect_tests', error: %s", err)
+		os.Exit(1)
+	}
 }
 
 func TestDissect(t *testing.T) {
+	if len(tests) == 0 {
+		t.Error("No test cases were loaded")
+	}
+
 	for _, test := range tests {
 		if test.Skip {
 			continue

--- a/libbeat/processors/dissect/testdata/dissect_tests.json
+++ b/libbeat/processors/dissect/testdata/dissect_tests.json
@@ -133,7 +133,7 @@
 		"tok": "%{?key} %{\u0026key}",
 		"msg": "hello world",
 		"expected": {
-			"hello": "world",
+			"hello": "world"
 		},
 		"skip": false,
 		"fail": false


### PR DESCRIPTION
## What does this PR do?

There was a JSON syntax error in the fixtures file (in `libbeat/processors/dissect/testdata/dissect_tests.json`) that prevented the set of tests from being called in the `TestDissect` function. This caused that no test case was loaded from the file and none were executed.

With this PR the test fails/exists if the content of the file cannot be unmarshalled. An additional check for the number of test cases was also added to the `TestDissect` function.

## Why is it important?

The tests for the `dissect` processor were failing silently.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works