### PR TITLE
[7.x] export default kibana client config (#16042)

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -78,7 +78,7 @@ func extractError(result []byte) error {
 
 // NewKibanaClient builds and returns a new Kibana client
 func NewKibanaClient(cfg *common.Config) (*Client, error) {
-	config := defaultClientConfig
+	config := DefaultClientConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
 	}

--- a/libbeat/kibana/client_config.go
+++ b/libbeat/kibana/client_config.go
@@ -36,8 +36,9 @@ type ClientConfig struct {
 	IgnoreVersion bool
 }
 
-var (
-	defaultClientConfig = ClientConfig{
+// DefaultClientConfig connects to a locally running kibana over HTTP
+func DefaultClientConfig() ClientConfig {
+	return ClientConfig{
 		Protocol: "http",
 		Host:     "localhost:5601",
 		Path:     "",
@@ -47,4 +48,4 @@ var (
 		Timeout:  90 * time.Second,
 		TLS:      nil,
 	}
-)
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - export default kibana client config (#16042)