### PR TITLE
Honor kube event resysncs to handle missed watch events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -359,6 +359,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added the `max_cached_sessions` option to the script processor. {pull}19562[19562]
 - Add support for DNS over TLS for the dns_processor. {pull}19321[19321]
 - Set index.max_docvalue_fields_search in index template to increase value to 200 fields. {issue}20215[20215]
+- Honor kube event resysncs to handle missed watch events {pull}16322[16322]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -169,8 +169,6 @@ func (a *Autodiscover) worker() {
 }
 
 func (a *Autodiscover) handleStart(event bus.Event) bool {
-	var updated bool
-
 	a.logger.Debugf("Got a start event: %v", event)
 
 	eventID := getID(event)
@@ -181,7 +179,7 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 
 	// Ensure configs list exists for this instance
 	if _, ok := a.configs[eventID]; !ok {
-		a.configs[eventID] = map[uint64]*reload.ConfigWithMeta{}
+		a.configs[eventID] = make(map[uint64]*reload.ConfigWithMeta)
 	}
 
 	configs, err := a.configurer.CreateConfig(event)
@@ -195,6 +193,11 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 			a.logger.Debugf("Generated config: %+v", common.DebugString(c, true))
 		}
 	}
+
+	var (
+		updated bool
+		newCfg  = make(map[uint64]*reload.ConfigWithMeta)
+	)
 
 	meta := a.getMeta(event)
 	for _, config := range configs {
@@ -215,16 +218,24 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 		// Update meta no matter what
 		dynFields := a.meta.Store(hash, meta)
 
-		if a.configs[eventID][hash] != nil {
+		if cfg, ok := a.configs[eventID][hash]; ok {
 			a.logger.Debugf("Config %v is already running", common.DebugString(config, true))
+			newCfg[hash] = cfg
 			continue
+		} else {
+			newCfg[hash] = &reload.ConfigWithMeta{
+				Config: config,
+				Meta:   &dynFields,
+			}
 		}
 
-		a.configs[eventID][hash] = &reload.ConfigWithMeta{
-			Config: config,
-			Meta:   &dynFields,
-		}
 		updated = true
+	}
+
+	// By replacing the config's for eventID we make sure that all old configs that are no longer in use
+	// are stopped correctly. This will ensure that a resync event is handled correctly.
+	if updated {
+		a.configs[eventID] = newCfg
 	}
 
 	return updated

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -72,7 +72,10 @@ type mockAdapter struct {
 }
 
 // CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
-func (m *mockAdapter) CreateConfig(bus.Event) ([]*common.Config, error) {
+func (m *mockAdapter) CreateConfig(event bus.Event) ([]*common.Config, error) {
+	if cfgs, ok := event["config"]; ok {
+		return cfgs.([]*common.Config), nil
+	}
 	return m.configs, nil
 }
 
@@ -84,7 +87,6 @@ func (m *mockAdapter) CheckConfig(c *common.Config) error {
 	c.Unpack(&config)
 
 	if config.Broken {
-		fmt.Println("broken")
 		return fmt.Errorf("Broken config")
 	}
 
@@ -373,6 +375,131 @@ func TestAutodiscoverWithConfigCheckFailures(t *testing.T) {
 	// As only the second config is valid, total runners will be 1
 	wait(t, func() bool { return len(adapter.Runners()) == 1 })
 	assert.Equal(t, 1, len(autodiscover.configs["mock:foo"]))
+}
+
+func TestAutodiscoverWithMutlipleEntries(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+	defer goroutines.Check(t)
+
+	// Register mock autodiscover provider
+	busChan := make(chan bus.Bus, 1)
+	Registry = NewRegistry()
+	Registry.AddProvider("mock", func(b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
+		// intercept bus to mock events
+		busChan <- b
+
+		return &mockProvider{}, nil
+	})
+
+	// Create a mock adapter
+	runnerConfig, _ := common.NewConfigFrom(map[string]string{
+		"runner": "1",
+	})
+	adapter := mockAdapter{
+		configs: []*common.Config{runnerConfig},
+	}
+
+	// and settings:
+	providerConfig, _ := common.NewConfigFrom(map[string]string{
+		"type": "mock",
+	})
+	config := Config{
+		Providers: []*common.Config{providerConfig},
+	}
+	k, _ := keystore.NewFileKeystore("test")
+	// Create autodiscover manager
+	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start it
+	autodiscover.Start()
+	defer autodiscover.Stop()
+	eventBus := <-busChan
+
+	// Test start event
+	eventBus.Publish(bus.Event{
+		"id":       "foo",
+		"provider": "mock",
+		"start":    true,
+		"meta": common.MapStr{
+			"foo": "bar",
+		},
+		"config": []*common.Config{
+			common.MustNewConfigFrom(map[string]interface{}{
+				"a": "b",
+			}),
+			common.MustNewConfigFrom(map[string]interface{}{
+				"x": "y",
+			}),
+		},
+	})
+	wait(t, func() bool { return len(adapter.Runners()) == 2 })
+
+	runners := adapter.Runners()
+	assert.Equal(t, len(runners), 2)
+	assert.Equal(t, len(autodiscover.configs["mock:foo"]), 2)
+	assert.True(t, runners[0].started)
+	assert.False(t, runners[0].stopped)
+	assert.True(t, runners[1].started)
+	assert.False(t, runners[1].stopped)
+	assert.Equal(t, runners[1].config, common.MustNewConfigFrom(map[string]interface{}{"x": "y"}))
+
+	// Test start event with changed configurations
+	eventBus.Publish(bus.Event{
+		"id":       "foo",
+		"provider": "mock",
+		"start":    true,
+		"meta": common.MapStr{
+			"foo": "bar",
+		},
+		"config": []*common.Config{
+			common.MustNewConfigFrom(map[string]interface{}{
+				"a": "b",
+			}),
+			common.MustNewConfigFrom(map[string]interface{}{
+				"x": "c",
+			}),
+		},
+	})
+	wait(t, func() bool { return len(adapter.Runners()) == 3 })
+	runners = adapter.Runners()
+	// Ensure the first config is the same as before
+	assert.Equal(t, runners[0].config, common.MustNewConfigFrom(map[string]interface{}{"a": "b"}))
+	assert.Equal(t, len(runners), 3)
+	assert.Equal(t, len(autodiscover.configs["mock:foo"]), 2)
+	assert.True(t, runners[0].started)
+	assert.False(t, runners[0].stopped)
+	// Ensure that the runner for the stale config is stopped
+	wait(t, func() bool { return adapter.Runners()[1].stopped == true })
+
+	// Ensure that the new runner is started
+	assert.False(t, runners[2].stopped)
+	assert.True(t, runners[2].started)
+	assert.Equal(t, runners[2].config, common.MustNewConfigFrom(map[string]interface{}{"x": "c"}))
+
+	// Stop all the configs
+	eventBus.Publish(bus.Event{
+		"id":       "foo",
+		"provider": "mock",
+		"stop":     true,
+		"meta": common.MapStr{
+			"foo": "bar",
+		},
+		"config": []*common.Config{
+			common.MustNewConfigFrom(map[string]interface{}{
+				"a": "b",
+			}),
+			common.MustNewConfigFrom(map[string]interface{}{
+				"x": "c",
+			}),
+		},
+	})
+
+	wait(t, func() bool { return adapter.Runners()[2].stopped == true })
+	runners = adapter.Runners()
+	assert.True(t, runners[0].stopped)
 }
 
 func wait(t *testing.T, test func() bool) {

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -271,6 +271,7 @@ func (d *Provider) emitContainer(container *docker.Container, meta *dockerMetada
 		host = container.IPAddresses[0]
 	}
 
+	var events []bus.Event
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
@@ -283,7 +284,7 @@ func (d *Provider) emitContainer(container *docker.Container, meta *dockerMetada
 			"meta":      meta.Metadata,
 		}
 
-		d.publish(event)
+		events = append(events, event)
 	}
 
 	// Emit container container and port information
@@ -298,25 +299,38 @@ func (d *Provider) emitContainer(container *docker.Container, meta *dockerMetada
 			"container": meta.Container,
 			"meta":      meta.Metadata,
 		}
-
-		d.publish(event)
+		events = append(events, event)
 	}
+	d.publish(events)
 }
 
-func (d *Provider) publish(event bus.Event) {
-	// Try to match a config
-	if config := d.templates.GetConfig(event); config != nil {
-		event["config"] = config
-	} else {
-		// If no template matches, try builders:
-		if config := d.builders.GetConfig(d.generateHints(event)); config != nil {
-			event["config"] = config
+func (d *Provider) publish(events []bus.Event) {
+	if len(events) == 0 {
+		return
+	}
+
+	configs := make([]*common.Config, 0)
+	for _, event := range events {
+		// Try to match a config
+		if config := d.templates.GetConfig(event); config != nil {
+			configs = append(configs, config...)
+		} else {
+			// If there isn't a default template then attempt to use builders
+			e := d.generateHints(event)
+			if config := d.builders.GetConfig(e); config != nil {
+				configs = append(configs, config...)
+			}
 		}
 	}
 
+	// Since all the events belong to the same event ID pick on and add in all the configs
+	event := bus.Event(common.MapStr(events[0]).Clone())
+	// Remove the port to avoid ambiguity during debugging
+	delete(event, "port")
+	event["config"] = configs
+
 	// Call all appenders to append any extra configuration
 	d.appenders.Append(event)
-
 	d.bus.Publish(event)
 }
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -138,17 +138,30 @@ func (p *Provider) String() string {
 	return "kubernetes"
 }
 
-func (p *Provider) publish(event bus.Event) {
-	// Try to match a config
-	if config := p.templates.GetConfig(event); config != nil {
-		event["config"] = config
-	} else {
-		// If there isn't a default template then attempt to use builders
-		e := p.eventer.GenerateHints(event)
-		if config := p.builders.GetConfig(e); config != nil {
-			event["config"] = config
+func (p *Provider) publish(events []bus.Event) {
+	if len(events) == 0 {
+		return
+	}
+
+	configs := make([]*common.Config, 0)
+	for _, event := range events {
+		// Try to match a config
+		if config := p.templates.GetConfig(event); config != nil {
+			configs = append(configs, config...)
+		} else {
+			// If there isn't a default template then attempt to use builders
+			e := p.eventer.GenerateHints(event)
+			if config := p.builders.GetConfig(e); config != nil {
+				configs = append(configs, config...)
+			}
 		}
 	}
+
+	// Since all the events belong to the same event ID pick on and add in all the configs
+	event := bus.Event(common.MapStr(events[0]).Clone())
+	// Remove the port to avoid ambiguity during debugging
+	delete(event, "port")
+	event["config"] = configs
 
 	// Call all appenders to append any extra configuration
 	p.appenders.Append(event)

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -40,12 +40,12 @@ type node struct {
 	config  *Config
 	metagen metadata.MetaGen
 	logger  *logp.Logger
-	publish func(bus.Event)
+	publish func([]bus.Event)
 	watcher kubernetes.Watcher
 }
 
 // NewNodeEventer creates an eventer that can discover and process node objects
-func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event []bus.Event)) (Eventer, error) {
 	logger := logp.NewLogger("autodiscover.node")
 
 	config := defaultConfig()
@@ -68,6 +68,7 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 		SyncTimeout: config.SyncPeriod,
 		Node:        config.Node,
 		IsUpdated:   isUpdated,
+		HonorReSyncs: true,
 	}, nil)
 
 	if err != nil {
@@ -189,7 +190,7 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 			"kubernetes": meta,
 		},
 	}
-	n.publish(event)
+	n.publish([]bus.Event{event})
 }
 
 func isUpdated(o, n interface{}) bool {

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -65,9 +65,9 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Node:        config.Node,
-		IsUpdated:   isUpdated,
+		SyncTimeout:  config.SyncPeriod,
+		Node:         config.Node,
+		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
 	}, nil)
 

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -39,13 +39,13 @@ type service struct {
 	config           *Config
 	metagen          metadata.MetaGen
 	logger           *logp.Logger
-	publish          func(bus.Event)
+	publish          func([]bus.Event)
 	watcher          kubernetes.Watcher
 	namespaceWatcher kubernetes.Watcher
 }
 
 // NewServiceEventer creates an eventer that can discover and process service objects
-func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event []bus.Event)) (Eventer, error) {
 	logger := logp.NewLogger("autodiscover.service")
 
 	config := defaultConfig()
@@ -55,8 +55,9 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 	}
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Namespace:   config.Namespace,
+		SyncTimeout:  config.SyncPeriod,
+		Namespace:    config.Namespace,
+		HonorReSyncs: true,
 	}, nil)
 
 	if err != nil {
@@ -217,6 +218,7 @@ func (s *service) emit(svc *kubernetes.Service, flag string) {
 		}
 	}
 
