### PR TITLE
Kubernetes: node autodiscover, add InternalIP

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -188,17 +188,28 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 		},
 	}
 	n.publish(event)
-
 }
 
+// getAddress returns an IP address from a kubernetes node.
+//
+// It will use external IP if existing, falling back to Internal IP if not,
+// hostname and DNS entries are not taken into account.
 func getAddress(node *kubernetes.Node) string {
+	nodeAddress := ""
 	for _, address := range node.Status.Addresses {
+		if address.Address == "" {
+			continue
+		}
 		if address.Type == v1.NodeExternalIP && address.Address != "" {
-			return address.Address
+			nodeAddress = address.Address
+			break
+		}
+		if address.Type == v1.NodeInternalIP && address.Address != "" {
+			nodeAddress = address.Address
 		}
 	}
 
-	return ""
+	return nodeAddress
 }
 
 func isNodeReady(node *kubernetes.Node) bool {

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -192,13 +192,13 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 
 func getAddress(node *kubernetes.Node) string {
 	for _, address := range node.Status.Addresses {
-		if address.Type == v1.NodeExternalIP && address.Address == "" {
+		if address.Type == v1.NodeExternalIP && address.Address != "" {
 			return address.Address
 		}
 	}
 
 	for _, address := range node.Status.Addresses {
-		if address.Type == v1.NodeInternalIP && address.Address == "" {
+		if address.Type == v1.NodeInternalIP && address.Address != "" {
 			return address.Address
 		}
 	}

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -190,26 +190,20 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 	n.publish(event)
 }
 
-// getAddress returns an IP address from a kubernetes node.
-//
-// It will use external IP if existing, falling back to Internal IP if not,
-// hostname and DNS entries are not taken into account.
 func getAddress(node *kubernetes.Node) string {
-	nodeAddress := ""
 	for _, address := range node.Status.Addresses {
-		if address.Address == "" {
-			continue
-		}
-		if address.Type == v1.NodeExternalIP {
-			nodeAddress = address.Address
-			break
-		}
-		if address.Type == v1.NodeInternalIP {
-			nodeAddress = address.Address
+		if address.Type == v1.NodeExternalIP && address.Address == "" {
+			return address.Address
 		}
 	}
 
-	return nodeAddress
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeInternalIP && address.Address == "" {
+			return address.Address
+		}
+	}
+
+	return ""
 }
 
 func isNodeReady(node *kubernetes.Node) bool {

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -200,11 +200,11 @@ func getAddress(node *kubernetes.Node) string {
 		if address.Address == "" {
 			continue
 		}
-		if address.Type == v1.NodeExternalIP && address.Address != "" {
+		if address.Type == v1.NodeExternalIP {
 			nodeAddress = address.Address
 			break
 		}
-		if address.Type == v1.NodeInternalIP && address.Address != "" {
+		if address.Type == v1.NodeInternalIP {
 			nodeAddress = address.Address
 		}
 	}


### PR DESCRIPTION
complementary to https://github.com/elastic/beats/pull/14738#issuecomment-578205897

Autodiscover for nodes should use not only the external IP but also the internal one.
