### PR TITLE
Make field names in Functionbeat ECS compliant

### DIFF
--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -161,10 +161,7 @@ func GoTestUnit() {
 func BuildPkgForFunctions() error {
 	mg.Deps(Update, Build)
 
-	err := os.MkdirAll("pkg", 700)
-	if err != nil {
-		return err
-	}
+	err := os.RemoveAll("pkg")
 
 	filesToCopy := map[string]string{
 		filepath.Join("provider", "aws", "functionbeat-aws"):           filepath.Join("pkg", "functionbeat-aws"),

--- a/x-pack/functionbeat/provider/gcp/gcp/transformer.go
+++ b/x-pack/functionbeat/provider/gcp/gcp/transformer.go
@@ -33,7 +33,7 @@ func transformPubSub(mData *metadata.Metadata, msg pubsub.Message) (beat.Event, 
 			"message":        string(msg.Data),
 			"attributes":     msg.Attributes,
 			"id":             mData.EventID,
-			"pubsub_resource": common.MapStr{
+			"resource": common.MapStr{
 				"service":    mData.Resource.Service,
 				"name":       mData.Resource.Name,
 				"event_type": mData.Resource.Type,
@@ -50,17 +50,20 @@ func transformStorage(mData *metadata.Metadata, evt StorageEvent) (beat.Event, e
 		Fields: common.MapStr{
 			"read_timestamp": time.Now(),
 			"id":             mData.EventID,
-			"storage_resource": common.MapStr{
+			"resource": common.MapStr{
 				"service":    mData.Resource.Service,
 				"name":       mData.Resource.Name,
 				"event_type": mData.Resource.Type,
 				"state":      evt.ResourceState,
 			},
 			"storage_bucket": evt.Bucket,
-			"file_name":      evt.Name,
-			"metageneration": evt.Metageneration,
-			"update_time":    evt.Updated,
-			"create_time":    evt.Created,
+			"file": common.MapStr{
+				"name":    evt.Name,
+				"mtime":   evt.Updated,
+				"ctime":   evt.Updated,
+				"created": evt.Created,
+			},
+			"meta-generation": evt.Metageneration,
 		},
 	}, nil
 }

--- a/x-pack/functionbeat/provider/gcp/gcp/transformer.go
+++ b/x-pack/functionbeat/provider/gcp/gcp/transformer.go
@@ -33,7 +33,7 @@ func transformPubSub(mData *metadata.Metadata, msg pubsub.Message) (beat.Event, 
 			"message":        string(msg.Data),
 			"attributes":     msg.Attributes,
 			"id":             mData.EventID,
-			"resource": common.MapStr{
+			"pubsub_resource": common.MapStr{
 				"service":    mData.Resource.Service,
 				"name":       mData.Resource.Name,
 				"event_type": mData.Resource.Type,
@@ -50,17 +50,17 @@ func transformStorage(mData *metadata.Metadata, evt StorageEvent) (beat.Event, e
 		Fields: common.MapStr{
 			"read_timestamp": time.Now(),
 			"id":             mData.EventID,
-			"resource": common.MapStr{
+			"storage_resource": common.MapStr{
 				"service":    mData.Resource.Service,
 				"name":       mData.Resource.Name,
 				"event_type": mData.Resource.Type,
 				"state":      evt.ResourceState,
 			},
-			"bucket":         evt.Bucket,
-			"file":           evt.Name,
+			"storage_bucket": evt.Bucket,
+			"file_name":      evt.Name,
 			"metageneration": evt.Metageneration,
-			"updated":        evt.Updated,
-			"created":        evt.Created,
+			"update_time":    evt.Updated,
+			"create_time":    evt.Created,
 		},
 	}, nil
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue in the `storage` function of Functionbeat. ES was not able to index events coming from the function as one of its fields had a different type:

```
{
    "textPayload": "2020-01-31T15:03:10.758Z\tWARN\telasticsearch/client.go:516\tCannot index event publisher.Event{Content:beat.Event{Timestamp:time.Time{wall:0xf60c480, ext:63716079787, loc:(*time.Location)(nil)}, Meta:null, Fields:{\"agent\":{\"ephemeral_id\":\"d86f3440-cb23-431a-81b7-d3360017ad2b\",\"hostname\":\"localhost\",\"id\":\"1a0a7af8-b927-460f-9746-7f8eae8dd417\",\"type\":\"functionbeat\",\"version\":\"7.6.0\"},\"bucket\":\"test-elastic-bucket\",\"created\":\"2020-01-31T15:03:06.783Z\",\"ecs\":{\"version\":\"1.4.0\"},\"file\":\"Untitled\",\"host\":{\"name\":\"localhost\"},\"id\":\"951771144251331\",\"metageneration\":\"1\",\"read_timestamp\":\"2020-01-31T15:03:10.209Z\",\"resource\":{\"event_type\":\"storage#object\",\"name\":\"projects/_/buckets/test-elastic-bucket/objects/Untitled\",\"service\":\"storage.googleapis.com\",\"state\":\"\"},\"updated\":\"2020-01-31T15:03:06.783Z\"}, Private:interface {}(nil), TimeSeries:false}, Flags:0x1, Cache:publisher.EventCache{m:common.MapStr(nil)}} (status=400): {\"type\":\"mapper_parsing_exception\",\"reason\":\"object mapping for [file] tried to parse field [file] as object, but found a concrete value\"}",
    "insertId": "000000-4f927011-4af5-4876-b471-62889ff0796b",
    "resource": {
      "type": "cloud_function",
      "labels": {
        "project_id": "elastic-metricbeat",
        "region": "europe-west2",
        "function_name": "storage"
      }
    },
    "timestamp": "2020-01-31T15:03:10.758Z",
    "labels": {
      "execution_id": "951771144251331"
    },
    "logName": "projects/elastic-metricbeat/logs/cloudfunctions.googleapis.com%2Fcloud-functions",
    "trace": "projects/elastic-metricbeat/traces/571a3f3523594e819691f0672c32c413",
    "receiveTimestamp": "2020-01-31T15:03:12.107405704Z"
  }
```

## Why is it important?

This problem prevented ES from indexing new storage events.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
