### PR TITLE
[Metricbeat] Fix PostgreSQL Dashboard

### DIFF
--- a/metricbeat/module/postgresql/_meta/kibana/7/dashboard/Metricbeat-postgresql-overview.json
+++ b/metricbeat/module/postgresql/_meta/kibana/7/dashboard/Metricbeat-postgresql-overview.json
@@ -32,7 +32,7 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Query Latency",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -48,7 +48,7 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "Database Transactions",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -64,7 +64,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Fileblock IO",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -80,7 +80,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Rows Fetched/Returned",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -96,7 +96,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Rows Inserted/Deleted/Updated",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -112,7 +112,7 @@
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Conflict/Deadlock Rates",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -128,7 +128,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Database Filter",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -144,7 +144,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_7",
             "title": "Top Queries",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -160,7 +160,7 @@
             "panelIndex": "9",
             "panelRefName": "panel_8",
             "title": "Local block cache stats",
-            "version": "7.5.0"
+            "version": "7.3.1"
           },
           {
             "embeddableConfig": {
@@ -176,7 +176,7 @@
             "panelIndex": "10",
             "panelRefName": "panel_9",
             "title": "Shared block cache stats",
-            "version": "7.5.0"
+            "version": "7.3.1"
           }
         ],
         "timeRestore": false,
@@ -1390,5 +1390,5 @@
       "version": "WzQwMzEsMV0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.3.1"
 }

--- a/metricbeat/module/postgresql/_meta/kibana/7/dashboard/Metricbeat-postgresql-overview.json
+++ b/metricbeat/module/postgresql/_meta/kibana/7/dashboard/Metricbeat-postgresql-overview.json
@@ -19,9 +19,11 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Query Latency"
+            },
             "gridData": {
-              "h": 12,
+              "h": 13,
               "i": "1",
               "w": 24,
               "x": 0,
@@ -30,10 +32,12 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Query Latency",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Database Transactions"
+            },
             "gridData": {
               "h": 12,
               "i": "2",
@@ -44,24 +48,28 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "Database Transactions",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Fileblock IO"
+            },
             "gridData": {
               "h": 10,
               "i": "3",
               "w": 24,
               "x": 0,
-              "y": 18
+              "y": 19
             },
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Fileblock IO",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Rows Fetched/Returned"
+            },
             "gridData": {
               "h": 6,
               "i": "4",
@@ -72,10 +80,12 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Rows Fetched/Returned",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Rows Inserted/Deleted/Updated"
+            },
             "gridData": {
               "h": 9,
               "i": "5",
@@ -86,24 +96,28 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Rows Inserted/Deleted/Updated",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Conflict/Deadlock Rates"
+            },
             "gridData": {
               "h": 11,
               "i": "6",
               "w": 24,
               "x": 0,
-              "y": 28
+              "y": 29
             },
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Conflict/Deadlock Rates",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Database Filter"
+            },
             "gridData": {
               "h": 6,
               "i": "7",
@@ -114,10 +128,12 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Database Filter",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Top Queries"
+            },
             "gridData": {
               "h": 10,
               "i": "8",
@@ -127,13 +143,15 @@
             },
             "panelIndex": "8",
             "panelRefName": "panel_7",
-            "title": "Query Calls Count",
-            "version": "7.3.0"
+            "title": "Top Queries",
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Local block cache stats"
+            },
             "gridData": {
-              "h": 8,
+              "h": 9,
               "i": "9",
               "w": 12,
               "x": 24,
@@ -142,12 +160,14 @@
             "panelIndex": "9",
             "panelRefName": "panel_8",
             "title": "Local block cache stats",
-            "version": "7.3.0"
+            "version": "7.5.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Shared block cache stats"
+            },
             "gridData": {
-              "h": 8,
+              "h": 9,
               "i": "10",
               "w": 12,
               "x": 36,
@@ -156,7 +176,7 @@
             "panelIndex": "10",
             "panelRefName": "panel_9",
             "title": "Shared block cache stats",
-            "version": "7.3.0"
+            "version": "7.5.0"
           }
         ],
         "timeRestore": false,
