### PR TITLE
Cherry-pick #16233 to 7.x: Remove spaces in prometheus commented out option

### DIFF
--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -36,7 +36,7 @@ metricbeat.modules:
   #password: "secret"
 
   # This can be used for service account based authorization:
-  #  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 ----

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -703,7 +703,7 @@ metricbeat.modules:
   #password: "secret"
 
   # This can be used for service account based authorization:
-  #  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -6,6 +6,6 @@
   #password: "secret"
 
   # This can be used for service account based authorization:
-  #  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -9,6 +9,6 @@
   #password: "secret"
 
   # This can be used for service account based authorization:
-  #  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -902,7 +902,7 @@ metricbeat.modules:
   #password: "secret"
 
   # This can be used for service account based authorization:
-  #  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 


### PR DESCRIPTION
Cherry-pick of PR #16233 to 7.x branch. Original message: 

## What does this PR do?

Remove spaces before commented out option in Prometheus docs.

## Why is it important?

In general, commented out options in beats reference config can be used by just removing the `#`. In this case removing the `#` leaves two additional spaces that can lead to incorrect or misleading configuration.