### PR TITLE
Bug:Update wrong Auditbeat docker version

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -74,7 +74,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:8.0.0
+        image: docker.elastic.co/beats/auditbeat:7.5.2
         args: [
           "-c", "/etc/auditbeat.yml"
         ]


### PR DESCRIPTION
-Bug

No such image for 8.0.0 - docker.elastic.co/beats/auditbeat:8.0.0 which causes kubernetes unable to pull image from remote repository


## What does this PR do?
Updated the yml file to pull the latest auditbeat available from https://www.docker.elastic.co/
docker.elastic.co/beats/auditbeat:7.5.2

## Why is it important?

To fix the issue for pulling the available images for auditbeat

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Deploy current yml file to kubernetes and it would fail due to no image availability

