### PR TITLE
ci: Set PYTHON_ENV environment variable path outside the beats folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -563,7 +563,7 @@ def withBeatsEnv(Closure body){
     "LANG=C.UTF-8",
     "LANGUAGE=C.UTF-8",
     "PYTHONUTF8=1",
-    "PYTHON_ENV?=${WORKSPACE}/python-env"
+    "PYTHON_ENV=${WORKSPACE}/python-env"
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -584,7 +584,9 @@ def withBeatsEnvWin(Closure body){
     "GOROOT=${goRoot}",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
-    "LANG=C.UTF-8",
+    "LC_ALL=en_US.UTF-8",
+    "LANG=en_US.UTF-8",
+    "LANGUAGE=en_US.UTF-8",
     "PYTHON_ENV?=${WORKSPACE}/python-env"
   ]){
     deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -559,6 +559,11 @@ def withBeatsEnv(Closure body){
     "MAGEFILE_CACHE=${WORKSPACE}\\.magefile",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
+    "LC_ALL=C.UTF-8",
+    "LANG=C.UTF-8",
+    "LANGUAGE=C.UTF-8",
+    "PYTHONUTF8=1",
+    "PYTHON_ENV?=${WORKSPACE}/python-env"
   ]){
     deleteDir()
     unstash 'source'
@@ -584,10 +589,6 @@ def withBeatsEnvWin(Closure body){
     "GOROOT=${goRoot}",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
-    "LC_ALL=C.UTF-8",
-    "LANG=C.UTF-8",
-    "LANGUAGE=C.UTF-8",
-    "PYTHON_ENV?=${WORKSPACE}/python-env"
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -564,6 +564,7 @@ def withBeatsEnv(Closure body){
     "LANGUAGE=C.UTF-8",
     "PYTHONUTF8=1",
     "PYTHON_ENV=${WORKSPACE}/python-env"
+    "PYTHONIOENCODING=UTF-8"
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -559,12 +559,7 @@ def withBeatsEnv(Closure body){
     "MAGEFILE_CACHE=${WORKSPACE}\\.magefile",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
-    "LC_ALL=C.UTF-8",
-    "LANG=C.UTF-8",
-    "LANGUAGE=C.UTF-8",
-    "PYTHONUTF8=1",
-    "PYTHON_ENV=${WORKSPACE}/python-env"
-    "PYTHONIOENCODING=UTF-8"
+    "PYTHON_ENV=${WORKSPACE}/python-env",
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     BASE_DIR = 'src/github.com/elastic/beats'
     GOX_FLAGS = "-arch amd64"
     DOCKER_COMPOSE_VERSION = "1.21.0"
-    LANG = "C.UTF-8"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -585,6 +584,8 @@ def withBeatsEnvWin(Closure body){
     "GOROOT=${goRoot}",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
+    "LANG=C.UTF-8",
+    "PYTHON_ENV?=${WORKSPACE}/python-env"
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -584,9 +584,9 @@ def withBeatsEnvWin(Closure body){
     "GOROOT=${goRoot}",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
-    "LC_ALL=en_US.UTF-8",
-    "LANG=en_US.UTF-8",
-    "LANGUAGE=en_US.UTF-8",
+    "LC_ALL=C.UTF-8",
+    "LANG=C.UTF-8",
+    "LANGUAGE=C.UTF-8",
     "PYTHON_ENV?=${WORKSPACE}/python-env"
   ]){
     deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
     BASE_DIR = 'src/github.com/elastic/beats'
     GOX_FLAGS = "-arch amd64"
     DOCKER_COMPOSE_VERSION = "1.21.0"
+    LANG = "C.UTF-8"
   }
   options {
     timeout(time: 2, unit: 'HOURS')

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ clean-vendor:
 .PHONY: check
 check: python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) check || exit 1;)
-#	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -not -path "*/vendor/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
-#	@$(FIND) -name *.py -not -path "*/build/*" -not -path "*/vendor/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
+	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -not -path "*/vendor/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
+	@$(FIND) -name *.py -not -path "*/build/*" -not -path "*/vendor/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
 	@# Validate that all updates were committed
 	@$(MAKE) update
 	@$(MAKE) check-headers

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ clean-vendor:
 .PHONY: check
 check: python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) check || exit 1;)
-	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -not -path "*/vendor/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
-	@$(FIND) -name *.py -not -path "*/build/*" -not -path "*/vendor/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
+#	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -not -path "*/vendor/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
+#	@$(FIND) -name *.py -not -path "*/build/*" -not -path "*/vendor/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
 	@# Validate that all updates were committed
 	@$(MAKE) update
 	@$(MAKE) check-headers


### PR DESCRIPTION
## What does this PR do?

It set the path to create the virtual environment outside the beats folder.

## Why is it important?

For some reason if the virtualenv is inside beats the python files are corrupted and can not be run.

## Related issues
Closes https://github.com/elastic/beats/issues/16266
