### PR TITLE
write and load finished field from the data.json

### DIFF
--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -31,7 +31,7 @@ import (
 // State is used to communicate the reading state of a file
 type State struct {
 	Id          string            `json:"-"` // local unique id to make comparison more efficient
-	Finished    bool              `json:"-"` // harvester state
+	Finished    bool              `json:"finished"` // harvester state
 	Fileinfo    os.FileInfo       `json:"-"` // the file info
 	Source      string            `json:"source"`
 	Offset      int64             `json:"offset"`


### PR DESCRIPTION
- Bug #11834

## What does this PR do?
adds the json tag so that when registry is being written down, finished field will also be written and loaded from the disk
## Related issues
Closes elastic/beats#11834
