### PR TITLE
[7.6][docs] Backport: Fix install command to match instructions on docker hub (#16249)

### DIFF
--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -29,7 +29,7 @@ https://github.com/elastic/beats[beats] GitHub repo.
 +
 ["source","sh",subs="attributes"]
 ----
-docker plugin install store/elastic/{log-driver-alias}:{version} --alias {log-driver-alias}
+docker plugin install elastic/{log-driver-alias}:{version}
 ----
 +
 *To build and install from source:*


### PR DESCRIPTION
Backports #16249 to 7.6 branch.