### PR TITLE
[Filebeat] Refactor mqtt input

### DIFF
--- a/filebeat/input/mqtt/client.go
+++ b/filebeat/input/mqtt/client.go
@@ -18,191 +18,37 @@
 package mqtt
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/json"
-	"io/ioutil"
-	"strings"
-	"time"
+	libmqtt "github.com/eclipse/paho.mqtt.golang"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
-
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
-
-	MQTT "github.com/eclipse/paho.mqtt.golang"
+	"github.com/elastic/beats/libbeat/outputs"
 )
 
-func (input *mqttInput) newTLSConfig() (*tls.Config, error) {
-	config := input.config
+func createClientOptions(config mqttInputConfig, onConnectHandler func(client libmqtt.Client)) (*libmqtt.ClientOptions, error) {
+	clientOptions := libmqtt.NewClientOptions().
+		SetClientID(config.ClientID).
+		SetUsername(config.Username).
+		SetPassword(config.Password).
+		SetConnectRetry(true).
+		SetOnConnectHandler(onConnectHandler)
 
-	// Import trusted certificates from CAfile.pem.
-	// Alternatively, manually add CA certificates to
-	// default openssl CA bundle.
-	certpool := x509.NewCertPool()
-	if config.CA != "" {
-		logp.Info("[MQTT] Set the CA")
-		pemCerts, err := ioutil.ReadFile(config.CA)
+	for _, host := range config.Hosts {
+		clientOptions.AddBroker(host)
+	}
+
+	if config.TLS != nil {
+		tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 		if err != nil {
 			return nil, err
 		}
-		certpool.AppendCertsFromPEM(pemCerts)
+		clientOptions.SetTLSConfig(tlsConfig.BuildModuleConfig(""))
 	}
-
-	tlsconfig := &tls.Config{
-		// RootCAs = certs used to verify server cert.
-		RootCAs: certpool,
-		// ClientAuth = whether to request cert from server.
-		// Since the server is set up for SSL, this happens
-		// anyways.
-		ClientAuth: tls.NoClientCert,
-		// ClientCAs = certs used to validate client cert.
-		ClientCAs: nil,
-		// InsecureSkipVerify = verify that cert contents
-		// match server. IP matches what is in cert etc.
-		InsecureSkipVerify: true,
-	}
-
-	// Import client certificate/key pair
-	if config.ClientCert != "" && config.ClientKey != "" {
-		logp.Info("[MQTT] Set the Certs")
-		cert, err := tls.LoadX509KeyPair(config.ClientCert, config.ClientKey)
-		if err != nil {
-			return nil, err
-		}
-
-		// Certificates = list of certs client sends to server.
-		tlsconfig.Certificates = []tls.Certificate{cert}
-	}
-
-	// Create tls.Config with desired tls properties
-	return tlsconfig, nil
+	return clientOptions, nil
 }
 
-// Prepare MQTT client
-func (input *mqttInput) setupMqttClient() error {
-	c := input.config
-
-	logp.Info("[MQTT] Connect to broker URL: %s", c.Host)
-
-	mqttClientOpt := MQTT.NewClientOptions()
-	mqttClientOpt.SetClientID(c.ClientID)
-	mqttClientOpt.AddBroker(c.Host)
-
-	mqttClientOpt.SetMaxReconnectInterval(1 * time.Second)
-	mqttClientOpt.SetConnectionLostHandler(input.connectionLostHandler)
-	mqttClientOpt.SetOnConnectHandler(input.subscribeOnConnect)
-	mqttClientOpt.SetAutoReconnect(true)
-
-	if c.Username != "" {
-		logp.Info("[MQTT] Broker username: %s", c.Username)
-		mqttClientOpt.SetUsername(c.Username)
-	}
-
-	if c.Password != "" {
-		mqttClientOpt.SetPassword(c.Password)
-	}
-
-	if c.SSL == true {
-		logp.Info("[MQTT] Configure session to use SSL")
-		tlsconfig, err := input.newTLSConfig()
-		if err != nil {
-			return err
-		}
-		mqttClientOpt.SetTLSConfig(tlsconfig)
-	}
-
-	input.client = MQTT.NewClient(mqttClientOpt)
-	return nil
-}
-
-func (input *mqttInput) connect() error {
-	if token := input.client.Connect(); token.WaitTimeout(input.config.WaitClose) && token.Error() != nil {
-		logp.Err("MQTT Failed to connect")
-		return token.Error()
-	}
-	logp.Info("MQTT Client connected: %t", input.client.IsConnected())
-	return nil
-}
-
-func (input *mqttInput) subscribeOnConnect(client MQTT.Client) {
-	subscriptions := prepareSubscriptionsForTopics(input.config.Topics, input.config.QoS)
-
-	// Mqtt client - Subscribe to every topic in the config file, and bind with message handler
-	if token := input.client.SubscribeMultiple(subscriptions, input.onMessage); token.WaitTimeout(input.config.WaitClose) && token.Error() != nil {
-		logp.Error(token.Error())
-	}
-	logp.Info("MQTT Subscribed to configured topics")
-}
-
-// Mqtt message handler
-func (input *mqttInput) onMessage(client MQTT.Client, msg MQTT.Message) {
-	logp.Debug("MQTT", "MQTT message received: %s", string(msg.Payload()))
-	var beatEvent beat.Event
-	eventFields := make(common.MapStr)
-
-	// default case
-	var mqtt = make(common.MapStr)
-	eventFields["message"] = string(msg.Payload())
-	if input.config.DecodePayload {
-		mqtt["fields"] = decodeBytes(msg.Payload())
-	}
-
-	eventFields["is_system_topic"] = strings.HasPrefix(msg.Topic(), "$")
-	eventFields["topic"] = msg.Topic()
-
-	mqtt["id"] = msg.MessageID()
-	mqtt["retained"] = msg.Retained()
-	eventFields["mqtt"] = mqtt
-
-	// Finally sending the message to elasticsearch
-	beatEvent.Fields = eventFields
-	isSent := input.outlet.OnEvent(beatEvent)
-
-	logp.Debug("MQTT", "Event sent: %t", isSent)
-}
-
-// connectionLostHandler will try to reconnect when connection is lost
-func (input *mqttInput) connectionLostHandler(client MQTT.Client, reason error) {
-	logp.Warn("[MQTT] Connection lost: %s", reason.Error())
-
-	//Rerun the input
-	input.Run()
-}
-
-// decodeBytes will try to decode the bytes in the following order
-// 1.) Check for msgpack format
-// 2.) Check for json format
-// 3.) If every check fails, it will
-// return the the string representation
-func decodeBytes(payload []byte) common.MapStr {
-	event := make(common.MapStr)
-
-	// A msgpack payload must be a json-like object
-	err := msgpack.Unmarshal(payload, &event)
-	if err == nil {
-		logp.Debug("MQTT", "Payload decoded - msgpack")
-		return event
-	}
-
-	err = json.Unmarshal(payload, &event)
-	if err == nil {
-		logp.Debug("MQTT", "Payload decoded - as json")
-		return event
-	}
-
-	logp.Debug("MQTT", "decoded - as text")
-	return event
-}
-
-// ParseTopics will parse the config file and return a map with topic:QoS
-func prepareSubscriptionsForTopics(topics []string, qos int) map[string]byte {
-	subscriptions := make(map[string]byte)
-	for _, value := range topics {
-		// Finally, filling the subscriptions map
-		subscriptions[value] = byte(qos)
-		logp.Info("Subscribe to %v with QoS %v", value, qos)
+func createClientSubscriptions(config mqttInputConfig) map[string]byte {
+	subscriptions := map[string]byte{}
+	for _, topic := range config.Topics {
+		subscriptions[topic] = byte(config.QoS)
 	}
 	return subscriptions
 }

--- a/filebeat/input/mqtt/client_mocked.go
+++ b/filebeat/input/mqtt/client_mocked.go
@@ -1,0 +1,192 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mqtt
+
+import (
+	"time"
+
+	libmqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/elastic/beats/filebeat/channel"
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type mockedMessage struct {
+	duplicate bool
+	messageID uint16
+	qos       byte
+	retained  bool
+	topic     string
+	payload   []byte
+	ack       func()
+}
+
+var _ libmqtt.Message = new(mockedMessage)
+
+func (m *mockedMessage) Duplicate() bool {
+	return m.duplicate
+}
+
+func (m *mockedMessage) Qos() byte {
+	return m.qos
+}
+
+func (m *mockedMessage) Retained() bool {
+	return m.retained
+}
+
+func (m *mockedMessage) Topic() string {
+	return m.topic
+}
+
+func (m *mockedMessage) MessageID() uint16 {
+	return m.messageID
+}
+
+func (m *mockedMessage) Payload() []byte {
+	return m.payload
+}
+
+func (m *mockedMessage) Ack() {
+	panic("implement me")
+}
+
+type mockedToken struct{}
+
+var _ libmqtt.Token = new(mockedToken)
+
+func (m *mockedToken) Wait() bool {
+	panic("implement me")
+}
+
+func (m *mockedToken) WaitTimeout(time.Duration) bool {
+	return true
+}
+
+func (m *mockedToken) Error() error {
+	panic("implement me")
+}
+
+type mockedClient struct {
+	connectCount           int
+	disconnectCount        int
+	subscribeMultipleCount int
+
+	subscriptions []string
+	messages      []mockedMessage
+
+	onConnectHandler func(client libmqtt.Client)
+	onMessageHandler func(client libmqtt.Client, message libmqtt.Message)
+}
+
+var _ libmqtt.Client = new(mockedClient)
+
+func (m *mockedClient) IsConnected() bool {
+	panic("implement me")
+}
+
+func (m *mockedClient) IsConnectionOpen() bool {
+	panic("implement me")
+}
+
+func (m *mockedClient) Connect() libmqtt.Token {
+	m.connectCount++
+
+	if m.onConnectHandler != nil {
+		m.onConnectHandler(m)
+	}
+	return nil
+}
+
+func (m *mockedClient) Disconnect(quiesce uint) {
+	m.disconnectCount++
+}
+
+func (m *mockedClient) Publish(topic string, qos byte, retained bool, payload interface{}) libmqtt.Token {
+	panic("implement me")
+}
+
+func (m *mockedClient) Subscribe(topic string, qos byte, callback libmqtt.MessageHandler) libmqtt.Token {
+	panic("implement me")
+}
+
+func (m *mockedClient) SubscribeMultiple(filters map[string]byte, callback libmqtt.MessageHandler) libmqtt.Token {
+	m.subscribeMultipleCount++
+
+	for filter := range filters {
+		m.subscriptions = append(m.subscriptions, filter)
+	}
+	m.onMessageHandler = callback
+
+	go func() {
+		for _, msg := range m.messages {
+			m.onMessageHandler(m, &msg)
+		}
+	}()
+	return new(mockedToken)
+}
+
+func (m *mockedClient) Unsubscribe(topics ...string) libmqtt.Token {
+	panic("implement me")
+}
+
+func (m *mockedClient) AddRoute(topic string, callback libmqtt.MessageHandler) {
+	panic("implement me")
+}
+
+func (m *mockedClient) OptionsReader() libmqtt.ClientOptionsReader {
+	panic("implement me")
+}
+
+type mockedConnector struct {
+	connectWithError error
+	outlet           channel.Outleter
+}
+
+var _ channel.Connector = new(mockedConnector)
+
+func (m *mockedConnector) Connect(*common.Config) (channel.Outleter, error) {
+	panic("implement me")
+}
+
+func (m *mockedConnector) ConnectWith(*common.Config, beat.ClientConfig) (channel.Outleter, error) {
+	if m.connectWithError != nil {
+		return nil, m.connectWithError
+	}
+	return m.outlet, nil
+}
+
+type mockedOutleter struct {
+	events chan<- beat.Event
+}
+
+var _ channel.Outleter = new(mockedOutleter)
+
+func (m mockedOutleter) Close() error {
+	panic("implement me")
+}
+
+func (m mockedOutleter) Done() <-chan struct{} {
+	panic("implement me")
+}
+
+func (m mockedOutleter) OnEvent(event beat.Event) bool {
+	m.events <- event
+	return true
+}

--- a/filebeat/input/mqtt/config.go
+++ b/filebeat/input/mqtt/config.go
@@ -25,7 +25,7 @@ import (
 
 type mqttInputConfig struct {
 	Hosts  []string `config:"hosts" validate:"required,min=1"`
-	Topics []string `config:"topics" validate:"nonzero,min=1"`
+	Topics []string `config:"topics" validate:"required,min=1"`
 	QoS    int      `config:"qos" validate:"nonzero,min=0,max=2"`
 
 	ClientID string `config:"clientID" validate:"nonzero"`

--- a/filebeat/input/mqtt/input.go
+++ b/filebeat/input/mqtt/input.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	disconnectTimeout = 3 * 1000 // 3000 ms = 3 sec
+	disconnectTimeout = 3 * time.Second
 
 	subscribeTimeout       = 35 * time.Second // in client: subscribeWaitTimeout = 30s
 	subscribeRetryInterval = 1 * time.Second
@@ -174,12 +174,12 @@ func (mi *mqttInput) Run() {
 // Stop method stops the input.
 func (mi *mqttInput) Stop() {
 	mi.logger.Debug("Stop the input.")
-	mi.client.Disconnect(disconnectTimeout)
-	mi.Wait()
+	mi.client.Disconnect(uint(disconnectTimeout.Milliseconds()))
 }
 
-// Wait method waits until event processing is finished.
+// Wait method stops the input and waits until event processing is finished.
 func (mi *mqttInput) Wait() {
+	mi.Stop()
 	mi.logger.Debug("Wait for the input to finish processing.")
 	mi.inflightMessages.Wait()
 }

--- a/filebeat/input/mqtt/input.go
+++ b/filebeat/input/mqtt/input.go
@@ -173,7 +173,7 @@ func (mi *mqttInput) Stop() {
 	mi.Wait()
 }
 
-// Wait method waits until event processing is finished and stops the input.
+// Wait method waits until event processing is finished.
 func (mi *mqttInput) Wait() {
 	mi.logger.Debug("Wait for the input to finish processing.")
 	mi.inflightMessages.Wait()

--- a/filebeat/input/mqtt/input.go
+++ b/filebeat/input/mqtt/input.go
@@ -40,6 +40,8 @@ const (
 	subscribeRetryInterval = 1 * time.Second
 )
 
+var newMqttClient = libmqtt.NewClient
+
 // Input contains the input and its config
 type mqttInput struct {
 	once sync.Once
@@ -90,7 +92,7 @@ func NewInput(
 	}
 
 	return &mqttInput{
-		client:           libmqtt.NewClient(clientOptions),
+		client:           newMqttClient(clientOptions),
 		inflightMessages: inflightMessages,
 		logger:           logp.NewLogger("mqtt input").With("hosts", config.Hosts),
 	}, nil

--- a/filebeat/input/mqtt/input.go
+++ b/filebeat/input/mqtt/input.go
@@ -40,7 +40,10 @@ const (
 	subscribeRetryInterval = 1 * time.Second
 )
 
-var newMqttClient = libmqtt.NewClient
+var (
+	newMqttClient = libmqtt.NewClient
+	newBackoff    = backoff.NewEqualJitterBackoff
+)
 
 // Input contains the input and its config
 type mqttInput struct {
@@ -127,7 +130,7 @@ func createOnMessageHandler(logger *logp.Logger, outlet channel.Outleter, inflig
 func createOnConnectHandler(logger *logp.Logger, inputContext *input.Context, onMessageHandler func(client libmqtt.Client, message libmqtt.Message), clientSubscriptions map[string]byte) func(client libmqtt.Client) {
 	// The function subscribes the client to the specific topics (with retry backoff in case of failure).
 	return func(client libmqtt.Client) {
-		backoff := backoff.NewEqualJitterBackoff(
+		backoff := newBackoff(
 			inputContext.Done,
 			subscribeRetryInterval,
 			8*subscribeRetryInterval)

--- a/filebeat/input/mqtt/input_test.go
+++ b/filebeat/input/mqtt/input_test.go
@@ -1,0 +1,205 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mqtt
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	libmqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/require"
+
+	finput "github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+var (
+	logger = logp.NewLogger("test")
+)
+
+func TestNewInput_MissingConfigField(t *testing.T) {
+	config := common.MustNewConfigFrom(common.MapStr{
+		"topics": "#",
+	})
+	connector := new(mockedConnector)
+	var inputContext finput.Context
+
+	input, err := NewInput(config, connector, inputContext)
+
+	require.Error(t, err)
+	require.Nil(t, input)
+}
+
+func TestNewInput_ConnectWithFailed(t *testing.T) {
+	connectWithError := errors.New("failure")
+	config := common.MustNewConfigFrom(common.MapStr{
+		"hosts":  "tcp://mocked:1234",
+		"topics": "#",
+	})
+	connector := &mockedConnector{
+		connectWithError: connectWithError,
+	}
+	var inputContext finput.Context
+
+	input, err := NewInput(config, connector, inputContext)
+
+	require.Equal(t, connectWithError, err)
+	require.Nil(t, input)
+}
+
+func TestNewInput_Run(t *testing.T) {
+	config := common.MustNewConfigFrom(common.MapStr{
+		"hosts":  "tcp://mocked:1234",
+		"topics": []string{"first", "second"},
+		"qos":    2,
+	})
+
+	events := make(chan beat.Event)
+	outlet := &mockedOutleter{
+		events: events,
+	}
+	connector := &mockedConnector{
+		outlet: outlet,
+	}
+	var inputContext finput.Context
+
+	firstMessage := mockedMessage{
+		duplicate: false,
+		messageID: 1,
+		qos:       2,
+		retained:  false,
+		topic:     "first",
+		payload:   []byte("first-message"),
+	}
+	secondMessage := mockedMessage{
+		duplicate: false,
+		messageID: 2,
+		qos:       2,
+		retained:  false,
+		topic:     "second",
+		payload:   []byte("second-message"),
+	}
+
+	var client *mockedClient
+	newMqttClient = func(o *libmqtt.ClientOptions) libmqtt.Client {
+		client = &mockedClient{
+			onConnectHandler: o.OnConnect,
+			messages:         []mockedMessage{firstMessage, secondMessage},
+		}
+		return client
+	}
+
+	input, err := NewInput(config, connector, inputContext)
+	require.NoError(t, err)
+	require.NotNil(t, input)
+
+	input.Run()
+
+	require.Equal(t, 1, client.connectCount)
+	require.Equal(t, 1, client.subscribeMultipleCount)
+	require.ElementsMatch(t, []string{"first", "second"}, client.subscriptions)
+
+	for _, event := range []beat.Event{<-events, <-events} {
+		topic, err := event.GetValue("mqtt.topic")
+		require.NoError(t, err)
+
+		if topic == "first" {
+			assertEventMatches(t, firstMessage, event)
+		} else {
+			assertEventMatches(t, secondMessage, event)
+		}
+	}
+}
+
+func TestRun_Once(t *testing.T) {
+	client := new(mockedClient)
+	input := &mqttInput{
+		client: client,
+		logger: logger,
+	}
+
+	input.Run()
+
+	require.Equal(t, 1, client.connectCount)
+}
+
+func TestRun_Twice(t *testing.T) {
+	client := new(mockedClient)
+	input := &mqttInput{
+		client: client,
+		logger: logger,
+	}
+
+	input.Run()
+	input.Run()
+
+	require.Equal(t, 1, client.connectCount)
+}
+
+func TestStop(t *testing.T) {
+	inflightMessages := new(sync.WaitGroup)
+	client := new(mockedClient)
+	input := &mqttInput{
+		client:           client,
+		logger:           logger,
+		inflightMessages: inflightMessages,
+	}
+
+	input.Stop()
+
+	require.Equal(t, 1, client.disconnectCount)
+}
+
+func TestWait(t *testing.T) {
+	inflightMessages := new(sync.WaitGroup)
+	input := &mqttInput{
+		logger:           logger,
+		inflightMessages: inflightMessages,
+	}
+
+	input.Wait()
+}
+
+func assertEventMatches(t *testing.T, expected mockedMessage, got beat.Event) {
+	topic, err := got.GetValue("mqtt.topic")
+	require.NoError(t, err)
+	require.Equal(t, expected.topic, topic)
+
+	duplicate, err := got.GetValue("mqtt.duplicate")
+	require.NoError(t, err)
+	require.Equal(t, expected.duplicate, duplicate)
+
+	messageID, err := got.GetValue("mqtt.message_id")
+	require.NoError(t, err)
+	require.Equal(t, expected.messageID, messageID)
+
+	qos, err := got.GetValue("mqtt.qos")
+	require.NoError(t, err)
+	require.Equal(t, expected.qos, qos)
+
+	retained, err := got.GetValue("mqtt.retained")
+	require.NoError(t, err)
+	require.Equal(t, expected.retained, retained)
+
+	message, err := got.GetValue("message")
+	require.NoError(t, err)
+	require.Equal(t, string(expected.payload), message)
+}

--- a/filebeat/input/mqtt/input_test.go
+++ b/filebeat/input/mqtt/input_test.go
@@ -226,7 +226,7 @@ func TestRun_Twice(t *testing.T) {
 	require.Equal(t, 1, client.connectCount)
 }
 
-func TestStop(t *testing.T) {
+func TestWait(t *testing.T) {
 	inflightMessages := new(sync.WaitGroup)
 	client := new(mockedClient)
 	input := &mqttInput{
@@ -235,19 +235,19 @@ func TestStop(t *testing.T) {
 		inflightMessages: inflightMessages,
 	}
 
-	input.Stop()
+	input.Wait()
 
 	require.Equal(t, 1, client.disconnectCount)
 }
 
-func TestWait(t *testing.T) {
-	inflightMessages := new(sync.WaitGroup)
+func TestStop(t *testing.T) {
+	client := new(mockedClient)
 	input := &mqttInput{
-		logger:           logger,
-		inflightMessages: inflightMessages,
+		client: client,
+		logger: logger,
 	}
 
-	input.Wait()
+	input.Stop()
 }
 
 func TestOnCreateHandler_SubscribeMultiple_Succeeded(t *testing.T) {

--- a/filebeat/input/mqtt/logging.go
+++ b/filebeat/input/mqtt/logging.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mqtt
+
+import (
+	"sync"
+
+	libmqtt "github.com/eclipse/paho.mqtt.golang"
+	"go.uber.org/zap"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+var setupLoggingOnce sync.Once
+
+type loggerWrapper struct {
+	log *logp.Logger
+}
+
+type (
+	debugLogger loggerWrapper
+	errorLogger loggerWrapper
+	warnLogger  loggerWrapper
+)
+
+var (
+	_ libmqtt.Logger = new(debugLogger)
+	_ libmqtt.Logger = new(errorLogger)
+	_ libmqtt.Logger = new(warnLogger)
+)
+
+func setupLibraryLogging() {
+	setupLoggingOnce.Do(func() {
+		logger := logp.NewLogger("libmqtt", zap.AddCallerSkip(1))
+		libmqtt.CRITICAL = &errorLogger{log: logger}
+		libmqtt.DEBUG = &debugLogger{log: logger}
+		libmqtt.ERROR = &errorLogger{log: logger}
+		libmqtt.WARN = &warnLogger{log: logger}
+	})
+}
+
+func (l *debugLogger) Println(v ...interface{}) {
+	l.log.Debug(v...)
+}
+
+func (l *debugLogger) Printf(format string, v ...interface{}) {
+	l.log.Debugf(format, v...)
+}
+
+func (l *errorLogger) Println(v ...interface{}) {
+	l.log.Error(v...)
+}
+
+func (l *errorLogger) Printf(format string, v ...interface{}) {
+	l.log.Errorf(format, v...)
+}
+
+func (l *warnLogger) Println(v ...interface{}) {
+	l.log.Warn(v...)
+}
+
+func (l *warnLogger) Printf(format string, v ...interface{}) {
+	l.log.Warnf(format, v...)
+}


### PR DESCRIPTION
Issue: https://github.com/elastic/beats/issues/15982

This PR refactor recently developed mqtt input (https://github.com/elastic/beats/pull/15287) to provide the following features:
* automatic reconnect on connection lost/failure
* TLS support with `tlscommon.TLS`
* improved shutdown procedure (first disconnect, then wait for `onMessage` handler functions to finish processing
* supported and enabled logging in the library `github.com/eclipse/paho.mqtt.golang`

I removed data decoding to MsgPack/JSON as (to my understanding) processors should be responsible for that (see: https://www.elastic.co/guide/en/beats/filebeat/current/decode-json-fields.html)

Filebeat.yml to test this change:
```
filebeat.inputs:
- type: mqtt
  hosts:
    - ssl://mqtt.eclipse.org:8883
  topics:
    - motion

output.elasticsearch:
  hosts: ["localhost:9200"]
```

Sample output with input logging enabled:

```
2020-02-04T12:27:18.647+0100    INFO    [beat]  instance/beat.go:991    Process info    {"system_info": {"process": {"cwd": "/Users/marcin.tojek/go/src/github.com/elastic/beats/filebeat", "exe": "./filebeat", "name": "filebeat", "pid": 71825, "ppid": 25569, "start_time": "2020-02-04T12:27:18.612+0100"}}}
2020-02-04T12:27:18.647+0100    INFO    instance/beat.go:297    Setup Beat: filebeat; Version: 8.0.0
2020-02-04T12:27:18.647+0100    INFO    [index-management]      idxmgmt/std.go:182      Set output.elasticsearch.index to 'filebeat-8.0.0' as ILM is enabled.
2020-02-04T12:27:18.647+0100    INFO    elasticsearch/client.go:174     Elasticsearch url: http://localhost:9200
2020-02-04T12:27:18.648+0100    INFO    [publisher]     pipeline/module.go:110  Beat name: MacBook-Elastic.local
2020-02-04T12:27:18.648+0100    INFO    [monitoring]    log/log.go:118  Starting metrics logging every 30s
2020-02-04T12:27:18.648+0100    INFO    instance/beat.go:438    filebeat start running.
2020-02-04T12:27:18.648+0100    INFO    registrar/registrar.go:145      Loading registrar data from /Users/marcin.tojek/go/src/github.com/elastic/beats/filebeat/data/registry/filebeat/data.json
2020-02-04T12:27:18.649+0100    INFO    registrar/registrar.go:152      States Loaded from registrar: 0
2020-02-04T12:27:18.649+0100    INFO    crawler/crawler.go:72   Loading Inputs: 1
2020-02-04T12:27:18.649+0100    INFO    input/input.go:114      Starting input of type: mqtt; ID: 1514614463779256881
2020-02-04T12:27:18.649+0100    INFO    crawler/crawler.go:106  Loading and starting Inputs completed. Enabled inputs: 1
2020-02-04T12:27:18.649+0100    DEBUG   [mqtt input]    mqtt/input.go:169       Run the input once.     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.209+0100    WARN    [libmqtt]       paho.mqtt.golang/memstore.go:137        [store]   memorystore wiped
2020-02-04T12:27:19.209+0100    DEBUG   [mqtt input]    mqtt/input.go:145       Try subscribe to topics: motion {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.476+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 176     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.635+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 176     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.741+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.847+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 180     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.848+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 179     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:19.955+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.111+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.221+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.327+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 179     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.327+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.437+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 179     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:27:20.480+0100    INFO    pipeline/output.go:95   Connecting to backoff(elasticsearch(http://localhost:9200))
2020-02-04T12:27:20.587+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 177     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
```

Sample output with library logging enabled:
```
2020-02-04T12:26:11.829+0100    INFO    crawler/crawler.go:72   Loading Inputs: 1
2020-02-04T12:26:11.830+0100    INFO    input/input.go:114      Starting input of type: mqtt; ID: 1514614463779256881
2020-02-04T12:26:11.830+0100    INFO    crawler/crawler.go:106  Loading and starting Inputs completed. Enabled inputs: 1
2020-02-04T12:26:11.830+0100    DEBUG   [mqtt input]    mqtt/input.go:169       Run the input once.     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:26:11.830+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:214  [client]  Connect()
2020-02-04T12:26:11.830+0100    DEBUG   [libmqtt]       paho.mqtt.golang/memstore.go:48 [store]   memorystore initialized
2020-02-04T12:26:11.830+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:257  [client]  about to write new connect msg
2020-02-04T12:26:12.287+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:263  [client]  socket connected to broker
2020-02-04T12:26:12.287+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:278  [client]  Using MQTT 3.1.1 protocol
2020-02-04T12:26:12.287+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:485  [net]     connect started
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:503  [net]     received connack
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:347  [client]  client is connected
2020-02-04T12:26:12.395+0100    WARN    [libmqtt]       paho.mqtt.golang/memstore.go:137        [store]   memorystore wiped
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:366  [client]  exit startClient
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:210     [net]     logic started
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:110     [net]     incoming started
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:148     [net]     outgoing started
2020-02-04T12:26:12.395+0100    DEBUG   [mqtt input]    mqtt/input.go:145       Try subscribe to topics: motion {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:26:12.395+0100    DEBUG   [libmqtt]       paho.mqtt.golang/ping.go:27     [pinger]  keepalive starting
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:151     [net]     outgoing waiting for an outbound message
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:213     [net]     logic waiting for msg on ibound
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:740  [client]  enter SubscribeMultiple
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:782  [client]  sending subscribe message, topics:[motion]
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/client.go:793  [client]  exit SubscribeMultiple
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:181     [net]     obound priority msg to write, type*packets.SubscribePacket
2020-02-04T12:26:12.396+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:151     [net]     outgoing waiting for an outbound message
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:116     [net]     Received Message
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:217     [net]     logic got msg on ibound
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/memstore.go:113        [store]   memorystore del: message1was deleted
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:224     [net]     received suback, id:1
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:228     [net]     granted qoss[0]
2020-02-04T12:26:12.507+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:213     [net]     logic waiting for msg on ibound
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:116     [net]     Received Message
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:217     [net]     logic got msg on ibound
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:240     [net]     received publish, msgId:0
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:241     [net]     putting msg on onPubChan
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:254     [net]     done putting msg on incomingPubChan
2020-02-04T12:26:12.620+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:213     [net]     logic waiting for msg on ibound
2020-02-04T12:26:12.620+0100    DEBUG   [mqtt input]    mqtt/input.go:108       Received message on topic 'motion', messageID: 0, size: 178     {"hosts": ["ssl://mqtt.eclipse.org:8883"]}
2020-02-04T12:26:12.784+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:116     [net]     Received Message
2020-02-04T12:26:12.784+0100    DEBUG   [libmqtt]       paho.mqtt.golang/net.go:217     [net]     logic got msg on ibound
```