### PR TITLE
Cherry-pick #15930 to 7.x: Kubernetes: node autodiscover, add InternalIP

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -188,12 +188,17 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 		},
 	}
 	n.publish(event)
-
 }
 
 func getAddress(node *kubernetes.Node) string {
 	for _, address := range node.Status.Addresses {
 		if address.Type == v1.NodeExternalIP && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeInternalIP && address.Address != "" {
 			return address.Address
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #15930 to 7.x branch. Original message: 

complementary to https://github.com/elastic/beats/pull/14738#issuecomment-578205897

Autodiscover for nodes should use not only the external IP but also the internal one.
