### PR TITLE
[elastic log driver] Use CrossBuild to build binary

### DIFF
--- a/x-pack/dockerlogbeat/Dockerfile
+++ b/x-pack/dockerlogbeat/Dockerfile
@@ -1,18 +1,4 @@
-ARG versionString
-FROM golang:${versionString} as builder
-
-WORKDIR /go/src/github.com/elastic/beats/x-pack/dockerlogbeat
-COPY . ../..
-
-ENV GOPATH=/go
-ARG GOOS=linux
-ARG GOARCH=amd64
-ARG GOARM=
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o dockerlogbeat
-
-
-FROM alpine:3.7 as final
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
-RUN mkdir /contmount
-COPY --from=builder /go/src/github.com/elastic/beats/x-pack/dockerlogbeat/dockerlogbeat /usr/bin/dockerlogbeat
+COPY build/dockerlogbeat /usr/bin/
+

--- a/x-pack/dockerlogbeat/Dockerfile
+++ b/x-pack/dockerlogbeat/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
-COPY build/dockerlogbeat /usr/bin/
+COPY build/plugin/dockerlogbeat /usr/bin/
 

--- a/x-pack/dockerlogbeat/config.json
+++ b/x-pack/dockerlogbeat/config.json
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "description": "libbeat env hack",
+      "description": "Remove strict config file checking, as there is no config file",
       "name": "BEAT_STRICT_PERMS",
       "value": "false"
     },

--- a/x-pack/dockerlogbeat/config.json
+++ b/x-pack/dockerlogbeat/config.json
@@ -1,32 +1,36 @@
 {
-    "description": "A beat for docker logs",
-    "documentation": "https://docs.docker.com/engine/extend/plugin_api/",
-    "entrypoint": ["/usr/bin/dockerlogbeat"],
-    "network": {
-      "type": "host"
+  "description": "A beat for docker logs",
+  "documentation": "https://docs.docker.com/engine/extend/plugin_api/",
+  "entrypoint": [
+    "/usr/bin/dockerlogbeat"
+  ],
+  "network": {
+    "type": "host"
+  },
+  "interface": {
+    "types": [
+      "docker.logdriver/1.0"
+    ],
+    "socket": "beatSocket.sock"
+  },
+  "env": [
+    {
+      "description": "debug level",
+      "name": "LOG_DRIVER_LEVEL",
+      "value": "info",
+      "Settable": [
+        "value"
+      ]
     },
-    "interface": {
-      "types": ["docker.logdriver/1.0"],
-      "socket": "beatSocket.sock"
+    {
+      "description": "libbeat env hack",
+      "name": "BEAT_STRICT_PERMS",
+      "value": "false"
     },
-    "env":[
-      {
-        "description": "debug level",
-        "name": "LOG_DRIVER_LEVEL",
-        "value": "info",
-        "Settable": [
-          "value"
-        ]
-      },
-      {
-        "description": "libbeat env hack",
-        "name": "BEAT_STRICT_PERMS",
-        "value": "false"
-      }, 
-      {
-        "description": "config for dockerlogbeat",
-        "name": "BEAT_UNIX_SOCK_PATH",
-        "value": "/contmount/controller.sock"
-      }
-    ]
-  }
+    {
+      "description": "config for dockerlogbeat",
+      "name": "BEAT_UNIX_SOCK_PATH",
+      "value": "/contmount/controller.sock"
+    }
+  ]
+}

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -112,11 +112,6 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 		return errors.Wrap(err, "error reading from docker output")
 	}
 	fmt.Printf("%s\n", string(buildStr))
-	// move back to the x-pack dir
-	err = os.Chdir(dockerLogBeatDir)
-	if err != nil {
-		return errors.Wrap(err, "error returning to dockerlogbeat dir")
-	}
 
 	return nil
 }
@@ -335,7 +330,7 @@ func GolangCrossBuild() error {
 	buildArgs := devtools.DefaultBuildArgs()
 	buildArgs.CGO = false
 	buildArgs.Static = true
-	buildArgs.OutputDir = "build"
+	buildArgs.OutputDir = "build/plugin"
 	return devtools.GolangCrossBuild(buildArgs)
 }
 

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -114,11 +114,11 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 	}
 	defer buildResp.Body.Close()
 	// This blocks until the build operation completes
-	_, errBufRead := ioutil.ReadAll(buildResp.Body)
+	buildStr, errBufRead := ioutil.ReadAll(buildResp.Body)
 	if errBufRead != nil {
 		return errors.Wrap(err, "error reading from docker output")
 	}
-
+	fmt.Printf("%s\n", string(buildStr))
 	// move back to the x-pack dir
 	err = os.Chdir(dockerLogBeatDir)
 	if err != nil {


### PR DESCRIPTION
This is an attempt to deal with some of the issues that @mikemadden42 and others are running into with regards to the release process. My hope is that this will cut down on disk space and speed up build time.