### PR TITLE
[7.6][docs] Backport: Add link to observability release blog (#16246)

### DIFF
--- a/libbeat/docs/release-notes/highlights/highlights-7.6.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.6.0.asciidoc
@@ -7,8 +7,8 @@
 Each release of {beats} brings new features and product improvements. 
 Following are the most notable features and enhancements in 7.6.
 
-//For a complete list of highlights, see the 
-//https://www.elastic.co/blog/elastic-observability-7-6-0-released[Observability 7.6 release blog].
+For a complete list of related highlights, see the 
+https://www.elastic.co/blog/elastic-observability-7-6-0-released[Observability 7.6 release blog].
 
 For a list of bug fixes and other changes, see the {beats}
 <<breaking-changes-7.6, Breaking Changes>> and <<release-notes, Release Notes>>.


### PR DESCRIPTION
Backports #16246 to 7.6 branch.