### PR TITLE
[Uptime] Fix scheduler limit semaphore issues incl. panic

### DIFF
--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -247,8 +247,15 @@ func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *
 	s.stats.waitingTasks.Inc()
 
 	// Acquire an execution slot in keeping with heartbeat.scheduler.limit
-	s.limitSem.Acquire(s.ctx, 1)
-	defer s.limitSem.Release(1)
+	// this should block until resources are available.
+	// In the case where the semaphore has free resources immediately
+	// it will not block and will not check the cancelled status of the
+	// context, which is OK, because we check it later anyway.
+	limitErr := s.limitSem.Acquire(jobCtx, 1)
+	s.stats.waitingTasks.Dec()
+	if limitErr == nil {
+		defer s.limitSem.Release(1)
+	}
 
 	// Record the time this task started now that we have a resource to execute with
 	startedAt = time.Now()
@@ -259,7 +266,6 @@ func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *
 		return startedAt
 	default:
 		s.stats.activeTasks.Inc()
-		s.stats.waitingTasks.Dec()
 
 		continuations := task(jobCtx)
 		s.stats.activeTasks.Dec()

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	batomic "github.com/elastic/beats/libbeat/common/atomic"
-	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	batomic "github.com/elastic/beats/libbeat/common/atomic"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 // The runAt in the island of tarawa 🏝. Good test TZ because it's pretty rare for a local box

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	batomic "github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/monitoring"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -172,6 +172,71 @@ func TestScheduler_Stop(t *testing.T) {
 	}))
 
 	assert.Equal(t, ErrAlreadyStopped, err)
+}
+
+func TestScheduler_runRecursiveTask(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	testCases := []struct {
+		name          string
+		jobCtx        context.Context
+		overLimit     bool
+		shouldRunTask bool
+	}{
+		{
+			"context not cancelled",
+			context.Background(),
+			false,
+			true,
+		},
+		{
+			"context cancelled",
+			cancelledCtx,
+			false,
+			false,
+		},
+		{
+			"context cancelled over limit",
+			cancelledCtx,
+			true,
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			limit := int64(100)
+			s := NewWithLocation(limit, monitoring.NewRegistry(), tarawaTime())
+
+			if testCase.overLimit {
+				s.limitSem.Acquire(context.Background(), limit)
+			}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			executed := batomic.MakeBool(false)
+
+			tf := func(ctx context.Context) []TaskFunc {
+				executed.Store(true)
+				return nil
+			}
+
+			beforeStart := time.Now()
+			startedAt := s.runRecursiveTask(testCase.jobCtx, tf, wg)
+
+			// This will panic in the case where we don't check s.limitSem.Acquire
+			// for an error value and released an unacquired resource in scheduler.go.
+			// In that case this will release one more resource than allowed causing
+			// the panic.
+			if testCase.overLimit {
+				s.limitSem.Release(limit)
+			}
+
+			require.Equal(t, testCase.shouldRunTask, executed.Load())
+			require.True(t, startedAt.Equal(beforeStart) || startedAt.After(beforeStart))
+		})
+	}
 }
 
 func BenchmarkScheduler(b *testing.B) {


### PR DESCRIPTION
Limit semaphores block when acquired, but may exit early when cancelled if the semaphore is blocked.  Fixes https://github.com/elastic/beats/issues/16397

Also fixes accounting of waiting tasks during scheduler shutdown by more consistently decrementing the waiting counter even in the event of cancelled contexts.

This also avoids using the scheduler global context in favor of the job context when dealing  with the semaphore. This is more correct since the job context wraps the global context so cancels are propagated. 

We were only sometimes acquiring the resource, but always releasing it.Now we do the right thing.

In the wild this showed up as 

```

panic: semaphore: released more than held
goroutine 5468335 [running]:
github.com/elastic/beats/vendor/golang.org/x/sync/semaphore.(*Weighted).Release(0xc00018e050, 0x1)
	/Users/user/workspace/go/src/github.com/elastic/beats/vendor/golang.org/x/sync/semaphore/semaphore.go:98 +0x1f6
github.com/elastic/beats/heartbeat/scheduler.(*Scheduler).runRecursiveTask(0xc00048e000, 0x1df9140, 0xc02eef4740, 0xc02c0f3140, 0xc0427f73b0, 0xbf8afe6762e6cecb, 0x40fd74c851, 0x2e36860)
	/Users/user/workspace/go/src/github.com/elastic/beats/heartbeat/scheduler/scheduler.go:275 +0x280
github.com/elastic/beats/heartbeat/scheduler.(*Scheduler).runRecursiveJob(0xc00048e000, 0x1df9140, 0xc02eef4740, 0xc02c0f3140, 0xc05d212d80, 0xc05e31e480, 0xc05d212f00)
	/Users/user/workspace/go/src/github.com/elastic/beats/heartbeat/scheduler/scheduler.go:233 +0x89
github.com/elastic/beats/heartbeat/scheduler.(*Scheduler).Add.func1(0xbf8afe6400011777, 0x3dd3b2cf19, 0x2e36860)
	/Users/user/workspace/go/src/github.com/elastic/beats/heartbeat/scheduler/scheduler.go:192 +0xa3
created by github.com/elastic/beats/heartbeat/scheduler.(*Scheduler).runOnce.func1
	/Users/user/workspace/go/src/github.com/elastic/beats/heartbeat/scheduler/scheduler.go:223 +0x50
```


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

