### PR TITLE
Clean up functionbeat/build/vendor folder before collecting dependencies

### DIFF
--- a/x-pack/functionbeat/scripts/mage/update.go
+++ b/x-pack/functionbeat/scripts/mage/update.go
@@ -5,6 +5,7 @@
 package mage
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,6 +56,10 @@ func (Update) IncludeFields() error {
 func (Update) VendorBeats() error {
 	for _, f := range []string{"pubsub", "storage"} {
 		gcpVendorPath := filepath.Join("provider", "gcp", "build", f, "vendor")
+		err := os.RemoveAll(gcpVendorPath)
+		if err != nil {
+			return err
+		}
 
 		deps, err := gotool.ListDeps("github.com/elastic/beats/x-pack/functionbeat/provider/gcp/" + f)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

This PR clean up `build/{functionname}/vendor` folder before collecting the dependencies.

## Why is it important?

Previously, it was possible that various dependency versions got messed up in the folder `vendor`. That lead to broken packages when building it locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Run the packaging target of Functionbeat.

```
mage package
```

Extract the appropriate package and check if the functions can be built:

Pubsub function:

```
cd pkg/pubsub
go build pubsub.go
```

Storage function:

```
cd pkg/storage
go build storage.go
```
