### PR TITLE
Cherry-pick #16081 to 7.x: Elasticsearch index must be lowercase

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,7 +71,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue where default go logger is not discarded when either * or stdout is selected. {issue}10251[10251] {pull}15708[15708]
 - Fix issue where TLS settings would be ignored when a forward proxy was in use. {pull}15516{15516}
 - Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
-- Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
 - Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue where default go logger is not discarded when either * or stdout is selected. {issue}10251[10251] {pull}15708[15708]
 - Fix issue where TLS settings would be ignored when a forward proxy was in use. {pull}15516{15516}
 - Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
+- Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
+- Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -79,7 +79,7 @@ func newKafkaClient(
 		hosts:    hosts,
 		topic:    topic,
 		key:      key,
-		index:    index,
+		index:    strings.ToLower(index),
 		codec:    writer,
 		config:   *cfg,
 	}

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -18,6 +18,7 @@
 package logstash
 
 import (
+	"strings"
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -80,7 +81,7 @@ func readConfig(cfg *common.Config, info beat.Info) (*Config, error) {
 	}
 
 	if c.Index == "" {
-		c.Index = info.IndexPrefix
+		c.Index = strings.ToLower(info.IndexPrefix)
 	}
 
 	return &c, nil

--- a/libbeat/outputs/logstash/enc.go
+++ b/libbeat/outputs/logstash/enc.go
@@ -18,6 +18,8 @@
 package logstash
 
 import (
+	"strings"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/codec/json"
 )
@@ -27,6 +29,7 @@ func makeLogstashEventEncoder(info beat.Info, escapeHTML bool, index string) fun
 		Pretty:     false,
 		EscapeHTML: escapeHTML,
 	})
