### PR TITLE
Cherry-pick #16364 to 7.x: Add changelog for python 3

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -28,6 +28,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Altered all remaining uses of mapval to use the renamed and enhanced version: https://github.com/elastic/go-lookslike[go-lookslike] instead, which is a separate project. The mapval tree is now gone. {pull}14165[14165]
 - Move light modules to OSS. {pull}14369[14369]
 - Deprecate test flags, `generate` and `update_expected`, in favor of `data`. {pull}15292[15292]
+- Python 3 is required now to run python tests and tools. {pull}14798[14798]
 
 ==== Bugfixes
 

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -37,7 +37,7 @@ import (
 // platforms. So do verify the version with python.exe --version.
 //
 // Setting up a python virtual environment on a network drive does not work
-// well. So if this applies to your development environment set PYTHON_EXE
+// well. So if this applies to your development environment set PYTHON_ENV
 // to point to somewhere on C:\.
 
 const (


### PR DESCRIPTION
Cherry-pick of PR #16364 to 7.x branch. Original message: 

Add entry in the developers changelog about the migration to Python 3,
and fix typo in comment.