### PR TITLE
Cherry-pick #14957 to 7.6: [Metricbeat] Don't query unused Uids in socket_summary metricset

### DIFF
--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -79,7 +79,13 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages(devtools.WithModulesD())
+	return devtools.TestPackages(
+		devtools.WithModulesD(),
+		devtools.WithModules(),
+
+		// To be increased or removed when more light modules are added
+		devtools.MinModules(1),
+	)
 }
 
 // Dashboards collects all the dashboards and generates index patterns.

--- a/metricbeat/scripts/mage/package.go
+++ b/metricbeat/scripts/mage/package.go
@@ -18,6 +18,7 @@
 package mage
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -31,6 +32,7 @@ import (
 )
 
 const (
+	dirModulesGenerated  = "build/package/module"
 	dirModulesDGenerated = "build/package/modules.d"
 )
 
@@ -39,6 +41,8 @@ const (
 // not supported. You must declare a dependency on either
 // PrepareModulePackagingOSS or PrepareModulePackagingXPack.
 func CustomizePackaging() {
+	mg.Deps(customizeLightModulesPackaging)
+
 	var (
 		modulesDTarget = "modules.d"
 		modulesD       = devtools.PackageFile{
@@ -101,6 +105,10 @@ func CustomizePackaging() {
 // PrepareModulePackagingOSS generates build/package/modules and
 // build/package/modules.d directories for use in packaging.
 func PrepareModulePackagingOSS() error {
+	err := prepareLightModulesPackaging("module")
+	if err != nil {
+		return err
+	}
 	return prepareModulePackaging([]struct{ Src, Dst string }{
 		{devtools.OSSBeatDir("modules.d"), dirModulesDGenerated},
 	}...)
@@ -109,6 +117,10 @@ func PrepareModulePackagingOSS() error {
 // PrepareModulePackagingXPack generates build/package/modules and
 // build/package/modules.d directories for use in packaging.
 func PrepareModulePackagingXPack() error {
+	err := prepareLightModulesPackaging("module", devtools.OSSBeatDir("module"))
+	if err != nil {
+		return err
+	}
 	return prepareModulePackaging([]struct{ Src, Dst string }{
 		{devtools.OSSBeatDir("modules.d"), dirModulesDGenerated},
 		{"modules.d", dirModulesDGenerated},
@@ -184,6 +196,80 @@ func GenerateDirModulesD() error {
 
 		err := copyWithHeader(header, f, path, os.FileMode(mode))
 		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// customizeLightModulesPackaging customizes packaging to add light modules
+func customizeLightModulesPackaging() error {
+	var (
+		moduleTarget = "module"
+		module       = devtools.PackageFile{
+			Mode:   0644,
+			Source: dirModulesGenerated,
+		}
+	)
+
+	for _, args := range devtools.Packages {
+		pkgType := args.Types[0]
+		switch pkgType {
+		case devtools.TarGz, devtools.Zip, devtools.Docker:
+			args.Spec.Files[moduleTarget] = module
+		case devtools.Deb, devtools.RPM:
+			args.Spec.Files["/usr/share/{{.BeatName}}/"+moduleTarget] = module
+		case devtools.DMG:
+			args.Spec.Files["/Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/"+moduleTarget] = module
+		default:
+			return fmt.Errorf("unhandled package type: %v", pkgType)
+		}
+	}
+	return nil
+}
+
+// prepareLightModulesPackaging generates light modules
+func prepareLightModulesPackaging(paths ...string) error {
+	err := devtools.Clean([]string{dirModulesGenerated})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dirModulesGenerated, 0755); err != nil {
+		return err
+	}
+
+	filePatterns := []string{
+		"*/module.yml",
+		"*/*/manifest.yml",
+	}
+
+	var tasks []devtools.CopyTask
+	for _, path := range paths {
+		for _, pattern := range filePatterns {
+			matches, err := filepath.Glob(filepath.Join(path, pattern))
+			if err != nil {
+				return err
+			}
+
+			for _, file := range matches {
+				rel, _ := filepath.Rel(path, file)
+				dest := filepath.Join(dirModulesGenerated, rel)
+				tasks = append(tasks, devtools.CopyTask{
+					Source:  file,
+					Dest:    dest,
+					Mode:    0644,
+					DirMode: 0755,
+				})
+			}
+		}
+	}
+
+	if len(tasks) == 0 {
+		return fmt.Errorf("no light modules found")
+	}
+
+	for _, task := range tasks {
+		if err := task.Execute(); err != nil {
 			return err
 		}
 	}

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -9,8 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/magefile/mage/mg"
@@ -22,10 +20,6 @@ import (
 	"github.com/elastic/beats/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/compose"
-)
-
-const (
-	dirModulesGenerated = "build/package/module"
 )
 
 func init() {
@@ -78,7 +72,6 @@ func Package() {
 	devtools.UseElasticBeatXPackPackaging()
 	metricbeat.CustomizePackaging()
 	devtools.PackageKibanaDashboardsFromBuildDir()
-	packageLightModules()
 
 	mg.Deps(Update, metricbeat.PrepareModulePackagingXPack)
 	mg.Deps(CrossBuild, CrossBuildGoDaemon)
@@ -92,7 +85,8 @@ func TestPackages() error {
 		devtools.WithModules(),
 
 		// To be increased or removed when more light modules are added
-		devtools.MinModules(3))
+		devtools.MinModules(5),
+	)
 }
 
 // Fields generates a fields.yml and fields.go for each module.
@@ -146,78 +140,6 @@ func GoUnitTest(ctx context.Context) error {
 func PythonUnitTest() error {
 	mg.Deps(devtools.BuildSystemTestBinary)
 	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
-}
-
-// prepareLightModules generates light modules
-func prepareLightModules(path string) error {
-	err := devtools.Clean([]string{dirModulesGenerated})
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(dirModulesGenerated, 0755); err != nil {
-		return err
-	}
-
-	filePatterns := []string{
-		"*/module.yml",
-		"*/*/manifest.yml",
-	}
-
-	var files []string
-	for _, pattern := range filePatterns {
-		matches, err := filepath.Glob(filepath.Join(path, pattern))
-		if err != nil {
-			return err
-		}
-		files = append(files, matches...)
-	}
-
-	if len(files) == 0 {
-		return fmt.Errorf("no light modules found")
-	}
-
-	for _, file := range files {
-		rel, _ := filepath.Rel(path, file)
-		dest := filepath.Join(dirModulesGenerated, rel)
-		err := (&devtools.CopyTask{
-			Source:  file,
-			Dest:    dest,
-			Mode:    0644,
-			DirMode: 0755,
-		}).Execute()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// packageLightModules customizes packaging to add light modules
-func packageLightModules() error {
-	prepareLightModules("module")
-
-	var (
-		moduleTarget = "module"
-		module       = devtools.PackageFile{
-			Mode:   0644,
-			Source: dirModulesGenerated,
-		}
-	)
-
-	for _, args := range devtools.Packages {
-		pkgType := args.Types[0]
-		switch pkgType {
-		case devtools.TarGz, devtools.Zip, devtools.Docker:
-			args.Spec.Files[moduleTarget] = module
-		case devtools.Deb, devtools.RPM:
-			args.Spec.Files["/usr/share/{{.BeatName}}/"+moduleTarget] = module
-		case devtools.DMG:
-			args.Spec.Files["/Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/"+moduleTarget] = module
-		default:
-			return fmt.Errorf("unhandled package type: %v", pkgType)
-		}
-	}
-	return nil
 }
 
 // IntegTest executes integration tests (it uses Docker to run the tests).


### PR DESCRIPTION
Cherry-pick of PR #14957 to 7.6 branch. Original message: 

Closes elastic/beats#14649

Update gopsutil to tags/v2.19.11 and use `WithoutUids` function to avoid querying UIDs that we don't use in `calculateConnStats`.

### Performance
For call graph performance see the gopsutil discussion [here](https://github.com/shirou/gopsutil/pull/782#issue-331711001).

On an smp with 500 endpoints the performance went from measurable to noise with this change:

| field | beats off mean | beats on mean | delta (diff) | beats off P99 |  beats on P99 | delta(diff) |
|-------|---------------:|--------------:|-------------:|--------------:|--------------:|------------:|
|total cpu usage:sys |           0.91|           1.24|+36.03%(0.33)|           6.02|           6.65|+10.48%(0.63)|
|total cpu usage:usr |           8.11|           8.19|+1.02%(0.08)|          94.68|          93.30|-1.46%(-1.38)|

Additional testing was done on 50,000 endpoint systems.

Before change:
![oldhtop](https://user-images.githubusercontent.com/15200179/70251303-3d80e700-174d-11ea-9740-99720c75ff7b.png)

After change:
![newhtop](https://user-images.githubusercontent.com/15200179/70251313-4376c800-174d-11ea-95f4-ca3d7d41c0fa.png)
