### PR TITLE
Use mage target instead of nosetests on Windows jenkins CI

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -65,9 +65,9 @@ exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test 
 
 if (Test-Path "tests\system") {
     echo "Running python tests"
-    choco install python -y -r --version 3.8.1.20200110
+    choco install python -y -r --no-progress --version 3.8.1.20200110
     refreshenv
-    $env:PATH = "$env:PATH;C:\\Python38;C:\\Python38\\Scripts"
+    $env:PATH = "C:\\Python38;C:\\Python38\\Scripts;$env:PATH"
     python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -68,7 +68,7 @@ if (Test-Path "tests\system") {
     $currentDir = (Get-Item -Path ".\").FullName
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe" -OutFile "build\python-installer.exe"
-    .\build\python-installer.exe /quiet InstallAllUsers=0 SimpleInstall=1 Shortcuts=0 Include_launcher=0 AssociateFiles=0 Include_test=0 Include_doc=0 TargetDir="$currentDir\build\python"
+    .\build\python-installer.exe /quiet InstallAllUsers=0 SimpleInstall=1 Shortcuts=0 Include_launcher=0 AssociateFiles=0 Include_test=0 Include_doc=0 TargetDir="$currentDir\build\python" | Out-Null
     $env:PATH = "$currentDir\build\python;$env:PATH"
     python --version
     python -m venv --help

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -68,7 +68,7 @@ if (Test-Path "tests\system") {
     choco install python -y -r --no-progress --version 3.8.1.20200110
     refreshenv
     $env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
-    $env:PYTHON_ENV = "$env:TEMP\python-env
+    $env:PYTHON_ENV = "$env:TEMP\python-env"
     python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -64,7 +64,12 @@ $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
 
 if (Test-Path "tests\system") {
+    # Installation of python 3 to be removed once it is installed in the base image
+    echo "Installing python 3"
+    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip" | Expand-Archive -DestinationPath "build/python" -Force
+    $currentDir = (Get-Item -Path ".\").FullName
+    $env:PATH = "$currentDir\build\python;$env:PATH"
+
     echo "Running python tests"
-    $env:PYTHON_EXE = "python3"
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -65,5 +65,7 @@ exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test 
 
 if (Test-Path "tests\system") {
     echo "Running python tests"
+    choco install -y python3
+    python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -67,7 +67,7 @@ if (Test-Path "tests\system") {
     echo "Running python tests"
     choco install python -y -r --no-progress --version 3.8.1.20200110
     refreshenv
-    $env:PATH = "C:\\Python38;C:\\Python38\\Scripts;$env:PATH"
+    $env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
     python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -65,5 +65,5 @@ exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test 
 
 if (Test-Path "tests\system") {
     Set-Location -Path tests\system
-    exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"
+    exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -64,15 +64,6 @@ $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
 
 if (Test-Path "tests\system") {
-    echo "Installing python 3"
-    $currentDir = (Get-Item -Path ".\").FullName
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe" -OutFile "build\python-installer.exe"
-    .\build\python-installer.exe /quiet InstallAllUsers=0 SimpleInstall=1 Shortcuts=0 Include_launcher=0 AssociateFiles=0 Include_test=0 Include_doc=0 TargetDir="$currentDir\build\python" | Out-Null
-    $env:PATH = "$currentDir\build\python;$env:PATH"
-    python --version
-    python -m venv --help
-
     echo "Running python tests"
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -64,5 +64,6 @@ $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
 
 if (Test-Path "tests\system") {
+    echo "Running python tests"
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -64,11 +64,14 @@ $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
 
 if (Test-Path "tests\system") {
-    # Installation of python 3 to be removed once it is installed in the base image
     echo "Installing python 3"
-    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip" | Expand-Archive -DestinationPath "build/python" -Force
     $currentDir = (Get-Item -Path ".\").FullName
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe" -OutFile "build\python-installer.exe"
+    .\build\python-installer.exe /quiet InstallAllUsers=0 SimpleInstall=1 Shortcuts=0 Include_launcher=0 AssociateFiles=0 Include_test=0 Include_doc=0 TargetDir="$currentDir\build\python"
     $env:PATH = "$currentDir\build\python;$env:PATH"
+    python --version
+    python -m venv --help
 
     echo "Running python tests"
     exec { mage pythonUnitTest } "System test FAILURE"

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -68,6 +68,7 @@ if (Test-Path "tests\system") {
     choco install python -y -r --no-progress --version 3.8.1.20200110
     refreshenv
     $env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
+    $env:PYTHON_ENV = "$env:TEMP\python-env
     python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -65,5 +65,6 @@ exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test 
 
 if (Test-Path "tests\system") {
     echo "Running python tests"
+    $env:PYTHON_EXE = "python3"
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -64,6 +64,5 @@ $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
 
 if (Test-Path "tests\system") {
-    Set-Location -Path tests\system
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -65,7 +65,9 @@ exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test 
 
 if (Test-Path "tests\system") {
     echo "Running python tests"
-    choco install -y python3
+    choco install python -y -r --version 3.8.1.20200110
+    refreshenv
+    $env:PATH = "$env:PATH;C:\\Python38;C:\\Python38\\Scripts"
     python --version
     exec { mage pythonUnitTest } "System test FAILURE"
 }

--- a/filebeat/tests/open-file-handlers/log_stdout.py
+++ b/filebeat/tests/open-file-handlers/log_stdout.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 import time
 import sys
 
@@ -19,5 +18,5 @@ line_length = len(str(total_lines)) + 1
 # Setup python log handler
 handler = logging.handlers.RotatingFileHandler(
     log_file, maxBytes=line_length * lines_per_file + 1,
-    backupCount=old_div(total_lines, lines_per_file) + 1)
+    backupCount=int(total_lines/lines_per_file) + 1)
 logger.addHandler(handler)

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -517,7 +517,7 @@ class Test(BaseTest):
             max_timeout=15)
 
         # Add utf-8 Chars for the first time
-        with codecs.open(testfile, "w", "utf-8") as f:
+        with codecs.open(testfile, "w", "utf_8") as f:
             # Write lines before registrar started
 
             # Special encoding needed?!?
@@ -528,7 +528,7 @@ class Test(BaseTest):
                 lambda: self.output_has(lines=1), max_timeout=10)
 
         # Append utf-8 chars to check if it keeps reading
-        with codecs.open(testfile, "a", "utf-8") as f:
+        with codecs.open(testfile, "a", "utf_8") as f:
             # write additional lines
             f.write("Hello\n")
             f.write("薩科Ruflin" + "\n")

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -528,7 +528,7 @@ class Test(BaseTest):
                 lambda: self.output_has(lines=1), max_timeout=10)
 
         # Append utf-8 chars to check if it keeps reading
-        with codecs.open(testfile, "a") as f:
+        with codecs.open(testfile, "a", "utf-8") as f:
             # write additional lines
             f.write("Hello\n")
             f.write("薩科Ruflin" + "\n")

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 from filebeat import BaseTest
 import os
 import logging
@@ -41,7 +40,7 @@ class Test(BaseTest):
         # Setup python log handler
         handler = logging.handlers.RotatingFileHandler(
             log_file, maxBytes=line_length * lines_per_file + 1,
-            backupCount=old_div(total_lines, lines_per_file) + 1)
+            backupCount=int(total_lines / lines_per_file) + 1)
         logger.addHandler(handler)
 
         self.render_config_template(

--- a/heartbeat/magefile.go
+++ b/heartbeat/magefile.go
@@ -35,6 +35,8 @@ import (
 	"github.com/elastic/beats/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
 )
 
 func init() {

--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -35,6 +35,8 @@ import (
 	"github.com/elastic/beats/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/integtest/notests"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
 )
 
 func init() {

--- a/libbeat/magefile.go
+++ b/libbeat/magefile.go
@@ -26,6 +26,8 @@ import (
 
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/common"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
 )
 
 // Build builds the Beat binary.

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -10,7 +10,6 @@ dockerpty==0.4.1
 docopt==0.6.2
 elasticsearch==7.1.0
 enum34==1.1.6
-future==0.18.2
 idna==2.6
 ipaddress==1.0.19
 Jinja2==2.10.1

--- a/script/kibana-migration.py
+++ b/script/kibana-migration.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 import yaml
 import glob
 

--- a/script/renamed_fields.py
+++ b/script/renamed_fields.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 import yaml
 
 

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -15,6 +15,8 @@ import (
 	_ "github.com/elastic/beats/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/dev-tools/mage/target/integtest"
+	// mage:import
+	_ "github.com/elastic/beats/dev-tools/mage/target/unittest"
 )
 
 func init() {


### PR DESCRIPTION
## What does this PR do?

Replaces use of nosetests with mage wrapper in script for Windows CI workers.

Mage manages their own python virtual environments, this is preferred to directly
call python commands.

Installs python 3 using chocolatey, as it is still not available in windows CI workers.

`future` was failing to install in Windows, but we don't actually need it anymore,
so it is removed.

## Why is it important?

To fix Windows builds in Python 3 branch (https://github.com/elastic/beats/pull/14798).