### PR TITLE
Fix generation of notice file in CSV format

### DIFF
--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import glob
 import os
 import datetime
@@ -221,7 +222,7 @@ def create_notice(filename, beat, copyright, vendor_dirs, csvfile, overrides=Non
             write_notice_file(f, beat, copyright, dependencies)
             print("Available at {}".format(filename))
     else:
-        with open(csvfile, "wb", encoding='utf_8') as f:
+        with open(csvfile, "w") as f:
             csvwriter = csv.writer(f)
             write_csv_file(csvwriter, dependencies)
             print("Available at {}".format(csvfile))


### PR DESCRIPTION
Fix generation of notice file in CSV format, and make `./dev-tools/generate_notice.py` executable, so it can be directly executed and correct python interpreter will be taken from the shebang.

This script was failing with this error when used to generate the output in CSV format.
```
Get the licenses available from ['./vendor']
WARNING: No version information found for: github.com/prometheus/client_model
WARNING: No version information found for: github.com/Azure/azure-storage-blob-go
WARNING: No version information found for: github.com/Azure/azure-pipeline-go
WARNING: No version information found for: github.com/godror/godror/odpi
WARNING: No version information found for: github.com/go-ini/ini
Traceback (most recent call last):
  File "dev-tools/generate_notice.py", line 417, in <module>
    dependencies = create_notice(notice, args.beat, args.copyright, vendor_dirs, args.csvfile, overrides=overrides)
  File "dev-tools/generate_notice.py", line 227, in create_notice
    write_csv_file(csvwriter, dependencies)
  File "dev-tools/generate_notice.py", line 204, in write_csv_file
    csvwriter.writerow(["name", "url", "version", "revision", "license"])
TypeError: a bytes-like object is required, not 'str'
```

It could be reproduced with `python3 ./dev-tools/generate_notice.py . --csv foo.csv`.