### PR TITLE
Cherry-pick #15999 to 7.x: Update github.com/magefile/mage to v1.9.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4658,8 +4658,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 --------------------------------------------------------------------
 Dependency: github.com/magefile/mage
-Version: v1.8.0
-Revision: aedfce64c122eef47009b7f80c9771044753215d
+Version: v1.9.0
+Revision: 1c36bf78a98209d91af71354deb001cca75e11fc
 License type (autodetected): Apache-2.0
 ./vendor/github.com/magefile/mage/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/magefile/mage/README.md
+++ b/vendor/github.com/magefile/mage/README.md
@@ -3,7 +3,7 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/3185864/32058716-5ee9b512-ba38-11e7-978a-287eb2a62743.png"/></p>
 
-## About 
+## About
 
 Mage is a make-like build tool using Go.  You write plain-old go functions,
 and Mage automatically uses them as Makefile-like runnable targets.
@@ -11,7 +11,7 @@ and Mage automatically uses them as Makefile-like runnable targets.
 ## Installation
 
 Mage has no dependencies outside the Go standard library, and builds with Go 1.7
-and above (possibly even lower versions, but they're not regularly tested). 
+and above (possibly even lower versions, but they're not regularly tested).
 
 **Using GOPATH**
 
@@ -24,7 +24,7 @@ go run bootstrap.go
 **Using Go Modules**
 
 ```
-git clone https://github.com:magefile/mage
+git clone https://github.com/magefile/mage
 cd mage
 go run bootstrap.go
 ```
@@ -39,7 +39,7 @@ with the correct version information.
 The mage binary will be created in your $GOPATH/bin directory.
 
 You may also install a binary release from our
-[releases](https://github.com/magefile/mage/releases) page. 
+[releases](https://github.com/magefile/mage/releases) page.
 
 ## Demo
 
@@ -47,8 +47,8 @@ You may also install a binary release from our
 
 ## Discussion
 
-Join the `#mage` channel on [gophers slack](https://gophers.slack.com/messages/general/) 
-or post on the [magefile google group](https://groups.google.com/forum/#!forum/magefile) 
+Join the `#mage` channel on [gophers slack](https://gophers.slack.com/messages/general/)
+or post on the [magefile google group](https://groups.google.com/forum/#!forum/magefile)
 for discussion of usage, development, etc.
 
 # Documentation
@@ -71,4 +71,10 @@ superior to bash for any non-trivial task involving branching, looping, anything
 that's not just straight line execution of commands.  And if your project is
 written in Go, why introduce another language as idiosyncratic as bash?  Why not
 use the language your contributors are already comfortable with?
+
+# Thanks
+
+If you use mage and like it, or any of my other software, and you'd like to show your appreciation, you can do so on my patreon:
+
+[<img src=https://user-images.githubusercontent.com/3185864/49846051-64eddf80-fd97-11e8-9f59-d09f5652d214.png>](https://www.patreon.com/join/natefinch?)
 

--- a/vendor/github.com/magefile/mage/go.mod
+++ b/vendor/github.com/magefile/mage/go.mod
@@ -1,1 +1,3 @@
 module github.com/magefile/mage
+
+go 1.12

--- a/vendor/github.com/magefile/mage/magefile.go
+++ b/vendor/github.com/magefile/mage/magefile.go
@@ -1,7 +1,7 @@
 //+build mage
 
 // This is the build script for Mage. The install target is all you really need.
-// The release target is for generating offial releases and is really only
+// The release target is for generating official releases and is really only
 // useful to project admins.
 package main
 
@@ -27,12 +27,20 @@ func Install() error {
 	}
 
 	gocmd := mg.GoCmd()
-	gopath, err := sh.Output(gocmd, "env", "GOPATH")
+	// use GOBIN if set in the environment, otherwise fall back to first path
+	// in GOPATH environment string
+	bin, err := sh.Output(gocmd, "env", "GOBIN")
 	if err != nil {
-		return fmt.Errorf("can't determine GOPATH: %v", err)
+		return fmt.Errorf("can't determine GOBIN: %v", err)
 	}
-	paths := strings.Split(gopath, string([]rune{os.PathListSeparator}))
-	bin := filepath.Join(paths[0], "bin")
+	if bin == "" {
+		gopath, err := sh.Output(gocmd, "env", "GOPATH")
+		if err != nil {
+			return fmt.Errorf("can't determine GOPATH: %v", err)
+		}
+		paths := strings.Split(gopath, string([]rune{os.PathListSeparator}))
+		bin = filepath.Join(paths[0], "bin")
+	}
 	// specifically don't mkdirall, if you have an invalid gopath in the first
 	// place, that's not on us to fix.
 	if err := os.Mkdir(bin, 0700); err != nil && !os.IsExist(err) {

--- a/vendor/github.com/magefile/mage/mg/deps.go
+++ b/vendor/github.com/magefile/mage/mg/deps.go
@@ -214,6 +214,21 @@ func (o *onceFun) run() error {
 	return o.err
 }
 
+// Returns a location of mg.Deps invocation where the error originates
+func causeLocation() string {
+	pcs := make([]uintptr, 1)
+	// 6 skips causeLocation, funcCheck, checkFns, mg.CtxDeps, mg.Deps in stacktrace
+	if runtime.Callers(6, pcs) != 1 {
+		return "<unknown>"
+	}
+	frames := runtime.CallersFrames(pcs)
+	frame, _ := frames.Next()
+	if frame.Function == "" && frame.File == "" && frame.Line == 0 {
+		return "<unknown>"
+	}
+	return fmt.Sprintf("%s %s:%d", frame.Function, frame.File, frame.Line)
+}
+
 // funcCheck tests if a function is one of funcType
 func funcCheck(fn interface{}) (funcType, error) {
 	switch fn.(type) {
@@ -227,7 +242,7 @@ func funcCheck(fn interface{}) (funcType, error) {
 		return contextErrorType, nil
 	}
 
-	err := fmt.Errorf("Invalid type for dependent function: %T. Dependencies must be func(), func() error, func(context.Context), func(context.Context) error, or the same method on an mg.Namespace.", fn)
+	err := fmt.Errorf("Invalid type for dependent function: %T. Dependencies must be func(), func() error, func(context.Context), func(context.Context) error, or the same method on an mg.Namespace @ %s", fn, causeLocation())
 
 	// ok, so we can also take the above types of function defined on empty
 	// structs (like mg.Namespace). When you pass a method of a type, it gets

--- a/vendor/github.com/magefile/mage/mg/runtime.go
+++ b/vendor/github.com/magefile/mage/mg/runtime.go
@@ -19,13 +19,20 @@ const VerboseEnv = "MAGEFILE_VERBOSE"
 // debug mode when running mage.
 const DebugEnv = "MAGEFILE_DEBUG"
 
-// GoCmdEnv is the environment variable that indicates the user requested
-// verbose mode when running a magefile.
+// GoCmdEnv is the environment variable that indicates the go binary the user
+// desires to utilize for Magefile compilation.
 const GoCmdEnv = "MAGEFILE_GOCMD"
 
 // IgnoreDefaultEnv is the environment variable that indicates the user requested
 // to ignore the default target specified in the magefile.
 const IgnoreDefaultEnv = "MAGEFILE_IGNOREDEFAULT"
+
+// HashFastEnv is the environment variable that indicates the user requested to
+// use a quick hash of magefiles to determine whether or not the magefile binary
+// needs to be rebuilt. This results in faster runtimes, but means that mage
+// will fail to rebuild if a dependency has changed. To force a rebuild, run
+// mage with the -f flag.
+const HashFastEnv = "MAGEFILE_HASHFAST"
 
 // Verbose reports whether a magefile was run with the verbose flag.
 func Verbose() bool {
@@ -33,7 +40,7 @@ func Verbose() bool {
 	return b
 }
 
-// Debug reports whether a magefile was run with the verbose flag.
+// Debug reports whether a magefile was run with the debug flag.
 func Debug() bool {
 	b, _ := strconv.ParseBool(os.Getenv(DebugEnv))
 	return b
@@ -46,6 +53,13 @@ func GoCmd() string {
 		return cmd
 	}
 	return "go"
+}
+
+// HashFast reports whether the user has requested to use the fast hashing
+// mechanism rather than rely on go's rebuilding mechanism.
+func HashFast() bool {
+	b, _ := strconv.ParseBool(os.Getenv(HashFastEnv))
+	return b
 }
 
 // IgnoreDefault reports whether the user has requested to ignore the default target

--- a/vendor/github.com/magefile/mage/sh/cmd.go
+++ b/vendor/github.com/magefile/mage/sh/cmd.go
@@ -76,7 +76,7 @@ func Output(cmd string, args ...string) (string, error) {
 	return strings.TrimSuffix(buf.String(), "\n"), err
 }
 
-// OutputWith is like RunWith, ubt returns what is written to stdout.
+// OutputWith is like RunWith, but returns what is written to stdout.
 func OutputWith(env map[string]string, cmd string, args ...string) (string, error) {
 	buf := &bytes.Buffer{}
 	_, err := Exec(env, buf, os.Stderr, cmd, args...)

--- a/vendor/github.com/magefile/mage/sh/helpers.go
+++ b/vendor/github.com/magefile/mage/sh/helpers.go
@@ -31,6 +31,7 @@ func Copy(dst string, src string) error {
 	if err != nil {
 		return fmt.Errorf(`can't copy to %s: %v`, dst, err)
 	}
+	defer to.Close()
 	_, err = io.Copy(to, from)
 	if err != nil {
 		return fmt.Errorf(`error copying %s to %s: %v`, src, dst, err)

--- a/vendor/github.com/magefile/mage/target/target.go
+++ b/vendor/github.com/magefile/mage/target/target.go
@@ -1,18 +1,30 @@
 package target
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
 )
 
-// Path reports if any of the sources have been modified more recently
-// than the destination.  Path does not descend into directories, it literally
-// just checks the modtime of each thing you pass to it.  If the destination
-// file doesn't exist, it always returns true and nil.  It's an error if any of
-// the sources don't exist.
+// expand takes a collection of sources as strings, and for each one, it expands
+// environment variables in the form $FOO or ${FOO} using os.ExpandEnv
+func expand(sources []string) []string {
+	for i, s := range sources {
+		// first expand the environment
+		sources[i] = os.ExpandEnv(s)
+	}
+	return sources
+}
+
+// Path first expands environment variables like $FOO or ${FOO}, and then
+// reports if any of the sources have been modified more recently than the
+// destination. Path does not descend into directories, it literally just checks
+// the modtime of each thing you pass to it. If the destination file doesn't
+// exist, it always returns true and nil. It's an error if any of the sources
+// don't exist.
 func Path(dst string, sources ...string) (bool, error) {
-	stat, err := os.Stat(dst)
+	stat, err := os.Stat(os.ExpandEnv(dst))
 	if os.IsNotExist(err) {
 		return true, nil
 	}
@@ -20,7 +32,7 @@ func Path(dst string, sources ...string) (bool, error) {
 		return false, err
 	}
 	srcTime := stat.ModTime()
-	dt, err := loadTargets(sources)
+	dt, err := loadTargets(expand(sources))
 	if err != nil {
 		return false, err
 	}
@@ -31,13 +43,41 @@ func Path(dst string, sources ...string) (bool, error) {
 	return false, nil
 }
 
+// Glob expands each of the globs (file patterns) into individual sources and
+// then calls Path on the result, reporting if any of the resulting sources have
+// been modified more recently than the destination. Syntax for Glob patterns is
+// the same as stdlib's filepath.Glob. Note that Glob does not expand
+// environment variables before globbing -- env var expansion happens during
+// the call to Path. It is an error for any glob to return an empty result.
+func Glob(dst string, globs ...string) (bool, error) {
+	for _, g := range globs {
+		files, err := filepath.Glob(g)
+		if err != nil {
+			return false, err
+		}
+		if len(files) == 0 {
+			return false, errors.New("glob didn't match any files: " + g)
+		}
+		// it's best to evaluate each glob as we do it
+		// because we may be able to early-exit
+		shouldDo, err := Path(dst, files...)
+		if err != nil {
+			return false, err
+		}
+		if shouldDo {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Dir reports whether any of the sources have been modified more recently than
 // the destination.  If a source or destination is a directory, modtimes of
 // files under those directories are compared instead.  If the destination file
 // doesn't exist, it always returns true and nil.  It's an error if any of the
 // sources don't exist.
 func Dir(dst string, sources ...string) (bool, error) {
-	stat, err := os.Stat(dst)
+	stat, err := os.Stat(os.ExpandEnv(dst))
 	if os.IsNotExist(err) {
 		return true, nil
 	}
@@ -51,7 +91,7 @@ func Dir(dst string, sources ...string) (bool, error) {
 			return false, err
 		}
 	}
-	dt, err := loadTargets(sources)
+	dt, err := loadTargets(expand(sources))
 	if err != nil {
 		return false, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3961,60 +3961,60 @@
 			"revisionTime": "2019-05-07T19:18:18Z"
 		},
 		{
-			"checksumSHA1": "ASXhLVfIA2mzHf+7muYxT38JaHU=",
+			"checksumSHA1": "ZcE3YAClBwbAQWRcgp31Qsrii/M=",
 			"path": "github.com/magefile/mage",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
 			"checksumSHA1": "fHpo/9Tke6VFfZZAT+PRnoNOiiY=",
 			"path": "github.com/magefile/mage/internal",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
-			"checksumSHA1": "RVSwuhHOfojhN74rfwRe4AktDIA=",
+			"checksumSHA1": "a5Sja7VEvuyh6gJTZCTJ8W26kOI=",
 			"path": "github.com/magefile/mage/mage",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
-			"checksumSHA1": "irRTBkCBnOGMX+PZhOdHFUckgBY=",
+			"checksumSHA1": "eNlaZsWRGHEIkiX4kkQClBU+Q7s=",
 			"path": "github.com/magefile/mage/mg",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
 			"checksumSHA1": "QGt/JRmNp+D+lO0hHZsUUyH7y5U=",
 			"path": "github.com/magefile/mage/parse",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
-			"checksumSHA1": "4JzH55TcYdctQksrCafgKT8lZRU=",
+			"checksumSHA1": "i3NX8AtbllkQLVYYUyhvb5GZGgg=",
 			"path": "github.com/magefile/mage/sh",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
-			"checksumSHA1": "91U4Tlwnjdmwjd0w/XNw3+fxFKo=",
+			"checksumSHA1": "iL3ochY7eRpRxqij1wXklQKw6pQ=",
 			"path": "github.com/magefile/mage/target",
-			"revision": "aedfce64c122eef47009b7f80c9771044753215d",
-			"revisionTime": "2018-12-11T21:18:45Z",
-			"version": "v1.8.0",
-			"versionExact": "v1.8.0"
+			"revision": "1c36bf78a98209d91af71354deb001cca75e11fc",
+			"revisionTime": "2019-09-12T19:43:23Z",
+			"version": "v1.9.0",
+			"versionExact": "v1.9.0"
 		},
 		{
 			"path": "github.com/magefile/mage^",


### PR DESCRIPTION
Cherry-pick of PR #15999 to 7.x branch. Original message: 

## What does this PR do?

This PR update `github.com/magefile/mage` to v1.9.0 to make moving to modules smoother.

## Why is it important?

The minimal selected version for mage is currently v1.9.0. By updating it now, it makes the actual go-modules PR smaller.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made the corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

Needed by https://github.com/elastic/beats/pull/15998