### PR TITLE
[7.x] Updates Metricbeat stack module tests to use require.* (#15993)

### DIFF
--- a/metricbeat/module/beat/beat_integration_test.go
+++ b/metricbeat/module/beat/beat_integration_test.go
@@ -22,7 +22,7 @@ package beat_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -43,10 +43,8 @@ func TestFetch(t *testing.T) {
 		f := mbtest.NewReportingMetricSetV2Error(t, beat.GetConfig(metricSet, service.Host()))
 		events, errs := mbtest.ReportingFetchV2Error(f)
 
-		assert.Empty(t, errs)
-		if !assert.NotEmpty(t, events) {
-			t.FailNow()
-		}
+		require.Empty(t, errs)
+		require.NotEmpty(t, events)
 
 		t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 			events[0].BeatEvent("beat", metricSet).Fields.StringToPrint())
@@ -59,8 +57,6 @@ func TestData(t *testing.T) {
 	for _, metricSet := range metricSets {
 		f := mbtest.NewReportingMetricSetV2Error(t, beat.GetConfig(metricSet, service.Host()))
 		err := mbtest.WriteEventsReporterV2Error(f, t, metricSet)
-		if err != nil {
-			t.Fatal("write", err)
-		}
+		require.NoError(t, err)
 	}
 }

--- a/metricbeat/module/beat/state/data_test.go
+++ b/metricbeat/module/beat/state/data_test.go
@@ -24,17 +24,17 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/metricbeat/module/beat"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEventMapping(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/state.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	info := beat.Info{
 		UUID: "1234",
@@ -43,13 +43,13 @@ func TestEventMapping(t *testing.T) {
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventMapping(reporter, info, input)
 
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/beat/stats/data_test.go
+++ b/metricbeat/module/beat/stats/data_test.go
@@ -24,17 +24,17 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/metricbeat/module/beat"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEventMapping(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/stats.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	info := beat.Info{
 		UUID: "1234",
@@ -43,13 +43,13 @@ func TestEventMapping(t *testing.T) {
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventMapping(reporter, info, input)
 
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/elasticsearch/ccr/data_test.go
+++ b/metricbeat/module/elasticsearch/ccr/data_test.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -40,10 +40,10 @@ func TestMapper(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	input, err := ioutil.ReadFile("./_meta/test/empty.700.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	eventsMapping(reporter, info, input)
-	assert.Equal(t, 0, len(reporter.GetErrors()))
-	assert.Equal(t, 0, len(reporter.GetEvents()))
+	require.Equal(t, 0, len(reporter.GetErrors()))
+	require.Equal(t, 0, len(reporter.GetEvents()))
 }

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -80,9 +79,7 @@ func TestFetch(t *testing.T) {
 	host := service.Host()
 
 	version, err := getElasticsearchVersion(host)
-	if err != nil {
-		t.Fatal("getting elasticsearch version", err)
-	}
+	require.NoError(t, err)
 
 	setupTest(t, host, version)
 
@@ -92,10 +89,9 @@ func TestFetch(t *testing.T) {
 			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet, host))
 			events, errs := mbtest.ReportingFetchV2Error(f)
 
-			assert.Empty(t, errs)
-			if !assert.NotEmpty(t, events) {
-				t.FailNow()
-			}
+			require.Empty(t, errs)
+			require.NotEmpty(t, events)
+
 			t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 				events[0].BeatEvent("elasticsearch", metricSet).Fields.StringToPrint())
 		})
@@ -107,18 +103,14 @@ func TestData(t *testing.T) {
 	host := service.Host()
 
 	version, err := getElasticsearchVersion(host)
-	if err != nil {
-		t.Fatal("getting elasticsearch version", err)
-	}
+	require.NoError(t, err)
 
 	for _, metricSet := range metricSets {
 		t.Run(metricSet, func(t *testing.T) {
 			checkSkip(t, metricSet, version)
 			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet, host))
 			err := mbtest.WriteEventsReporterV2Error(f, t, metricSet)
-			if err != nil {
-				t.Fatal("write", err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/metricbeat/module/elasticsearch/enrich/data_test.go
+++ b/metricbeat/module/elasticsearch/enrich/data_test.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -40,10 +40,10 @@ func TestMapper(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	input, err := ioutil.ReadFile("./_meta/test/empty.750.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	eventsMapping(reporter, info, input)
-	assert.Equal(t, 0, len(reporter.GetErrors()))
-	assert.Equal(t, 0, len(reporter.GetEvents()))
+	require.Equal(t, 0, len(reporter.GetErrors()))
+	require.Equal(t, 0, len(reporter.GetEvents()))
 }

--- a/metricbeat/module/elasticsearch/index/data_test.go
+++ b/metricbeat/module/elasticsearch/index/data_test.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -40,9 +40,9 @@ func TestMapper(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	input, err := ioutil.ReadFile("./_meta/test/empty.512.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	eventsMapping(reporter, info, input)
-	assert.Equal(t, 0, len(reporter.GetEvents()))
+	require.Equal(t, 0, len(reporter.GetEvents()))
 }

--- a/metricbeat/module/elasticsearch/index_summary/data_test.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_test.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -40,10 +40,10 @@ func TestMapper(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	input, err := ioutil.ReadFile("../index/_meta/test/empty.512.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	eventMapping(reporter, info, input)
-	assert.Empty(t, reporter.GetErrors())
-	assert.Equal(t, 1, len(reporter.GetEvents()))
+	require.Empty(t, reporter.GetErrors())
+	require.Equal(t, 1, len(reporter.GetEvents()))
 }

--- a/metricbeat/module/elasticsearch/node/data_test.go
+++ b/metricbeat/module/elasticsearch/node/data_test.go
@@ -23,9 +23,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -43,9 +43,9 @@ func TestInvalid(t *testing.T) {
 	file := "./_meta/test/invalid.json"
 
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -35,14 +35,14 @@ import (
 func TestFetch(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/node.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Makes sure glob matches at least 1 file
-	assert.True(t, len(files) > 0)
+	require.True(t, len(files) > 0)
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
 			response, err := ioutil.ReadFile(f)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.RequestURI {

--- a/metricbeat/module/elasticsearch/pending_tasks/data_test.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -43,65 +43,65 @@ var info = elasticsearch.Info{
 func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/empty.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.NoError(t, err)
-	assert.True(t, len(reporter.GetEvents()) >= 1)
-	assert.Zero(t, len(reporter.GetErrors()))
+	require.NoError(t, err)
+	require.True(t, len(reporter.GetEvents()) >= 1)
+	require.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 	file := "./_meta/test/empty.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.Zero(t, len(reporter.GetEvents()))
-	assert.Zero(t, len(reporter.GetErrors()))
+	require.Zero(t, len(reporter.GetEvents()))
+	require.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.Equal(t, 3, len(reporter.GetEvents()))
-	assert.Zero(t, len(reporter.GetErrors()))
+	require.Equal(t, 3, len(reporter.GetEvents()))
+	require.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_required_field.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestInvalidJsonForBadFormatShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_format.json"
 	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, info, content)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestEventsMappedMatchToContentReceived(t *testing.T) {
@@ -199,7 +199,7 @@ func TestEventsMappedMatchToContentReceived(t *testing.T) {
 
 	for _, testCase := range testCases {
 		content, err := ioutil.ReadFile(testCase.given)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventsMapping(reporter, info, content)

--- a/metricbeat/module/elasticsearch/shard/data_test.go
+++ b/metricbeat/module/elasticsearch/shard/data_test.go
@@ -22,23 +22,23 @@ import (
 	"path/filepath"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestStats(t *testing.T) {
 	files, err := filepath.Glob("./_meta/test/routing_table.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		eventsMapping(reporter, input)
 
-		assert.True(t, len(reporter.GetEvents()) >= 1)
-		assert.Equal(t, 0, len(reporter.GetErrors()))
+		require.True(t, len(reporter.GetEvents()) >= 1)
+		require.Equal(t, 0, len(reporter.GetErrors()))
 	}
 }

--- a/metricbeat/module/elasticsearch/testing.go
+++ b/metricbeat/module/elasticsearch/testing.go
@@ -24,29 +24,29 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // TestMapper tests mapping methods
 func TestMapper(t *testing.T, glob string, mapper func(mb.ReporterV2, []byte) error) {
 	files, err := filepath.Glob(glob)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Makes sure glob matches at least 1 file
-	assert.True(t, len(files) > 0)
+	require.True(t, len(files) > 0)
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
 			input, err := ioutil.ReadFile(f)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}
 			err = mapper(reporter, input)
-			assert.NoError(t, err)
-			assert.True(t, len(reporter.GetEvents()) >= 1)
-			assert.Equal(t, 0, len(reporter.GetErrors()))
+			require.NoError(t, err)
+			require.True(t, len(reporter.GetEvents()) >= 1)
+			require.Equal(t, 0, len(reporter.GetErrors()))
 		})
 	}
 }
@@ -54,9 +54,9 @@ func TestMapper(t *testing.T, glob string, mapper func(mb.ReporterV2, []byte) er
 // TestMapperWithInfo tests mapping methods with Info fields
 func TestMapperWithInfo(t *testing.T, glob string, mapper func(mb.ReporterV2, Info, []byte) error) {
 	files, err := filepath.Glob(glob)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Makes sure glob matches at least 1 file
-	assert.True(t, len(files) > 0)
+	require.True(t, len(files) > 0)
 
 	info := Info{
 		ClusterID:   "1234",
@@ -66,13 +66,13 @@ func TestMapperWithInfo(t *testing.T, glob string, mapper func(mb.ReporterV2, In
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
 			input, err := ioutil.ReadFile(f)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}
 			err = mapper(reporter, info, input)
-			assert.NoError(t, err)
-			assert.True(t, len(reporter.GetEvents()) >= 1)
-			assert.Equal(t, 0, len(reporter.GetErrors()))
+			require.NoError(t, err)
+			require.True(t, len(reporter.GetEvents()) >= 1)
+			require.Equal(t, 0, len(reporter.GetErrors()))
 		})
 	}
 }

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,9 +20,9 @@ package kibana
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestIsStatsAPIAvailable(t *testing.T) {
@@ -38,6 +38,6 @@ func TestIsStatsAPIAvailable(t *testing.T) {
 
 	for _, test := range tests {
 		actual := IsStatsAPIAvailable(common.MustNewVersion(test.input))
-		assert.Equal(t, test.expected, actual)
+		require.Equal(t, test.expected, actual)
 	}
 }

--- a/metricbeat/module/kibana/stats/data_test.go
+++ b/metricbeat/module/kibana/stats/data_test.go
@@ -24,24 +24,24 @@ import (
 	"path/filepath"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestEventMapping(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/stats.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventMapping(reporter, input)
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/kibana/stats/data_xpack_test.go
+++ b/metricbeat/module/kibana/stats/data_xpack_test.go
@@ -25,45 +25,45 @@ import (
 	"testing"
 	"time"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestEventMappingStatsXPack(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/stats-legacy.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		now := time.Now()
 
 		err = eventMappingStatsXPack(reporter, 10000, now, input)
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }
 
 func TestEventMappingSettingsXPack(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/settings.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		now := time.Now()
 
 		err = eventMappingSettingsXPack(reporter, 10000, now, input)
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/tests/compose"
@@ -41,14 +41,10 @@ func TestFetch(t *testing.T) {
 	config := mtest.GetConfig("stats", service.Host(), false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(t, host)
-	if err != nil {
-		t.Fatal("getting kibana version", err)
-	}
+	require.NoError(t, err)
 
 	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
-	if err != nil {
-		t.Fatal("checking if kibana stats API is available", err)
-	}
+	require.NoError(t, err)
 
 	if !isStatsAPIAvailable {
 		t.Skip("Kibana stats API is not available until 6.4.0")
@@ -57,10 +53,8 @@ func TestFetch(t *testing.T) {
 	f := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(f)
 
-	assert.Empty(t, errs)
-	if !assert.NotEmpty(t, events) {
-		t.FailNow()
-	}
+	require.Empty(t, errs)
+	require.NotEmpty(t, events)
 
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 		events[0].BeatEvent("kibana", "stats").Fields.StringToPrint())
@@ -72,14 +66,10 @@ func TestData(t *testing.T) {
 	config := mtest.GetConfig("stats", service.Host(), false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(t, host)
-	if err != nil {
-		t.Fatal("getting kibana version", err)
-	}
+	require.NoError(t, err)
 
 	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
-	if err != nil {
-		t.Fatal("checking if kibana stats API is available", err)
-	}
+	require.NoError(t, err)
 
 	if !isStatsAPIAvailable {
 		t.Skip("Kibana stats API is not available until 6.4.0")
@@ -87,9 +77,7 @@ func TestData(t *testing.T) {
 
 	f := mbtest.NewReportingMetricSetV2Error(t, config)
 	err = mbtest.WriteEventsReporterV2Error(f, t, "")
-	if err != nil {
-		t.Fatal("write", err)
-	}
+	require.NoError(t, err)
 }
 
 func getKibanaVersion(t *testing.T, kibanaHostPort string) (*common.Version, error) {

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -24,7 +24,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/kibana/mtest"
@@ -44,17 +44,17 @@ func TestFetchUsage(t *testing.T) {
 			// Make GET /api/stats return 503 for first call, 200 for subsequent calls
 			switch numStatsRequests {
 			case 0: // first call
-				assert.Equal(t, "false", excludeUsage)
+				require.Equal(t, "false", excludeUsage)
 				w.WriteHeader(503)
 
 			case 1: // second call
 				// Make sure exclude_usage is still false since first call failed
-				assert.Equal(t, "false", excludeUsage)
+				require.Equal(t, "false", excludeUsage)
 				w.WriteHeader(200)
 
 			case 2: // third call
 				// Make sure exclude_usage is now true since second call succeeded
-				assert.Equal(t, "true", excludeUsage)
+				require.Equal(t, "true", excludeUsage)
 				w.WriteHeader(200)
 			}
 

--- a/metricbeat/module/kibana/status/data_test.go
+++ b/metricbeat/module/kibana/status/data_test.go
@@ -23,19 +23,19 @@ import (
 	"io/ioutil"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestEventMapping(t *testing.T) {
 	f := "./_meta/test/input.json"
 	content, err := ioutil.ReadFile(f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
-	assert.NoError(t, err, f)
-	assert.True(t, len(reporter.GetEvents()) >= 1, f)
-	assert.Equal(t, 0, len(reporter.GetErrors()), f)
+	require.NoError(t, err, f)
+	require.True(t, len(reporter.GetEvents()) >= 1, f)
+	require.Equal(t, 0, len(reporter.GetErrors()), f)
 }

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -22,7 +22,7 @@ package status
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -35,10 +35,8 @@ func TestFetch(t *testing.T) {
 	f := mbtest.NewReportingMetricSetV2Error(t, mtest.GetConfig("status", service.Host(), false))
 	events, errs := mbtest.ReportingFetchV2Error(f)
 
-	assert.Empty(t, errs)
-	if !assert.NotEmpty(t, events) {
-		t.FailNow()
-	}
+	require.Empty(t, errs)
+	require.NotEmpty(t, events)
 
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 		events[0].BeatEvent("kibana", "status").Fields.StringToPrint())

--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -22,7 +22,7 @@ package logstash_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -45,10 +45,8 @@ func TestFetch(t *testing.T) {
 			f := mbtest.NewReportingMetricSetV2Error(t, config)
 			events, errs := mbtest.ReportingFetchV2Error(f)
 
-			assert.Empty(t, errs)
-			if !assert.NotEmpty(t, events) {
-				t.FailNow()
-			}
+			require.Empty(t, errs)
+			require.NotEmpty(t, events)
 
 			t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 				events[0].BeatEvent("logstash", metricSet).Fields.StringToPrint())
@@ -64,9 +62,7 @@ func TestData(t *testing.T) {
 			config := getConfig(metricSet, service.Host())
 			f := mbtest.NewReportingMetricSetV2Error(t, config)
 			err := mbtest.WriteEventsReporterV2Error(f, t, metricSet)
-			if err != nil {
-				t.Fatal("write", err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -84,14 +80,12 @@ func TestXPackEnabled(t *testing.T) {
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
 	for _, metricSet := range metricSets {
 		events, errs := mbtest.ReportingFetchV2Error(metricSet)
-		assert.Empty(t, errs)
-		if !assert.NotEmpty(t, events) {
-			t.FailNow()
-		}
+		require.Empty(t, errs)
+		require.NotEmpty(t, events)
 
 		event := events[0]
-		assert.Equal(t, metricSetToTypeMap[metricSet.Name()], event.RootFields["type"])
-		assert.Regexp(t, `^.monitoring-logstash-\d-mb`, event.Index)
+		require.Equal(t, metricSetToTypeMap[metricSet.Name()], event.RootFields["type"])
+		require.Regexp(t, `^.monitoring-logstash-\d-mb`, event.Index)
 	}
 }
 

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -24,25 +24,25 @@ import (
 	"path/filepath"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestEventMapping(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/node.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventMapping(reporter, input)
 
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -24,25 +24,25 @@ import (
 	"path/filepath"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestEventMapping(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/node_stats.*.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
 		err = eventMapping(reporter, input)
 
-		assert.NoError(t, err, f)
-		assert.True(t, len(reporter.GetEvents()) >= 1, f)
-		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+		require.NoError(t, err, f)
+		require.True(t, len(reporter.GetEvents()) >= 1, f)
+		require.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Updates Metricbeat stack module tests to use require.*  (#15993)