### PR TITLE
Make Explicitly use python2 and pip2 in "make python-env"

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -254,12 +254,12 @@ load-tests: ## @testing Runs load tests
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
-	@test -e ${PYTHON_ENV}/bin/activate || virtualenv $(if ${PYTHON_EXE},-p ${PYTHON_EXE}) ${VIRTUALENV_PARAMS} ${PYTHON_ENV}
-	@. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -q --upgrade pip ; \
+	@test -e ${PYTHON_ENV}/bin/activate || virtualenv2 $(if ${PYTHON_EXE},-p ${PYTHON_EXE}) ${VIRTUALENV_PARAMS} ${PYTHON_ENV}
+	@. ${PYTHON_ENV}/bin/activate && pip2 install ${PIP_INSTALL_PARAMS} -q --upgrade pip ; \
 	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
-		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \
+		. ${PYTHON_ENV}/bin/activate && pip2 install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \
 	else \
-		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
+		. ${PYTHON_ENV}/bin/activate && pip2 install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
 	fi
 	@# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find ${PYTHON_ENV} -type d -name 'dist-packages' -exec sh -c "echo dist-packages > {}.pth" ';'


### PR DESCRIPTION
## What does this PR do?
This PR makes explicit use of python2 when launching `make python-env`. It's a very small change to avoid symlinking and better feedback when output says `pip2 command not found` for example. It's also temporal because we are fixing this "already" but...

## Why is it important?
We have many situations and comments where users needs to symlink their environments to use python2 (while they have python3 as default) like the following [example](https://github.com/elastic/beats/pull/14755#issuecomment-558601699). In my experience, aliases doesn't seem to work either so symlinking seems the most reasonable approach.

With this slight change, at least users will have a direct solution at the fingertrips about how to solve it quickly (say installing `python2` and `pip2` executables) but no more symlinking `python -> python2` when they might be working with other things using python3.

## Example of current output
```
➜  filebeat git:(master) ls
autodiscover  config              Dockerfile  filebeat.docker.yml     fileset    input        main.go       _meta      README.md
beater        crawler             docs        filebeat.reference.yml  generator  inputsource  main_test.go  module     registrar
channel       data                fields.yml  filebeat.test           harvester  logs         make.bat      modules.d  scripts
cmd           docker-compose.yml  filebeat    filebeat.yml            include    magefile.go  Makefile      processor  tests
➜  filebeat git:(master) git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
➜  filebeat git:(master) python --version
Python 3.8.1
➜  filebeat git:(master) make python-env
Using base prefix '/usr'
New python executable in /home/mcastro/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python
Installing setuptools, pip, wheel...
done.
    ERROR: Command errored out with exit status 1:
     command: /home/mcastro/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-y3nx20ms/functools32/setup.py'"'"'; __file__='"'"'/tmp/pip-install-y3nx20ms/functools32/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-y3nx20ms/functools32/pip-egg-info
         cwd: /tmp/pip-install-y3nx20ms/functools32/
    Complete output (1 lines):
    This backport is for Python 2.7 only.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
make: *** [../libbeat/scripts/Makefile:258: python-env] Error 1
```

But, if we have this change:
```
➜  filebeat git:(master) rm -rf build
➜  filebeat git:(master) echo "Applying changes to Makefile"
Applying changes to Makefile
➜  filebeat git:(master) python --version
Python 3.8.1
➜  filebeat git:(master) ✗ make python-env
New python executable in /home/mcastro/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python2
Also creating executable in /home/mcastro/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python
Installing setuptools, pip, wheel...
done.
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
➜  filebeat git:(master) ✗ source build/python-env/bin/activate
(python-env) ➜  filebeat git:(build-env/make-explicit-use-of-python-2)
```

At least you don't need to change your env so much.

It took me more to write the description of the PR than to actually figure out how to reach to this so no worries about rejecting this :smile: 