### PR TITLE
Adding integration test for kibana Metricbeat module, xpack code path

### DIFF
--- a/metricbeat/module/kibana/kibana_integration_test.go
+++ b/metricbeat/module/kibana/kibana_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/kibana"
+	_ "github.com/elastic/beats/metricbeat/module/kibana/stats"
 )
 
 var xpackMetricSets = []string{

--- a/metricbeat/module/kibana/kibana_integration_test.go
+++ b/metricbeat/module/kibana/kibana_integration_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build integration
+
+package kibana_test
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/tests/compose"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/kibana"
+	"github.com/stretchr/testify/assert"
+)
+
+var xpackMetricSets = []string{
+	"stats",
+}
+
+func TestXPackEnabled(t *testing.T) {
+	service := compose.EnsureUpWithTimeout(t, 300, "kibana")
+
+	metricSetToTypeMap := map[string]string{
+		"stats": "kibana_stats",
+	}
+
+	config := getXPackConfig(service.Host())
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	for _, metricSet := range metricSets {
+		events, errs := mbtest.ReportingFetchV2Error(metricSet)
+		assert.Empty(t, errs)
+		if !assert.NotEmpty(t, events) {
+			t.FailNow()
+		}
+
+		event := events[0]
+		assert.Equal(t, metricSetToTypeMap[metricSet.Name()], event.RootFields["type"])
+		assert.Regexp(t, `^.monitoring-kibana-\d-mb`, event.Index)
+	}
+}
+
+func getXPackConfig(host string) map[string]interface{} {
+	return map[string]interface{}{
+		"module":        kibana.ModuleName,
+		"metricsets":    xpackMetricSets,
+		"hosts":         []string{host},
+		"xpack.enabled": true,
+	}
+}

--- a/metricbeat/module/kibana/kibana_integration_test.go
+++ b/metricbeat/module/kibana/kibana_integration_test.go
@@ -22,10 +22,11 @@ package kibana_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/kibana"
-	"github.com/stretchr/testify/assert"
 )
 
 var xpackMetricSets = []string{

--- a/metricbeat/module/kibana/kibana_integration_test.go
+++ b/metricbeat/module/kibana/kibana_integration_test.go
@@ -22,7 +22,7 @@ package kibana_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -46,14 +46,12 @@ func TestXPackEnabled(t *testing.T) {
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
 	for _, metricSet := range metricSets {
 		events, errs := mbtest.ReportingFetchV2Error(metricSet)
-		assert.Empty(t, errs)
-		if !assert.NotEmpty(t, events) {
-			t.FailNow()
-		}
+		require.Empty(t, errs)
+		require.NotEmpty(t, events)
 
 		event := events[0]
-		assert.Equal(t, metricSetToTypeMap[metricSet.Name()], event.RootFields["type"])
-		assert.Regexp(t, `^.monitoring-kibana-\d-mb`, event.Index)
+		require.Equal(t, metricSetToTypeMap[metricSet.Name()], event.RootFields["type"])
+		require.Regexp(t, `^.monitoring-kibana-\d-mb`, event.Index)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds an integration test for the Metricbeat `kibana` module when `xpack.enabled: true` is set in the module configuration.

## Why is it important?

The code path in the `kibana` module when `xpack.enabled` was set to `true` was previously not being exercised by integration tests. Moreover, it's a critical code path as it powers the Stack Monitoring feature.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Requires #15800, as it introduces some necessary changes to the integration tests framework itself.