+	index = strings.ToLower(index)
 	return func(event interface{}) (d []byte, err error) {
 		d, err = enc.Encode(index, event.(*beat.Event))
 		if err != nil {

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -92,7 +92,8 @@ func esConnect(t *testing.T, index string) *esConnection {
 
 	host := getElasticsearchHost()
 	indexFmt := fmtstr.MustCompileEvent(fmt.Sprintf("%s-%%{+yyyy.MM.dd}", index))
-	indexSel := outil.MakeSelector(outil.FmtSelectorExpr(indexFmt, ""))
+	indexFmtExpr, _ := outil.FmtSelectorExpr(indexFmt, "")
+	indexSel := outil.MakeSelector(indexFmtExpr)
 	index, _ = indexSel.Select(&beat.Event{
 		Timestamp: ts,
 	})

--- a/libbeat/outputs/outil/select_test.go
+++ b/libbeat/outputs/outil/select_test.go
@@ -31,74 +31,92 @@ import (
 type node map[string]interface{}
 
 func TestSelector(t *testing.T) {
-	tests := []struct {
-		title    string
+	tests := map[string]struct {
 		config   string
 		event    common.MapStr
 		expected string
 	}{
-		{
-			"constant key",
+		"constant key": {
 			`key: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"format string key",
+		"lowercase constant key": {
+			`key: VaLuE`,
+			common.MapStr{},
+			"value",
+		},
+		"format string key": {
 			`key: '%{[key]}'`,
 			common.MapStr{"key": "value"},
 			"value",
 		},
-		{
-			"key with empty keys",
+		"lowercase format string key": {
+			`key: '%{[key]}'`,
+			common.MapStr{"key": "VaLuE"},
+			"value",
+		},
+		"key with empty keys": {
 			`{key: value, keys: }`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"constant in multi key",
+		"lowercase key with empty keys": {
+			`{key: vAlUe, keys: }`,
+			common.MapStr{},
+			"value",
+		},
+		"constant in multi key": {
 			`keys: [key: 'value']`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"format string in multi key",
+		"format string in multi key": {
 			`keys: [key: '%{[key]}']`,
 			common.MapStr{"key": "value"},
 			"value",
 		},
-		{
-			"missing format string key with default in rule",
+		"missing format string key with default in rule": {
 			`keys:
 			        - key: '%{[key]}'
 			          default: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"empty format string key with default in rule",
+		"lowercase missing format string key with default in rule": {
+			`keys:
+			        - key: '%{[key]}'
+			          default: vAlUe`,
+			common.MapStr{},
+			"value",
+		},
+		"empty format string key with default in rule": {
 			`keys:
 						        - key: '%{[key]}'
 						          default: value`,
 			common.MapStr{"key": ""},
 			"value",
 		},
-		{
-			"missing format string key with constant in next rule",
+		"lowercase empty format string key with default in rule": {
+			`keys:
+						        - key: '%{[key]}'
+						          default: vAluE`,
+			common.MapStr{"key": ""},
+			"value",
+		},
+		"missing format string key with constant in next rule": {
 			`keys:
 						        - key: '%{[key]}'
 						        - key: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"missing format string key with constant in top-level rule",
+		"missing format string key with constant in top-level rule": {
 			`{ key: value, keys: [key: '%{[key]}']}`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"apply mapping",
+		"apply mapping": {
 			`keys:
 						       - key: '%{[key]}'
 						         mappings:
@@ -106,8 +124,15 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "v"},
 			"value",
 		},
-		{
-			"apply mapping with default on empty key",
+		"lowercase applied mapping": {
+			`keys:
+						       - key: '%{[key]}'
+						         mappings:
+						           v: vAlUe`,
+			common.MapStr{"key": "v"},
+			"value",
+		},
+		"apply mapping with default on empty key": {
 			`keys:
 						       - key: '%{[key]}'
 						         default: value
@@ -116,8 +141,16 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": ""},
 			"value",
 		},
-		{
-			"apply mapping with default on empty lookup",
+		"lowercase apply mapping with default on empty key": {
+			`keys:
+						       - key: '%{[key]}'
+						         default: vAluE
+						         mappings:
+						           v: 'v'`,
+			common.MapStr{"key": ""},
+			"value",
+		},
+		"apply mapping with default on empty lookup": {
 			`keys:
 			       - key: '%{[key]}'
 			         default: value
@@ -126,8 +159,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "v"},
 			"value",
 		},
-		{
-			"apply mapping without match",
+		"apply mapping without match": {
 			`keys:
 						       - key: '%{[key]}'
 						         mappings:
@@ -136,8 +168,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "x"},
 			"value",
 		},
-		{
-			"mapping with constant key",
+		"mapping with constant key": {
 			`keys:
 						       - key: k
 						         mappings:
@@ -145,8 +176,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"mapping with missing constant key",
+		"mapping with missing constant key": {
 			`keys:
 						       - key: unknown
 						         mappings: {k: wrong}
@@ -154,8 +184,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"mapping with missing constant key, but default",
+		"mapping with missing constant key, but default": {
 			`keys:
 						       - key: unknown
 						         default: value
@@ -163,16 +192,14 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"matching condition",
+		"matching condition": {
 			`keys:
 						       - key: value
 						         when.equals.test: test`,
 			common.MapStr{"test": "test"},
 			"value",
 		},
-		{
-			"failing condition",
+		"failing condition": {
 			`keys:
 						       - key: wrong
 						         when.equals.test: test
@@ -182,113 +209,98 @@ func TestSelector(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("run (%v): %v", i, test.title)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			yaml := strings.Replace(test.config, "\t", "  ", -1)
+			cfg, err := common.NewConfigWithYAML([]byte(yaml), "test")
+			if err != nil {
+				t.Fatalf("YAML parse error: %v\n%v", err, yaml)
+			}
 
-		yaml := strings.Replace(test.config, "\t", "  ", -1)
-		cfg, err := common.NewConfigWithYAML([]byte(yaml), "test")
-		if err != nil {
-			t.Errorf("YAML parse error: %v\n%v", err, yaml)
-			continue
-		}
+			sel, err := BuildSelectorFromConfig(cfg, Settings{
+				Key:              "key",
+				MultiKey:         "keys",
+				EnableSingleOnly: true,
+				FailEmpty:        true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		sel, err := BuildSelectorFromConfig(cfg, Settings{
-			Key:              "key",
-			MultiKey:         "keys",
-			EnableSingleOnly: true,
-			FailEmpty:        true,
+			event := beat.Event{
+				Timestamp: time.Now(),
+				Fields:    test.event,
+			}
+			actual, err := sel.Select(&event)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, test.expected, actual)
 		})
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-
-		event := beat.Event{
-			Timestamp: time.Now(),
-			Fields:    test.event,
-		}
-		actual, err := sel.Select(&event)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-
-		assert.Equal(t, test.expected, actual)
 	}
 }
 
 func TestSelectorInitFail(t *testing.T) {
-	tests := []struct {
-		title  string
+	tests := map[string]struct {
 		config string
 	}{
-		{
-			"keys missing",
+		"keys missing": {
 			`test: no key`,
 		},
-		{
-			"invalid keys type",
+		"invalid keys type": {
 			`keys: 5`,
 		},
-		{
-			"invaid keys element type",
+		"invaid keys element type": {
 			`keys: [5]`,
 		},
-		{
-			"invalid key type",
+		"invalid key type": {
 			`key: {}`,
 		},
-		{
-			"missing key in list",
+		"missing key in list": {
 			`keys: [default: value]`,
 		},
-		{
-			"invalid key type in list",
+		"invalid key type in list": {
 			`keys: [key: {}]`,
 		},
-		{
-			"fail on invalid format string",
+		"fail on invalid format string": {
 			`key: '%{[abc}'`,
 		},
-		{
-			"fail on invalid format string in list",
+		"fail on invalid format string in list": {
 			`keys: [key: '%{[abc}']`,
 		},
-		{
-			"default value type mismatch",
+		"default value type mismatch": {
 			`keys: [{key: ok, default: {}}]`,
 		},
-		{
-			"mappings type mismatch",
+		"mappings type mismatch": {
 			`keys:
        - key: '%{[k]}'
          mappings: {v: {}}`,
 		},
-		{
-			"condition empty",
+		"condition empty": {
 			`keys:
        - key: value
          when:`,
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("run (%v): %v", i, test.title)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := common.NewConfigWithYAML([]byte(test.config), "test")
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		cfg, err := common.NewConfigWithYAML([]byte(test.config), "test")
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			_, err = BuildSelectorFromConfig(cfg, Settings{
+				Key:              "key",
+				MultiKey:         "keys",
+				EnableSingleOnly: true,
+				FailEmpty:        true,
+			})
 
-		_, err = BuildSelectorFromConfig(cfg, Settings{
-			Key:              "key",
-			MultiKey:         "keys",
-			EnableSingleOnly: true,
-			FailEmpty:        true,
+			assert.Error(t, err)
+			t.Log(err)
 		})
 
-		assert.Error(t, err)
-		t.Log(err)
 	}
 }

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/garyburd/redigo/redis"
@@ -77,7 +78,7 @@ func newClient(
 		observer: observer,
 		timeout:  timeout,
 		password: pass,
-		index:    index,
+		index:    strings.ToLower(index),
 		db:       db,
 		dataType: dt,
 		key:      key,


### PR DESCRIPTION
Cherry-pick of PR #16081 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

This change ensure that index names are always converted to lowercase.
Static strings are converted to lowercase upfront, while dynamic strings
will be post-processed.

## Why is it important?

When indexing into Elasticsearch index names must always be lowercase.
If the index or indices setting are configured to produce non-lowercase
strings (e.g. by extracting part of the index name from the event
contents), we need to normalize them to be lowercase.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Index with different index/indices configurations into Elasticsearch:
- use upper case in `index` setting
- extract index name from event, that has the field value as upper case string
- configure a mapping via `indices` where the target index is upper case

Run same checks with Redis, Kafka, Logstash outputs (the index name should consistently be lower case for all outputs).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->
- Closes elastic/beats#6342 
- Closes elastic/beats#6640 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
