### PR TITLE
Cherry-pick #16348 to 7.x: Fix loading processors from autodiscover hints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -197,7 +197,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS tls and categorization fields to apache module. {issue}16032[16032] {pull}16121[16121]
 - Add MQTT input. {issue}15602[15602] {pull}16204[16204]
 - Add a TLS test and more debug output to httpjson input {pull}16315[16315]
-- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320]
+- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320] 
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
 - Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
 - Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
+- Add `ssl.ca_sha256` option to the supported TLS option, this allow to check that a specific certificate is used as part of the verified chain. {issue}15717[15717]
+- Fix loading processors from annotation hints. {pull}16348[16348]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,7 +75,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
 - Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
 - Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
-- Add `ssl.ca_sha256` option to the supported TLS option, this allow to check that a specific certificate is used as part of the verified chain. {issue}15717[15717]
 - Fix loading processors from annotation hints. {pull}16348[16348]
 
 *Auditbeat*
@@ -198,7 +197,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS tls and categorization fields to apache module. {issue}16032[16032] {pull}16121[16121]
 - Add MQTT input. {issue}15602[15602] {pull}16204[16204]
 - Add a TLS test and more debug output to httpjson input {pull}16315[16315]
-- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320] 
+- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320]
 
 *Heartbeat*
 

--- a/libbeat/autodiscover/builder/helper.go
+++ b/libbeat/autodiscover/builder/helper.go
@@ -86,7 +86,20 @@ func GetHintAsList(hints common.MapStr, key, config string) []string {
 
 // GetProcessors gets processor definitions from the hints and returns a list of configs as a MapStr
 func GetProcessors(hints common.MapStr, key string) []common.MapStr {
-	return GetConfigs(hints, key, "processors")
+	processors := GetConfigs(hints, key, "processors")
+	for _, proc := range processors {
+		for key, value := range proc {
+			if str, ok := value.(string); ok {
+				cfg := common.MapStr{}
+				if err := json.Unmarshal([]byte(str), &cfg); err != nil {
+					logp.Debug("autodiscover.builder", "unable to unmarshal json due to error: %v", err)
+					continue
+				}
+				proc[key] = cfg
+			}
+		}
+	}
+	return processors
 }
 
 // GetConfigs takes in a key and returns a list of configs as a slice of MapStr

--- a/libbeat/autodiscover/builder/helper_test.go
+++ b/libbeat/autodiscover/builder/helper_test.go
@@ -25,6 +25,30 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+func TestGetProcessors(t *testing.T) {
+	hints := common.MapStr{
+		"co": common.MapStr{
+			"elastic": common.MapStr{
+				"logs": common.MapStr{
+					"processors": common.MapStr{
+						"add_fields": `{"fields": {"foo": "bar"}}`,
+					},
+				},
+			},
+		},
+	}
+	procs := GetProcessors(hints, "co.elastic.logs")
+	assert.Equal(t, []common.MapStr{
+		common.MapStr{
+			"add_fields": common.MapStr{
+				"fields": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		},
+	}, procs)
+}
+
 func TestGenerateHints(t *testing.T) {
 	tests := []struct {
 		annotations map[string]string
@@ -38,6 +62,7 @@ func TestGenerateHints(t *testing.T) {
 
 		// Scenarios being tested:
 		// logs/multiline.pattern must be a nested common.MapStr under hints.logs
+		// logs/processors.add_fields must be nested common.MapStr under hints.logs
 		// logs/json.keys_under_root must be a nested common.MapStr under hints.logs
 		// metrics/module must be found in hints.metrics
 		// not.to.include must not be part of hints
@@ -191,6 +216,6 @@ func TestGenerateHints(t *testing.T) {
 		for k, v := range test.annotations {
 			annMap.Put(k, v)
 		}
-		assert.Equal(t, GenerateHints(annMap, "foobar", "co.elastic"), test.result)
+		assert.Equal(t, test.result, GenerateHints(annMap, "foobar", "co.elastic"))
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #16348 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fixes an issue where processors from autodiscover hints where not convered into a `common.MapStr`.

## Why is it important?

Allows processors to be defined in autodiscover hints.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Converts `string` to `common.MapStr`

## How to test this PR locally

Run filebeat with:

```
filebeat.autodiscover:
  providers:
    - type: docker
      hints.enabled: true

output.console:
  pretty: true
```

Start container with processor:

`docker run -l 'co.elastic.logs/processors.add_fields={"fields":{"foo":"bar"}}' busybox echo hello`

Check that filebeat was able to start logging it the container with the fields added.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #16343

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
