### PR TITLE
Cherry-pick #15923 to 7.x: [Metricbeat] Support processors defined for light modules

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -198,6 +198,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `key/value` mode for SQL module. {issue}15770[15770] {pull]15845[15845]
 - Add support for Unix socket in Memcached metricbeat module. {issue}13685[13685] {pull}15822[15822]
 - Make the `system/cpu` metricset collect normalized CPU metrics by default. {issue}15618[15618] {pull}15729[15729]
+- Add support for processors in light modules. {issue}14740[14740] {pull}15923[15923]
 
 *Packetbeat*
 

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -20,18 +20,16 @@ package beater
 import (
 	"sync"
 
-	"github.com/elastic/beats/libbeat/common/reload"
-	"github.com/elastic/beats/libbeat/management"
-	"github.com/elastic/beats/libbeat/paths"
-
-	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/management"
+	"github.com/elastic/beats/libbeat/paths"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/module"
 
@@ -44,18 +42,13 @@ import (
 
 // Metricbeat implements the Beater interface for metricbeat.
 type Metricbeat struct {
-	done         chan struct{}  // Channel used to initiate shutdown.
-	modules      []staticModule // Active list of modules.
+	done         chan struct{}   // Channel used to initiate shutdown.
+	runners      []module.Runner // Active list of module runners.
 	config       Config
 	autodiscover *autodiscover.Autodiscover
 
 	// Options
 	moduleOptions []module.Option
-}
-
-type staticModule struct {
-	connector *module.Connector
-	module    *module.Wrapper
 }
 
 // Option specifies some optional arguments used for configuring the behavior
@@ -162,46 +155,28 @@ func newMetricbeat(b *beat.Beat, c *common.Config, options ...Option) (*Metricbe
 	moduleOptions := append(
 		[]module.Option{module.WithMaxStartDelay(config.MaxStartDelay)},
 		metricbeat.moduleOptions...)
-	var errs multierror.Errors
+
+	factory := module.NewFactory(b.Info, moduleOptions...)
+
 	for _, moduleCfg := range config.Modules {
 		if !moduleCfg.Enabled() {
 			continue
 		}
 
-		failed := false
-
-		connector, err := module.NewConnector(b.Info, b.Publisher, moduleCfg, nil)
+		runner, err := factory.Create(b.Publisher, moduleCfg, nil)
 		if err != nil {
-			errs = append(errs, err)
-			failed = true
+			return nil, err
 		}
 
-		module, err := module.NewWrapper(moduleCfg, mb.Registry, moduleOptions...)
-		if err != nil {
-			errs = append(errs, err)
-			failed = true
-		}
-
-		if failed {
-			continue
-		}
-
-		metricbeat.modules = append(metricbeat.modules, staticModule{
-			connector: connector,
-			module:    module,
-		})
+		metricbeat.runners = append(metricbeat.runners, runner)
 	}
 
-	if err := errs.Err(); err != nil {
-		return nil, err
-	}
-	if len(metricbeat.modules) == 0 && !dynamicCfgEnabled {
+	if len(metricbeat.runners) == 0 && !dynamicCfgEnabled {
 		return nil, mb.ErrAllModulesDisabled
 	}
 
 	if config.Autodiscover != nil {
 		var err error
-		factory := module.NewFactory(b.Info, metricbeat.moduleOptions...)
 		adapter := autodiscover.NewFactoryAdapter(factory)
 		metricbeat.autodiscover, err = autodiscover.NewAutodiscover("metricbeat", b.Publisher, adapter, config.Autodiscover)
 		if err != nil {
@@ -220,20 +195,16 @@ func newMetricbeat(b *beat.Beat, c *common.Config, options ...Option) (*Metricbe
 func (bt *Metricbeat) Run(b *beat.Beat) error {
 	var wg sync.WaitGroup
 
-	// Static modules (metricbeat.modules)
-	for _, m := range bt.modules {
-		client, err := m.connector.Connect()
-		if err != nil {
-			return err
-		}
-
-		r := module.NewRunner(client, m.module)
+	// Static modules (metricbeat.runners)
+	for _, r := range bt.runners {
 		r.Start()
 		wg.Add(1)
+
+		thatRunner := r
 		go func() {
 			defer wg.Done()
 			<-bt.done
-			r.Stop()
+			thatRunner.Stop()
 		}()
 	}
 
@@ -289,38 +260,7 @@ func (bt *Metricbeat) Stop() {
 	close(bt.done)
 }
 
-// Modules return a list of all configured modules, including anyone present
-// under dynamic config settings.
+// Modules return a list of all configured modules.
 func (bt *Metricbeat) Modules() ([]*module.Wrapper, error) {
-	var modules []*module.Wrapper
-	for _, m := range bt.modules {
-		modules = append(modules, m.module)
-	}
-
-	// Add dynamic modules
-	if bt.config.ConfigModules.Enabled() {
-		config := cfgfile.DefaultDynamicConfig
-		bt.config.ConfigModules.Unpack(&config)
-
-		modulesManager, err := cfgfile.NewGlobManager(config.Path, ".yml", ".disabled")
-		if err != nil {
-			return nil, errors.Wrap(err, "initialization error")
-		}
-
-		for _, file := range modulesManager.ListEnabled() {
-			confs, err := cfgfile.LoadList(file.Path)
-			if err != nil {
-				return nil, errors.Wrap(err, "error loading config files")
-			}
-			for _, conf := range confs {
-				m, err := module.NewWrapper(conf, mb.Registry, bt.moduleOptions...)
-				if err != nil {
-					return nil, errors.Wrap(err, "module initialization error")
-				}
-				modules = append(modules, m)
-			}
-		}
-	}
-
-	return modules, nil
+	return module.ConfiguredModules(bt.config.Modules, bt.config.ConfigModules, bt.moduleOptions)
 }

--- a/metricbeat/docs/modules/activemq.asciidoc
+++ b/metricbeat/docs/modules/activemq.asciidoc
@@ -35,36 +35,6 @@ metricbeat.modules:
   path: '/api/jolokia/?ignoreErrors=true&canonicalNaming=false'
   username: admin # default username
   password: admin # default password
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var broker_memory_broker_pct = event.Get("activemq.broker.memory.broker.pct")
-            if (broker_memory_broker_pct != null) {
-              event.Put("activemq.broker.memory.broker.pct", broker_memory_broker_pct / 100.0)
-            }
-
-            var broker_memory_temp_pct = event.Get("activemq.broker.memory.temp.pct")
-            if (broker_memory_temp_pct != null) {
-              event.Put("activemq.broker.memory.temp.pct", broker_memory_temp_pct / 100.0)
-            }
-
-            var broker_memory_store_pct = event.Get("activemq.broker.memory.store.pct")
-            if (broker_memory_store_pct != null) {
-              event.Put("activemq.broker.memory.store.pct", broker_memory_store_pct / 100.0)
-            }
-
-            var queue_memory_broker_pct = event.Get("activemq.queue.memory.broker.pct")
-            if (queue_memory_broker_pct != null) {
-              event.Put("activemq.queue.memory.broker.pct", queue_memory_broker_pct / 100.0)
-            }
-
-            var topic_memory_broker_pct = event.Get("activemq.topic.memory.broker.pct")
-            if (topic_memory_broker_pct != null) {
-              event.Put("activemq.topic.memory.broker.pct", topic_memory_broker_pct / 100.0)
-            }
-          }
 ----
 
 [float]

--- a/metricbeat/docs/modules/ibmmq.asciidoc
+++ b/metricbeat/docs/modules/ibmmq.asciidoc
@@ -55,26 +55,6 @@ metricbeat.modules:
   # This module uses the Prometheus collector metricset, all
   # the options for this metricset are also available here.
   metrics_path: /metrics
-
-  # The custom processor is responsible for filtering Prometheus metrics
-  # not stricly related to the IBM MQ domain, e.g. system load, process,
-  # metrics HTTP server.
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var metrics = event.Get("prometheus.metrics");
-            Object.keys(metrics).forEach(function(key) {
-              if (!(key.match(/^ibmmq_.*$/))) {
-                event.Delete("prometheus.metrics." + key);
-              }
-            });
-            metrics = event.Get("prometheus.metrics");
-            if (Object.keys(metrics).length == 0) {
-              event.Cancel();
-            }
-          }
 ----
 
 It also supports the options described in <<module-http-config-options>>.

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
 )
 
 // LightMetricSet contains the definition of a non-registered metric set
@@ -33,6 +34,7 @@ type LightMetricSet struct {
 		MetricSet string      `config:"metricset" validate:"required"`
 		Defaults  interface{} `config:"defaults"`
 	} `config:"input" validate:"required"`
+	Processors processors.PluginConfig `config:"processors"`
 }
 
 // Registration obtains a metric set registration for this light metric set, this registration

--- a/metricbeat/mb/lightmodules.go
+++ b/metricbeat/mb/lightmodules.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
 )
 
 const (
@@ -148,6 +149,19 @@ func (s *LightModulesSource) ModulesInfo(r *Register) string {
 type lightModuleConfig struct {
 	Name       string   `config:"name"`
 	MetricSets []string `config:"metricsets"`
+}
+
+// ProcessorsForMetricSet returns processors defined for the light metricset.
+func (s *LightModulesSource) ProcessorsForMetricSet(r *Register, moduleName string, metricSetName string) (*processors.Processors, error) {
+	module, err := s.loadModule(r, moduleName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading processors for metricset '%s' in module '%s' failed", metricSetName, moduleName)
+	}
+	metricSet, ok := module.MetricSets[metricSetName]
+	if !ok {
+		return nil, fmt.Errorf("unknown metricset '%s' in module '%s'", metricSetName, moduleName)
+	}
+	return processors.New(metricSet.Processors)
 }
 
 // LightModule contains the definition of a light module

--- a/metricbeat/mb/lightmodules_test.go
+++ b/metricbeat/mb/lightmodules_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	_ "github.com/elastic/beats/libbeat/processors/add_id"
 )
 
 // TestLightModulesAsModuleSource checks that registry correctly lists
@@ -300,6 +301,31 @@ func TestNewModulesCallModuleFactory(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, called, "module factory must be called if registered")
+}
+
+func TestProcessorsForMetricSet_UnknownModule(t *testing.T) {
+	r := NewRegister()
+	source := NewLightModulesSource("testdata/lightmodules")
+	procs, err := source.ProcessorsForMetricSet(r, "nonexisting", "fake")
+	require.Error(t, err)
+	require.Nil(t, procs)
+}
+
+func TestProcessorsForMetricSet_UnknownMetricSet(t *testing.T) {
+	r := NewRegister()
+	source := NewLightModulesSource("testdata/lightmodules")
+	procs, err := source.ProcessorsForMetricSet(r, "unpack", "nonexisting")
+	require.Error(t, err)
+	require.Nil(t, procs)
+}
+
+func TestProcessorsForMetricSet_ProcessorsRead(t *testing.T) {
+	r := NewRegister()
+	source := NewLightModulesSource("testdata/lightmodules")
+	procs, err := source.ProcessorsForMetricSet(r, "unpack", "withprocessors")
+	require.NoError(t, err)
+	require.NotNil(t, procs)
+	require.Len(t, procs.List, 1)
 }
 
 type metricSetWithOption struct {

--- a/metricbeat/mb/module/configuration.go
+++ b/metricbeat/mb/module/configuration.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package module
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+// ConfiguredModules returns a list of all configured modules, including anyone present under dynamic config settings.
+func ConfiguredModules(modulesData []*common.Config, configModulesData *common.Config, moduleOptions []Option) ([]*Wrapper, error) {
+	var modules []*Wrapper
+
+	for _, moduleCfg := range modulesData {
+		module, err := NewWrapper(moduleCfg, mb.Registry, nil)
+		if err != nil {
+			return nil, err
+		}
+		modules = append(modules, module)
+	}
+
+	// Add dynamic modules
+	if configModulesData.Enabled() {
+		config := cfgfile.DefaultDynamicConfig
+		configModulesData.Unpack(&config)
+
+		modulesManager, err := cfgfile.NewGlobManager(config.Path, ".yml", ".disabled")
+		if err != nil {
+			return nil, errors.Wrap(err, "initialization error")
+		}
+
+		for _, file := range modulesManager.ListEnabled() {
+			confs, err := cfgfile.LoadList(file.Path)
+			if err != nil {
+				return nil, errors.Wrap(err, "error loading config files")
+			}
+			for _, conf := range confs {
+				m, err := NewWrapper(conf, mb.Registry, moduleOptions...)
+				if err != nil {
+					return nil, errors.Wrap(err, "module initialization error")
+				}
+				modules = append(modules, m)
+			}
+		}
+	}
+	return modules, nil
+}

--- a/metricbeat/mb/module/connector_test.go
+++ b/metricbeat/mb/module/connector_test.go
@@ -18,13 +18,16 @@
 package module
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
 )
 
 func TestProcessorsForConfig(t *testing.T) {
@@ -89,6 +92,44 @@ func TestProcessorsForConfig(t *testing.T) {
 			}
 		}
 	}
+}
+
+type fakeMetricSetRegister struct {
+	success bool
+}
+
+func (fmsr *fakeMetricSetRegister) ProcessorsForMetricSet(moduleName, metricSetName string) (*processors.Processors, error) {
+	if !fmsr.success {
+		return nil, errors.New("failure")
+	}
+
+	procs := new(processors.Processors)
+	procs.List = []processors.Processor{nil, nil}
+	return procs, nil
+}
+
+func TestUseMetricSetProcessors_ReadingProcessorsFailed(t *testing.T) {
+	r := new(fakeMetricSetRegister)
+
+	var connector Connector
+	err := connector.UseMetricSetProcessors(r, "module", "metricset")
+	require.Error(t, err)
+	require.Nil(t, connector.processors)
+}
+
+func TestUseMetricSetProcessors_ReadingProcessorsSucceeded(t *testing.T) {
+	r := &fakeMetricSetRegister{
+		success: true,
+	}
+
+	connector := Connector{
+		processors: &processors.Processors{
+			List: []processors.Processor{},
+		},
+	}
+	err := connector.UseMetricSetProcessors(r, "module", "metricset")
+	require.NoError(t, err)
+	require.Len(t, connector.processors.List, 2)
 }
 
 // Helper function to convert from YML input string to an unpacked

--- a/metricbeat/mb/module/factory.go
+++ b/metricbeat/mb/module/factory.go
@@ -18,8 +18,6 @@
 package module
 
 import (
-	"github.com/joeshaw/multierror"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -43,28 +41,36 @@ func NewFactory(beatInfo beat.Info, options ...Option) *Factory {
 
 // Create creates a new metricbeat module runner reporting events to the passed pipeline.
 func (r *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
-	var errs multierror.Errors
-
-	connector, err := NewConnector(r.beatInfo, p, c, meta)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	w, err := NewWrapper(c, mb.Registry, r.options...)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	if err := errs.Err(); err != nil {
-		return nil, err
-	}
-
-	client, err := connector.Connect()
+	module, metricSets, err := mb.NewModule(c, mb.Registry)
 	if err != nil {
 		return nil, err
 	}
 
-	mr := NewRunner(client, w)
-	return mr, nil
+	var runners []Runner
+	for _, metricSet := range metricSets {
+		wrapper, err := NewWrapperForMetricSet(module, metricSet, r.options...)
+		if err != nil {
+			return nil, err
+		}
+
+		connector, err := NewConnector(r.beatInfo, p, c, meta)
+		if err != nil {
+			return nil, err
+		}
+
+		err = connector.UseMetricSetProcessors(mb.Registry, module.Name(), metricSet.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := connector.Connect()
+		if err != nil {
+			return nil, err
+		}
+		runners = append(runners, NewRunner(client, wrapper))
+	}
+
+	return newRunnerGroup(runners), nil
 }
 
 // CheckConfig checks if a config is valid or not

--- a/metricbeat/mb/module/runner_group.go
+++ b/metricbeat/mb/module/runner_group.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package module
+
+import (
+	"strings"
+	"sync"
+)
+
+type runnerGroup struct {
+	runners []Runner
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+var _ Runner = new(runnerGroup)
+
+func newRunnerGroup(runners []Runner) Runner {
+	return &runnerGroup{
+		runners: runners,
+	}
+}
+
+func (rg *runnerGroup) Start() {
+	rg.startOnce.Do(func() {
+		for _, runner := range rg.runners {
+			runner.Start()
+		}
+	})
+}
+
+func (rg *runnerGroup) Stop() {
+	rg.stopOnce.Do(func() {
+		for _, runner := range rg.runners {
+			runner.Stop()
+		}
+	})
+}
+
+func (rg *runnerGroup) String() string {
+	var entries []string
+	for _, runner := range rg.runners {
+		entries = append(entries, runner.String())
+	}
+	return "RunnerGroup{" + strings.Join(entries, ", ") + "}"
+}

--- a/metricbeat/mb/module/runner_group_test.go
+++ b/metricbeat/mb/module/runner_group_test.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package module
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common/atomic"
+)
+
+const (
+	fakeRunnersNum = 3
+	fakeRunnerName = "fakeRunner"
+)
+
+type fakeRunner struct {
+	id int
+
+	startCounter *atomic.Int
+	stopCounter  *atomic.Int
+}
+
+func (fr *fakeRunner) Start() {
+	if fr.startCounter != nil {
+		fr.startCounter.Inc()
+	}
+}
+
+func (fr *fakeRunner) Stop() {
+	if fr.stopCounter != nil {
+		fr.stopCounter.Inc()
+	}
+}
+
+func (fr *fakeRunner) String() string {
+	return fmt.Sprintf("%s-%d", fakeRunnerName, fr.id)
+}
+
+func TestStartStop(t *testing.T) {
+	startCounter := atomic.NewInt(0)
+	stopCounter := atomic.NewInt(0)
+
+	var runners []Runner
+	for i := 0; i < fakeRunnersNum; i++ {
+		runners = append(runners, &fakeRunner{
+			id:           i,
+			startCounter: startCounter,
+			stopCounter:  stopCounter,
+		})
+	}
+
+	runnerGroup := newRunnerGroup(runners)
+	runnerGroup.Start()
+
+	runnerGroup.Stop()
+
+	assert.Equal(t, fakeRunnersNum, startCounter.Load())
+	assert.Equal(t, fakeRunnersNum, stopCounter.Load())
+}
+
+func TestString(t *testing.T) {
+	var runners []Runner
+	for i := 0; i < fakeRunnersNum; i++ {
+		runners = append(runners, &fakeRunner{
+			id: i,
+		})
+	}
+	runnerGroup := newRunnerGroup(runners)
+	assert.Equal(t, "RunnerGroup{fakeRunner-0, fakeRunner-1, fakeRunner-2}", runnerGroup.String())
+}

--- a/metricbeat/mb/module/wrapper_test.go
+++ b/metricbeat/mb/module/wrapper_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/module"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -107,24 +108,18 @@ func newFakePushMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func newTestRegistry(t testing.TB) *mb.Register {
 	r := mb.NewRegister()
 
-	if err := r.AddMetricSet(moduleName, eventFetcherName, newFakeEventFetcher); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddMetricSet(moduleName, reportingFetcherName, newFakeReportingFetcher); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddMetricSet(moduleName, pushMetricSetName, newFakePushMetricSet); err != nil {
-		t.Fatal(err)
-	}
-
+	err := r.AddMetricSet(moduleName, eventFetcherName, newFakeEventFetcher)
+	require.NoError(t, err)
+	err = r.AddMetricSet(moduleName, reportingFetcherName, newFakeReportingFetcher)
+	require.NoError(t, err)
+	err = r.AddMetricSet(moduleName, pushMetricSetName, newFakePushMetricSet)
+	require.NoError(t, err)
 	return r
 }
 
 func newConfig(t testing.TB, moduleConfig interface{}) *common.Config {
 	config, err := common.NewConfigFrom(moduleConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return config
 }
 
@@ -139,9 +134,7 @@ func TestWrapperOfEventFetcher(t *testing.T) {
 	})
 
 	m, err := module.NewWrapper(c, newTestRegistry(t))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	done := make(chan struct{})
 	output := m.Start(done)
@@ -172,9 +165,7 @@ func TestWrapperOfReportingFetcher(t *testing.T) {
 	})
 
 	m, err := module.NewWrapper(c, newTestRegistry(t))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	done := make(chan struct{})
 	output := m.Start(done)
@@ -205,9 +196,7 @@ func TestWrapperOfPushMetricSet(t *testing.T) {
 	})
 
 	m, err := module.NewWrapper(c, newTestRegistry(t))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	done := make(chan struct{})
 	output := m.Start(done)
@@ -254,9 +243,7 @@ func TestPeriodIsAddedToEvent(t *testing.T) {
 			})
 
 			m, err := module.NewWrapper(config, registry, module.WithMetricSetInfo())
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			done := make(chan struct{})
 			defer close(done)
@@ -268,5 +255,35 @@ func TestPeriodIsAddedToEvent(t *testing.T) {
 			hasPeriod, _ := event.Fields.HasKey("metricset.period")
 			assert.Equal(t, c.hasPeriod, hasPeriod, "has metricset.period in event %+v", event)
 		})
