### PR TITLE
Fix: don't miss address scheme

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change lookup_fields from metricset.host to service.address {pull}15883[15883]
 - Add dedot for cloudwatch metric name. {issue}15916[15916] {pull}15917[15917]
 - Fixed issue `logstash-xpack` module suddenly ceasing to monitor Logstash. {issue}15974[15974] {pull}16044[16044]
+- Fix skipping protocol scheme by light modules. {pull}16205[pull]
 
 *Packetbeat*
 

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -100,6 +100,8 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 	return registration, nil
 }
 
+// useHostURISchemeIfPossible method parses given URI to extract protocol scheme and prepend it to the host.
+// It prevents from skipping protocol scheme (e.g. https) while executing HostParser.
 func (m *LightMetricSet) useHostURISchemeIfPossible(host, uri string) string {
 	u, err := url.ParseRequestURI(uri)
 	if err == nil {

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -86,17 +86,7 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 		// At this point host parser was already run, we need to run this again
 		// with the overriden defaults
 		if registration.HostParser != nil {
-			u, err := url.Parse(base.hostData.URI)
-			if err != nil {
-				return nil, errors.Wrapf(err, "host data URI parsing failed on light metricset factory for '%s/%s'", m.Module, m.Name)
-			}
-
-			var host string
-			if u.Scheme != "" {
-				host = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
-			} else {
-				host = base.host
-			}
+			host := m.useHostURISchemeIfPossible(base.host, base.hostData.URI)
 			base.hostData, err = registration.HostParser(base.module, host)
 			if err != nil {
 				return nil, errors.Wrapf(err, "host parser failed on light metricset factory for '%s/%s'", m.Module, m.Name)
@@ -108,6 +98,16 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 	}
 
 	return registration, nil
+}
+
+func (m *LightMetricSet) useHostURISchemeIfPossible(host, uri string) string {
+	u, err := url.ParseRequestURI(uri)
+	if err == nil {
+		if u.Scheme != "" {
+			return fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		}
+	}
+	return host
 }
 
 // baseModule does the configuration overrides in the base module configuration

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -18,6 +18,9 @@
 package mb
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -83,7 +86,18 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 		// At this point host parser was already run, we need to run this again
 		// with the overriden defaults
 		if registration.HostParser != nil {
-			base.hostData, err = registration.HostParser(base.module, base.host)
+			u, err := url.Parse(base.hostData.URI)
+			if err != nil {
+				return nil, errors.Wrapf(err, "host data URI parsing failed on light metricset factory for '%s/%s'", m.Module, m.Name)
+			}
+
+			var host string
+			if u.Scheme != "" {
+				host = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+			} else {
+				host = base.host
+			}
+			base.hostData, err = registration.HostParser(base.module, host)
 			if err != nil {
 				return nil, errors.Wrapf(err, "host parser failed on light metricset factory for '%s/%s'", m.Module, m.Name)
 			}

--- a/metricbeat/mb/lightmodules_test.go
+++ b/metricbeat/mb/lightmodules_test.go
@@ -300,9 +300,8 @@ func TestLightMetricSet_VerifyHostDataURI(t *testing.T) {
 				return HostData{}, err
 			}
 			return HostData{
-				Host:         u.Host,
-				URI:          host,
-				SanitizedURI: host,
+				Host: u.Host,
+				URI:  host,
 			}, nil
 		}))
 	r.SetSecondarySource(NewLightModulesSource("testdata/lightmodules"))