@@ -220,8 +240,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-08-19T14:53:17.203Z",
-      "version": "WzE1NjQsMV0="
+      "updated_at": "2020-02-06T12:05:20.696Z",
+      "version": "WzQzNTYsMV0="
     },
     {
       "attributes": {
@@ -253,12 +273,17 @@
             "id": "919c5570-b796-11e9-8ed3-ef1959e6b366",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
                 "chart_type": "line",
                 "color": "rgba(0,156,224,1)",
-                "fill": 0,
+                "fill": "0.1",
+                "filter": {
+                  "language": "kuery",
+                  "query": "not postgresql.statement.query.text : (\"BEGIN;\" or \"begin\" or \"commit\" or \"end\" or \"END;\" or \"SELECT * FROM pg_stat_statements\" or \"SELECT * FROM pg_stat_database\" or \"SELECT * FROM pg_stat_bgwriter\" or \"SELECT * FROM pg_stat_activity\")"
+                },
                 "formatter": "number",
                 "id": "919c5571-b796-11e9-8ed3-ef1959e6b366",
                 "label": "Query Latency",
@@ -284,11 +309,13 @@
                 ],
                 "point_size": 0,
                 "separate_axis": 0,
+                "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
                 "terms_field": "postgresql.statement.query.text",
                 "terms_order_by": "919c7c80-b796-11e9-8ed3-ef1959e6b366",
                 "terms_size": "10",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -303,12 +330,12 @@
       },
       "id": "fbfa67e0-b796-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:40:30.561Z",
-      "version": "WzExNjcsMV0="
+      "updated_at": "2020-02-06T11:59:01.903Z",
+      "version": "WzQzNTAsMV0="
     },
     {
       "attributes": {
@@ -340,6 +367,7 @@
             "id": "7af01590-b797-11e9-8816-2992f1df7a62",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -372,6 +400,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               },
               {
@@ -405,6 +434,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -419,12 +449,12 @@
       },
       "id": "d733c630-b797-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:40:44.158Z",
-      "version": "WzExNzMsMV0="
+      "updated_at": "2020-02-05T15:49:18.236Z",
+      "version": "WzQzMTIsMV0="
     },
     {
       "attributes": {
@@ -438,7 +468,7 @@
             }
           }
         },
-        "title": "Fileblock IO [Metricbeat PostgreSQL] ECS",
+        "title": "Fileblock IO Rate [Metricbeat PostgreSQL] ECS",
         "uiStateJSON": {},
         "version": 1,
         "visState": {
@@ -456,6 +486,7 @@
             "id": "fbc27280-b797-11e9-b46b-4f80f005c4a5",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -488,6 +519,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               },
               {
@@ -521,6 +553,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -529,18 +562,18 @@
             "time_field": "@timestamp",
             "type": "timeseries"
           },
-          "title": "Fileblock IO [Metricbeat PostgreSQL] ECS",
+          "title": "Fileblock IO Rate [Metricbeat PostgreSQL] ECS",
           "type": "metrics"
         }
       },
       "id": "570973a0-b798-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:41:16.761Z",
-      "version": "WzExODgsMV0="
+      "updated_at": "2020-02-05T19:01:54.390Z",
+      "version": "WzQzMjQsMV0="
     },
     {
       "attributes": {
@@ -590,6 +623,7 @@
             "id": "a6981ed0-b798-11e9-a598-8baa89257193",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -600,7 +634,7 @@
                   "language": "kuery",
                   "query": ""
                 },
-                "formatter": "number",
+                "formatter": "'0.0 a'",
                 "id": "a6981ed1-b798-11e9-a598-8baa89257193",
                 "label": "Rows Returned",
                 "line_width": 2,
@@ -635,6 +669,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               },
               {
@@ -669,6 +704,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -683,12 +719,12 @@
       },
       "id": "66d67200-b799-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:40:15.889Z",