+	}
+}
+
+func TestNewWrapperForMetricSet(t *testing.T) {
+	hosts := []string{"alpha"}
+	c := newConfig(t, map[string]interface{}{
+		"module":     moduleName,
+		"metricsets": []string{eventFetcherName},
+		"hosts":      hosts,
+	})
+
+	aModule, metricSets, err := mb.NewModule(c, newTestRegistry(t))
+	require.NoError(t, err)
+
+	m, err := module.NewWrapperForMetricSet(aModule, metricSets[0], module.WithMetricSetInfo())
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	output := m.Start(done)
+
+	<-output
+	close(done)
+
+	// Validate that the channel is closed after receiving the event.
+	select {
+	case _, ok := <-output:
+		if !ok {
+			return // Channel is closed.
+		}
+		assert.Fail(t, "received unexpected event")
 	}
 }

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
 )
 
 const initialSize = 20 // initialSize specifies the initial size of the Register.
@@ -121,6 +122,7 @@ type ModulesSource interface {
 	HasMetricSet(module, name string) bool
 	MetricSetRegistration(r *Register, module, name string) (MetricSetRegistration, error)
 	ModulesInfo(r *Register) string
+	ProcessorsForMetricSet(r *Register, module, name string) (*processors.Processors, error)
 }
 
 // NewRegister creates and returns a new Register.
