### PR TITLE
[DOCS] Recommend env variables rather than keystore for functionbeat

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -100,7 +100,9 @@ ifeval::["{beatname_lc}"=="functionbeat"]
 endif::[]
 |<<export-command,`export`>> |{export-command-short-desc}.
 |<<help-command,`help`>> |{help-command-short-desc}.
+ifndef::serverless[]
 |<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
+endif::[]
 ifeval::["{beatname_lc}"=="functionbeat"]
 |<<package-command,`package`>> |{package-command-short-desc}.
 |<<remove-command,`remove`>> |{remove-command-short-desc}.
@@ -320,6 +322,7 @@ Specifies the name of the command to show help for.
 {beatname_lc} help export
 -----
 
+ifndef::serverless[]
 [[keystore-command]]
 ==== `keystore` command
 
@@ -374,6 +377,8 @@ Shows help for the `keystore` command.
 -----
 
 See <<keystore>> for more examples.
+
+endif::[]
 
 ifeval::["{beatname_lc}"=="functionbeat"]
 [[package-command]]

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -116,7 +116,13 @@ connect to a secured Elasticsearch cluster, you also need to pass Elasticsearch
 credentials.
 
 TIP: The example shows a hard-coded password, but you should store sensitive
-values in the <<keystore,secrets keystore>>.
+values
+ifndef::serverless[]
+in the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+in environment variables.
+endif::[]
 
 ifdef::deb_os,rpm_os[]
 *deb and rpm:*

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -31,8 +31,13 @@ output.elasticsearch:
 <3> This setting enables the HTTPS protocol.
 <4> The IP and port of the Elasticsearch nodes.
 
-TIP: To obfuscate passwords and other sensitive settings, use the
-<<keystore,secrets keystore>>.
+TIP: To obfuscate passwords and other sensitive settings,
+ifndef::serverless[]
+use the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+use environment variables.
+endif::[]
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -25,7 +25,13 @@ output.elasticsearch:
 <1> Let's assume this user has the privileges required to publish events to
 {es}.
 <2> The example shows a hard-coded password, but you should store sensitive
-values in the <<keystore,secrets keystore>>.
+values
+ifndef::serverless[]
+in the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+in environment variables.
+endif::[]
 --
 ifndef::apm-server[]
 +

--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -26,7 +26,13 @@ setup.kibana:
   password: "{pwd}"
 ----
 <1> This examples shows a hard-coded password, but you should store sensitive
-values in the <<keystore,secrets keystore>>.
+values
+ifndef::serverless[]
+in the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+in environment variables.
+endif::[]
 <2> The `username` and `password` settings for {kib} are optional. If you don't
 specify credentials for {kib}, {beatname_uc} uses the `username` and `password`
 specified for the {es} output.

--- a/x-pack/functionbeat/docs/deploying.asciidoc
+++ b/x-pack/functionbeat/docs/deploying.asciidoc
@@ -82,7 +82,6 @@ that contains:
 +
 * a binary, called `functionbeat-aws`, that contains the function code
 * the `functionbeat.yml` config file
-* `/tmp/functionbeat.keystore`, if a keystore is used
 
 . If certificates are required, add the cert files to the zip package under the
 same path as the configured +{beatname_lc}.yml+ file. 

--- a/x-pack/functionbeat/docs/setting-up-running.asciidoc
+++ b/x-pack/functionbeat/docs/setting-up-running.asciidoc
@@ -17,8 +17,6 @@ This section includes additional information on how to set up and run
 
 * <<directory-layout>>
 
-* <<keystore>>
-
 * <<iam-permissions>>
 
 * <<deploy-to-cloud-provider>>
@@ -32,9 +30,6 @@ This section includes additional information on how to set up and run
 
 [role="xpack"]
 include::{libbeat-dir}/shared-directory-layout.asciidoc[]
-
-[role="xpack"]
-include::{libbeat-dir}/keystore.asciidoc[]
 
 include::iam-permissions.asciidoc[]
 


### PR DESCRIPTION
Closes https://github.com/elastic/beats/issues/15876.

Also suppresses content about the keystore so that it does not appear in the functionbeat docs.