### PR TITLE
Reduce use of global loggers in libbeat/common

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -31,8 +31,6 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-const eventDebugSelector = "event"
-
 var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 
 type Float float64
@@ -51,7 +49,7 @@ type GenericEventConverter struct {
 // NewGenericEventConverter creates an EventConverter with the given configuration options
 func NewGenericEventConverter(keepNull bool) *GenericEventConverter {
 	return &GenericEventConverter{
-		log:      logp.NewLogger(eventDebugSelector),
+		log:      logp.NewLogger("event"),
 		keepNull: keepNull,
 	}
 }

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -33,8 +33,6 @@ import (
 
 const eventDebugSelector = "event"
 
-var eventDebugf = logp.MakeDebug(eventDebugSelector)
-
 var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 
 type Float float64
@@ -46,12 +44,14 @@ type EventConverter interface {
 
 // GenericEventConverter is used to normalize MapStr objects for publishing
 type GenericEventConverter struct {
+	log      *logp.Logger
 	keepNull bool
 }
 
 // NewGenericEventConverter creates an EventConverter with the given configuration options
 func NewGenericEventConverter(keepNull bool) *GenericEventConverter {
 	return &GenericEventConverter{
+		log:      logp.NewLogger(eventDebugSelector),
 		keepNull: keepNull,
 	}
 }
@@ -64,7 +64,7 @@ func (e *GenericEventConverter) Convert(m MapStr) MapStr {
 	keys := make([]string, 0, 10)
 	event, errs := e.normalizeMap(m, keys...)
 	if len(errs) > 0 {
-		logp.Warn("Unsuccessful conversion to generic event: %v errors: %v, "+
+		e.log.Warnf("Unsuccessful conversion to generic event: %v errors: %v, "+
 			"event=%#v", len(errs), errs, m)
 	}
 	return event
@@ -85,8 +85,8 @@ func (e *GenericEventConverter) normalizeMap(m MapStr, keys ...string) (MapStr, 
 
 		// Drop nil values from maps.
 		if !e.keepNull && v == nil {
-			if logp.IsDebug(eventDebugSelector) {
-				eventDebugf("Dropped nil value from event where key=%v", joinKeys(append(keys, key)...))
+			if e.log.IsDebug() {
+				e.log.Debugf("Dropped nil value from event where key=%v", joinKeys(append(keys, key)...))
 			}
 			continue
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

Remove usage of logp.Debug/Warn by creating a logger instance in the GenericEventNormalizer. The `Normalizer` uses `logp.New` for now to keep the change less disruptive.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Getting rid of global loggers functions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#15699 
