### PR TITLE
Only initialize service URL once

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -78,6 +78,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Avoid parsing errors returned from prometheus endpoints. {pull}15712[15712]
 - Change lookup_fields from metricset.host to service.address {pull}15883[15883]
 - Add dedot for cloudwatch metric name. {issue}15916[15916] {pull}15917[15917]
+- Fixed issue `logstash-xpack` module suddenly ceasing to monitor Logstash. {issue}15974[15974] {pull}16044[16044]
 
 *Packetbeat*
 

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -18,7 +18,7 @@
 package node_stats
 
 import (
-	"strings"
+	"sync"
 
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -50,6 +50,7 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*logstash.MetricSet
+	initialized sync.Once
 }
 
 // New create a new instance of the MetricSet
@@ -60,7 +61,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	return &MetricSet{
-		ms,
+		MetricSet: ms,
 	}, nil
 }
 
@@ -68,7 +69,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	err := m.init()
+	var err error
+	m.initialized.Do(func() {
+		err = m.init()
+	})
 	if err != nil {
 		if m.XPack {
 			m.Logger().Error(err)
@@ -105,11 +109,7 @@ func (m *MetricSet) init() error {
 			return err
 		}
 
-		const verticesParam = "vertices=true"
-		currentURI := m.HTTP.GetURI()
-		if !strings.Contains(currentURI, verticesParam) {
-			m.HTTP.SetURI(currentURI + "?" + verticesParam)
-		}
+		m.HTTP.SetURI(m.HTTP.GetURI() + "?vertices=true")
 	}
 
 	return nil

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -18,6 +18,8 @@
 package node_stats
 
 import (
+	"strings"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
@@ -103,7 +105,11 @@ func (m *MetricSet) init() error {
 			return err
 		}
 
-		m.HTTP.SetURI(m.HTTP.GetURI() + "?vertices=true")
+		const verticesParam = "vertices=true"
+		currentURI := m.HTTP.GetURI()
+		if !strings.Contains(currentURI, verticesParam) {
+			m.HTTP.SetURI(currentURI + "?" + verticesParam)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR do?

It initializes the URL for the Logstash node stats API to be called by the `logstash` module when `xpack.enabled: true` is set **exactly once.**  

## Why is it important?

Before this fix, the `?vertices=true` query parameter string was getting appended to the Logstash node stats API URL repeatedly, each time the `logstash/node_stats`'s `Fetch()` method was invoked. This resulted in Logstash eventually returning HTTP 400 responses and Logstash monitoring data not being collected by the Logstash Metricbeat module.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~. There are existing tests that verify correctness of collecting Logstash monitoring data. To test this particular bugfix, manual testing is OK IMO.

## How to test this PR locally

1. Run Logstash with a simple pipeline.
   ```
   ./bin/logstash -e 'input { stdin {} }'
   ```

2. Enable the `logstash-xpack` module in Metricbeat.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Run Metricbeat.
   ```
   ./metricbeat -e
   ```

4. Open up Wireshark (or similar) and sniff for HTTP traffic on localhost going to port 9600 (the Logstash HTTP API port). Verify that you are seeing calls like `GET /_node/stats?vertices=true` every 10 seconds. Verify that the `?vertices=true` query parameter string is not being appended in each iteration.
 
## Related issues

- Closes #15974
