### PR TITLE
Adding integration test for elasticsearch Metricbeat module, xpack code path

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -201,7 +201,6 @@ func TestXPackEnabled(t *testing.T) {
 			}
 
 			for i, event := range events {
-				fmt.Println(metricSet.Name())
 				assert.Equal(t, types[i], event.RootFields["type"])
 				assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
 			}

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/tests/compose"
@@ -150,26 +151,19 @@ func TestXPackEnabled(t *testing.T) {
 		t.Run(metricSet.Name(), func(t *testing.T) {
 			checkSkip(t, metricSet.Name(), version)
 			events, errs := mbtest.ReportingFetchV2Error(metricSet)
-			assert.Empty(t, errs)
-			if !assert.NotEmpty(t, events) {
-				t.FailNow()
-			}
+			require.Empty(t, errs)
+			require.NotEmpty(t, events)
 
 			// Special case: the `index` metricset generates as many events
 			// as there are distinct indices in Elasticsearch
 			if metricSet.Name() == "index" {
 				numIndices, err := countIndices(host)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				if !assert.Len(t, events, numIndices) {
-					t.FailNow()
-				}
+				require.NoError(t, err)
+				require.Len(t, events, numIndices)
 
 				for _, event := range events {
-					assert.Equal(t, "index_stats", event.RootFields["type"])
-					assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+					require.Equal(t, "index_stats", event.RootFields["type"])
+					require.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
 				}
 
 				return
@@ -179,30 +173,23 @@ func TestXPackEnabled(t *testing.T) {
 			// as there are distinct shards in Elasticsearch
 			if metricSet.Name() == "shard" {
 				numShards, err := countShards(host)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				if !assert.Len(t, events, numShards) {
-					t.FailNow()
-				}
+				require.NoError(t, err)
+				require.Len(t, events, numShards)
 
 				for _, event := range events {
-					assert.Equal(t, "shards", event.RootFields["type"])
-					assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+					require.Equal(t, "shards", event.RootFields["type"])
+					require.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
 				}
 
 				return
 			}
 
 			types := metricSetToTypesMap[metricSet.Name()]
-			if !assert.Len(t, events, len(types)) {
-				t.FailNow()
-			}
+			require.Len(t, events, len(types))
 
 			for i, event := range events {
-				assert.Equal(t, types[i], event.RootFields["type"])
-				assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+				require.Equal(t, types[i], event.RootFields["type"])
+				require.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
 			}
 		})
 	}
@@ -229,19 +216,19 @@ func getXPackConfig(host string) map[string]interface{} {
 
 func setupTest(t *testing.T, esHost string, esVersion *common.Version) {
 	err := createIndex(esHost)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = enableTrialLicense(esHost, esVersion)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = createMLJob(esHost, esVersion)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = createCCRStats(esHost)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = createEnrichStats(esHost)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // createIndex creates and elasticsearch index in case it does not exit yet

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -103,7 +103,6 @@ func TestFetch(t *testing.T) {
 
 func TestData(t *testing.T) {
 	service := compose.EnsureUpWithTimeout(t, 300, "elasticsearch")
-
 	host := service.Host()
 
 	version, err := getElasticsearchVersion(host)
@@ -123,6 +122,93 @@ func TestData(t *testing.T) {
 	}
 }
 
+func TestXPackEnabled(t *testing.T) {
+	service := compose.EnsureUpWithTimeout(t, 300, "elasticsearch")
+	host := service.Host()
+
+	version, err := getElasticsearchVersion(host)
+	if err != nil {
+		t.Fatal("getting elasticsearch version", err)
+	}
+
+	setupTest(t, host, version)
+
+	metricSetToTypesMap := map[string][]string{
+		"ccr":            []string{"ccr_stats", "ccr_auto_follow_stats"},
+		"cluster_stats":  []string{"cluster_stats"},
+		"enrich":         []string{"enrich_coordinator_stats"},
+		"index_recovery": []string{"index_recovery"},
+		"index_summary":  []string{"indices_stats"},
+		"ml_job":         []string{"job_stats"},
+		"node_stats":     []string{"node_stats"},
+	}
+
+	config := getXPackConfig(host)
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	for _, metricSet := range metricSets {
+		t.Run(metricSet.Name(), func(t *testing.T) {
+			checkSkip(t, metricSet.Name(), version)
+			events, errs := mbtest.ReportingFetchV2Error(metricSet)
+			assert.Empty(t, errs)
+			if !assert.NotEmpty(t, events) {
+				t.FailNow()
+			}
+
+			// Special case: the `index` metricset generates as many events
+			// as there are distinct indices in Elasticsearch
+			if metricSet.Name() == "index" {
+				numIndices, err := countIndices(host)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+
+				if !assert.Len(t, events, numIndices) {
+					t.FailNow()
+				}
+
+				for _, event := range events {
+					assert.Equal(t, "index_stats", event.RootFields["type"])
+					assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+				}
+
+				return
+			}
+
+			// Special case: the `shard` metricset generates as many events
+			// as there are distinct shards in Elasticsearch
+			if metricSet.Name() == "shard" {
+				numShards, err := countShards(host)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+
+				if !assert.Len(t, events, numShards) {
+					t.FailNow()
+				}
+
+				for _, event := range events {
+					assert.Equal(t, "shards", event.RootFields["type"])
+					assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+				}
+
+				return
+			}
+
+			types := metricSetToTypesMap[metricSet.Name()]
+			if !assert.Len(t, events, len(types)) {
+				t.FailNow()
+			}
+
+			for i, event := range events {
+				fmt.Println(metricSet.Name())
+				assert.Equal(t, types[i], event.RootFields["type"])
+				assert.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)
+			}
+		})
+	}
+}
+
 // GetConfig returns config for elasticsearch module
 func getConfig(metricset string, host string) map[string]interface{} {
 	return map[string]interface{}{
@@ -130,6 +216,15 @@ func getConfig(metricset string, host string) map[string]interface{} {
 		"metricsets":                 []string{metricset},
 		"hosts":                      []string{host},
 		"index_recovery.active_only": false,
+	}
+}
+
+func getXPackConfig(host string) map[string]interface{} {
+	return map[string]interface{}{
+		"module":        elasticsearch.ModuleName,
+		"metricsets":    xpackMetricSets,
+		"hosts":         []string{host},
+		"xpack.enabled": true,
 	}
 }
 
@@ -465,6 +560,36 @@ func ingestAndEnrichDoc(host string) error {
 	docURL := "/my_index/_doc/my_id?pipeline=user_lookup"
 	_, _, err = httpPutJSON(host, docURL, targetDoc)
 	return err
+}
+
+func countIndices(elasticsearchHostPort string) (int, error) {
+	return countCatItems(elasticsearchHostPort, "indices")
+
+}
+
+func countShards(elasticsearchHostPort string) (int, error) {
+	return countCatItems(elasticsearchHostPort, "shards")
+}
+
+func countCatItems(elasticsearchHostPort, catObject string) (int, error) {
+	resp, err := http.Get("http://" + elasticsearchHostPort + "/_cat/" + catObject + "?format=json")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var data []common.MapStr
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
 }
 
 func checkSkip(t *testing.T, metricset string, version *common.Version) {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -86,8 +86,8 @@ func TestFetch(t *testing.T) {
 	setupTest(t, host, version)
 
 	for _, metricSet := range metricSets {
-		checkSkip(t, metricSet, version)
 		t.Run(metricSet, func(t *testing.T) {
+			checkSkip(t, metricSet, version)
 			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet, host))
 			events, errs := mbtest.ReportingFetchV2Error(f)
 
@@ -112,8 +112,8 @@ func TestData(t *testing.T) {
 	}
 
 	for _, metricSet := range metricSets {
-		checkSkip(t, metricSet, version)
 		t.Run(metricSet, func(t *testing.T) {
+			checkSkip(t, metricSet, version)
 			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet, host))
 			err := mbtest.WriteEventsReporterV2Error(f, t, metricSet)
 			if err != nil {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -128,9 +128,7 @@ func TestXPackEnabled(t *testing.T) {
 	host := service.Host()
 
 	version, err := getElasticsearchVersion(host)
-	if err != nil {
-		t.Fatal("getting elasticsearch version", err)
-	}
+	require.NoError(err)
 
 	setupTest(t, host, version)
 

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -128,7 +128,7 @@ func TestXPackEnabled(t *testing.T) {
 	host := service.Host()
 
 	version, err := getElasticsearchVersion(host)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	setupTest(t, host, version)
 

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -76,27 +76,14 @@ var xpackMetricSets = []string{
 
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUpWithTimeout(t, 300, "elasticsearch")
-
 	host := service.Host()
-	err := createIndex(host)
-	assert.NoError(t, err)
 
 	version, err := getElasticsearchVersion(host)
 	if err != nil {
 		t.Fatal("getting elasticsearch version", err)
 	}
 
-	err = enableTrialLicense(host, version)
-	assert.NoError(t, err)
-
-	err = createMLJob(host, version)
-	assert.NoError(t, err)
-
-	err = createCCRStats(host)
-	assert.NoError(t, err)
-
-	err = createEnrichStats(host)
-	assert.NoError(t, err)
+	setupTest(t, host, version)
 
 	for _, metricSet := range metricSets {
 		checkSkip(t, metricSet, version)
@@ -144,6 +131,23 @@ func getConfig(metricset string, host string) map[string]interface{} {
 		"hosts":                      []string{host},
 		"index_recovery.active_only": false,
 	}
+}
+
+func setupTest(t *testing.T, esHost string, esVersion *common.Version) {
+	err := createIndex(esHost)
+	assert.NoError(t, err)
+
+	err = enableTrialLicense(esHost, esVersion)
+	assert.NoError(t, err)
+
+	err = createMLJob(esHost, esVersion)
+	assert.NoError(t, err)
+
+	err = createCCRStats(esHost)
+	assert.NoError(t, err)
+
+	err = createEnrichStats(esHost)
+	assert.NoError(t, err)
 }
 
 // createIndex creates and elasticsearch index in case it does not exit yet

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -62,6 +62,18 @@ var metricSets = []string{
 	"shard",
 }
 
+var xpackMetricSets = []string{
+	"ccr",
+	"enrich",
+	"cluster_stats",
+	"index",
+	"index_recovery",
+	"index_summary",
+	"ml_job",
+	"node_stats",
+	"shard",
+}
+
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUpWithTimeout(t, 300, "elasticsearch")
 


### PR DESCRIPTION
## What does this PR do?

This PR:
- adds an integration test for the Metricbeat `elasticsearch` module when `xpack.enabled: true` is set in the module configuration, and
- does some minor cleanup and refactoring in the Metricbeat `elasticsearch` integration test code.

## Why is it important?

The code path in the `elasticsearch` module when `xpack.enabled` was set to `true` was previously not being exercised by integration tests. Moreover, it's a critical code path as it powers the Stack Monitoring feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Requires #15800, as it introduces some necessary changes to the integration tests framework itself.
