### PR TITLE
Fix timeout option of Functionbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,7 +100,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix timeout option of GCP functions. {issue}16282[16282] {pull}16287[16287]
 
-
 ==== Added
 
 *Affecting all Beats*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,6 +98,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- Fix timeout option of GCP functions. {issue}16282[16282] {pull}16287[16287]
+
 
 ==== Added
 

--- a/x-pack/functionbeat/manager/gcp/template_builder.go
+++ b/x-pack/functionbeat/manager/gcp/template_builder.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"time"
 
 	cloudfunctions "google.golang.org/api/cloudfunctions/v1"
 	yaml "gopkg.in/yaml.v2"
@@ -115,7 +114,7 @@ func (d *defaultTemplateBuilder) cloudFunction(name string, config *fngcp.Functi
 		Runtime:             runtime,
 		ServiceAccountEmail: config.ServiceAccountEmail,
 		SourceArchiveUrl:    sourceArchiveURL,
-		Timeout:             config.Timeout.String(),
+		Timeout:             config.Timeout,
 		VpcConnector:        config.VPCConnector,
 	}
 }
@@ -142,8 +141,8 @@ func (d *defaultTemplateBuilder) RawTemplate(name string) (string, error) {
 		},
 	}
 
-	if config.Timeout > 0*time.Second {
-		properties["timeout"] = config.Timeout.String()
+	if config.Timeout != "" {
+		properties["timeout"] = config.Timeout
 	}
 	if config.MemorySize != "" {
 		properties["availableMemoryMb"] = config.MemorySize

--- a/x-pack/functionbeat/provider/gcp/gcp/config.go
+++ b/x-pack/functionbeat/provider/gcp/gcp/config.go
@@ -6,14 +6,13 @@ package gcp
 
 import (
 	"fmt"
-	"time"
 )
 
 // FunctionConfig stores the configuration of a Google Cloud Function
 type FunctionConfig struct {
 	Description         string            `config:"description"`
 	MemorySize          string            `config:"memory_size"`
-	Timeout             time.Duration     `config:"timeout" validate:"nonzero,positive"`
+	Timeout             string            `config:"timeout"`
 	ServiceAccountEmail string            `config:"service_account_email"`
 	Labels              map[string]string `config:"labels"`
 	VPCConnector        string            `config:"vpc_connector"`


### PR DESCRIPTION
## What does this PR do?

This PR changes the type of `timeout` option of GCP functions to `string` from `time.Duration`.

## Why is it important?

The option was parsed as `time.Duration` and then converted to `string` when creating the payload to upload a function. However, the format of the converted value was not accepted by GCP. This prevented users from setting the timeout from the manager.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Set the timeout option of a GCP function and try to deploy it.

## Related issues

Closes elastic/beats#16282
