### PR TITLE
Cherry-pick #16320 to 7.x: Add an SSL config example in config.yml for filebeat MISP module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -195,6 +195,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS tls and categorization fields to apache module. {issue}16032[16032] {pull}16121[16121]
 - Add MQTT input. {issue}15602[15602] {pull}16204[16204]
 - Add a TLS test and more debug output to httpjson input {pull}16315[16315]
+- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320] 
 
 *Heartbeat*
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -515,6 +515,12 @@ filebeat.modules:
 
     # URL of the MISP REST API
     #var.url
+   
+    # You can also pass SSL options. For example:
+    #var.ssl: |-
+    #  {
+    #    verification_mode: none
+    #  }
 
 #------------------------------- Mongodb Module -------------------------------
 #- module: mongodb

--- a/x-pack/filebeat/module/misp/_meta/config.yml
+++ b/x-pack/filebeat/module/misp/_meta/config.yml
@@ -9,3 +9,9 @@
 
     # URL of the MISP REST API
     #var.url
+   
+    # You can also pass SSL options. For example:
+    #var.ssl: |-
+    #  {
+    #    verification_mode: none
+    #  }

--- a/x-pack/filebeat/modules.d/misp.yml.disabled
+++ b/x-pack/filebeat/modules.d/misp.yml.disabled
@@ -12,3 +12,9 @@
 
     # URL of the MISP REST API
     #var.url
+   
+    # You can also pass SSL options. For example:
+    #var.ssl: |-
+    #  {
+    #    verification_mode: none
+    #  }


### PR DESCRIPTION
Cherry-pick of PR #16320 to 7.x branch. Original message: 

Add an SSL config example in config.yml for filebeat MISP module