### PR TITLE
Cherry-pick #15906 to 7.x: Fix Filebeat Zeek Weird Ingest Pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed dashboard for Cisco ASA Firewall. {issue}15420[15420] {pull}15553[15553]
 - Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
 - Fix typos in zeek notice fileset config file. {issue}15764[15764] {pull}15765[15765]
+- Fix mapping error when zeek weird logs do not contain IP addresses. {pull}15906[15906]
+- Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
+- Prevent Elasticsearch from spewing log warnings about redundant wildcards when setting up ingest pipelines for the `elasticsearch` module. {issue}15840[15840] {pull}15900[15900]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -90,8 +90,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
 - Fix typos in zeek notice fileset config file. {issue}15764[15764] {pull}15765[15765]
 - Fix mapping error when zeek weird logs do not contain IP addresses. {pull}15906[15906]
-- Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
-- Prevent Elasticsearch from spewing log warnings about redundant wildcards when setting up ingest pipelines for the `elasticsearch` module. {issue}15840[15840] {pull}15900[15900]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/weird/ingest/pipeline.json
+++ b/x-pack/filebeat/module/zeek/weird/ingest/pipeline.json
@@ -28,13 +28,15 @@
     {
       "set": {
         "field": "source.ip",
-        "value": "{{source.address}}"
+        "value": "{{source.address}}",
+        "if": "ctx?.source?.address != null"
       }
     },
     {
       "set": {
         "field": "destination.ip",
-        "value": "{{destination.address}}"
+        "value": "{{destination.address}}",
+        "if": "ctx?.destination?.address != null"
       }
     }
   ],

--- a/x-pack/filebeat/module/zeek/weird/test/weird-json.log
+++ b/x-pack/filebeat/module/zeek/weird/test/weird-json.log
@@ -1,1 +1,2 @@
 {"ts":1543877999.99354,"uid":"C1ralPp062bkwWt4e","id.orig_h":"192.168.1.1","id.orig_p":64521,"id.resp_h":"192.168.1.2","id.resp_p":53,"name":"dns_unmatched_reply","notice":false,"peer":"worker-6"}
+{"ts":1580227259.342809,"name":"non_ip_packet_in_ethernet","notice":false,"peer":"ens3f1-4"}

--- a/x-pack/filebeat/module/zeek/weird/test/weird-json.log-expected.json
+++ b/x-pack/filebeat/module/zeek/weird/test/weird-json.log-expected.json
@@ -21,5 +21,20 @@
         "zeek.weird.name": "dns_unmatched_reply",
         "zeek.weird.notice": false,
         "zeek.weird.peer": "worker-6"
+    },
+    {
+        "@timestamp": "2020-01-28T16:00:59.342Z",
+        "event.dataset": "zeek.weird",
+        "event.module": "zeek",
+        "fileset.name": "weird",
+        "input.type": "log",
+        "log.offset": 197,
+        "service.type": "zeek",
+        "tags": [
+            "zeek.weird"
+        ],
+        "zeek.weird.name": "non_ip_packet_in_ethernet",
+        "zeek.weird.notice": false,
+        "zeek.weird.peer": "ens3f1-4"
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #15906 to 7.x branch. Original message: 

Some Zeek Weird logs do not contain IP addresses, causing the warning seen below:

**Logstash Output**
`[2020-01-28T15:49:35,993][WARN ][logstash.outputs.elasticsearch] Could not index event to Elasticsearch. {:status=>400, :action=>["index", {:_id=>nil, :_index=>"filebeat-zeek-2020.01.28", :routing=>nil, :_type=>"_doc", :pipeline=>"filebeat-7.5.2-zeek-weird-pipeline"}, #<LogStash::Event:0x3f1f2270>], :response=>{"index"=>{"_index"=>"filebeat-zeek-2020.01.28", "_type"=>"_doc", "_id"=>"r3PX7G8BxFIJZtUR_Ruu", "status"=>400, "error"=>{"type"=>"mapper_parsing_exception", "reason"=>"failed to parse field [destination.ip] of type [ip] in document with id 'r3PX7G8BxFIJZtUR_Ruu'. Preview of field's value: ''", "caused_by"=>{"type"=>"illegal_argument_exception", "reason"=>"'' is not an IP string literal."}}}}}`

**Sample from weird.log**
`{"ts":1580227259.342809,"name":"non_ip_packet_in_ethernet","notice":false,"peer":"ens3f1-4"}`