### PR TITLE
Cherry-pick #16039 to 7.x: [elastic log driver] Use CrossBuild to build binary

### DIFF
--- a/x-pack/dockerlogbeat/Dockerfile
+++ b/x-pack/dockerlogbeat/Dockerfile
@@ -1,18 +1,4 @@
-ARG versionString
-FROM golang:${versionString} as builder
-
-WORKDIR /go/src/github.com/elastic/beats/x-pack/dockerlogbeat
-COPY . ../..
-
-ENV GOPATH=/go
-ARG GOOS=linux
-ARG GOARCH=amd64
-ARG GOARM=
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o dockerlogbeat
-
-
-FROM alpine:3.7 as final
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
-RUN mkdir /contmount
-COPY --from=builder /go/src/github.com/elastic/beats/x-pack/dockerlogbeat/dockerlogbeat /usr/bin/dockerlogbeat
+COPY build/plugin/dockerlogbeat /usr/bin/
+

--- a/x-pack/dockerlogbeat/config.json
+++ b/x-pack/dockerlogbeat/config.json
@@ -1,24 +1,36 @@
 {
-    "description": "A beat for docker logs",
-    "documentation": "https://docs.docker.com/engine/extend/plugin_api/",
-    "entrypoint": ["/usr/bin/dockerlogbeat"],
-    "network": {
-      "type": "host"
+  "description": "A beat for docker logs",
+  "documentation": "https://docs.docker.com/engine/extend/plugin_api/",
+  "entrypoint": [
+    "/usr/bin/dockerlogbeat"
+  ],
+  "network": {
+    "type": "host"
+  },
+  "interface": {
+    "types": [
+      "docker.logdriver/1.0"
+    ],
+    "socket": "beatSocket.sock"
+  },
+  "env": [
+    {
+      "description": "debug level",
+      "name": "LOG_DRIVER_LEVEL",
+      "value": "info",
+      "Settable": [
+        "value"
+      ]
     },
-    "interface": {
-      "types": ["docker.logdriver/1.0"],
-      "socket": "beatSocket.sock"
+    {
+      "description": "Remove strict config file checking, as there is no config file",
+      "name": "BEAT_STRICT_PERMS",
+      "value": "false"
     },
-    "env":[
-      {
-        "description": "libbeat env hack",
-        "name": "BEAT_STRICT_PERMS",
-        "value": "false"
-      }, 
-      {
-        "description": "config for dockerlogbeat",
-        "name": "BEAT_UNIX_SOCK_PATH",
-        "value": "/contmount/controller.sock"
-      }
-    ]
-  }
+    {
+      "description": "config for dockerlogbeat",
+      "name": "BEAT_UNIX_SOCK_PATH",
+      "value": "/contmount/controller.sock"
+    }
+  ]
+}

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -76,12 +76,6 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 		return errors.Errorf("not in dockerlogbeat directory: %s", dockerLogBeatDir)
 	}
 
-	// change back to the root beats dir so we can send the proper build context to docker
-	err = os.Chdir("../..")
-	if err != nil {
-		return errors.Wrap(err, "error changing directory")
-	}
-
 	// start to build the root container that'll be used to build the plugin
 	tmpDir, err := ioutil.TempDir("", "dockerBuildTar")
 	if err != nil {
@@ -103,39 +97,30 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 
 	buildOpts := types.ImageBuildOptions{
 		BuildArgs:  map[string]*string{"versionString": &goVersion},
-		Target:     "final",
 		Tags:       []string{rootImageName},
-		Dockerfile: "x-pack/dockerlogbeat/Dockerfile",
+		Dockerfile: "Dockerfile",
 	}
 	//build, wait for output
 	buildResp, err := cli.ImageBuild(ctx, buildContext, buildOpts)
 	defer buildResp.Body.Close()
-	buf, errBufRead := ioutil.ReadAll(buildResp.Body)
+	// This blocks until the build operation completes
+	buildStr, errBufRead := ioutil.ReadAll(buildResp.Body)
 	if errBufRead != nil {
 		return errors.Wrap(err, "error reading from docker output")
 	}
-	if err != nil {
-		fmt.Printf("Docker response: \n %s\n", string(buf))
-		return errors.Wrap(err, "error building final container image")
-	}
-
-	// move back to the x-pack dir
-	err = os.Chdir(dockerLogBeatDir)
-	if err != nil {
-		return errors.Wrap(err, "error returning to dockerlogbeat dir")
-	}
+	fmt.Printf("%s\n", string(buildStr))
 
 	return nil
 }
 
-// Build builds docker rootfs container root
+// BuildContainer builds docker rootfs container root
 // There's a somewhat complicated process for this:
 // * Create a container to build the plugin itself
 // * Copy that to a bare-bones container that will become the runc container used by docker
 // * Export that container
 // * Unpack the tar from the exported container
 // * send this to the plugin create API endpoint
-func Build(ctx context.Context) error {
+func BuildContainer(ctx context.Context) error {
 	// setup
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -323,6 +308,27 @@ func Export() error {
 	}
 
 	return nil
+}
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	return devtools.CrossBuild(devtools.ForPlatforms("linux/amd64"))
+}
+
+// Build builds the base container used by the docker plugin
+func Build() {
+	mg.SerialDeps(CrossBuild, BuildContainer)
+}
+
+// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// Do not use directly, use crossBuild instead.
+func GolangCrossBuild() error {
+
+	buildArgs := devtools.DefaultBuildArgs()
+	buildArgs.CGO = false
+	buildArgs.Static = true
+	buildArgs.OutputDir = "build/plugin"
+	return devtools.GolangCrossBuild(buildArgs)
 }
 
 // Package builds a "release" tarball that can be used later with `docker plugin create`


### PR DESCRIPTION
Cherry-pick of PR #16039 to 7.x branch. Original message: 

This is an attempt to deal with some of the issues that @mikemadden42 and others are running into with regards to the release process. My hope is that this will cut down on disk space and speed up build time.