### PR TITLE
Omit monitoring object from logstash_stats.logstash object

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -88,6 +88,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dedot for cloudwatch metric name. {issue}15916[15916] {pull}15917[15917]
 - Fixed issue `logstash-xpack` module suddenly ceasing to monitor Logstash. {issue}15974[15974] {pull}16044[16044]
 - Fix skipping protocol scheme by light modules. {pull}16205[pull]
+- Made `logstash-xpack` module once again have parity with internally-collected Logstash monitoring data. {pull}16198[16198]
 
 *Packetbeat*
 

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -96,9 +96,13 @@ type nodeInfo struct {
 	Status      string   `json:"status"`
 	HTTPAddress string   `json:"http_address"`
 	Pipeline    pipeline `json:"pipeline"`
-	Monitoring  struct {
-		ClusterID string `json:"cluster_uuid"`
-	} `json:"monitoring"`
+}
+
+type inNodeInfo struct {
+	nodeInfo
+	Monitoring struct {
+		ClusterID string `json:"cluster_uuid,omitempty"`
+	} `json:"monitoring,omitempty"`
 }
 
 type reloads struct {
@@ -108,7 +112,7 @@ type reloads struct {
 
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
-	nodeInfo
+	inNodeInfo
 	commonStats
 	Process   process                  `json:"process"`
 	OS        os                       `json:"os"`

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -98,6 +98,9 @@ type nodeInfo struct {
 	Pipeline    pipeline `json:"pipeline"`
 }
 
+// inNodeInfo represents the Logstash node info to be parsed from the Logstash API
+// response. It contains nodeInfo (which is also used as-is elsewhere) + monitoring
+// information.
 type inNodeInfo struct {
 	nodeInfo
 	Monitoring struct {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -101,8 +101,8 @@ type nodeInfo struct {
 type inNodeInfo struct {
 	nodeInfo
 	Monitoring struct {
-		ClusterID string `json:"cluster_uuid,omitempty"`
-	} `json:"monitoring,omitempty"`
+		ClusterID string `json:"cluster_uuid"`
+	} `json:"monitoring"`
 }
 
 type reloads struct {


### PR DESCRIPTION
## What does this PR do?

It removes a redundant field from Logstash monitoring data being indexed by Metricbeat for Stack Monitoring. 

## Why is it important?

It brings parity between Metricbeat collection and internal collection for Logstash monitoring data, specifically documents of `type:logstash_stats`.

## Checklist

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~ There are existing tests ([stack monitoring parity tests](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+master+multijob-logstash/)) that are currently failing and should start passing once this PR is merged.

## How to test this PR locally

1. Install Logstash 7.6.0 or higher.

2. Configure Logstash to set the override cluster UUID. Edit `config/logstash.yml` and set `monitoring.cluster_uuid: foobar`.

3. Build Metricbeat with this PR.

4. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

5. Run Metricbeat, outputting events to the Console so we can inspect them easily.
   ```
   /metricbeat -E output.elasticsearch.enabled=false -E output.console.enabled=true | jq '.'
   ```

6. Check that events with `"type": "logstash_stats"` or `"type": "logstash_state"` both have a top-level `"cluster_uuid": "foobar"` field in them.

7. Also check that events with `"type": "logstash_stats"` has a `"logstash_stats.logstash"` field which is an object. Check that this object **does not** contain a `"monitoring"` field.

## Related issues

- Relates https://github.com/elastic/logstash/pull/11106#issuecomment-583456891