### PR TITLE
Cherry-pick #16235 to 7.x: Freeze virtualenv version until issue with CI is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv; fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv==16.7.9; fi
 
 
 # Skips installations step


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#16235 to 7.x branch. Original message: 

CI when fetching new version of virtualenv (20.0.0) is failing on 
```
Generated fields.yml for filebeat to /Users/travis/gopath/src/github.com/elastic/beats/filebeat/build/fields/fields.all.yml
Traceback (most recent call last):
  File "/Users/travis/gopath/src/github.com/elastic/beats/build/ve/darwin/bin/pip", line 6, in <module>
    from pip._internal.cli.main import main
ImportError: No module named main
Error: running "/Users/travis/gopath/src/github.com/elastic/beats/build/ve/darwin/bin/pip install --quiet -Ur /Users/travis/gopath/src/github.com/elastic/beats/libbeat/tests/system/requirements.txt" failed with exit code 1
make: *** [update] Error 1
```
This PR just freezes version so we can get a green run, issue with new virtualenv still needs to be solved