### PR TITLE
Cherry-pick #16116 to 7.x: [Journalbeat] Improve parsing of syslog.pid in journalbeat to strip the username when present

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -37,6 +37,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Journalbeat*
 
 - Remove broken dashboard. {pull}15288[15288]
+- Improve parsing of syslog.pid in journalbeat to strip the username when present {pull}16116[16116]
+
 
 *Metricbeat*
 

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -288,8 +288,16 @@ func (r *Reader) convertNamedField(fc fieldConversion, value string) interface{}
 	if fc.isInteger {
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			r.logger.Debugf("Failed to convert field: %s \"%v\" to int: %v", fc.name, value, err)
-			return value
+			// On some versions of systemd the 'syslog.pid' can contain the username
+			// appended to the end of the pid. In most cases this does not occur
+			// but in the cases that it does, this tries to strip ',\w*' from the
+			// value and then perform the conversion.
+			s := strings.Split(value, ",")
+			v, err = strconv.ParseInt(s[0], 10, 64)
+			if err != nil {
+				r.logger.Debugf("Failed to convert field: %s \"%v\" to int: %v", fc.name, value, err)
+				return value
+			}
 		}
 		return v
 	}

--- a/journalbeat/reader/journal_test.go
+++ b/journalbeat/reader/journal_test.go
@@ -57,6 +57,45 @@ func TestToEvent(t *testing.T) {
 				},
 			},
 		},
+		// 'syslog.pid' field without user append
+		ToEventTestCase{
+			entry: sdjournal.JournalEntry{
+				Fields: map[string]string{
+					sdjournal.SD_JOURNAL_FIELD_SYSLOG_PID: "123456",
+				},
+			},
+			expectedFields: common.MapStr{
+				"syslog": common.MapStr{
+					"pid": int64(123456),
+				},
+			},
+		},
+		// 'syslog.pid' field with user append
+		ToEventTestCase{
+			entry: sdjournal.JournalEntry{
+				Fields: map[string]string{
+					sdjournal.SD_JOURNAL_FIELD_SYSLOG_PID: "123456,root",
+				},
+			},
+			expectedFields: common.MapStr{
+				"syslog": common.MapStr{
+					"pid": int64(123456),
+				},
+			},
+		},
+		// 'syslog.pid' field empty
+		ToEventTestCase{
+			entry: sdjournal.JournalEntry{
+				Fields: map[string]string{
+					sdjournal.SD_JOURNAL_FIELD_SYSLOG_PID: "",
+				},
+			},
+			expectedFields: common.MapStr{
+				"syslog": common.MapStr{
+					"pid": "",
+				},
+			},
+		},
 		// custom field
 		ToEventTestCase{
 			entry: sdjournal.JournalEntry{


### PR DESCRIPTION
Cherry-pick of PR #16116 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fixes an issue where syslog.pid is reported as an integer followed by the username.

## Why is it important?

In some cases journald reports the syslog.pid with the user that started the pid following it. This strips the username and only sends the pid in the event.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

I was unable to reproduce this issue with journald on Ubuntu 19.10. But was able to reproduce the failure using a unit test, so best way to test is just by running the unit tests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #15849 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
