### PR TITLE
Remove Deprecated os.SEEK Constants

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -566,12 +566,12 @@ func (h *Harvester) initFileOffset(file *os.File) (int64, error) {
 	// continue from last known offset
 	if h.state.Offset > 0 {
 		logp.Debug("harvester", "Set previous offset for file: %s. Offset: %d ", h.state.Source, h.state.Offset)
-		return file.Seek(h.state.Offset, os.SEEK_SET)
+		return file.Seek(h.state.Offset, io.SeekStart)
 	}
 
 	// get offset from file in case of encoding factory was required to read some data.
 	logp.Debug("harvester", "Setting offset for file based on seek: %s", h.state.Source)
-	return file.Seek(0, os.SEEK_CUR)
+	return file.Seek(0, io.SeekCurrent)
 }
 
 // getState returns an updated copy of the harvester state

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -19,7 +19,6 @@ package log
 
 import (
 	"io"
-	"os"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester"
@@ -45,7 +44,7 @@ func NewLog(
 	var offset int64
 	if seeker, ok := fs.(io.Seeker); ok {
 		var err error
-		offset, err = seeker.Seek(0, os.SEEK_CUR)
+		offset, err = seeker.Seek(0, io.SeekCurrent)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This replaces the deprecated constants `os.SEEK_CUR` and `os.SEEK_SET` with their `io` equivalents.