@@ -360,6 +362,28 @@ func (r *Register) MetricSets(module string) []string {
 	}
 
 	return metricsets
+}
+
+// ProcessorsForMetricSet returns a list of processors defined in manifest of the registered metricset.
+func (r *Register) ProcessorsForMetricSet(module, name string) (*processors.Processors, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	module = strings.ToLower(module)
+	name = strings.ToLower(name)
+
+	metricSets, exists := r.metricSets[module]
+	if exists {
+		_, exists := metricSets[name]
+		if exists {
+			return processors.NewList(nil), nil // Standard metricsets don't have processor definitions.
+		}
+	}
+
+	if source := r.secondarySource; source != nil {
+		return source.ProcessorsForMetricSet(r, module, name)
+	}
+	return nil, fmt.Errorf(`metricset "%s" is not registered (module: %s)'`, name, module)
 }
 
 // SetSecondarySource sets an additional source of modules

--- a/metricbeat/mb/testdata/lightmodules/unpack/module.yml
+++ b/metricbeat/mb/testdata/lightmodules/unpack/module.yml
@@ -1,0 +1,4 @@
+name: service
+metricsets:
+- withprocessors
+- noprocessors

--- a/metricbeat/mb/testdata/lightmodules/unpack/noprocessors/manifest.yml
+++ b/metricbeat/mb/testdata/lightmodules/unpack/noprocessors/manifest.yml
@@ -1,0 +1,6 @@
+default: true
+input:
+  module: foo
+  metricset: bar
+  defaults:
+    option: test

