### PR TITLE
[7.6] Re-enabling golang integration tests (#15819)

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -197,7 +197,7 @@ unit: ## @testing Runs the unit tests without coverage reports.
 integration-tests: ## @testing Run integration tests. Unit tests are run as part of the integration tests.
 integration-tests: prepare-tests mage
 	rm -f docker-compose.yml.lock
-	mage goIntegTest
+	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
 
 .PHONY: integration-tests-environment
 integration-tests-environment:  ## @testing Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
@@ -207,7 +207,12 @@ integration-tests-environment: prepare-tests build-image
 	#
 	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
 	# by default because it can create noise if the test inside the container fails.
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
+	${DOCKER_COMPOSE} run \
+	  -e RACE_DETECTOR=$(RACE_DETECTOR) \
+	  -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} \
+	  -e TEST_ENVIRONMENT=${TEST_ENVIRONMENT} \
+	  -e BEATS_DOCKER_INTEGRATION_TEST_ENV=${BEATS_DOCKER_INTEGRATION_TEST_ENV} \
+	  beat make integration-tests
 
 # Runs the system tests
 .PHONY: system-tests

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -3,6 +3,7 @@ BEAT_NAME?=metricbeat
 BEAT_TITLE?=Metricbeat
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
+BEATS_DOCKER_INTEGRATION_TEST_ENV?=true
 ES_BEATS?=..
 
 # Metricbeat can only be cross-compiled on platforms not requiring CGO.
@@ -76,3 +77,9 @@ assets:
 	go run ${ES_BEATS}/metricbeat/scripts/assets/assets.go ${ES_BEATS}/metricbeat/module
 	mkdir -p include/fields
 	go run  ${ES_BEATS}/libbeat/scripts/cmd/global_fields/main.go -es_beats_path ${ES_BEATS} -beat_path ${PWD} | go run  ${ES_BEATS}/dev-tools/cmd/asset/asset.go -license ${LICENSE} -out ./include/fields/fields.go -pkg include -priority asset.LibbeatFieldsPri ${ES_BEATS}/libbeat/fields.yml $(BEAT_NAME)
+
+.PHONY: integration-tests
+integration-tests: ## @testing Run golang integration tests.
+integration-tests: prepare-tests mage
+	rm -f docker-compose.yml.lock
+	mage goIntegTest

--- a/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build integration windows
+// +build integration
+// +build windows
 
 package perfmon
 


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Re-enabling golang integration tests  (#15819)