### PR TITLE
Add support for kubernetes provider to recognize namespace level defaults

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -138,6 +138,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove experimental flag from `setup.template.append_fields` {pull}16576[16576]
 - Add `add_cloudfoundry_metadata` processor to annotate events with Cloud Foundry application data. {pull}16621[16621]
 - Add Kerberos support to Kafka input and output. {pull}16781[16781]
+- Add `add_cloudfoundry_metadata` processor to annotate events with Cloud Foundry application data. {pull}16621[16621
+- Add support for kubernetes provider to recognize namespace level defaults {pull}16321[16321]
 
 *Auditbeat*
 

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -155,6 +155,24 @@ annotations:
   co.elastic.logs.sidecar/exclude_lines: '^DBG'
 -----
 
+[float]
+===== Configuring Namespace Defaults
+
+Hints can be configured on the Namespace's annotations as defaults to use when Pod level annotations are missing.
+The resultant hints are a combination of Pod annotations and Namespace annotations with the Pod's taking precedence. To
+enable Namespace defaults configure the `add_resource_metadata` for Namespace objects as follows:
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+filebeat.autodiscover:
+  providers:
+    - type: kubernetes
+      hints.enabled: true
+      add_resource_metadata:
+        namespace:
+          enabled: true
+-------------------------------------------------------------------------------------
+
 
 
 [float]

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -140,8 +140,11 @@ func (p *Provider) publish(event bus.Event) {
 		event["config"] = config
 	} else {
 		// If there isn't a default template then attempt to use builders
-		if config := p.builders.GetConfig(p.eventer.GenerateHints(event)); config != nil {
+		e := p.eventer.GenerateHints(event)
+		if config := p.builders.GetConfig(e); config != nil {
 			event["config"] = config
+		} else {
+
 		}
 	}
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -143,8 +143,6 @@ func (p *Provider) publish(event bus.Event) {
 		e := p.eventer.GenerateHints(event)
 		if config := p.builders.GetConfig(e); config != nil {
 			event["config"] = config
-		} else {
-
 		}
 	}
 

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -161,15 +161,27 @@ func (p *pod) GenerateHints(event bus.Event) bus.Event {
 	// Try to build a config with enabled builders. Send a provider agnostic payload.
 	// Builders are Beat specific.
 	e := bus.Event{}
-	var annotations common.MapStr
 	var kubeMeta, container common.MapStr
+
+	annotations := make(common.MapStr, 0)
 	rawMeta, ok := event["kubernetes"]
 	if ok {
 		kubeMeta = rawMeta.(common.MapStr)
 		// The builder base config can configure any of the field values of kubernetes if need be.
 		e["kubernetes"] = kubeMeta
 		if rawAnn, ok := kubeMeta["annotations"]; ok {
-			annotations = rawAnn.(common.MapStr)
+			anns, _ := rawAnn.(common.MapStr)
+			if len(anns) != 0 {
+				annotations = anns.Clone()
+			}
+		}
+
+		// Look at all the namespace level default annotations and do a merge with priority going to the pod annotations.
+		if rawNsAnn, ok := kubeMeta["namespace_annotations"]; ok {
+			nsAnn, _ := rawNsAnn.(common.MapStr)
+			if len(nsAnn) != 0 {
+				annotations.DeepUpdateNoOverwrite(nsAnn)
+			}
 		}
 	}
 	if host, ok := event["host"]; ok {
@@ -188,16 +200,10 @@ func (p *pod) GenerateHints(event bus.Event) bus.Event {
 	}
 
 	cname := builder.GetContainerName(container)
+
+	// Generate hints based on the cumulative of both namespace and pod annotations.
 	hints := builder.GenerateHints(annotations, cname, p.config.Prefix)
 	p.logger.Debugf("Generated hints %+v", hints)
-
-	// Fall back to defaults on the namespace if there were no hints on the pods
-	if len(hints) == 0 {
-		if rawAnn, ok := kubeMeta["defaults"]; ok {
-			annotations = rawAnn.(common.MapStr)
-			hints = builder.GenerateHints(annotations, cname, p.config.Prefix)
-		}
-	}
 
 	if len(hints) != 0 {
 		e["hints"] = hints
@@ -309,12 +315,12 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 		if p.namespaceWatcher != nil {
 			if rawNs, ok, err := p.namespaceWatcher.Store().GetByKey(pod.Namespace); ok && err == nil {
 				if namespace, ok := rawNs.(*kubernetes.Namespace); ok {
-					defaults := common.MapStr{}
+					nsAnn := common.MapStr{}
 
 					for k, v := range namespace.GetAnnotations() {
-						safemapstr.Put(defaults, k, v)
+						safemapstr.Put(nsAnn, k, v)
 					}
-					kubemeta["defaults"] = defaults
+					kubemeta["namespace_annotations"] = nsAnn
 				}
 			}
 		}

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -150,6 +150,174 @@ func TestGenerateHints(t *testing.T) {
 				},
 			},
 		},
+		// Scenarios tested:
+		// Have one set of hints come from the pod and the other come from namespaces
+		// The resultant hints should have a combination of both
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.logs/multiline.pattern":    "^test",
+						"co.elastic.logs/json.keys_under_root": "true",
+						"not.to.include":                       "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "prometheus",
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+					}),
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+					"namespace": "ns",
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.logs/multiline.pattern":    "^test",
+						"co.elastic.logs/json.keys_under_root": "true",
+						"not.to.include":                       "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+						"co.elastic.metrics/module":        "prometheus",
+					}),
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+					"namespace": "ns",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"multiline": common.MapStr{
+							"pattern": "^test",
+						},
+						"json": common.MapStr{
+							"keys_under_root": "true",
+						},
+					},
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "15s",
+					},
+				},
+				"container": common.MapStr{
+					"name":    "foobar",
+					"id":      "abc",
+					"runtime": "docker",
+				},
+			},
+		},
+		// Scenarios tested:
+		// Have one set of hints come from the pod and the same keys come from namespaces
+		// The resultant hints should honor only pods and not namespace.
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "prometheus",
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+						"not.to.include":                   "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "dropwizard",
+						"co.elastic.metrics/period":        "60s",
+						"co.elastic.metrics.foobar/period": "25s",
+					}),
+					"namespace": "ns",
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "prometheus",
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+						"not.to.include":                   "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "dropwizard",
+						"co.elastic.metrics/period":        "60s",
+						"co.elastic.metrics.foobar/period": "25s",
+					}),
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+					"namespace": "ns",
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "15s",
+					},
+				},
+				"container": common.MapStr{
+					"name":    "foobar",
+					"id":      "abc",
+					"runtime": "docker",
+				},
+			},
+		},
+		// Scenarios tested:
+		// Have no hints on the pod and have namespace level defaults.
+		// The resultant hints should honor only namespace defaults.
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "prometheus",
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+					}),
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+					"namespace": "ns",
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module":        "prometheus",
+						"co.elastic.metrics/period":        "10s",
+						"co.elastic.metrics.foobar/period": "15s",
+					}),
+					"container": common.MapStr{
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
+					},
+					"namespace": "ns",
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "15s",
+					},
+				},
+				"container": common.MapStr{
+					"name":    "foobar",
+					"id":      "abc",
+					"runtime": "docker",
+				},
+			},
+		},
 	}
 
 	cfg := defaultConfig()