--- a/metricbeat/mb/testdata/lightmodules/unpack/withprocessors/manifest.yml
+++ b/metricbeat/mb/testdata/lightmodules/unpack/withprocessors/manifest.yml
@@ -1,0 +1,8 @@
+default: true
+input:
+  module: foo
+  metricset: bar
+  defaults:
+    option: test
+processors:
+  - add_id:

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -41,12 +41,12 @@ class TestAutodiscover(metricbeat.BaseTest):
         docker_client.images.pull('memcached:latest')
         container = docker_client.containers.run('memcached:latest', detach=True)
 
-        self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Starting runner: RunnerGroup{memcached'))
 
         self.wait_until(lambda: self.output_count(lambda x: x >= 1))
         container.stop()
 
-        self.wait_until(lambda: self.log_contains('Stopping runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Stopping runner: RunnerGroup{memcached'))
 
         output = self.read_output_json()
         proc.check_kill_and_wait()
@@ -85,12 +85,12 @@ class TestAutodiscover(metricbeat.BaseTest):
         }
         container = docker_client.containers.run('memcached:latest', labels=labels, detach=True)
 
-        self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Starting runner: RunnerGroup{memcached'))
 
         self.wait_until(lambda: self.output_count(lambda x: x >= 1))
         container.stop()
 
-        self.wait_until(lambda: self.log_contains('Stopping runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Stopping runner: RunnerGroup{memcached'))
 
         output = self.read_output_json()
         proc.check_kill_and_wait()
@@ -136,12 +136,12 @@ class TestAutodiscover(metricbeat.BaseTest):
         }
         container = docker_client.containers.run('memcached:latest', labels=labels, detach=True)
 
