### PR TITLE
Fix leaks with metadata processors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -180,6 +180,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Explicitly detect missing variables in autodiscover configuration, log them at the debug level. {issue}20568[20568] {pull}20898[20898]
 - Fix `libbeat.output.write.bytes` and `libbeat.output.read.bytes` metrics of the Elasticsearch output. {issue}20752[20752] {pull}21197[21197]
 - The `o365input` and `o365` module now recover from an authentication problem or other fatal errors, instead of terminating. {pull}21259[21258]
+- Orderly close processors when processing pipelines are not needed anymore to release their resources. {pull}16349[16349]
 
 *Auditbeat*
 

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -138,6 +138,7 @@ type ClientEventer interface {
 
 type ProcessorList interface {
 	Processor
+	Close() error
 	All() []Processor
 }
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -371,6 +371,11 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := b.processing.Close(); err != nil {
+			logp.Warn("Failed to close global processing: %v", err)
+		}
+	}()
 
 	// Windows: Mark service as stopped.
 	// After this is run, a Beat service is considered by the OS to be stopped

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -138,6 +138,7 @@ func NewWatcher(log *logp.Logger, host string, tls *TLSConfig, storeShortID bool
 	// Extra check to confirm that Docker is available
 	_, err = client.Info(context.Background())
 	if err != nil {
+		client.Close()
 		return nil, err
 	}
 
@@ -395,14 +396,12 @@ func (w *watcher) cleanupWorker() {
 	log := w.log
 
 	for {
-		// Wait a full period
-		time.Sleep(w.cleanupTimeout)
-
 		select {
 		case <-w.ctx.Done():
 			w.stopped.Done()
 			return
-		default:
+		// Wait a full period
+		case <-time.After(w.cleanupTimeout):
 			// Check entries for timeout
 			var toDelete []string
 			timeout := time.Now().Add(-w.cleanupTimeout)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -209,6 +209,18 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	return event, nil
 }
 
+func (d *addDockerMetadata) Close() error {
+	if d.cgroups != nil {
+		d.cgroups.StopJanitor()
+	}
+	d.watcher.Stop()
+	err := processors.Close(d.sourceProcessor)
+	if err != nil {
+		return errors.Wrap(err, "closing source processor of add_docker_metadata")
+	}
+	return nil
+}
+
 func (d *addDockerMetadata) String() string {
 	return fmt.Sprintf("%v=[match_fields=[%v] match_pids=[%v]]",
 		processorName, strings.Join(d.fields, ", "), strings.Join(d.pidFields, ", "))

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_integration_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_integration_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build linux darwin windows
+// +build integration
+
+package add_docker_metadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/docker"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	dockertest "github.com/elastic/beats/v7/libbeat/tests/docker"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+)
+
+func TestAddDockerMetadata(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+	defer goroutines.Check(t)
+
+	client, err := docker.NewClient(defaultConfig().Host, nil, nil)
+	require.NoError(t, err)
+
+	// Docker clients can affect the goroutines checker because they keep
+	// idle keep-alive connections, so we explicitly close them.
+	// These idle connections in principle wouldn't represent leaks even if
+	// the client is not explicitly closed because they are eventually closed.
+	defer client.Close()
+
+	// Start a container to have some data to enrich events
+	testClient, err := dockertest.NewClient()
+	require.NoError(t, err)
+	// Explicitly close client to don't affect goroutines checker
+	defer testClient.Close()
+
+	image := "busybox"
+	cmd := []string{"sleep", "60"}
+	labels := map[string]string{"label": "foo"}
+	id, err := testClient.ContainerStart(image, cmd, labels)
+	require.NoError(t, err)
+	defer testClient.ContainerRemove(id)
+
+	info, err := testClient.ContainerInspect(id)
+	require.NoError(t, err)
+	pid := info.State.Pid
+
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"match_fields": []string{"cid"},
+	})
+	watcherConstructor := newWatcherWith(client)
+	processor, err := buildDockerMetadataProcessor(logp.L(), config, watcherConstructor)
+	require.NoError(t, err)
+
+	t.Run("match container by container id", func(t *testing.T) {
+		input := &beat.Event{Fields: common.MapStr{
+			"cid": id,
+		}}
+		result, err := processor.Run(input)
+		require.NoError(t, err)
+
+		resultLabels, _ := result.Fields.GetValue("container.labels")
+		expectedLabels := common.MapStr{"label": "foo"}
+		assert.Equal(t, expectedLabels, resultLabels)
+		assert.Equal(t, id, result.Fields["cid"])
+	})
+
+	t.Run("match container by process id", func(t *testing.T) {
+		input := &beat.Event{Fields: common.MapStr{
+			"cid":         id,
+			"process.pid": pid,
+		}}
+		result, err := processor.Run(input)
+		require.NoError(t, err)
+
+		resultLabels, _ := result.Fields.GetValue("container.labels")
+		expectedLabels := common.MapStr{"label": "foo"}
+		assert.Equal(t, expectedLabels, resultLabels)
+		assert.Equal(t, id, result.Fields["cid"])
+	})
+
+	t.Run("don't enrich non existing container", func(t *testing.T) {
+		input := &beat.Event{Fields: common.MapStr{
+			"cid": "notexists",
+		}}
+		result, err := processor.Run(input)
+		require.NoError(t, err)
+		assert.Equal(t, input.Fields, result.Fields)
+	})
+
+	err = processors.Close(processor)
+	require.NoError(t, err)
+}
+
+func newWatcherWith(client docker.Client) docker.WatcherConstructor {
+	return func(log *logp.Logger, host string, tls *docker.TLSConfig, storeShortID bool) (docker.Watcher, error) {
+		return docker.NewWatcherWithClient(log, client, 60*time.Second, storeShortID)
+	}
+}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -16,6 +16,7 @@
 // under the License.
 
 // +build linux darwin windows
+// +build !integration
 
 package add_docker_metadata
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -242,6 +242,16 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 	return event, nil
 }
 
+func (k *kubernetesAnnotator) Close() error {
+	if k.watcher != nil {
+		k.watcher.Stop()
+	}
+	if k.cache != nil {
+		k.cache.stop()
+	}
+	return nil
+}
+
 func (k *kubernetesAnnotator) addPod(pod *kubernetes.Pod) {
 	metadata := k.indexers.GetMetadata(pod)
 	for _, m := range metadata {

--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -55,11 +55,12 @@ var (
 )
 
 type addProcessMetadata struct {
-	config      config
-	provider    processMetadataProvider
-	cidProvider cidProvider
-	log         *logp.Logger
-	mappings    common.MapStr
+	config       config
+	provider     processMetadataProvider
+	cgroupsCache *common.Cache
+	cidProvider  cidProvider
+	log          *logp.Logger
+	mappings     common.MapStr
 }
 
 type processMetadata struct {
@@ -81,16 +82,22 @@ type cidProvider interface {
 }
 
 func init() {
-	processors.RegisterPlugin(processorName, New)
+	processors.RegisterPlugin(processorName, NewWithCache)
 	jsprocessor.RegisterPlugin("AddProcessMetadata", New)
 }
 
 // New constructs a new add_process_metadata processor.
 func New(cfg *common.Config) (processors.Processor, error) {
-	return newProcessMetadataProcessorWithProvider(cfg, &procCache)
+	return newProcessMetadataProcessorWithProvider(cfg, &procCache, false)
 }
 
-func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider processMetadataProvider) (proc processors.Processor, err error) {
+// NewWithCache construct a new add_process_metadata processor with cache for container IDs.
+// Resulting processor implements `Close()` to release the cache resources.
+func NewWithCache(cfg *common.Config) (processors.Processor, error) {
+	return newProcessMetadataProcessorWithProvider(cfg, &procCache, true)
+}
+
+func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider processMetadataProvider, withCache bool) (proc processors.Processor, err error) {
 	// Logging (each processor instance has a unique ID).
 	var (
 		id  = int(instanceID.Inc())
@@ -118,19 +125,23 @@ func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider proces
 	}
 	// don't use cgroup.ProcessCgroupPaths to save it from doing the work when container id disabled
 	if ok := containsValue(mappings, "container.id"); ok {
-		if config.CgroupCacheExpireTime != 0 {
+		if withCache && config.CgroupCacheExpireTime != 0 {
 			p.log.Debug("Initializing cgroup cache")
 			evictionListener := func(k common.Key, v common.Value) {
 				p.log.Debugf("Evicted cached cgroups for PID=%v", k)
 			}
 
-			cgroupsCache := common.NewCacheWithRemovalListener(config.CgroupCacheExpireTime, 100, evictionListener)
-			cgroupsCache.StartJanitor(config.CgroupCacheExpireTime)
-			p.cidProvider = newCidProvider(config.HostPath, config.CgroupPrefixes, config.CgroupRegex, processCgroupPaths, cgroupsCache)
+			p.cgroupsCache = common.NewCacheWithRemovalListener(config.CgroupCacheExpireTime, 100, evictionListener)
+			p.cgroupsCache.StartJanitor(config.CgroupCacheExpireTime)
+			p.cidProvider = newCidProvider(config.HostPath, config.CgroupPrefixes, config.CgroupRegex, processCgroupPaths, p.cgroupsCache)
 		} else {
 			p.cidProvider = newCidProvider(config.HostPath, config.CgroupPrefixes, config.CgroupRegex, processCgroupPaths, nil)
 		}
 
+	}
+
+	if withCache {
+		return &addProcessMetadataCloser{p}, nil
 	}
 
 	return &p, nil
@@ -251,6 +262,17 @@ func (p *addProcessMetadata) getContainerID(pid int) (string, error) {
 		return "", err
 	}
 	return cid, nil
+}
+
+type addProcessMetadataCloser struct {
+	addProcessMetadata
+}
+
+func (p *addProcessMetadataCloser) Close() error {
+	if p.addProcessMetadata.cgroupsCache != nil {
+		p.addProcessMetadata.cgroupsCache.StopJanitor()
+	}
+	return nil
 }
 
 // String returns the processor representation formatted as a string

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -651,7 +651,7 @@ func TestAddProcessMetadata(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			proc, err := newProcessMetadataProcessorWithProvider(config, testProcs)
+			proc, err := newProcessMetadataProcessorWithProvider(config, testProcs, true)
 			if test.initErr == nil {
 				if err != nil {
 					t.Fatal(err)

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -44,6 +44,9 @@ type Processor interface {
 
 // Closer defines the interface for processors that should be closed after using
 // them.
+// Close() is not part of the Processor interface because implementing this method
+// is also a way to indicate that the processor keeps some resource that needs to
+// be released or orderly closed.
 type Closer interface {
 	Close() error
 }

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -20,6 +20,7 @@ package processors
 import (
 	"strings"
 
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -35,9 +36,24 @@ type Processors struct {
 	log  *logp.Logger
 }
 
+// Processor is the interface that all processors must implement
 type Processor interface {
 	Run(event *beat.Event) (*beat.Event, error)
 	String() string
+}
+
+// Closer defines the interface for processors that should be closed after using
+// them.
+type Closer interface {
+	Close() error
+}
+
+// Close closes a processor if it implements the Closer interface
+func Close(p Processor) error {
+	if closer, ok := p.(Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 // NewList creates a new empty processor list.
@@ -151,6 +167,17 @@ func (procs *Processors) All() []beat.Processor {
 		ret[i] = p
 	}
 	return ret
+}
+
+func (procs *Processors) Close() error {
+	var errs multierror.Errors
+	for _, p := range procs.List {
+		err := Close(p)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs.Err()
 }
 
 // Run executes the all processors serially and returns the event and possibly

--- a/libbeat/processors/script/javascript/module/processor/chain.go
+++ b/libbeat/processors/script/javascript/module/processor/chain.go
@@ -151,6 +151,17 @@ func newNativeProcessor(constructor processors.Constructor, call gojaCall) (proc
 	if err != nil {
 		return nil, err
 	}
+
+	if closer, ok := p.(processors.Closer); ok {
+		closer.Close()
+		// Script processor doesn't support releasing resources of stateful processors,
+		// what can lead to leaks, so prevent use of these processors. They shouldn't
+		// be registered. If this error happens, a processor that needs to be closed is
+		// being registered, this should be avoided.
+		// See https://github.com/elastic/beats/pull/16349
+		return nil, errors.Errorf("stateful processor cannot be used in script processor, this is probably a bug: %s", p)
+	}
+
 	return &nativeProcessor{p}, nil
 }
 

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
@@ -164,6 +165,15 @@ func (c *client) Close() error {
 		log.Debug("client: unlink from queue")
 		c.unlink()
 		log.Debug("client: done unlink")
+
+		if c.processors != nil {
+			log.Debug("client: closing processors")
+			err := processors.Close(c.processors)
+			if err != nil {
+				log.Errorf("client: error closing processors: %v", err)
+			}
+			log.Debug("client: done closing processors")
+		}
 	})
 	return nil
 }

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -338,7 +338,10 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	}
 
 	// setup 8: pipeline processors list
-	processors.add(b.processors)
+	if b.processors != nil {
+		// Add the global pipeline as a function processor, so clients cannot close it
+		processors.add(newProcessor(b.processors.title, b.processors.Run))
+	}
 
 	// setup 9: time series metadata
 	if b.timeSeries {
@@ -356,6 +359,13 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	}
 
 	return processors, nil
+}
+
+func (b *builder) Close() error {
+	if b.processors != nil {
+		return b.processors.Close()
+	}
+	return nil
 }
 
 func makeClientProcessors(

--- a/libbeat/publisher/processing/processing.go
+++ b/libbeat/publisher/processing/processing.go
@@ -33,6 +33,8 @@ type SupportFactory func(info beat.Info, log *logp.Logger, cfg *common.Config) (
 // will merge the global and local configurations into a common event
 // processor.
 // If `drop` is set, then the processor generated must always drop all events.
+// A Supporter needs to be closed with `Close()` to release its global resources.
 type Supporter interface {
 	Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, error)
+	Close() error
 }

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/joeshaw/multierror"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -75,6 +77,20 @@ func (p *group) add(processor processors.Processor) {
 	if processor != nil {
 		p.list = append(p.list, processor)
 	}
+}
+
+func (p *group) Close() error {
+	if p == nil {
+		return nil
+	}
+	var errs multierror.Errors
+	for _, processor := range p.list {
+		err := processors.Close(processor)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs.Err()
 }
 
 func (p *group) String() string {

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -77,8 +77,28 @@ func (c Client) ContainerWait(ID string) error {
 	return nil
 }
 
+// ContainerInspect recovers information of the container
+func (c Client) ContainerInspect(ID string) (types.ContainerJSON, error) {
+	ctx := context.Background()
+	return c.cli.ContainerInspect(ctx, ID)
+}
+
 // ContainerKill kills the given container
 func (c Client) ContainerKill(ID string) error {
 	ctx := context.Background()
 	return c.cli.ContainerKill(ctx, ID, "KILL")
+}
+
+// ContainerRemove kills and removed the given container
+func (c Client) ContainerRemove(ID string) error {
+	ctx := context.Background()
+	return c.cli.ContainerRemove(ctx, ID, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+		Force:         true,
+	})
+}
+
+// Close closes the underlying client
+func (c *Client) Close() error {
+	return c.cli.Close()
 }


### PR DESCRIPTION
## What does this PR do?

Add a closer interface for processors so their resources can be released when the processor is not needed anymore.

Explicitly close publisher pipelines so their processors are closed.

Add closers for `add_docker_metadata`, `add_kubernetes_metadata` and `add_process_metadata`.

## Why is it important?

Processors can be defined in dynamic configurations, as in autodiscover templates. Some processors open connections, files, or start goroutines that need to be closed or stopped.

Processors can be dynamically created at least when using autodiscover and when used in the [`script` processor](https://www.elastic.co/guide/en/beats/metricbeat/7.6/processor-script.html). When this issue appears it can be usually solved by configuration (as described in https://github.com/elastic/beats/issues/14389). So this case is probably not so serious.

Processors can include an on-disk cache since #20775, files open by this cache should be properly closed on shutdown.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

Check that resources are released in:
- [x] Filebeat
- [x] Metricbeat
  - [x] ~~Processors at the module level are open multiple times?~~ (One per metricset, to be reviewed as a different issue, only a real problem when a processor cannnot be instantiated twice with the same config, what only happens with `add_cloudfoundry_metadata`)
- [x] Autodiscover
- [x] Config reload
- [x] Check if there are other different pipelines that use processors in other beats (Everything using libbeat publisher pipeline should be covered, to open new issues if something that is not covered by this assumption should be covered).
- [x] Processors used in the script processor. Options to solve this:
   - [x] ~~Somehow call close on all the instantiated processors once the script is finished.~~
   - [x] Avoid registering processors implementing Closer for the script processor.

Add tests:
- [x] Native processors with closer in script processor.
- [x] Processing pipelines created by supporters don't close the global processors.

## Related issues

- Fixes elastic/beats#14389
- Fixes https://github.com/elastic/beats/issues/12096
- Fixes a pending issue from #20775 

## Use cases

* Add processors in dynamic configuration and release its resources when not needed anymore.
* Use processors that make use of files that should be closed (as cache on disk used by `add_cloudfoundry_metadata`).