### PR TITLE
Adding integration test for beat Metricbeat module, xpack code path

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -49,11 +49,11 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.3.0}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.5.2}-1
     build:
       context: ./module/beat/_meta
       args:
-        BEAT_VERSION: ${BEAT_VERSION:-7.3.0}
+        BEAT_VERSION: ${BEAT_VERSION:-7.5.2}
     command: '-e'
     ports:
       - 5066

--- a/metricbeat/module/beat/_meta/Dockerfile
+++ b/metricbeat/module/beat/_meta/Dockerfile
@@ -4,4 +4,4 @@ FROM docker.elastic.co/beats/metricbeat:${BEAT_VERSION}
 COPY healthcheck.sh /
 HEALTHCHECK --interval=1s --retries=300 CMD sh /healthcheck.sh
 
-ENTRYPOINT [ "metricbeat", "-E", "http.enabled=true", "-E", "http.host=0.0.0.0" ]
+ENTRYPOINT [ "metricbeat", "-E", "http.enabled=true", "-E", "http.host=0.0.0.0", "-E", "monitoring.cluster_uuid=foobar" ]

--- a/metricbeat/module/beat/beat_integration_test.go
+++ b/metricbeat/module/beat/beat_integration_test.go
@@ -69,15 +69,13 @@ func TestXPackEnabled(t *testing.T) {
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
 	for _, metricSet := range metricSets {
 		events, errs := mbtest.ReportingFetchV2Error(metricSet)
-		assert.Empty(t, errs)
-		if !assert.NotEmpty(t, events) {
-			t.FailNow()
-		}
+		require.Empty(t, errs)
+		require.NotEmpty(t, events)
 
 		event := events[0]
-		assert.Equal(t, "beats_"+metricSet.Name(), event.RootFields["type"])
-		assert.Equal(t, event.RootFields["cluster_uuid"], "foobar")
-		assert.Regexp(t, `^.monitoring-beats-\d-mb`, event.Index)
+		require.Equal(t, "beats_"+metricSet.Name(), event.RootFields["type"])
+		require.Equal(t, event.RootFields["cluster_uuid"], "foobar")
+		require.Regexp(t, `^.monitoring-beats-\d-mb`, event.Index)
 	}
 }
 

--- a/metricbeat/module/beat/beat_integration_test.go
+++ b/metricbeat/module/beat/beat_integration_test.go
@@ -60,3 +60,31 @@ func TestData(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestXPackEnabled(t *testing.T) {
+	service := compose.EnsureUpWithTimeout(t, 300, "metricbeat")
+
+	config := getXPackConfig(service.Host())
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	for _, metricSet := range metricSets {
+		events, errs := mbtest.ReportingFetchV2Error(metricSet)
+		assert.Empty(t, errs)
+		if !assert.NotEmpty(t, events) {
+			t.FailNow()
+		}
+
+		event := events[0]
+		assert.Equal(t, "beat_"+metricSet.Name(), event.RootFields["type"])
+		assert.Regexp(t, `^.monitoring-beat-\d-mb`, event.Index)
+	}
+}
+
+func getXPackConfig(host string) map[string]interface{} {
+	return map[string]interface{}{
+		"module":        beat.ModuleName,
+		"metricsets":    metricSets,
+		"hosts":         []string{host},
+		"xpack.enabled": true,
+	}
+}

--- a/metricbeat/module/beat/beat_integration_test.go
+++ b/metricbeat/module/beat/beat_integration_test.go
@@ -75,8 +75,9 @@ func TestXPackEnabled(t *testing.T) {
 		}
 
 		event := events[0]
-		assert.Equal(t, "beat_"+metricSet.Name(), event.RootFields["type"])
-		assert.Regexp(t, `^.monitoring-beat-\d-mb`, event.Index)
+		assert.Equal(t, "beats_"+metricSet.Name(), event.RootFields["type"])
+		assert.Equal(t, event.RootFields["cluster_uuid"], "foobar")
+		assert.Regexp(t, `^.monitoring-beats-\d-mb`, event.Index)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR:
- adds an integration test for the Metricbeat `beat` module when `xpack.enabled: true` is set in the module configuration, and
- updates the test beat's version to the latest released one.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The code path in the `beat` module when `xpack.enabled` was set to `true` was previously not being exercised by integration tests. Moreover, it's a critical code path as it powers the Stack Monitoring feature.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Requires #15800, as it introduces some necessary changes to the integration tests framework itself.