-        self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Starting runner: RunnerGroup{memcached'))
 
         self.wait_until(lambda: self.output_count(lambda x: x >= 1))
         container.stop()
 
-        self.wait_until(lambda: self.log_contains('Stopping runner: memcached'))
+        self.wait_until(lambda: self.log_contains('Stopping runner: RunnerGroup{memcached'))
 
         output = self.read_output_json()
         proc.check_kill_and_wait()

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -143,36 +143,6 @@ metricbeat.modules:
   path: '/api/jolokia/?ignoreErrors=true&canonicalNaming=false'
   username: admin # default username
   password: admin # default password
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var broker_memory_broker_pct = event.Get("activemq.broker.memory.broker.pct")
-            if (broker_memory_broker_pct != null) {
-              event.Put("activemq.broker.memory.broker.pct", broker_memory_broker_pct / 100.0)
-            }
-
-            var broker_memory_temp_pct = event.Get("activemq.broker.memory.temp.pct")
-            if (broker_memory_temp_pct != null) {
-              event.Put("activemq.broker.memory.temp.pct", broker_memory_temp_pct / 100.0)
-            }
-
-            var broker_memory_store_pct = event.Get("activemq.broker.memory.store.pct")
-            if (broker_memory_store_pct != null) {
-              event.Put("activemq.broker.memory.store.pct", broker_memory_store_pct / 100.0)
-            }
-
-            var queue_memory_broker_pct = event.Get("activemq.queue.memory.broker.pct")
-            if (queue_memory_broker_pct != null) {
-              event.Put("activemq.queue.memory.broker.pct", queue_memory_broker_pct / 100.0)
-            }
-
-            var topic_memory_broker_pct = event.Get("activemq.topic.memory.broker.pct")
-            if (topic_memory_broker_pct != null) {
-              event.Put("activemq.topic.memory.broker.pct", topic_memory_broker_pct / 100.0)
-            }
-          }
 
 #------------------------------ Aerospike Module ------------------------------
 - module: aerospike