-      "version": "WzExNTgsMV0="
+      "updated_at": "2020-02-06T11:56:03.315Z",
+      "version": "WzQzNDYsMV0="
     },
     {
       "attributes": {
@@ -720,6 +756,7 @@
             "id": "fc474800-b799-11e9-bfa6-bd2fe13c0445",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -832,12 +869,12 @@
       },
       "id": "20931ef0-b79a-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:41:36.559Z",
-      "version": "WzExOTYsMV0="
+      "updated_at": "2020-02-06T12:01:45.205Z",
+      "version": "WzQzNTMsMV0="
     },
     {
       "attributes": {
@@ -869,6 +906,7 @@
             "id": "6c90db30-b79a-11e9-a8f0-d7983cd3d871",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -883,7 +921,7 @@
                   {
                     "field": "postgresql.database.conflicts",
                     "id": "6c90db32-b79a-11e9-a8f0-d7983cd3d871",
-                    "type": "max"
+                    "type": "avg"
                   },
                   {
                     "field": "6c90db32-b79a-11e9-a8f0-d7983cd3d871",
@@ -901,6 +939,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               },
               {
@@ -916,7 +955,7 @@
                   {
                     "field": "postgresql.database.deadlocks",
                     "id": "6c90db36-b79a-11e9-a8f0-d7983cd3d871",
-                    "type": "max"
+                    "type": "avg"
                   },
                   {
                     "field": "6c90db36-b79a-11e9-a8f0-d7983cd3d871",
@@ -934,6 +973,7 @@
                 "separate_axis": 0,
                 "split_mode": "everything",
                 "stacked": "none",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -948,12 +988,12 @@
       },
       "id": "960ecdf0-b79a-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:42:02.764Z",
-      "version": "WzEyMDQsMV0="
+      "updated_at": "2020-02-05T15:46:52.411Z",
+      "version": "WzQzMDgsMV0="
     },
     {
       "attributes": {
@@ -1000,7 +1040,7 @@
       },
       "id": "98e6b0a0-b79b-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -1010,8 +1050,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:39:56.460Z",
-      "version": "WzExNTEsMV0="
+      "updated_at": "2020-01-22T13:56:51.268Z",
+      "version": "WzQwMjgsMV0="
     },
     {
       "attributes": {
@@ -1034,6 +1074,11 @@
             "axis_formatter": "number",
             "axis_position": "left",
             "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "d3cc2560-484b-11ea-a805-d7a3b4bc3300"
+              }
+            ],
             "bar_color_rules": [
               {
                 "id": "6da7d6e0-b902-11e9-9f00-7b1f283b2282"
@@ -1045,9 +1090,18 @@
               "language": "kuery",
               "query": ""
             },
+            "gauge_color_rules": [
+              {
+                "id": "d22727f0-484b-11ea-a805-d7a3b4bc3300"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
             "id": "2bc5fea0-b902-11e9-8b8c-f99be54b4271",
             "index_pattern": "metricbeat-*",
             "interval": "auto",
+            "isModelInvalid": false,
             "pivot_id": "postgresql.statement.query.text",
             "pivot_type": "string",
             "series": [
@@ -1056,7 +1110,11 @@
                 "chart_type": "line",
                 "color": "rgba(22,165,165,1)",
                 "fill": 0,
-                "formatter": "number",
+                "filter": {
+                  "language": "kuery",
+                  "query": "not postgresql.statement.query.text : (\"BEGIN;\" or \"begin\" or \"commit\" or \"end\" or \"END;\" or \"SELECT * FROM pg_stat_statements\" or \"SELECT * FROM pg_stat_database\" or \"SELECT * FROM pg_stat_bgwriter\" or \"SELECT * FROM pg_stat_activity\")"
+                },
+                "formatter": "'0a'",
                 "id": "2bc5fea1-b902-11e9-8b8c-f99be54b4271",
                 "label": "Number of times the query has been run",
                 "line_width": 2,
@@ -1064,7 +1122,7 @@
                   {
                     "field": "postgresql.statement.query.calls",
                     "id": "2bc5fea2-b902-11e9-8b8c-f99be54b4271",
-                    "type": "max"
+                    "type": "avg"
                   }
                 ],
                 "point_size": 0,
@@ -1073,13 +1131,15 @@
                 "stacked": "none",
                 "terms_field": "postgresql.statement.query.text",
                 "terms_order_by": "2bc5fea2-b902-11e9-8b8c-f99be54b4271",
-                "terms_size": "10",
+                "terms_size": "20",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "time_range_mode": "entire_time_range",
             "type": "top_n"
           },
           "title": "Query Calls Count [Metricbeat PostgreSQL] ECS",
@@ -1088,12 +1148,12 @@
       },
       "id": "147875b0-b903-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:40:59.993Z",
-      "version": "WzExODAsMV0="
+      "updated_at": "2020-02-06T12:04:42.628Z",
+      "version": "WzQzNTUsMV0="
     },
     {
       "attributes": {
@@ -1206,12 +1266,12 @@
       },
       "id": "0cb65170-b909-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:42:18.557Z",
-      "version": "WzEyMTAsMV0="
+      "updated_at": "2020-01-22T13:56:51.268Z",
+      "version": "WzQwMzAsMV0="
     },
     {
       "attributes": {
@@ -1322,13 +1382,13 @@
       },
       "id": "e2b28ce0-b908-11e9-a579-f5c0a5d81340",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-09T11:42:42.659Z",
-      "version": "WzEyMTksMV0="
+      "updated_at": "2020-01-22T13:56:51.268Z",
+      "version": "WzQwMzEsMV0="
     }
   ],
-  "version": "7.3.0"
+  "version": "7.5.0"
 }


### PR DESCRIPTION
The Top query calls visualization was using `Max` aggregation type. This fix changes the aggregation type to `Average`. It also improves filters for this and other visualizations.

<img width="2499" alt="Screen Shot 2020-02-06 at 13 16 01" src="https://user-images.githubusercontent.com/1685068/73936317-da453980-48e2-11ea-9eec-b4a1c7942704.png">

