### PR TITLE
Regenerate expected files after changes in date parsing

### DIFF
--- a/filebeat/module/system/auth/test/timestamp.log-expected.json
+++ b/filebeat/module/system/auth/test/timestamp.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-06-14T08:40:20.912-02:00",
+        "@timestamp": "2019-06-14T10:40:20.912-02:00",
         "event.dataset": "system.auth",
         "event.module": "system",
         "event.timezone": "-02:00",

--- a/filebeat/module/system/syslog/test/tz-offset.log-expected.json
+++ b/filebeat/module/system/syslog/test/tz-offset.log-expected.json
@@ -29,7 +29,7 @@
         "service.type": "system"
     },
     {
-        "@timestamp": "2019-06-14T08:40:20.912-02:00",
+        "@timestamp": "2019-06-14T10:40:20.912-02:00",
         "event.dataset": "system.syslog",
         "event.module": "system",
         "event.timezone": "-02:00",


### PR DESCRIPTION
Elasticsearch has modified the behaviour on date parsing when the date
doesn't include timezone data. Regenerate a couple of golden files that
are affected by this change.

New values are actually correct, so this will fix some issues on logs without
timezone information.

I think the change in Elasticsearch is https://github.com/elastic/elasticsearch/pull/51215

We will need to backport this for 7.7 as this change is going to be included
in Elasticsearch 7.7.