### PR TITLE
Skip monitoring flaky test

### DIFF
--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -11,6 +11,7 @@ import string
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
 
+@unittest.skip("flaky: https://github.com/elastic/beats/issues/16247")
 class Test(BaseTest):
 
     def setUp(self):
@@ -92,7 +93,6 @@ class Test(BaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
-    @unittest.skip("flaky: https://github.com/elastic/beats/issues/16247")
     def test_compare(self):
         """
         Test that monitoring docs are the same, regardless of how they are shipped.

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -92,6 +92,7 @@ class Test(BaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
+    @unittest.skip("flaky: https://github.com/elastic/beats/issues/16247")
     def test_compare(self):
         """
         Test that monitoring docs are the same, regardless of how they are shipped.


### PR DESCRIPTION
## What does this PR do?

Skip flaky test https://github.com/elastic/beats/issues/16247 in python 3 branch.

## Why is it important?

This test is failing quite frequently in the python 3 branch (#14798), skip it by now.