### PR TITLE
Experiment with afterfunc DO NOT MERGE

### DIFF
--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
-
 	"golang.org/x/sync/semaphore"
 
 	"github.com/elastic/beats/libbeat/common/atomic"
@@ -44,11 +42,6 @@ var debugf = logp.MakeDebug("scheduler")
 
 // ErrInvalidTransition is returned from start/stop when making an invalid state transition, say from preRunning to stopped
 var ErrInvalidTransition = fmt.Errorf("invalid state transition")
-
-type identifiableTimer struct {
-	id uuid.UUID
-	t  time.Timer
-}
 
 // Scheduler represents our async timer based scheduler.
 type Scheduler struct {


### PR DESCRIPTION
This is an experimental PR to see if our custom timer heap is unnecessary and `time.AfterFunc` could be just as efficient and let us delete code. Benchmarks make it seem like that's not the case. I'm going to leave this PR here for posterity however.

Results on master currently
```
➜  scheduler git:(master) ✗ time go test -bench=. -benchtime=60s
goos: linux
goarch: amd64
pkg: github.com/elastic/beats/heartbeat/scheduler
BenchmarkScheduler-12    	35169740	      2090 ns/op
PASS
ok  	github.com/elastic/beats/heartbeat/scheduler	75.622s
716.48user 16.29system 1:16.13elapsed 962%CPU (0avgtext+0avgdata 167736maxresident)k
16inputs+33576outputs (1major+60534minor)pagefaults 0swaps
```

Results on this branch
```
➜  scheduler git:(heartbeat-sched-afterfunc) ✗ time go test -bench=. -benchtime=60s
goos: linux
goarch: amd64
pkg: github.com/elastic/beats/heartbeat/scheduler
BenchmarkScheduler-12    	 5039883	     15191 ns/op
PASS
ok  	github.com/elastic/beats/heartbeat/scheduler	90.995s
925.57user 11.43system 1:31.51elapsed 1023%CPU (0avgtext+0avgdata 173696maxresident)k
440inputs+32872outputs (2major+68764minor)pagefaults 0swaps
```

Using HTOP it also seems that this branch uses more memory 63MiB to 28MiB when running the go benchmarks in the scheduler folder.