### PR TITLE
Build beats outside GOPATH

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -215,7 +215,7 @@ func (b GolangCrossBuilder) Build() error {
 		return errors.Wrap(err, "failed to determine repo root and package sub dir")
 	}
 
-	mountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.RootImportPath))
+	mountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.MountPoint))
 	// use custom dir for build if given, subdir if not:
 	cwd := repoInfo.SubDir
 	if b.InDir != "" {

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -215,7 +215,7 @@ func (b GolangCrossBuilder) Build() error {
 		return errors.Wrap(err, "failed to determine repo root and package sub dir")
 	}
 
-	mountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.MountPoint))
+	mountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.CanonicalRootImportPath))
 	// use custom dir for build if given, subdir if not:
 	cwd := repoInfo.SubDir
 	if b.InDir != "" {

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -18,6 +18,7 @@
 package gotool
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -54,6 +55,18 @@ type goTest func(opts ...ArgOpt) error
 
 // Test runs `go test` and provides optionals for adding command line arguments.
 var Test goTest = runGoTest
+
+// GetModuleName returns the name of the module.
+func GetModuleName() (string, error) {
+	lines, err := getLines(callGo(nil, "list", "-m"))
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", fmt.Errorf("unexpected number of lines")
+	}
+	return lines[0], nil
+}
 
 // ListProjectPackages lists all packages in the current project
 func ListProjectPackages() ([]string, error) {

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -55,10 +55,6 @@ After https://golang.org/doc/install[installing Go], set the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
 your workspace location, and make sure `$GOPATH/bin` is in your PATH.
 
-The location where you clone is important. Make a directory structure under
-`GOPATH` that matches the URL used for Elastic repositories, then clone the
-beats repository under the new directory:
-
 [source,shell]
 ----------------------------------------------------------------------
 mkdir -p ${GOPATH}/src/github.com/elastic
@@ -178,11 +174,9 @@ external tools.
 [float]
 ==== Golang
 
-To manage the `vendor/` folder we use
-https://github.com/kardianos/govendor[govendor]. Please see
-the govendor documentation on how to add or update vendored dependencies.
+To manage the `vendor/` folder we use go modules.
 
-In most cases `govendor fetch your/dependency@version +out` will get the job done.
+To update the contents of `vendor/`, run `mage vendor`.
 
 [float]
 ==== Other dependencies


### PR DESCRIPTION
## What does this PR do?

This PR adds support for building Beats outside GOPATH by separating repo information collection depending on the root path of the project.

## Why is it important?

This lets users compile and package Beats if they have checked out the code to a non-GOPATH folder.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made the corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works