### PR TITLE
feat: add environment variable representing the path to the build context

### DIFF
--- a/metricbeat/module/aerospike/docker-compose.yml
+++ b/metricbeat/module/aerospike/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   aerospike:
     image: docker.elastic.co/integrations-ci/beats-aerospike:${AEROSPIKE_VERSION:-3.9.0}-1
     build:
-      context: ./_meta
+      context: ${AEROSPIKE_PATH:-.}/_meta
       args:
         AEROSPIKE_VERSION: ${AEROSPIKE_VERSION:-3.9.0}
     ports:

--- a/metricbeat/module/apache/docker-compose.yml
+++ b/metricbeat/module/apache/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   apache:
     image: docker.elastic.co/integrations-ci/beats-apache:${APACHE_VERSION:-2.4.20}-1
     build:
-      context: ./_meta
+      context: ${APACHE_PATH:-.}/_meta
       args:
         APACHE_VERSION: ${APACHE_VERSION:-2.4.20}
     ports:

--- a/metricbeat/module/ceph/docker-compose.yml
+++ b/metricbeat/module/ceph/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ceph:
     image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-6373c6a-jewel-centos-7-x86_64}-1
     build:
-      context: ./_meta
+      context: ${CEPH_PATH:-.}/_meta
       args:
         CEPH_VERSION: ${CEPH_VERSION:-master-6373c6a-jewel-centos-7-x86_64}
     ports:

--- a/metricbeat/module/consul/docker-compose.yml
+++ b/metricbeat/module/consul/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   consul:
     image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.4.2}-1
     build:
-      context: ./_meta
+      context: ${CONSUL_PATH:-.}/_meta
       args:
         CONSUL_VERSION: ${CONSUL_VERSION:-1.4.2}
     ports:

--- a/metricbeat/module/couchbase/docker-compose.yml
+++ b/metricbeat/module/couchbase/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   couchbase:
     image: docker.elastic.co/integrations-ci/beats-couchbase:${COUCHBASE_VERSION:-4.5.1}-1
     build:
-      context: ./_meta
+      context: ${COUCHBASE_PATH:-.}/_meta
       args:
         COUCHBASE_VERSION: ${COUCHBASE_VERSION:-4.5.1}
     ports:

--- a/metricbeat/module/couchdb/docker-compose.yml
+++ b/metricbeat/module/couchdb/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   couchdb:
     image: docker.elastic.co/integrations-ci/beats-couchdb:${COUCHDB_VERSION:-1.7}-1
     build:
-      context: ./_meta
+      context: ${COUCHDB_PATH:-.}/_meta
       args:
         COUCHDB_VERSION: ${COUCHDB_VERSION:-1.7}
     ports:

--- a/metricbeat/module/dropwizard/docker-compose.yml
+++ b/metricbeat/module/dropwizard/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   dropwizard:
     image: docker.elastic.co/integrations-ci/beats-dropwizard:${MAVEN_VERSION:-3.3-jdk-8}-1
     build:
-      context: ./_meta
+      context: ${DROPWIZARD_PATH:-.}/_meta
       args:
         MAVEN_VERSION: ${MAVEN_VERSION:-3.3-jdk-8}
     ports:

--- a/metricbeat/module/envoyproxy/docker-compose.yml
+++ b/metricbeat/module/envoyproxy/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   envoyproxy:
     image: docker.elastic.co/integrations-ci/beats-envoyproxy:v${ENVOYPROXY_VERSION:-1.7.0}-1
     build:
-      context: ./_meta
+      context: ${ENVOYPROXY_PATH:-.}/_meta
       args:
         ENVOYPROXY_VERSION: ${ENVOYPROXY_VERSION:-1.7.0}
     ports:

--- a/metricbeat/module/etcd/docker-compose.yml
+++ b/metricbeat/module/etcd/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   etcd:
     image: docker.elastic.co/integrations-ci/beats-etcd:${ETCD_VERSION:-3.3.10}-1
     build:
-      context: ./_meta
+      context: ${ETCD_PATH:-.}/_meta
       args:
         ETCD_VERSION: ${ETCD_VERSION:-3.3.10}
     ports:

--- a/metricbeat/module/golang/docker-compose.yml
+++ b/metricbeat/module/golang/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   golang:
     image: docker.elastic.co/integrations-ci/beats-golang:1
     build:
