### PR TITLE
[7.6][docs] Backport: Index template will only be loaded if the configured output is Elasticsearch

### DIFF
--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -11,7 +11,7 @@ connecting to Elasticsearch.
 ifndef::no-output-logstash[]
 
 NOTE: A connection to Elasticsearch is required to load the index template. If
-the output is Logstash, you must <<load-template-manually,load the template
+the configured output is not Elasticsearch (or Elastic Cloud), you must <<load-template-manually,load the template
 manually>>.
 
 endif::[]


### PR DESCRIPTION
Backports #16124 to 7.6 branch