### PR TITLE
[docs] Fix install command to match instructions on docker hub

### DIFF
--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -29,7 +29,7 @@ https://github.com/elastic/beats[beats] GitHub repo.
 +
 ["source","sh",subs="attributes"]
 ----
-docker plugin install store/elastic/{log-driver-alias}:{version} --alias {log-driver-alias}
+docker plugin install elastic/{log-driver-alias}:{version}
 ----
 +
 *To build and install from source:*


### PR DESCRIPTION
Fixes install command to match https://hub.docker.com/r/elastic/elastic-logging-plugin.