@@ -516,26 +486,6 @@ metricbeat.modules:
   # This module uses the Prometheus collector metricset, all
   # the options for this metricset are also available here.
   metrics_path: /metrics
-
-  # The custom processor is responsible for filtering Prometheus metrics
-  # not stricly related to the IBM MQ domain, e.g. system load, process,
-  # metrics HTTP server.
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var metrics = event.Get("prometheus.metrics");
-            Object.keys(metrics).forEach(function(key) {
-              if (!(key.match(/^ibmmq_.*$/))) {
-                event.Delete("prometheus.metrics." + key);
-              }
-            });
-            metrics = event.Get("prometheus.metrics");
-            if (Object.keys(metrics).length == 0) {
-              event.Cancel();
-            }
-          }
 
 #-------------------------------- Istio Module --------------------------------
 # Istio mesh. To collect all all Mixer-generated metrics

--- a/x-pack/metricbeat/module/activemq/_meta/config.yml
+++ b/x-pack/metricbeat/module/activemq/_meta/config.yml
@@ -5,33 +5,3 @@
   path: '/api/jolokia/?ignoreErrors=true&canonicalNaming=false'
   username: admin # default username
   password: admin # default password
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var broker_memory_broker_pct = event.Get("activemq.broker.memory.broker.pct")
-            if (broker_memory_broker_pct != null) {
-              event.Put("activemq.broker.memory.broker.pct", broker_memory_broker_pct / 100.0)
-            }
-
-            var broker_memory_temp_pct = event.Get("activemq.broker.memory.temp.pct")
-            if (broker_memory_temp_pct != null) {
-              event.Put("activemq.broker.memory.temp.pct", broker_memory_temp_pct / 100.0)
-            }
-
-            var broker_memory_store_pct = event.Get("activemq.broker.memory.store.pct")
-            if (broker_memory_store_pct != null) {
-              event.Put("activemq.broker.memory.store.pct", broker_memory_store_pct / 100.0)
-            }
-
-            var queue_memory_broker_pct = event.Get("activemq.queue.memory.broker.pct")
-            if (queue_memory_broker_pct != null) {
-              event.Put("activemq.queue.memory.broker.pct", queue_memory_broker_pct / 100.0)
-            }
-
-            var topic_memory_broker_pct = event.Get("activemq.topic.memory.broker.pct")
-            if (topic_memory_broker_pct != null) {
-              event.Put("activemq.topic.memory.broker.pct", topic_memory_broker_pct / 100.0)
-            }
-          }