-      context: ./_meta
+      context: ${GOLANG_PATH:-.}/_meta
     ports:
       - 6060

--- a/metricbeat/module/haproxy/docker-compose.yml
+++ b/metricbeat/module/haproxy/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   haproxy:
     image: docker.elastic.co/integrations-ci/beats-haproxy:${HAPROXY_VERSION:-1.8.22}-1
     build: 
-      context: ./_meta
+      context: ${HAPROXY_PATH:-.}/_meta
       args:
         HAPROXY_VERSION: ${HAPROXY_VERSION:-1.8.22}
     ports:

--- a/metricbeat/module/http/docker-compose.yml
+++ b/metricbeat/module/http/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   http:
     image: docker.elastic.co/integrations-ci/beats-http:1
     build:
-      context: ./_meta
+      context: ${HTTP_PATH:-.}/_meta
     ports:
       - 8080

--- a/metricbeat/module/jolokia/docker-compose.yml
+++ b/metricbeat/module/jolokia/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   jolokia:
     image: docker.elastic.co/integrations-ci/beats-jolokia:${JOLOKIA_VERSION:-1.5.0}-1
     build:
-      context: ./_meta
+      context: ${JOLOKIA_PATH:-.}/_meta
       args:
         JOLOKIA_VERSION: ${JOLOKIA_VERSION:-1.5.0}
     ports:

--- a/metricbeat/module/kafka/docker-compose.yml
+++ b/metricbeat/module/kafka/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   kafka:
     image: docker.elastic.co/integrations-ci/beats-kafka:${KAFKA_VERSION:-2.1.1}-2
     build:
-      context: ./_meta
+      context: ${KAFKA_PATH:-.}/_meta
       args:
         KAFKA_VERSION: ${KAFKA_VERSION:-2.1.1}
     ports:

--- a/metricbeat/module/kubernetes/docker-compose.yml
+++ b/metricbeat/module/kubernetes/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   #kubestate:
   #  build:
-  #    context: ./_meta
+  #    context: ${KUBERNETES_PATH:-.}/_meta
   #    dockerfile: Dockerfile.kube-state
   #  depends_on:
   #    - kubernetes

--- a/metricbeat/module/logstash/docker-compose.yml
+++ b/metricbeat/module/logstash/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   logstash:
     image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.5.2}-1
     build:
-      context: ./_meta
+      context: ${LOGSTASH_PATH:-.}/_meta
       args:
         LOGSTASH_VERSION: ${LOGSTASH_VERSION:-7.5.2}
     ports:

--- a/metricbeat/module/memcached/docker-compose.yml
+++ b/metricbeat/module/memcached/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   memcached:
     image: docker.elastic.co/integrations-ci/beats-memcached:${MEMCACHED_VERSION:-1.4.35}-1
     build:
-      context: ./_meta
+      context: ${MEMCACHED_PATH:-.}/_meta
       args:
         MEMCACHED_VERSION: ${MEMCACHED_VERSION:-1.4.35}
     ports:

--- a/metricbeat/module/mongodb/docker-compose.yml
+++ b/metricbeat/module/mongodb/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mongodb:
     image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-3.4}-1
     build:
-      context: ./_meta
+      context: ${MONGODB_PATH:-.}/_meta
       args:
         MONGODB_VERSION: ${MONGODB_VERSION:-3.4}
     command: mongod --replSet beats

--- a/metricbeat/module/munin/docker-compose.yml
+++ b/metricbeat/module/munin/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   munin:
     image: docker.elastic.co/integrations-ci/beats-munin:1
     build:
-      context: ./_meta
+      context: ${MUNIN_PATH:-.}/_meta
     ports:
       - 4949

--- a/metricbeat/module/mysql/docker-compose.yml
+++ b/metricbeat/module/mysql/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: docker.elastic.co/integrations-ci/beats-mysql:${MYSQL_VARIANT:-mysql}-${MYSQL_VERSION:-5.7.12}-1
     build:
-      context: ./_meta
+      context: ${MYSQL_PATH:-.}/_meta
       args:
         MYSQL_IMAGE: ${MYSQL_VARIANT:-mysql}:${MYSQL_VERSION:-5.7.12}
     ports:

--- a/metricbeat/module/nats/docker-compose.yml
+++ b/metricbeat/module/nats/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nats:
     image: docker.elastic.co/integrations-ci/beats-nats:${NATS_VERSION:-2.0.4}-1
     build:
-      context: ./_meta
+      context: ${NATS_PATH:-.}/_meta
       dockerfile: Dockerfile.2.0.X
       args:
         NATS_VERSION: ${NATS_VERSION:-2.0.4}
@@ -14,7 +14,7 @@ services:
   nats_1_3:
     image: docker.elastic.co/integrations-ci/beats-nats:${NATS_VERSION:-1.3.0}-1
     build:
-      context: ./_meta
+      context: ${NATS_PATH:-.}/_meta
       dockerfile: Dockerfile.1.3
       args:
         NATS_VERSION: ${NATS_VERSION:-1.3.0}

--- a/metricbeat/module/nginx/docker-compose.yml
+++ b/metricbeat/module/nginx/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx:
     image: docker.elastic.co/integrations-ci/beats-nginx:${NGINX_VERSION:-1.9}-1
     build: 
-      context: ./_meta
+      context: ${NGINX_PATH:-.}/_meta
       args:
         NGINX_VERSION: ${NGINX_VERSION:-1.9}
     ports:

--- a/metricbeat/module/php_fpm/docker-compose.yml
+++ b/metricbeat/module/php_fpm/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   phpfpm:
     image: docker.elastic.co/integrations-ci/beats-phpfpm:${PHPFPM_VERSION:-7.1}-1
     build: 
-      context: ./_meta
+      context: ${PHPFPM_PATH:-.}/_meta
       args:
         PHPFPM_VERSION: ${PHPFPM_VERSION:-7.1}
     ports:

--- a/metricbeat/module/postgresql/docker-compose.yml
+++ b/metricbeat/module/postgresql/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgresql:
     image: docker.elastic.co/integrations-ci/beats-postgresql:${POSTGRESQL_VERSION:-9.5.3}-1
     build:
-      context: ./_meta
+      context: ${POSTGRESQL_PATH:-.}/_meta
       args:
         POSTGRESQL_VERSION: ${POSTGRESQL_VERSION:-9.5.3}
     ports:

--- a/metricbeat/module/prometheus/docker-compose.yml
+++ b/metricbeat/module/prometheus/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   prometheus:
     image: docker.elastic.co/integrations-ci/beats-prometheus:${PROMETHEUS_VERSION:-2.6.0}-1
     build:
-      context: ./_meta
+      context: ${PROMETHEUS_PATH:-.}/_meta
       args:
         PROMETHEUS_VERSION: ${PROMETHEUS_VERSION:-2.6.0}
     ports:

--- a/metricbeat/module/rabbitmq/docker-compose.yml
+++ b/metricbeat/module/rabbitmq/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   rabbitmq:
     image: docker.elastic.co/integrations-ci/beats-rabbitmq:${RABBITMQ_VERSION:-3.7.4}-1
     build:
-      context: ./_meta
+      context: ${RABBITMQ_PATH:-.}/_meta
       args:
         RABBITMQ_VERSION: ${RABBITMQ_VERSION:-3.7.4}
     ports:

--- a/metricbeat/module/redis/docker-compose.yml
+++ b/metricbeat/module/redis/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   redis:
     image: docker.elastic.co/integrations-ci/beats-redis:${REDIS_VERSION:-3.2.12}-1
     build:
-      context: ./_meta
+      context: ${REDIS_PATH:-.}/_meta
       args:
         REDIS_VERSION: ${REDIS_VERSION:-3.2.12}
     ports:

--- a/metricbeat/module/traefik/docker-compose.yml
+++ b/metricbeat/module/traefik/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   traefik:
     image: docker.elastic.co/integrations-ci/beats-traefik:${TRAEFIK_VERSION:-1.6}-1
     build:
-      context: ./_meta
+      context: ${TRAEFIK_PATH:-.}/_meta
       args:
         TRAEFIK_VERSION: ${TRAEFIK_VERSION:-1.6}
     ports:

--- a/metricbeat/module/uwsgi/docker-compose.yml
+++ b/metricbeat/module/uwsgi/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   uwsgi_tcp:
     image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
     build:
