### PR TITLE
Cherry-pick #16232 to 7.x: Add fb testing notes on developer guide

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -479,3 +479,12 @@ In addition, assuming you have a `test.log` file, you can add a
 documents as they are found via an Elasticsearch search. In this case, the
 integration tests will automatically check that the result is the same on each
 run.
+
+In order to test the filesets with the sample logs and/or generate the expected output one should run the tests
+locally for a specific module, using the following procedure under Filebeat directory:
+
+. Run an Elasticsearch instance locally using docker: `docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT`
+. Create python env: `make python-env`
+. Source python env: `./build/python-env/bin/activate`
+. Create the testing binary: `make filebeat.test`
+. Run the test, ie: `GENERATE=1 INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=nginx nosetests tests/system/test_modules.py`


### PR DESCRIPTION
Cherry-pick of PR #16232 to 7.x branch. Original message: 

## What does this PR do?
This PR adds the testing steps which can be used for testing a filebeat module while developing it. 

## Why is it important?
It is not documented so far.