### PR TITLE
Correctly format the path to read data from npipe.

### DIFF
--- a/metricbeat/mb/parse/url.go
+++ b/metricbeat/mb/parse/url.go
@@ -212,7 +212,7 @@ func getURL(
 		u.Scheme = "http"
 		u.Host = "unix"
 	case "http+npipe":
-		p := strings.Replace(u.Path, "/pipe", `\\.pipe`, 1)
+		p := strings.Replace(u.Path, "/pipe", `\\.\pipe`, 1)
 		p = strings.Replace(p, "/", "\\", -1)
 		t = dialer.NewNpipeDialerBuilder(p)
 		u.Path = ""

--- a/metricbeat/mb/parse/url_test.go
+++ b/metricbeat/mb/parse/url_test.go
@@ -97,7 +97,7 @@ func TestParseURL(t *testing.T) {
 		if assert.NoError(t, err) {
 			transport, ok := hostData.Transport.(*dialer.NpipeDialerBuilder)
 			assert.True(t, ok)
-			assert.Equal(t, `\\.pipe\custom`, transport.Path)
+			assert.Equal(t, `\\.\pipe\custom`, transport.Path)
 			assert.Equal(t, "http://npipe", hostData.URI)
 			assert.Equal(t, "http://npipe", hostData.SanitizedURI)
 			assert.Equal(t, "npipe", hostData.Host)
@@ -112,7 +112,7 @@ func TestParseURL(t *testing.T) {
 		if assert.NoError(t, err) {
 			transport, ok := hostData.Transport.(*dialer.NpipeDialerBuilder)
 			assert.True(t, ok)
-			assert.Equal(t, `\\.pipe\custom`, transport.Path)
+			assert.Equal(t, `\\.\pipe\custom`, transport.Path)
 			assert.Equal(t, "http://npipe/apath", hostData.URI)
 			assert.Equal(t, "http://npipe/apath", hostData.SanitizedURI)
 			assert.Equal(t, "npipe", hostData.Host)


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This is not a fix for #15832   this will be tackle in another PR.

When http+npipe:// scheme was initially parsed by the url parser of
metric the generated PATH wasn't correctly setup up this mean that Metricbeat was not able to collect metrics over a npipe. So I've fixed the parsing and the tests.



## Why is it important?

Fix an issue to read metric over a named pipe

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] This need to be tested under Windows.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Now to test the behavior on Windows you will need a beat that expose metrics over
named pipes, you can do so with a configuration like this.

```yaml
metricbeat.modules:
  - module: system

output.console: ~

http.enabled: true
http.host: \\.\pipe\custom
```

After you can start a Metricbeat instance with the beat modules to
collect the metric information.

```yaml
metricbeat.modules:
- module: beat
  hosts: http+npipe://./pipe/custom
  metricsets:
  - stats
  - state
output.console: ~
```
If you start metricbeat with the `-e -d "*"` flags this will output any
metrics fetched from the running beat instance.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->

- Closes: elastic/beats#15938
- Relates: elastic/beats#15832