-      context: ./_meta
+      context: ${UWSGI_PATH:-.}/_meta
       args:
         PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --wsgi-file app.py
@@ -14,7 +14,7 @@ services:
   uwsgi_http:
     image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
     build:
-      context: ./_meta
+      context: ${UWSGI_PATH:-.}/_meta
       args:
         PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9192 --memory-report --stats-http --wsgi-file app.py

--- a/metricbeat/module/zookeeper/docker-compose.yml
+++ b/metricbeat/module/zookeeper/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   zookeeper:
     image: docker.elastic.co/integrations-ci/beats-zookeeper:${ZOOKEEPER_VERSION:-3.5.5}-1
     build:
-      context: ./_meta
+      context: ${ZOOKEEPER_PATH:-.}/_meta
       args:
         ZOOKEEPER_VERSION: ${ZOOKEEPER_VERSION:-3.5.5}
     ports:

--- a/x-pack/metricbeat/module/activemq/docker-compose.yml
+++ b/x-pack/metricbeat/module/activemq/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   activemq:
     image: docker.elastic.co/integrations-ci/beats-activemq:${ACTIVEMQ_VERSION:-5.15.9}-1
     build:
-      context: ./_meta
+      context: ${ACTIVEMQ_PATH:-.}/_meta
       args:
         ACTIVEMQ_VERSION: ${ACTIVEMQ_VERSION:-5.15.9}
     ports:

--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 services:
   appsearch:
     build:
-      context: ./_meta
+      context: ${APPSEARCH_PATH:-.}/_meta
     depends_on:
       - elasticsearch
     environment:

--- a/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
+++ b/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   cockroachdb:
     image: docker.elastic.co/integrations-ci/beats-cockroachdb:${COCKROACHDB_VERSION:-19.1.1}-1
     build:
-      context: ./_meta
+      context: ${COCKROACHDB_PATH:-.}/_meta
       args:
         COCKROACHDB_VERSION: ${COCKROACHDB_VERSION:-19.1.1}
     ports:

--- a/x-pack/metricbeat/module/coredns/docker-compose.yml
+++ b/x-pack/metricbeat/module/coredns/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   coredns:
     image: docker.elastic.co/integrations-ci/beats-coredns:${COREDNS_VERSION:-1.5.0}-1
     build:
-      context: ./_meta
+      context: ${COREDNS_PATH:-.}/_meta
       args:
         COREDNS_VERSION: ${COREDNS_VERSION:-1.5.0}
     ports:

--- a/x-pack/metricbeat/module/ibmmq/docker-compose.yml
+++ b/x-pack/metricbeat/module/ibmmq/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ibmmq:
     image: docker.elastic.co/integrations-ci/beats-ibmmq:${IBMMQ_VERSION:-9.1.4.0-r1-amd64}-1
     build:
-      context: ./_meta
+      context: ${IBMMQ_PATH:-.}/_meta
       args:
         IBMMQ_VERSION: ${IBMMQ_VERSION:-9.1.4.0-r1-amd64}
     ports:

--- a/x-pack/metricbeat/module/mssql/docker-compose.yml
+++ b/x-pack/metricbeat/module/mssql/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mssql:
     image: docker.elastic.co/integrations-ci/beats-mssql:${MSSQL_VERSION:-2017-GA}-1
     build:
-      context: ./_meta
+      context: ${MSSQL_PATH:-.}/_meta
       args:
         MSSQL_VERSION: ${MSSQL_VERSION:-2017-GA}
     ports:

--- a/x-pack/metricbeat/module/stan/docker-compose.yml
+++ b/x-pack/metricbeat/module/stan/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   stan:
     image: docker.elastic.co/integrations-ci/beats-stan:${STAN_VERSION:-0.15.1}-1
     build:
-      context: ./_meta
+      context: ${STAN_PATH:-.}/_meta
       args:
         STAN_VERSION: ${STAN_VERSION:-0.15.1}
     ports:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
This PR adds an environment variable to the build context of the Docker images for metricbeat's integrations. This variable, named after service's name appending '_PATH' (uppercase, i.e. APACHE_PATH), will have a default value of '.', which is the current value to all of them.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We'd like to align the docker compose files in the end-2-end tests PoC (https://github.com/elastic/metricbeat-tests-poc) with those located in the Beats repo, so that we consume the same artifacts with same configurations.

