### PR TITLE
Make k8s meta processor initialisation asynchronous

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -51,7 +51,7 @@ type kubernetesAnnotator struct {
 
 const (
 	selector          = "kubernetes"
-	nodeReadyAttempts = 10
+	checkNodeReadyAttempts = 10
 )
 
 func init() {
@@ -111,7 +111,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 		kubernetesAvailable: false,
 	}
 
-	// complete processor's initialisation asyncronously so as to re-try on failing k8s client initialisations in case
+	// complete processor's initialisation asynchronously so as to re-try on failing k8s client initialisations in case
 	// the k8s node is not yet ready.
 	go func(processor *kubernetesAnnotator) {
 		client, err := kubernetes.GetKubernetesClient(config.KubeConfig)
@@ -128,7 +128,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 
 		connectionAttempts := 1
 		for ok := true; ok; ok = !isKubernetesAvailable(client) {
-			if connectionAttempts > nodeReadyAttempts {
+			if connectionAttempts > checkNodeReadyAttempts {
 				return
 			}
 			time.Sleep(3 * time.Second)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -28,11 +28,11 @@ import (
 	k8sclient "k8s.io/client-go/kubernetes"
 
 	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/common/kubernetes"
 	"github.com/elastic/beats/libbeat/common/kubernetes/metadata"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/libbeat/processors/script/javascript/module/processor"
 )
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -45,8 +45,6 @@ const (
 	checkNodeReadyAttempts = 10
 )
 
-var once sync.Once
-
 type kubernetesAnnotator struct {
 	log                 *logp.Logger
 	watcher             kubernetes.Watcher
@@ -54,6 +52,7 @@ type kubernetesAnnotator struct {
 	matchers            *Matchers
 	cache               *cache
 	kubernetesAvailable bool
+	initOnce            sync.Once
 }
 
 func init() {
@@ -136,7 +135,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Config) {
-	once.Do(func() {
+	k.initOnce.Do(func() {
 		client, err := kubernetes.GetKubernetesClient(config.KubeConfig)
 		if err != nil {
 			if kubernetes.IsInCluster(config.KubeConfig) {


### PR DESCRIPTION
## What does this PR do?
This PR changes `add_kubernetes_metadata` processor so as to get initialised asynchronously and being able to handle `node not ready` situations.

## Why is it important?
This will be solve the problem of having to restart Beat in case the processor was not initialised if the node was not ready yet when Beat started. 

## How to test this PR locally
With the use of Minikube:
1. `minikube start`
2. Have a `minikube ssh` in one tab so as to handle k8s health up and down
3. Build Filebeat on the host where Minikube runs
4. Use the kubeconfig of Minikube: `export KUBECONFIG=~/.kube/config`
5. Make sure that `add_kubernetes_metadata` processor is enabled:
```
processors:
  - add_kubernetes_metadata: ~
```
6.  Start filebeat and expect to see `2020-02-18T12:25:12.825+0200	INFO	add_kubernetes_metadata/kubernetes.go:77	add_kubernetes_metadata: kubernetes env detected, with version: v1.17.0` in your logs, meaning that processor was able to reach k8s API.
7. Stop filebeat
8. In the session you have inside Minikube vm run `sudo systemctl stop docker` to bring docker down and make k8s API unreachable
9. Start filebeat again and you should see (after ~30secs) sth like `2020-02-18T12:27:16.958+0200	INFO	add_kubernetes_metadata/kubernetes.go:89	add_kubernetes_metadata: could not detect kubernetes env: Get https://192.168.64.6:8443/version?timeout=32s: dial tcp 192.168.64.6:8443: connect: connection refused`
10. Stop filebeat and start it again.
11. Wait 3-4 seconds and go to Minkube vm and start docker daemon again: `sudo systemctl start` docker.
12. In Filebeat's logs you should expect to see that the processor reached k8s API like in step 6.


## Related issues

- Closes https://github.com/elastic/beats/issues/16064
