### PR TITLE
Reuse connections on sql module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -127,7 +127,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add STAN dashboard {pull}15654[15654]
 - Add support for Unix socket in Memcached metricbeat module. {issue}13685[13685] {pull}15822[15822]
 - Add support for processors in light modules. {issue}14740[14740] {pull}15923[15923]
-- Reuse connections in SQL module. {pull}[]
+- Reuse connections in SQL module. {pull}16001[16001]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add STAN dashboard {pull}15654[15654]
 - Add support for Unix socket in Memcached metricbeat module. {issue}13685[13685] {pull}15822[15822]
 - Add support for processors in light modules. {issue}14740[14740] {pull}15923[15923]
+- Reuse connections in SQL module. {pull}[]
 
 *Packetbeat*
 


### PR DESCRIPTION
## What does this PR do?

Reuse connections between fetches on SQL module.

## Why is it important?

Keep a connection open with the database instead of opening and closing connections on each fetch. this is consistent with other specific SQL modules we have, and is usually also prefered by users.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Same instructions as in https://github.com/elastic/beats/pull/13257, and then check in the database server that an only connection is created, and it is maintained along the lifetime of the module. This can be checked in MySQL with `SHOW PROCESSLIST`.