The reason why it is not possible before these changes is because of Docker Compose's expected behavior: when using multiple docker-compose files (as we do in the PoC), any relative path in the build-chain must be discoverable by the first `-f compose.yml` element (See https://github.com/docker/compose/issues/3568 and https://github.com/docker/compose/issues/3874). With current approach, existing compose files cannot be consumed by anybody else but Beats, as it expects having access to the `./_meta` from the build context. (See https://github.com/elastic/beats/blob/master/metricbeat/module/apache/docker-compose.yml#L1-L11)

Because of that, from PoC perspective, where we want to consume same compose files, we need a manner to discover each `_meta` directory from a first compose file, and the easiest manner is to override an environment variable with the path to the compose, which is known in runtime by the PoC, so it's able to put the proper value, resolving each `_meta` directory for each integration.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] I have built the docker images using Beats' build system

## How to test this PR locally

From metricbeat directory, run `mage compose:buildSupportedVersions`, the process should finish successfully.

<details><summary>Build Log</summary>
<p>


```terminal
$ mage compose:buildSupportedVersions
2020/02/13 17:30:50 Found Elastic Beats dir at /Users/mdelapenya/sourcecode/src/github.com/elastic/beats
>> compose: Building docker images for supported versions
>> compose: Using compose file module/apache/docker-compose.yml
>> compose: Building images for variant map[APACHE_VERSION:2.4.12]
>> compose: Building images for variant map[APACHE_VERSION:2.4.20]
>> compose: OK
>> compose: Using compose file module/envoyproxy/docker-compose.yml
>> compose: Building images for variant map[ENVOYPROXY_VERSION:1.7.0]
>> compose: Building images for variant map[ENVOYPROXY_VERSION:1.12.0]
>> compose: OK
>> compose: Using compose file module/etcd/docker-compose.yml
>> compose: Building images for variant map[ETCD_VERSION:3.2.25]
>> compose: Building images for variant map[ETCD_VERSION:3.3.10]
>> compose: OK
>> compose: Using compose file module/haproxy/docker-compose.yml
>> compose: Building images for variant map[HAPROXY_VERSION:2.0.9]
>> compose: Building images for variant map[HAPROXY_VERSION:1.9.12]
>> compose: Building images for variant map[HAPROXY_VERSION:1.8.22]
>> compose: Building images for variant map[HAPROXY_VERSION:1.7.12]
>> compose: Building images for variant map[HAPROXY_VERSION:1.6.15]
>> compose: OK
>> compose: Using compose file module/kafka/docker-compose.yml
>> compose: Building images for variant map[KAFKA_VERSION:2.1.1]
>> compose: Building images for variant map[KAFKA_VERSION:2.0.0]
>> compose: Building images for variant map[KAFKA_VERSION:1.1.0]
>> compose: Building images for variant map[KAFKA_VERSION:0.10.2.2]
>> compose: OK
>> compose: Using compose file module/mysql/docker-compose.yml
>> compose: Building images for variant map[MYSQL_VARIANT:mysql MYSQL_VERSION:5.7.12]
>> compose: Building images for variant map[MYSQL_VARIANT:mysql MYSQL_VERSION:8.0.13]
>> compose: Building images for variant map[MYSQL_VARIANT:percona MYSQL_VERSION:5.7.24]
>> compose: Building images for variant map[MYSQL_VARIANT:percona MYSQL_VERSION:8.0.13-4]
>> compose: Building images for variant map[MYSQL_VARIANT:mariadb MYSQL_VERSION:10.2.23]
>> compose: Building images for variant map[MYSQL_VARIANT:mariadb MYSQL_VERSION:10.3.14]
>> compose: Building images for variant map[MYSQL_VARIANT:mariadb MYSQL_VERSION:10.4.4]
>> compose: OK
>> compose: Using compose file module/redis/docker-compose.yml
>> compose: Building images for variant map[REDIS_VERSION:3.2.12]
>> compose: Building images for variant map[REDIS_VERSION:4.0.11]
>> compose: Building images for variant map[REDIS_VERSION:5.0.5]
>> compose: OK
```

</p>
</details>

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related Issues
- Relates https://github.com/elastic/metricbeat-tests-poc/issues/79