### PR TITLE
[Elastic Log Driver] Fix file check bug, deal with logging

### DIFF
--- a/x-pack/dockerlogbeat/config.json
+++ b/x-pack/dockerlogbeat/config.json
@@ -11,6 +11,14 @@
     },
     "env":[
       {
+        "description": "debug level",
+        "name": "LOG_DRIVER_LEVEL",
+        "value": "info",
+        "Settable": [
+          "value"
+        ]
+      },
+      {
         "description": "libbeat env hack",
         "name": "BEAT_STRICT_PERMS",
         "value": "false"

--- a/x-pack/dockerlogbeat/handlers.go
+++ b/x-pack/dockerlogbeat/handlers.go
@@ -64,7 +64,7 @@ func stopLoggingHandler(pm *pipelinemanager.PipelineManager) func(w http.Respons
 			http.Error(w, errors.Wrap(err, "error decoding json request").Error(), http.StatusBadRequest)
 			return
 		}
-		pm.Logger.Infof(" Got stop request object %#v\n", stopReq)
+		pm.Logger.Infof("Got stop request object %#v\n", stopReq)
 		// Run the stop async, since nothing 'depends' on it,
 		// and we can break people's docker automation if this times out.
 		go func() {

--- a/x-pack/dockerlogbeat/handlers.go
+++ b/x-pack/dockerlogbeat/handlers.go
@@ -39,7 +39,7 @@ func startLoggingHandler(pm *pipelinemanager.PipelineManager) func(w http.Respon
 		}
 
 		pm.Logger.Debugf("Homepath: %v\n", filepath.Dir(os.Args[0]))
-		pm.Logger.Debugf("Got start request object from container %#v\n", startReq.Info.ContainerName)
+		pm.Logger.Infof("Got start request object from container %#v\n", startReq.Info.ContainerName)
 		pm.Logger.Debugf("Got a container with the following labels: %#v\n", startReq.Info.ContainerLabels)
 		pm.Logger.Debugf("Got a container with the following log opts: %#v\n", startReq.Info.Config)
 
@@ -70,7 +70,7 @@ func stopLoggingHandler(pm *pipelinemanager.PipelineManager) func(w http.Respons
 		go func() {
 			err = pm.CloseClientWithFile(stopReq.File)
 			if err != nil {
-				pm.Logger.Infof(" Got stop request error %#v\n", err)
+				pm.Logger.Errorf(" Got stop request error %#v\n", err)
 			}
 		}()
 

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -109,15 +109,10 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 	}
 	//build, wait for output
 	buildResp, err := cli.ImageBuild(ctx, buildContext, buildOpts)
-	defer buildResp.Body.Close()
-	buf, errBufRead := ioutil.ReadAll(buildResp.Body)
-	if errBufRead != nil {
-		return errors.Wrap(err, "error reading from docker output")
-	}
 	if err != nil {
-		fmt.Printf("Docker response: \n %s\n", string(buf))
 		return errors.Wrap(err, "error building final container image")
 	}
+	defer buildResp.Body.Close()
 
 	// move back to the x-pack dir
 	err = os.Chdir(dockerLogBeatDir)

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -113,6 +113,11 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 		return errors.Wrap(err, "error building final container image")
 	}
 	defer buildResp.Body.Close()
+	// This blocks until the build operation completes
+	_, errBufRead := ioutil.ReadAll(buildResp.Body)
+	if errBufRead != nil {
+		return errors.Wrap(err, "error reading from docker output")
+	}
 
 	// move back to the x-pack dir
 	err = os.Chdir(dockerLogBeatDir)

--- a/x-pack/dockerlogbeat/main.go
+++ b/x-pack/dockerlogbeat/main.go
@@ -26,8 +26,12 @@ import (
 
 // genNewMonitoringConfig is a hacked-in function to enable a debug stderr logger
 func genNewMonitoringConfig() (*common.Config, error) {
+	lvl, isSet := os.LookupEnv("LOG_DRIVER_LEVEL")
+	if !isSet {
+		lvl = "info"
+	}
 	cfgObject := make(map[string]string)
-	cfgObject["level"] = "debug"
+	cfgObject["level"] = lvl
 	cfgObject["to_stderr"] = "true"
 
 	cfg, err := common.NewConfigFrom(cfgObject)

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -245,21 +245,21 @@ func loadMeta(metaPath string) (uuid.UUID, error) {
 func openRegular(filename string) (*os.File, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return f, errors.Wrapf(err, "error opening file %s", filename)
+		return f, err
 	}
 
 	info, err := f.Stat()
 	if err != nil {
 		f.Close()
-		return nil, errors.Wrapf(err, "error statting %s", filename)
+		return nil, err
 	}
 
 	if !info.Mode().IsRegular() {
 		f.Close()
 		if info.IsDir() {
-			return nil, fmt.Errorf("%s is a directory", filename)
+			return nil, err
 		}
-		return nil, fmt.Errorf("%s is not a regular file", filename)
+		return nil, err
 	}
 
 	return f, nil

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -43,8 +43,7 @@ type PipelineManager struct {
 // NewPipelineManager creates a new Pipeline map
 func NewPipelineManager(logCfg *common.Config) *PipelineManager {
 	return &PipelineManager{
-		Logger: logp.NewLogger("PipelineManager"),
-		//mu:        new(sync.Mutex),
+		Logger:    logp.NewLogger("PipelineManager"),
 		pipelines: make(map[string]*Pipeline),
 		clients:   make(map[string]*ClientLogger),
 	}


### PR DESCRIPTION
This addresses a bug where we weren't properly checking to see if a `meta.json` file existed, and also a default debug log level. Users can now config the log level with `LOG_DRIVER_LEVEL`