### PR TITLE
Template generation maintenance + remove number of routing shards from default template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update replicaset group to apps/v1 {pull}15854[15802]
 - Fix issue where default go logger is not discarded when either * or stdout is selected. {issue}10251[10251] {pull}15708[15708]
 - Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
+- Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1060,7 +1060,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1757,7 +1757,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1204,7 +1204,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -998,7 +998,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -941,7 +941,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -312,8 +312,9 @@ func buildIdxSettings(ver common.Version, userSettings common.MapStr) common.Map
 	}
 
 	// number_of_routing shards is only supported for ES version >= 6.1
+	// If ES >= 7.0 we can exclude this setting as well.
 	version61, _ := common.NewVersion("6.1.0")
-	if !ver.LessThan(version61) {
+	if !ver.LessThan(version61) && ver.Major < 7 {
 		indexSettings.Put("number_of_routing_shards", defaultNumberOfRoutingShards)
 	}
 

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -106,11 +106,28 @@ func TestNumberOfRoutingShards(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	currentVersion := getVersion("7.0.0")
-	template := createTestTemplate(t, currentVersion, currentVersion, DefaultConfig())
-	template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
-	template.Assert("order", 1)
-	template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+	currentVersion := getVersion("")
+
+	t.Run("for ES 6.x", func(t *testing.T) {
+		template := createTestTemplate(t, currentVersion, "6.4.0", DefaultConfig())
+		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
+		template.Assert("order", 1)
+		template.Assert("mappings.doc._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+	})
+
+	t.Run("for ES 7.x", func(t *testing.T) {
+		template := createTestTemplate(t, currentVersion, "7.2.0", DefaultConfig())
+		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
+		template.Assert("order", 1)
+		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+	})
+
+	t.Run("for ES 8.x", func(t *testing.T) {
+		template := createTestTemplate(t, currentVersion, "8.0.0", DefaultConfig())
+		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
+		template.Assert("order", 1)
+		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+	})
 }
 
 func createTestTemplate(t *testing.T, beatVersion, esVersion string, config TemplateConfig) *testTemplate {

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -20,75 +20,146 @@
 package template
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/version"
 )
 
-func TestNumberOfRoutingShards(t *testing.T) {
-
-	beatVersion := "6.1.0"
-	beatName := "testbeat"
-	config := TemplateConfig{}
-
-	// Test it exists in 6.1
-	ver := common.MustNewVersion("6.1.0")
-	template, err := New(beatVersion, beatName, *ver, config, false)
-	assert.NoError(t, err)
-
-	data := template.Generate(nil, nil)
-	shards, err := data.GetValue("settings.index.number_of_routing_shards")
-	assert.NoError(t, err)
-
-	assert.Equal(t, 30, shards.(int))
-
-	// Test it does not exist in 6.0
-	ver = common.MustNewVersion("6.0.0")
-	template, err = New(beatVersion, beatName, *ver, config, false)
-	assert.NoError(t, err)
-
-	data = template.Generate(nil, nil)
-	shards, err = data.GetValue("settings.index.number_of_routing_shards")
-	assert.Error(t, err)
-	assert.Equal(t, nil, shards)
+type testTemplate struct {
+	t    *testing.T
+	tmpl *Template
+	data common.MapStr
 }
 
-func TestNumberOfRoutingShardsOverwrite(t *testing.T) {
+func TestNumberOfRoutingShards(t *testing.T) {
+	const notPresent = 0 // setting missing indicator
+	const settingKey = "number_of_routing_shards"
+	const fullKey = "settings.index." + settingKey
 
-	beatVersion := "6.1.0"
-	beatName := "testbeat"
-	config := TemplateConfig{
-		Settings: TemplateSettings{
-			Index: map[string]interface{}{"number_of_routing_shards": 5},
+	cases := map[string]struct {
+		esVersion string
+		set       int
+		want      int
+	}{
+		"Do not set default for older version than 6.1": {
+			esVersion: "6.0.0",
+			want:      notPresent,
+		},
+		"Default present if ES 6.1.0 is used": {
+			esVersion: "6.1.0",
+			want:      30,
+		},
+		"Default present for newer ES 6.x version": {
+			esVersion: "6.8.2",
+			want:      30,
+		},
+		"Can overwrite default for ES 6.x": {
+			esVersion: "6.1.0",
+			set:       1024,
+			want:      1024,
+		},
+		"Do not set by default for ES 7.x": {
+			esVersion: "7.0.0",
+			want:      notPresent,
+		},
+		"Still configurable for ES 7.x": {
+			esVersion: "7.0.0",
+			set:       1024,
+			want:      1024,
+		},
+		"Do not set with current version": {
+			want: notPresent,
+		},
+		"Still configurable with current version": {
+			set:  1024,
+			want: 1024,
 		},
 	}
 
-	// Test it exists in 6.1
-	ver := common.MustNewVersion("6.1.0")
-	template, err := New(beatVersion, beatName, *ver, config, false)
-	assert.NoError(t, err)
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			beatVersion := getVersion("")
+			esVersion := getVersion(test.esVersion)
 
-	data := template.Generate(nil, nil)
-	shards, err := data.GetValue("settings.index.number_of_routing_shards")
-	assert.NoError(t, err)
+			indexSettings := map[string]interface{}{}
+			if test.set > 0 {
+				indexSettings[settingKey] = test.set
+			}
 
-	assert.Equal(t, 5, shards.(int))
+			template := createTestTemplate(t, beatVersion, esVersion, TemplateConfig{
+				Settings: TemplateSettings{
+					Index: indexSettings,
+				},
+			})
+
+			if test.want == notPresent {
+				template.AssertMissing(fullKey)
+			} else {
+				template.Assert(fullKey, test.want)
+			}
+		})
+	}
 }
 
 func TestTemplate(t *testing.T) {
-	beatVersion := "6.6.0"
-	beatName := "testbeat"
-	ver := common.MustNewVersion("6.6.0")
-	template, err := New(beatVersion, beatName, *ver, DefaultConfig(), false)
-	require.NoError(t, err)
+	currentVersion := getVersion("7.0.0")
+	template := createTestTemplate(t, currentVersion, currentVersion, DefaultConfig())
+	template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
+	template.Assert("order", 1)
+	template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+}
 
-	data := template.Generate(common.MapStr{}, nil)
-	assert.Equal(t, []string{"testbeat-6.6.0-*"}, data["index_patterns"])
-	assert.Equal(t, 1, data["order"])
-	meta, err := data.GetValue("mappings.doc._meta")
-	require.NoError(t, err)
-	assert.Equal(t, common.MapStr{"beat": "testbeat", "version": "6.6.0"}, meta)
+func createTestTemplate(t *testing.T, beatVersion, esVersion string, config TemplateConfig) *testTemplate {
+	beatVersion = getVersion(beatVersion)
+	esVersion = getVersion(esVersion)
+	ver := common.MustNewVersion(esVersion)
+	template, err := New(beatVersion, "testbeat", *ver, config, false)
+	if err != nil {
+		t.Fatalf("Failed to create the template: %+v", err)
+	}
+
+	return &testTemplate{t: t, tmpl: template, data: template.Generate(nil, nil)}
+}
+
+func (t *testTemplate) Has(path string) bool {
+	t.t.Helper()
+	has, err := t.data.HasKey(path)
+	if err != nil && err != common.ErrKeyNotFound {
+		serialized, _ := json.MarshalIndent(t.data, "", "    ")
+		t.t.Fatalf("error accessing '%v': %v\ntemplate: %s", path, err, serialized)
+	}
+	return has
+}
+
+func (t *testTemplate) Get(path string) interface{} {
+	t.t.Helper()
+	val, err := t.data.GetValue(path)
+	if err != nil {
+		serialized, _ := json.MarshalIndent(t.data, "", "    ")
+		t.t.Fatalf("error accessing '%v': %v\ntemplate: %s", path, err, serialized)
+	}
+	return val
+}
+
+func (t *testTemplate) AssertMissing(path string) {
+	t.t.Helper()
+	if t.Has(path) {
+		t.t.Fatalf("Expected '%v' to be missing", path)
+	}
+}
+
+func (t *testTemplate) Assert(path string, val interface{}) {
+	t.t.Helper()
+	assert.Equal(t.t, val, t.Get(path))
+}
+
+func getVersion(in string) string {
+	if in == "" {
+		return version.GetDefaultVersion()
+	}
+	return in
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1747,7 +1747,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1480,7 +1480,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -983,7 +983,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1111,7 +1111,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2285,7 +2285,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1009,7 +1009,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1980,7 +1980,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -986,7 +986,6 @@ setup.template.settings:
   #index:
     #number_of_shards: 1
     #codec: best_compression
-    #number_of_routing_shards: 30
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

- Remove `number_of_routing_shards` from default template if the setting is not present and if we target Elasticsearch >= 7.0.
- Update template generation unit tests adding some more test cases, and updating cases to use the the current Beat version as well.
- introduce testTemplate and other helpers for writing more concise tests.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

- The `number_of_routing_shards` setting has become optional with Elasticsearch 7.0 and should not be set by default anymore.
- Some of our tests only did check for one particular ES version. The template output has been slightly changed for 7.0 to deal with types removal. The tests haven't been adapted in the past.
- Helpers hopefully make it easier to see what is tested and encourage devs to add more tests in the future.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Export template and check `number_of_routing_shards` setting is missing by default from the template.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Closes elastic/beats#9119 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
