### PR TITLE
Cherry-pick #16316 to 7.x: Fix some issues with versioning of uwsgi in tests

### DIFF
--- a/metricbeat/module/uwsgi/_meta/Dockerfile
+++ b/metricbeat/module/uwsgi/_meta/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.6-alpine
+ARG UWSGI_PYTHON_VERSION
+FROM python:${UWSGI_PYTHON_VERSION}-alpine
 
+ARG UWSGI_VERSION
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers curl
-RUN pip install --no-cache-dir --trusted-host pypi.python.org uwsgi
+RUN pip install --no-cache-dir --trusted-host pypi.python.org uwsgi==${UWSGI_VERSION}
 
 WORKDIR /app
 COPY testdata/app /app
 
 HEALTHCHECK --interval=1s --retries=60 --timeout=10s CMD curl http://localhost:8080/
 EXPOSE 8080 9191 9192
-
-CMD [""]

--- a/metricbeat/module/uwsgi/_meta/supported-versions.yml
+++ b/metricbeat/module/uwsgi/_meta/supported-versions.yml
@@ -1,0 +1,2 @@
+variants:
+  - UWSGI_VERSION: 2.0.18

--- a/metricbeat/module/uwsgi/docker-compose.yml
+++ b/metricbeat/module/uwsgi/docker-compose.yml
@@ -2,21 +2,17 @@ version: '2.3'
 
 services:
   uwsgi_tcp:
-    image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
+    image: docker.elastic.co/integrations-ci/beats-uwsgi:${UWSGI_VERSION:-2.0.18}-py${UWSGI_PYTHON_VERSION:-3.8}-1
     build:
       context: ./_meta
       args:
-        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
-    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --wsgi-file app.py
+        UWSGI_VERSION: ${UWSGI_VERSION:-2.0.18}
+        UWSGI_PYTHON_VERSION: ${UWSGI_PYTHON_VERSION:-3.8}
     ports:
       - 9191
+    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --wsgi-file app.py
 
   uwsgi_http:
-    image: docker.elastic.co/integrations-ci/beats-uwsgi:py${PYTHON_VERSION:-3.6}-1
-    build:
-      context: ./_meta
-      args:
-        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
-    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9192 --memory-report --stats-http --wsgi-file app.py
-    ports:
-      - 9192
+    extends:
+      service: uwsgi_tcp
+    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --stats-http --wsgi-file app.py

--- a/metricbeat/module/uwsgi/test_uwsgi.py
+++ b/metricbeat/module/uwsgi/test_uwsgi.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 from nose.plugins.attrib import attr
+from parameterized import parameterized
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 import metricbeat
@@ -11,8 +12,9 @@ import metricbeat
 logger = logging.getLogger(__name__)
 
 
+@metricbeat.parameterized_with_supported_versions
 class Test(metricbeat.BaseTest):
-    COMPOSE_SERVICES = ['uwsgi_tcp']
+    COMPOSE_SERVICES = ['uwsgi_http', 'uwsgi_tcp']
 
     def common_checks(self, output):
         # Ensure no errors or warnings exist in the log.
@@ -52,16 +54,17 @@ class Test(metricbeat.BaseTest):
         assert "requests" in cores[0]
         assert "static" in cores[0]["requests"]
 
+    @parameterized.expand(["http", "tcp"])
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
-    def test_status(self):
+    def test_status(self, proto):
         """
         uWSGI module outputs an event.
         """
         self.render_config_template(modules=[{
             "name": "uwsgi",
             "metricsets": ["status"],
-            "hosts": [self.get_host()],
+            "hosts": [self.get_host(proto)],
             "period": "5s"
         }])
         proc = self.start_beat()
@@ -71,12 +74,5 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         self.common_checks(output)
 
-    def get_host(self):
-        return "tcp://" + self.compose_host()
-
-
-class TestHTTP(Test):
-    COMPOSE_SERVICES = ['uwsgi_http']
-
-    def get_host(self):
-        return "http://" + self.compose_host()
+    def get_host(self, proto):
+        return proto + "://" + self.compose_host(service="uwsgi_"+proto)


### PR DESCRIPTION
Cherry-pick of PR #16316 to 7.x branch. Original message: 

## What does this PR do?

* Actually use the build arguments in the docker file
* Add build argument for the UWSGI version
* Add `supported-versions.yml`
* Reuse service definition in `docker-compose.yml`

## Why is it important?

* Fix version used in testing for uwsgi
* Reduce some code duplication