@@ -321,6 +320,62 @@ func TestLightMetricSet_VerifyHostDataURI(t *testing.T) {
 
 	assert.Equal(t, hostEndpoint, metricSets[0].Host())
 	assert.Equal(t, sampleHttpsEndpoint, metricSets[0].HostData().URI)
+}
+
+func TestLightMetricSet_WithoutHostParser(t *testing.T) {
+	const sampleHttpsEndpoint = "https://ceph-restful:8003"
+
+	r := NewRegister()
+	r.MustAddMetricSet("http", "json", newMetricSetWithOption)
+	r.SetSecondarySource(NewLightModulesSource("testdata/lightmodules"))
+
+	config, err := common.NewConfigFrom(
+		common.MapStr{
+			"module":     "httpextended",
+			"metricsets": []string{"extends"},
+			"hosts":      []string{sampleHttpsEndpoint},
+		})
+	require.NoError(t, err)
+
+	_, metricSets, err := NewModule(config, r)
+	require.NoError(t, err)
+	require.Len(t, metricSets, 1)
+
+	assert.Equal(t, sampleHttpsEndpoint, metricSets[0].Host())
+	assert.Equal(t, sampleHttpsEndpoint, metricSets[0].HostData().URI)
+}
+
+func TestLightMetricSet_VerifyHostDataURI_NonParsableHost(t *testing.T) {
+	const (
+		postgresHost     = "host1:5432"
+		postgresEndpoint = "postgres://user1:pass@host1:5432?connect_timeout=2"
+		postgresParsed   = "connect_timeout=3 host=host1 password=pass port=5432 user=user1"
+	)
+
+	r := NewRegister()
+	r.MustAddMetricSet("http", "json", newMetricSetWithOption,
+		WithHostParser(func(module Module, host string) (HostData, error) {
+			return HostData{
+				Host: postgresHost,
+				URI:  postgresParsed,
+			}, nil
+		}))
+	r.SetSecondarySource(NewLightModulesSource("testdata/lightmodules"))
+
+	config, err := common.NewConfigFrom(
+		common.MapStr{
+			"module":     "httpextended",
+			"metricsets": []string{"extends"},
+			"hosts":      []string{postgresEndpoint},
+		})
+	require.NoError(t, err)
+
+	_, metricSets, err := NewModule(config, r)
+	require.NoError(t, err)
+	require.Len(t, metricSets, 1)
+
+	assert.Equal(t, postgresHost, metricSets[0].Host())
+	assert.Equal(t, postgresParsed, metricSets[0].HostData().URI)
 }
 
 func TestNewModulesCallModuleFactory(t *testing.T) {

--- a/metricbeat/mb/testdata/lightmodules/httpextended/extends/manifest.yml
+++ b/metricbeat/mb/testdata/lightmodules/httpextended/extends/manifest.yml
@@ -1,0 +1,4 @@
+default: true
+input:
+  module: http
+  metricset: json

--- a/metricbeat/mb/testdata/lightmodules/httpextended/module.yml
+++ b/metricbeat/mb/testdata/lightmodules/httpextended/module.yml
@@ -1,0 +1,3 @@
+name: httpextended
+metricsets:
+- extends


### PR DESCRIPTION
While working on the Ceph module (https://github.com/elastic/beats/issues/7723) I've prepared the following setup for a new metric set:

modules.d/ceph.yml:

```
- module: ceph
  metricsets:
    - mgr_cluster_health
  hosts: [ "https://ceph-restful:8003" ]
  username: "demo"
  password: "51dd94b3-f865-4f63-af79-9efb9130cd7f"
  ssl.verification_mode: "none"
```

module/ceph/mgr_cluster_health:

```
default: true
input:
  module: http
  metricset: json
  defaults:
    method: POST
    namespace: "json_namespace"
    basepath: "/request"
    headers:
      Content-Type: application/json
    query:
      wait: "1"
    body: '{"prefix": "status", "format": "json"}'

processors:
  - extract_array:
      field: http.json_namespace.finished
      mappings:
        ceph.request: 0
  - decode_json_fields:
      fields: ["ceph.request.outb"]
      process_array: true
      target: "ceph.mgr_cluster_status.output"
  - drop_fields:
      fields: ["http", "ceph.request"]
```

The problem: Ceph's request API is accessible via HTTPS (by default) and the information about protocol scheme (https://) is getting lost in runtime.