--- a/x-pack/metricbeat/module/activemq/broker/manifest.yml
+++ b/x-pack/metricbeat/module/activemq/broker/manifest.yml
@@ -27,3 +27,23 @@ input:
         field: messages.count
       - attr: TotalProducerCount
         field: producers.count
+processors:
+  - script:
+      lang: javascript
+      source: >
+        function process(event) {
+          var broker_memory_broker_pct = event.Get("activemq.broker.memory.broker.pct")
+          if (broker_memory_broker_pct != null) {
+            event.Put("activemq.broker.memory.broker.pct", broker_memory_broker_pct / 100.0)
+          }
+
+          var broker_memory_temp_pct = event.Get("activemq.broker.memory.temp.pct")
+          if (broker_memory_temp_pct != null) {
+            event.Put("activemq.broker.memory.temp.pct", broker_memory_temp_pct / 100.0)
+          }
+
+          var broker_memory_store_pct = event.Get("activemq.broker.memory.store.pct")
+          if (broker_memory_store_pct != null) {
+            event.Put("activemq.broker.memory.store.pct", broker_memory_store_pct / 100.0)
+          }
+        }

--- a/x-pack/metricbeat/module/activemq/queue/manifest.yml
+++ b/x-pack/metricbeat/module/activemq/queue/manifest.yml
@@ -35,3 +35,13 @@ input:
         field: messages.enqueue.time.min
       - attr: ProducerCount
         field: producers.count
+processors:
+  - script:
+      lang: javascript
+      source: >
+        function process(event) {
+          var queue_memory_broker_pct = event.Get("activemq.queue.memory.broker.pct")
+          if (queue_memory_broker_pct != null) {
+            event.Put("activemq.queue.memory.broker.pct", queue_memory_broker_pct / 100.0)
+          }
+        }

--- a/x-pack/metricbeat/module/activemq/topic/manifest.yml
+++ b/x-pack/metricbeat/module/activemq/topic/manifest.yml
@@ -33,3 +33,13 @@ input:
         field: messages.enqueue.time.min
       - attr: ProducerCount
         field: producers.count
+processors:
+  - script:
+      lang: javascript
+      source: >
+        function process(event) {
+          var topic_memory_broker_pct = event.Get("activemq.topic.memory.broker.pct")
+          if (topic_memory_broker_pct != null) {
+            event.Put("activemq.topic.memory.broker.pct", topic_memory_broker_pct / 100.0)
+          }
+        }

--- a/x-pack/metricbeat/module/ibmmq/_meta/config.yml
+++ b/x-pack/metricbeat/module/ibmmq/_meta/config.yml
@@ -6,23 +6,3 @@
   # This module uses the Prometheus collector metricset, all
   # the options for this metricset are also available here.
   metrics_path: /metrics
