### PR TITLE
Agent/ca sha256

### DIFF
--- a/agent/kibana/client.go
+++ b/agent/kibana/client.go
@@ -77,7 +77,7 @@ func New(
 }
 
 // NewConfigFromURL returns a Kibana Config based on a received host.
-func NewConfigFromURL(kURL string, CAs []string) (*Config, error) {
+func NewConfigFromURL(kURL string) (*Config, error) {
 	u, err := url.Parse(kURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse Kibana url")
@@ -96,12 +96,6 @@ func NewConfigFromURL(kURL string, CAs []string) (*Config, error) {
 	c.Path = u.Path
 	c.Username = username
 	c.Password = password
-
-	if len(CAs) > 0 {
-		c.TLS = &tlscommon.Config{
-			CAs: CAs,
-		}
-	}
 
 	return &c, nil
 }

--- a/libbeat/common/transport/tlscommon/config.go
+++ b/libbeat/common/transport/tlscommon/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	Certificate      CertificateConfig       `config:",inline" yaml:",inline"`
 	CurveTypes       []tlsCurveType          `config:"curve_types" yaml:"curve_types,omitempty"`
 	Renegotiation    tlsRenegotiationSupport `config:"renegotiation" yaml:"renegotiation"`
-	CASha256         pins                    `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
+	CASha256         []string                `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys

--- a/libbeat/common/transport/tlscommon/tls_config.go
+++ b/libbeat/common/transport/tlscommon/tls_config.go
@@ -67,7 +67,7 @@ type TLSConfig struct {
 
 	// CASha256 is the CA certificate pin, this is used to validate the CA that will be used to trust
 	// the server certificate.
-	CASha256 pins
+	CASha256 []string
 }
 
 // ToConfig generates a tls.Config object. Note, you must use BuildModuleConfig to generate a config with

--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -61,7 +61,7 @@ type EnrollCmdOption struct {
 	EnrollAPIKey         string
 }
 
-func (e *EnrollCmdOption) KibanaConfig() (*kibana.Config, error) {
+func (e *EnrollCmdOption) kibanaConfig() (*kibana.Config, error) {
 	cfg, err := kibana.NewConfigFromURL(e.URL)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func NewEnrollCmdWithStore(
 	store store,
 ) (*EnrollCmd, error) {
 
-	cfg, err := options.KibanaConfig()
+	cfg, err := options.kibanaConfig()
 	if err != nil {
 		return nil, errors.New(err,
 			"invalid Kibana configuration",

--- a/x-pack/agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/agent/kibana"
+	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/application/info"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/errors"
 	"github.com/elastic/beats/x-pack/agent/pkg/agent/storage"
@@ -43,24 +44,45 @@ type clienter interface {
 
 // EnrollCmd is an enroll subcommand that interacts between the Kibana API and the Agent.
 type EnrollCmd struct {
-	log                  *logger.Logger
-	enrollAPIKey         string
-	client               clienter
-	id                   string
-	userProvidedMetadata map[string]interface{}
-	configStore          store
-	kibanaConfig         *kibana.Config
+	log          *logger.Logger
+	options      *EnrollCmdOption
+	client       clienter
+	configStore  store
+	kibanaConfig *kibana.Config
+}
+
+// EnrollCmdOption define all the supported enrollment option.
+type EnrollCmdOption struct {
+	ID                   string
+	URL                  string
+	CAs                  []string
+	CASha256             []string
+	UserProvidedMetadata map[string]interface{}
+	EnrollAPIKey         string
+}
+
+func (e *EnrollCmdOption) KibanaConfig() (*kibana.Config, error) {
+	cfg, err := kibana.NewConfigFromURL(e.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add any SSL options from the CLI.
+	if len(e.CAs) > 0 || len(e.CASha256) > 0 {
+		cfg.TLS = &tlscommon.Config{
+			CAs:      e.CAs,
+			CASha256: e.CASha256,
+		}
+	}
+
+	return cfg, nil
 }
 
 // NewEnrollCmd creates a new enroll command that will registers the current beats to the remote
 // system.
 func NewEnrollCmd(
 	log *logger.Logger,
-	url string,
-	CAs []string,
-	enrollAPIKey string,
-	id string,
-	userProvidedMetadata map[string]interface{},
+	options *EnrollCmdOption,
 	configPath string,
 ) (*EnrollCmd, error) {
 
@@ -72,11 +94,7 @@ func NewEnrollCmd(
 
 	return NewEnrollCmdWithStore(
 		log,
-		url,
-		CAs,
-		enrollAPIKey,
-		id,
-		userProvidedMetadata,
+		options,
 		configPath,
 		store,
 	)
@@ -85,20 +103,17 @@ func NewEnrollCmd(
 //NewEnrollCmdWithStore creates an new enrollment and accept a custom store.
 func NewEnrollCmdWithStore(
 	log *logger.Logger,
-	url string,
-	CAs []string,
-	enrollAPIKey string,
-	id string,
-	userProvidedMetadata map[string]interface{},
+	options *EnrollCmdOption,
 	configPath string,
 	store store,
 ) (*EnrollCmd, error) {
-	cfg, err := kibana.NewConfigFromURL(url, CAs)
+
+	cfg, err := options.KibanaConfig()
 	if err != nil {
 		return nil, errors.New(err,
-			"invalid Kibana URL",
-			errors.TypeNetwork,
-			errors.M(errors.MetaKeyURI, url))
+			"invalid Kibana configuration",
+			errors.TypeConfig,
+			errors.M(errors.MetaKeyURI, options.URL))
 	}
 
 	client, err := fleetapi.NewWithConfig(log, cfg)
@@ -106,23 +121,15 @@ func NewEnrollCmdWithStore(
 		return nil, errors.New(err,
 			"fail to create the API client",
 			errors.TypeNetwork,
-			errors.M(errors.MetaKeyURI, url))
+			errors.M(errors.MetaKeyURI, options.URL))
 	}
 
-	if userProvidedMetadata == nil {
-		userProvidedMetadata = make(map[string]interface{})
-	}
-
-	// Extract the token
-	// Create the kibana client
 	return &EnrollCmd{
-		log:                  log,
-		client:               client,
-		enrollAPIKey:         enrollAPIKey,
-		id:                   id,
-		userProvidedMetadata: userProvidedMetadata,
-		kibanaConfig:         cfg,
-		configStore:          store,
+		log:          log,
+		client:       client,
+		options:      options,
+		kibanaConfig: cfg,
+		configStore:  store,
 	}, nil
 }
 
@@ -136,12 +143,12 @@ func (c *EnrollCmd) Execute() error {
 	}
 
 	r := &fleetapi.EnrollRequest{
-		EnrollAPIKey: c.enrollAPIKey,
-		SharedID:     c.id,
+		EnrollAPIKey: c.options.EnrollAPIKey,
+		SharedID:     c.options.ID,
 		Type:         fleetapi.PermanentEnroll,
 		Metadata: fleetapi.Metadata{
 			Local:        metadata,
-			UserProvided: c.userProvidedMetadata,
+			UserProvided: c.options.UserProvidedMetadata,
 		},
 	}
 
@@ -163,7 +170,7 @@ func (c *EnrollCmd) Execute() error {
 	}
 
 	if err := c.configStore.Save(reader); err != nil {
-		return errors.New(err, "could not save enroll credentials", errors.TypeFilesystem)
+		return errors.New(err, "could not save enrollment information", errors.TypeFilesystem)
 	}
 
 	if _, err := info.NewAgentInfo(); err != nil {

--- a/x-pack/agent/pkg/agent/application/enroll_cmd_test.go
+++ b/x-pack/agent/pkg/agent/application/enroll_cmd_test.go
@@ -81,11 +81,13 @@ func TestEnroll(t *testing.T) {
 			store := &mockStore{Err: errors.New("fail to save")}
 			cmd, err := NewEnrollCmdWithStore(
 				log,
-				url,
-				[]string{caFile},
-				"my-enrollment-token",
-				"my-id",
-				map[string]interface{}{"custom": "customize"},
+				&EnrollCmdOption{
+					ID:                   "my-id",
+					URL:                  url,
+					CAs:                  []string{caFile},
+					EnrollAPIKey:         "my-enrollment-token",
+					UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
+				},
 				"",
 				store,
 			)
@@ -133,11 +135,13 @@ func TestEnroll(t *testing.T) {
 			store := &mockStore{}
 			cmd, err := NewEnrollCmdWithStore(
 				log,
-				url,
-				[]string{caFile},
-				"my-enrollment-api-key",
-				"my-id",
-				map[string]interface{}{"custom": "customize"},
+				&EnrollCmdOption{
+					ID:                   "my-id",
+					URL:                  url,
+					CAs:                  []string{caFile},
+					EnrollAPIKey:         "my-enrollment-api-key",
+					UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
+				},
 				"",
 				store,
 			)
@@ -189,11 +193,13 @@ func TestEnroll(t *testing.T) {
 			store := &mockStore{}
 			cmd, err := NewEnrollCmdWithStore(
 				log,
-				url,
-				make([]string, 0),
-				"my-enrollment-api-key",
-				"my-id",
-				map[string]interface{}{"custom": "customize"},
+				&EnrollCmdOption{
+					ID:                   "my-id",
+					URL:                  url,
+					CAs:                  []string{},
+					EnrollAPIKey:         "my-enrollment-api-key",
+					UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
+				},
 				"",
 				store,
 			)
@@ -231,11 +237,13 @@ func TestEnroll(t *testing.T) {
 			store := &mockStore{}
 			cmd, err := NewEnrollCmdWithStore(
 				log,
-				url,
-				make([]string, 0),
-				"my-enrollment-token",
-				"my-id",
-				map[string]interface{}{"custom": "customize"},
+				&EnrollCmdOption{
+					ID:                   "my-id",
+					URL:                  url,
+					CAs:                  []string{},
+					EnrollAPIKey:         "my-enrollment-token",
+					UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
+				},
 				"",
 				store,
 			)
@@ -319,7 +327,7 @@ func readConfig(raw []byte) (*FleetAgentConfig, error) {
 		return nil, err
 	}
 
-	cfg := &FleetAgentConfig{}
+	cfg := defaultFleetAgentConfig()
 	if err := config.Unpack(cfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When you enroll an agent you can specify the `certificate_authorities`,
but when you fall back on the OS trust store you may want to be able to
check which CA was used to validate the remote server chain this PR
allow defining a CASHA256 to validate the remote server.

Based on work from elastic/beats#16019


The enrollment command will look like this.
```
agent enroll --ca_sha256 <ca_sha256pin> --certificate_authorities /etc/pki/root.ca https://localhost:5601 <enroll_api_key>
```

Fixes: #15718 
Fixes:  #15716
