### PR TITLE
Cherry-pick #16265 to 7.6: [Metricbeat] Update docs.asciidoc for cisco module

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -295,11 +295,11 @@ include::../include/timezone-support.asciidoc[]
 [[dynamic-script-compilations]]
 === Dynamic Script Compilations
 
-The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
+The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and make extensive
 use of script processors and painless conditions. This can cause the pipelines
 to fail loading the first time the module is used, due to exceeding the maximum
 script compilation limits. It is recommended to tune the following parameters
-on your cluster:
+on your Elasticsearch cluster:
 
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -290,11 +290,11 @@ include::../include/timezone-support.asciidoc[]
 [[dynamic-script-compilations]]
 === Dynamic Script Compilations
 
-The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
+The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and make extensive
 use of script processors and painless conditions. This can cause the pipelines
 to fail loading the first time the module is used, due to exceeding the maximum
 script compilation limits. It is recommended to tune the following parameters
-on your cluster:
+on your Elasticsearch cluster:
 
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.


### PR DESCRIPTION
Cherry-pick of PR #16265 to 7.6 branch. Original message: 

This PR is to continue @loekvangool's #16208 for updating cisco Metricbeat module documentation. 
