### PR TITLE
Upgrade python instead of the base image for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,8 +221,8 @@ addons:
 
 before_install:
         - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get update
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install python3.7 python3.7-venv
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get -q update
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install -y python3.7 python3.7-venv
   - python --version
   - python3 --version
   - umask 022

--- a/.travis.yml
+++ b/.travis.yml
@@ -224,8 +224,9 @@ addons:
       - python3.6-venv
 
 before_install:
+  - if [ x$TRAVIS_DIST = xtrusty ]; then sudo ln -sf python3.6 /usr/bin/python3; fi
   - python --version
-  - openssl version
+  - python3 --version
   - umask 022
   - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Docker-compose installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: trusty
 services:
   - docker
 
@@ -217,7 +217,7 @@ addons:
       - libpcap-dev
       - xsltproc
       - libxml2-utils
-      - libsystemd-dev
+      - libsystemd-journal-dev
       - librpm-dev
 
 before_install:
@@ -231,10 +231,7 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv; fi
-  # Docker update on Ubuntu Bionic
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" ; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update ; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -y install docker-ce docker-ce-cli containerd.io ; fi
+
 
 # Skips installations step
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,7 @@ addons:
       - librpm-dev
 
 before_install:
-        - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa
   - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get -q update
   - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install -y python3.7 python3.7-venv
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,8 +221,8 @@ addons:
       - libsystemd-journal-dev
       - librpm-dev
       # From deadsnakes PPA
-      - python3.7
-      - python3.7-venv
+      - python3
+      - python3-venv
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     # General checks
     - os: linux
-      env: TARGETS="check"
+      env: TARGETS="check" PYTHON_EXE="python3.7"
       go: $TRAVIS_GO_VERSION
       stage: check
 
@@ -224,9 +224,7 @@ addons:
       - python3.7-venv
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo ln -sf python3.7 /usr/bin/python3; fi
   - python --version
-  - python3 --version
   - umask 022
   - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Docker-compose installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     # General checks
     - os: linux
-      env: TARGETS="check" PYTHON_EXE="python3.8"
+      env: TARGETS="check" PYTHON_EXE="python3.6"
       go: $TRAVIS_GO_VERSION
       stage: check
 
@@ -220,8 +220,8 @@ addons:
       - libsystemd-journal-dev
       - librpm-dev
       # From deadsnakes PPA
-      - python3.8
-      - python3.8-venv
+      - python3.6
+      - python3.6-venv
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     # General checks
     - os: linux
-      env: TARGETS="check" PYTHON_EXE="python3.7"
+      env: TARGETS="check" PYTHON_EXE="python3.8"
       go: $TRAVIS_GO_VERSION
       stage: check
 
@@ -220,8 +220,8 @@ addons:
       - libsystemd-journal-dev
       - librpm-dev
       # From deadsnakes PPA
-      - python3.7
-      - python3.7-venv
+      - python3.8
+      - python3.8-venv
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     # General checks
     - os: linux
-      env: TARGETS="check" PYTHON_EXE="python3.6"
+      env: TARGETS="check"
       go: $TRAVIS_GO_VERSION
       stage: check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,9 +220,9 @@ addons:
       - librpm-dev
 
 before_install:
-  - sudo add-apt-repository ppa:deadsnakes/ppa
-  - sudo apt-get update
-  - sudo apt-get install python3.7
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository ppa:deadsnakes/ppa
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get update
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install python3.7 python3.7-venv
   - python --version
   - python3 --version
   - umask 022

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: xenial
 services:
   - docker
 
@@ -232,7 +232,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
   - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv; fi
   # Docker update on Ubuntu Bionic
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" ; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" ; fi
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update ; fi
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -y install docker-ce docker-ce-cli containerd.io ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,7 @@ addons:
       - librpm-dev
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository ppa:deadsnakes/ppa
+        - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa
   - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get update
   - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install python3.7 python3.7-venv
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,17 +212,19 @@ addons:
     config:
       retries: true
     update: true
+    sources:
+      - deadsnakes
     packages:
       - libpcap-dev
       - xsltproc
       - libxml2-utils
       - libsystemd-journal-dev
       - librpm-dev
+      # From deadsnakes PPA
+      - python3.7
+      - python3.7-venv
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get -q update; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install -y python3.7 python3.7-venv; fi
   - python --version
   - python3 --version
   - umask 022

--- a/.travis.yml
+++ b/.travis.yml
@@ -213,7 +213,6 @@ addons:
       retries: true
     update: true
     packages:
-      - python3-venv
       - libpcap-dev
       - xsltproc
       - libxml2-utils
@@ -221,6 +220,9 @@ addons:
       - librpm-dev
 
 before_install:
+  - sudo add-apt-repository ppa:deadsnakes/ppa
+  - sudo apt-get update
+  - sudo apt-get install python3.7
   - python --version
   - python3 --version
   - umask 022

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,6 +225,7 @@ addons:
 
 before_install:
   - python --version
+  - openssl version
   - umask 022
   - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Docker-compose installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,9 +220,9 @@ addons:
       - librpm-dev
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get -q update
-  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install -y python3.7 python3.7-venv
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo add-apt-repository -y ppa:deadsnakes/ppa; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get -q update; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; sudo apt-get install -y python3.7 python3.7-venv; fi
   - python --version
   - python3 --version
   - umask 022

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,6 @@ jobs:
             retries: true
           update: true
           packages:
-            - python3-venv
             - libpcap-dev
             - xsltproc
             - libxml2-utils
@@ -221,10 +220,11 @@ addons:
       - libsystemd-journal-dev
       - librpm-dev
       # From deadsnakes PPA
-      - python3
-      - python3-venv
+      - python3.7
+      - python3.7-venv
 
 before_install:
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo ln -sf python3.7 /usr/bin/python3; fi
   - python --version
   - python3 --version
   - umask 022


### PR DESCRIPTION
Travis builds are taking too long in the python 3 branch after upgrading the Ubuntu image.
Keeping the image in trusty seems to speed up the builds. Timeouts disappear.
So instead of upgrading the image, upgrade python to 3.6 using [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa),
this is the minimal version for venv to work properly.
Python 3.7 doesn't work well because the trusty image in Travis has an old openssl version,
and Python 3.8 is not available for trusty.

Failures in tests after this change are consistent with failures in linux build in Jenkins.