-
-  # The custom processor is responsible for filtering Prometheus metrics
-  # not stricly related to the IBM MQ domain, e.g. system load, process,
-  # metrics HTTP server.
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var metrics = event.Get("prometheus.metrics");
-            Object.keys(metrics).forEach(function(key) {
-              if (!(key.match(/^ibmmq_.*$/))) {
-                event.Delete("prometheus.metrics." + key);
-              }
-            });
-            metrics = event.Get("prometheus.metrics");
-            if (Object.keys(metrics).length == 0) {
-              event.Cancel();
-            }
-          }

--- a/x-pack/metricbeat/module/ibmmq/qmgr/manifest.yml
+++ b/x-pack/metricbeat/module/ibmmq/qmgr/manifest.yml
@@ -4,3 +4,27 @@ input:
   metricset: collector
   defaults:
     metrics_path: /metrics
+
+# The custom processor is responsible for filtering Prometheus metrics
+# not stricly related to the IBM MQ domain, e.g. system load, process,
+# metrics HTTP server.
+processors:
+  - script:
+      lang: javascript
+      source: >
+        function process(event) {
+          var metrics = event.Get("prometheus.metrics");
+          if (metrics == null) {
+            event.Cancel();
+            return;
+          }
+          Object.keys(metrics).forEach(function(key) {
+            if (!(key.match(/^ibmmq_.*$/))) {
+              event.Delete("prometheus.metrics." + key);
+            }
+          });
+          metrics = event.Get("prometheus.metrics");
+          if (Object.keys(metrics).length == 0) {
+            event.Cancel();
+          }
+        }

--- a/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
+++ b/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
@@ -33,3 +33,8 @@ class Test(XPackTest):
             self.assert_fields_are_documented(evt)
             self.assertIn("prometheus", evt.keys(), evt)
             self.assertIn("metrics", evt["prometheus"].keys(), evt)
+            self.assertGreater(len(evt["prometheus"]["metrics"].keys()), 0)
+
+            # Verify if processors are correctly setup.
+            for metric in evt["prometheus"]["metrics"].keys():
+                assert metric.startswith("ibmmq_")

--- a/x-pack/metricbeat/modules.d/activemq.yml.disabled
+++ b/x-pack/metricbeat/modules.d/activemq.yml.disabled
@@ -8,33 +8,3 @@
   path: '/api/jolokia/?ignoreErrors=true&canonicalNaming=false'
   username: admin # default username
   password: admin # default password
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var broker_memory_broker_pct = event.Get("activemq.broker.memory.broker.pct")
-            if (broker_memory_broker_pct != null) {
-              event.Put("activemq.broker.memory.broker.pct", broker_memory_broker_pct / 100.0)
-            }
-
-            var broker_memory_temp_pct = event.Get("activemq.broker.memory.temp.pct")
-            if (broker_memory_temp_pct != null) {
-              event.Put("activemq.broker.memory.temp.pct", broker_memory_temp_pct / 100.0)
-            }
-
-            var broker_memory_store_pct = event.Get("activemq.broker.memory.store.pct")
-            if (broker_memory_store_pct != null) {
-              event.Put("activemq.broker.memory.store.pct", broker_memory_store_pct / 100.0)
-            }
-
-            var queue_memory_broker_pct = event.Get("activemq.queue.memory.broker.pct")
-            if (queue_memory_broker_pct != null) {
-              event.Put("activemq.queue.memory.broker.pct", queue_memory_broker_pct / 100.0)
-            }
-
-            var topic_memory_broker_pct = event.Get("activemq.topic.memory.broker.pct")
-            if (topic_memory_broker_pct != null) {
-              event.Put("activemq.topic.memory.broker.pct", topic_memory_broker_pct / 100.0)
-            }
-          }

--- a/x-pack/metricbeat/modules.d/ibmmq.yml.disabled
+++ b/x-pack/metricbeat/modules.d/ibmmq.yml.disabled
@@ -9,23 +9,3 @@
   # This module uses the Prometheus collector metricset, all
   # the options for this metricset are also available here.
   metrics_path: /metrics
-
-  # The custom processor is responsible for filtering Prometheus metrics
-  # not stricly related to the IBM MQ domain, e.g. system load, process,
-  # metrics HTTP server.
-  processors:
-    - script:
-        lang: javascript
-        source: >
-          function process(event) {
-            var metrics = event.Get("prometheus.metrics");
-            Object.keys(metrics).forEach(function(key) {
-              if (!(key.match(/^ibmmq_.*$/))) {
-                event.Delete("prometheus.metrics." + key);
-              }
-            });
-            metrics = event.Get("prometheus.metrics");
-            if (Object.keys(metrics).length == 0) {
-              event.Cancel();
-            }
-          }


### PR DESCRIPTION
Cherry-pick of PR #15923 to 7.x branch. Original message: 

This PR adds processor support for light modules. Processors can be enabled using definitions in `manifest.yml`.

Issue: https://github.com/elastic/beats/issues/14740

Let me start with draft and if we're fine with design and implementation, I will cover it with tests.