### PR TITLE
Ensure Kibana version is checked

### DIFF
--- a/agent/kibana/round_trippers.go
+++ b/agent/kibana/round_trippers.go
@@ -151,7 +151,7 @@ func (r *EnforceKibanaVersionRoundTripper) RoundTrip(req *http.Request) (*http.R
 }
 
 // NewEnforceKibanaVersionRoundTripper enforce the remove endpoint to be a a certain version, if the
-// remove kibana is not equal or superiod on the requested version the call will fail.
+// remove kibana is not equal or superior on the requested version the call will fail.
 func NewEnforceKibanaVersionRoundTripper(wrapped http.RoundTripper, version string) http.RoundTripper {
 	return &EnforceKibanaVersionRoundTripper{rt: wrapped, version: version}
 }

--- a/x-pack/agent/docs/agent.asciidoc
+++ b/x-pack/agent/docs/agent.asciidoc
@@ -1,0 +1,8 @@
+Agent's notes
+
+
+[[requirements]]
+Requirements
+
+The remote Kibana version of the Agent must be equal or higher than the Agent version, if this is not meet
+Kibana will refuses the connection.

--- a/x-pack/agent/docs/agent.asciidoc
+++ b/x-pack/agent/docs/agent.asciidoc
@@ -4,5 +4,5 @@ Agent's notes
 [[requirements]]
 Requirements
 
-The remote Kibana version of the Agent must be equal or higher than the Agent version, if this is not meet
-Kibana will refuses the connection.
+The remote Kibana version of the Agent must be equal or higher than the Agent version, if this is not met
+Kibana will refuse the connection.


### PR DESCRIPTION
Remote Kibana version must be higher or equal to the current version of
the Agent. This commit add a test to ensure the client we generate have the right
RoundTripper to enforce the version check.

Note: The check is done on Kibana passing the `kbn-version` version header, when the version of
the client is higher than the remote server the Kibana will refuse the
connection.

Fixes: #16257