--- a/libbeat/autodiscover/providers/kubernetes/service_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/service_test.go
@@ -98,6 +98,127 @@ func TestGenerateHints_Service(t *testing.T) {
 				},
 			},
 		},
+		// Scenarios tested:
+		// Have one set of annotations come from service and the other from namespace defaults
+		// The resultant should have both
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"not.to.include":            "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/period": "10s",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+					"namespace": "ns",
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"not.to.include":            "true",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/period": "10s",
+					}),
+					"namespace": "ns",
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "10s",
+					},
+				},
+			},
+		},
+		// Scenarios tested:
+		// Have the same set of annotations come from both namespace and service.
+		// The resultant should have the ones from service alone
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+						"not.to.include":            "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "dropwizard",
+						"co.elastic.metrics/period": "60s",
+					}),
+					"namespace": "ns",
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+						"not.to.include":            "true",
+					}),
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "dropwizard",
+						"co.elastic.metrics/period": "60s",
+					}),
+					"namespace": "ns",
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "10s",
+					},
+				},
+			},
+		},
+		// Scenarios tested:
+		// Have no annotations on the service and only have namespace level defaults
+		// The resultant should have honored the namespace defaults
+		{
+			event: bus.Event{
+				"kubernetes": common.MapStr{
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+					"namespace": "ns",
+				},
+			},
+			result: bus.Event{
+				"kubernetes": common.MapStr{
+					"namespace_annotations": getNestedAnnotations(common.MapStr{
+						"co.elastic.metrics/module": "prometheus",
+						"co.elastic.metrics/period": "10s",
+					}),
+					"service": common.MapStr{
+						"name": "foobar",
+					},
+					"namespace": "ns",
+				},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "prometheus",
+						"period": "10s",
+					},
+				},
+			},
+		},
 	}
 
 	cfg := defaultConfig()

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -127,6 +127,25 @@ annotations:
 -------------------------------------------------------------------------------------
 
 [float]
+===== Configuring Namespace Defaults
+
+Hints can be configured on the Namespace's annotations as defaults to use when Pod level annotations are missing.
+The resultant hints are a combination of Pod annotations and Namespace annotations with the Pod's taking precedence. To
+enable Namespace defaults configure the `add_resource_metadata` for Namespace objects as follows:
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+metricbeat.autodiscover:
+  providers:
+    - type: kubernetes
+      hints.enabled: true
+      add_resource_metadata:
+        namespace:
+          enabled: true
+-------------------------------------------------------------------------------------
+
+
+[float]
 === Docker
 
 Docker autodiscover provider supports hints in labels. To enable it just set `hints.enabled`:


### PR DESCRIPTION
This PR allows namespace level defaults to be configured on the namespace object for either service or pod hints autodiscover. This will need:

```
add_resource_metadata.namespace.enabled: true
```

to be set on the kubernetes autodiscover provider. 

This PR has a known gap where a pod is deployed before the namespace annotations are added. In this case, autodiscover wouldnt be able to add in the defaults. To fix that behavior we would need to ensure that we handle resync events as updates. Currently we ignore resync events as the resource version remains the same. 