### PR TITLE
[Heartbeat] Fix accumulation/location of redirects

### DIFF
--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -479,25 +479,27 @@ func TestRedirect(t *testing.T) {
 	sched, _ := schedule.Parse("@every 1s")
 	job := wrappers.WrapCommon(jobs, "test", "", "http", sched, time.Duration(0))[0]
 
-	event := &beat.Event{}
-	_, err = job(event)
-	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		event := &beat.Event{}
+		_, err = job(event)
+		require.NoError(t, err)
 
-	testslike.Test(
-		t,
-		lookslike.Strict(lookslike.Compose(
-			hbtest.BaseChecks("", "up", "http"),
-			hbtest.SummaryChecks(1, 0),
-			minimalRespondingHTTPChecks(testURL, 200),
-			lookslike.MustCompile(map[string]interface{}{
-				"http.redirects": []string{
-					server.URL + redirectingPaths["/redirect_one"],
-					server.URL + redirectingPaths["/redirect_two"],
-				},
-			}),
-		)),
-		event.Fields,
-	)
+		testslike.Test(
+			t,
+			lookslike.Strict(lookslike.Compose(
+				hbtest.BaseChecks("", "up", "http"),
+				hbtest.SummaryChecks(1, 0),
+				minimalRespondingHTTPChecks(testURL, 200),
+				lookslike.MustCompile(map[string]interface{}{
+					"http.response.redirects": []string{
+						server.URL + redirectingPaths["/redirect_one"],
+						server.URL + redirectingPaths["/redirect_two"],
+					},
+				}),
+			)),
+			event.Fields,
+		)
+	}
 }
 
 func TestNewRoundTripper(t *testing.T) {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -479,6 +479,8 @@ func TestRedirect(t *testing.T) {
 	sched, _ := schedule.Parse("@every 1s")
 	job := wrappers.WrapCommon(jobs, "test", "", "http", sched, time.Duration(0))[0]
 
+	// Run this test multiple times since in the past we had an issue where the redirects
+	// list was added onto by each request. See https://github.com/elastic/beats/pull/15944
 	for i := 0; i < 10; i++ {
 		event := &beat.Event{}
 		_, err = job(event)

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -188,10 +188,6 @@ func createPingFactory(
 	})
 }
 
-func makeIPClient() {
-
-}
-
 func buildRequest(addr string, config *Config, enc contentEncoder) (*http.Request, error) {
 	method := strings.ToUpper(config.Check.Request.Method)
 	request, err := http.NewRequest(method, addr, nil)
@@ -326,9 +322,6 @@ func makeCheckRedirect(max int, redirects *[]string) func(*http.Request, []*http
 	}
 
 	return func(r *http.Request, via []*http.Request) error {
-		if via == nil {
-			redirects = nil
-		}
 		if redirects != nil {
 			*redirects = append(*redirects, r.URL.String())
 		}


### PR DESCRIPTION
**Note, since this fixes a blocker, #15941 I've targeted this PR directly against 7.6. I will forward port this to to 7.x / master once it is merged**

This patch fixes two issues:

1. Fixes: #15941 . Each invoked check using redirects would add to the previous list of redirects, resulting in an eventually gigantic list of redirects.
2. The redirects should be in the `http.response.redirects` field, not
the `http.redirects` field  where they reside today. The docs and
mapping both indicate that `http.response.redirects` is the correct
place already.
redirects from the last check, resulting in huge arrays.

Note that this patch requires us to create a new `http.Client` per request when either proxies are enabled or redirects are enabled (this is internally known as a 'host' job). This should be OK because:

1. We disable keep-alive in the transport which should prevent resource leaks
2. There's no other (good) way to keep context with hooks like `CheckRedirect` which are defined at the client level, and not per request. In an ideal world the go HTTP client would let you override settings per-request, but we cannot do that here.

Before this patch you'd see repeated things in the redirects list like


```
          "redirects" : [
              "http://localhost:3000/World",
              "http://localhost:3000/Pakistan",
              "http://localhost:3000/Berlin",
              "http://localhost:3000/hide",
              "http://localhost:3000/World",
              "http://localhost:3000/Pakistan",
              "http://localhost:3000/Berlin",
              "http://localhost:3000/hide",
              "http://localhost:3000/World",
              "http://localhost:3000/Pakistan",
              "http://localhost:3000/Berlin",
              "http://localhost:3000/hide",
              "http://localhost:3000/World",
              "http://localhost:3000/Pakistan",
              "http://localhost:3000/Berlin",
              "http://localhost:3000/hide"
            ],
```