### PR TITLE
Fix: imports order

### DIFF
--- a/x-pack/libbeat/autodiscover/providers/aws/ec2/provider_test.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/ec2/provider_test.go
@@ -8,15 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/logp"
 	awsauto "github.com/elastic/beats/x-pack/libbeat/autodiscover/providers/aws"
 	"github.com/elastic/beats/x-pack/libbeat/autodiscover/providers/aws/test"
-	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_internalBuilder(t *testing.T) {

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/bus"
-	"github.com/elastic/beats/libbeat/logp"
-	awsauto "github.com/elastic/beats/x-pack/libbeat/autodiscover/providers/aws"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/logp"
+	awsauto "github.com/elastic/beats/x-pack/libbeat/autodiscover/providers/aws"
 )
 
 type testEventAccumulator struct {


### PR DESCRIPTION
This PR adjusts imports order in `x-pack/libbeat`.

Spotted while investigating a failed test in Jenkins CI: https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-linux/6174/beat=x-pack%2Flibbeat,label=linux-immutable/console