### PR TITLE
[7.6][Heartbeat] Improved redirect support (#14125)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,6 +21,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Removed the `add_host_metadata` and `add_cloud_metadata` processors from the default config. These don't fit well with ECS for Heartbeat and were rarely used.
+- Fixed/altered redirect behavior. `max_redirects` now defaults to 0 (no redirects). Following redirects now works across hosts, but some timing fields will not be reported. {pull}14125[14125]
+- Removed `host.name` field that should never have been included. Heartbeat uses `observer.*` fields instead. {pull}14140[14140]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -490,7 +490,7 @@ func TestRedirect(t *testing.T) {
 			hbtest.SummaryChecks(1, 0),
 			minimalRespondingHTTPChecks(testURL, 200),
 			lookslike.MustCompile(map[string]interface{}{
-				"http.redirects": []string{
+				"http.response.redirects": []string{
 					server.URL + redirectingPaths["/redirect_one"],
 					server.URL + redirectingPaths["/redirect_two"],
 				},

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -222,7 +222,7 @@ func execPing(
 	validator multiValidator,
 	responseConfig responseConfig,
 	redirects *[]string,
-) (start, end time.Time, err reason.Reason) {
+) (start, end time.Time, errReason reason.Reason) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -247,10 +247,10 @@ func execPing(
 	}
 
 	httpFields := common.MapStr{"response": responseFields}
-
 	if redirects != nil && len(*redirects) > 0 {
-		httpFields["redirects"] = redirects
+		responseFields["redirects"] = redirects
 	}
+
 	eventext.MergeEventFields(event, common.MapStr{"http": httpFields})
 
 	// Mark the end time as now, since we've finished downloading


### PR DESCRIPTION
Backport of #14125

This patch better handles redirects in heartbeat. It takes a different tack than what was described in #13146 . This PR is on the whole more pragmatic, accomplishing substantive change with undue complication of the schema and beats codebase.

Changes in this patch:

* Added http.response.redirects field. This is an array of URLs redirected to inclusive of the final destination, exclusive of the original
* Utilize the host codepath, rather than the IP codepath for execution of the check, previously only used for proxies in heartbeat, for redirects. This simplifies the code, hides timing data that can be screwy with redirects (things like fine grained DNS resolution). This means that the following fields no longer appear with redirects enabled in the event: http.rtt.content.us, http.rtt.response_header.us, http.rtt.total.us, http.rtt.validate.us, http.rtt.write_request.us.
* Default max_redirects: 0 instead of 10

The new default does make this a breaking change, however, we either need to break that setting and preserve the timing information for the common use case of someone checking a non-redirecting URL, or keeping it at 10 but losing the timing info. The third option would be to invest additional eng. effort here to track those numbers across reqs, but the benefit seems, minimal given that they are not displayed in the UI, only in dashboards.

(cherry picked from commit 694dac8f342dbde742e1eb1fe42b0edadf6c1409)