+	var events []bus.Event
 	for _, port := range svc.Spec.Ports {
 		event := bus.Event{
 			"provider":   s.uuid,
@@ -229,7 +231,8 @@ func (s *service) emit(svc *kubernetes.Service, flag string) {
 				"kubernetes": meta,
 			},
 		}
-		s.publish(event)
+		events = append(events, event)
 	}
+	s.publish(events)
 
 }

--- a/libbeat/autodiscover/providers/kubernetes/service_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/service_test.go
@@ -279,7 +279,6 @@ func TestEmitEvent_Service(t *testing.T) {
 				"host":     "192.168.0.1",
 				"id":       uid,
 				"provider": UUID,
-				"port":     8080,
 				"kubernetes": common.MapStr{
 					"service": common.MapStr{
 						"name": "metricbeat",
@@ -366,7 +365,6 @@ func TestEmitEvent_Service(t *testing.T) {
 				"stop":     true,
 				"host":     "",
 				"id":       uid,
-				"port":     8080,
 				"provider": UUID,
 				"kubernetes": common.MapStr{
 					"service": common.MapStr{

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -69,6 +69,8 @@ type WatchOptions struct {
 	// IsUpdated allows registering a func that allows the invoker of the Watch to decide what amounts to an update
 	// vs what does not.
 	IsUpdated func(old, new interface{}) bool
+	// HonorReSyncs allows resync events to be requeued on the worker
+	HonorReSyncs bool
 }
 
 type item struct {
@@ -137,6 +139,8 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 		UpdateFunc: func(o, n interface{}) {
 			if opts.IsUpdated(o, n) {
 				w.enqueue(n, update)
+			} else if opts.HonorReSyncs {
+				w.enqueue(n, add)
 			}
 		},
 	})


### PR DESCRIPTION
Enhancement

## What does this PR do?

This PR adds a `HonorReSyncs` watcher option to allow resyncs to be queued in as add events. The deduplication on the autodiscover module would ensure that we don't spin up more than one. 

## Why is it important?

This is needed if beats has been up and running and we add namespace level default hints. Without a resync it would require beats to be restarted. The resync will make sure that every x minutes we reconcile and ensure that these configurations are added in. It also makes sure that any missed add/update events are handled properly. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

## Related issues

## Use cases
