### PR TITLE
Cherry-pick #16077 to 7.x: Enable netinfo in add metadata processors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -164,6 +164,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fingerprint processor adds a new xxhash hashing algorithm {pull}15418[15418]
 - Enable DEP (Data Execution Protection) for Windows packages. {pull}15149[15149]
 - Add document_id setting to decode_json_fields processor. {pull}15859[15859]
+- Include network information by default on add_host_metadata and add_observer_metadata. {issue}15347[15347] {pull}16077[16077]
 - Add `aws_ec2` provider for autodiscover. {issue}12518[12518] {pull}14823[14823]
 
 *Auditbeat*

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -315,8 +315,7 @@ auditbeat.modules:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1020,8 +1020,7 @@ filebeat.inputs:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -459,8 +459,7 @@ heartbeat.scheduler:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -253,8 +253,7 @@ setup.template.settings:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -196,8 +196,7 @@
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -64,21 +64,21 @@ func TestConfigDefault(t *testing.T) {
 	assert.NotNil(t, v)
 
 	v, err = newEvent.GetValue("host.ip")
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 
 	v, err = newEvent.GetValue("host.mac")
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 }
 
-func TestConfigNetInfoEnabled(t *testing.T) {
+func TestConfigNetInfoDisabled(t *testing.T) {
 	event := &beat.Event{
 		Fields:    common.MapStr{},
 		Timestamp: time.Now(),
 	}
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{
-		"netinfo.enabled": true,
+		"netinfo.enabled": false,
 	})
 	assert.NoError(t, err)
 
@@ -107,12 +107,12 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	assert.NotNil(t, v)
 
 	v, err = newEvent.GetValue("host.ip")
-	assert.NoError(t, err)
-	assert.NotNil(t, v)
+	assert.Error(t, err)
+	assert.Nil(t, v)
 
 	v, err = newEvent.GetValue("host.mac")
-	assert.NoError(t, err)
-	assert.NotNil(t, v)
+	assert.Error(t, err)
+	assert.Nil(t, v)
 }
 
 func TestConfigName(t *testing.T) {

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -33,7 +33,7 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		NetInfoEnabled: false,
+		NetInfoEnabled: true,
 		CacheTTL:       5 * time.Minute,
 	}
 }

--- a/libbeat/processors/add_host_metadata/docs/add_host_metadata.asciidoc
+++ b/libbeat/processors/add_host_metadata/docs/add_host_metadata.asciidoc
@@ -5,7 +5,6 @@
 -------------------------------------------------------------------------------
 processors:
 - add_host_metadata:
-    netinfo.enabled: false
     cache.ttl: 5m
     geo:
       name: nyc-dc1-rack1
@@ -19,7 +18,7 @@ processors:
 
 It has the following settings:
 
-`netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields host.ip and host.mac
+`netinfo.enabled`:: (Optional) Default true. Include IP addresses and MAC addresses as fields host.ip and host.mac
 
 `cache.ttl`:: (Optional) The processor uses an internal cache for the host metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
 

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
@@ -42,12 +42,12 @@ func TestConfigDefault(t *testing.T) {
 	assert.NoError(t, err)
 
 	v, err := newEvent.GetValue("observer.ip")
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 
 	v, err = newEvent.GetValue("observer.mac")
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 }
 
 func TestOverwriteFalse(t *testing.T) {
@@ -86,13 +86,13 @@ func TestOverwriteTrue(t *testing.T) {
 	assert.NotNil(t, v)
 }
 
-func TestConfigNetInfoEnabled(t *testing.T) {
+func TestConfigNetInfoDisabled(t *testing.T) {
 	event := &beat.Event{
 		Fields:    common.MapStr{},
 		Timestamp: time.Now(),
 	}
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{
-		"netinfo.enabled": true,
+		"netinfo.enabled": false,
 	})
 	assert.NoError(t, err)
 
@@ -102,12 +102,12 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	v, err := newEvent.GetValue("observer.ip")
-	assert.NoError(t, err)
-	assert.NotNil(t, v)
+	assert.Error(t, err)
+	assert.Nil(t, v)
 
 	v, err = newEvent.GetValue("observer.mac")
-	assert.NoError(t, err)
-	assert.NotNil(t, v)
+	assert.Error(t, err)
+	assert.Nil(t, v)
 }
 
 func TestConfigGeoEnabled(t *testing.T) {

--- a/libbeat/processors/add_observer_metadata/config.go
+++ b/libbeat/processors/add_observer_metadata/config.go
@@ -33,7 +33,7 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		NetInfoEnabled: false,
+		NetInfoEnabled: true,
 		CacheTTL:       5 * time.Minute,
 	}
 }

--- a/libbeat/processors/add_observer_metadata/docs/add_observer_metadata.asciidoc
+++ b/libbeat/processors/add_observer_metadata/docs/add_observer_metadata.asciidoc
@@ -7,7 +7,6 @@ beta[]
 -------------------------------------------------------------------------------
 processors:
 - add_observer_metadata:
-    netinfo.enabled: false
     cache.ttl: 5m
     geo:
       name: nyc-dc1-rack1
@@ -21,7 +20,7 @@ processors:
 
 It has the following settings:
 
-`netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields observer.ip and observer.mac
+`netinfo.enabled`:: (Optional) Default true. Include IP addresses and MAC addresses as fields observer.ip and observer.mac
 
 `cache.ttl`:: (Optional) The processor uses an internal cache for the observer metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1004,8 +1004,7 @@ metricbeat.modules:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -737,8 +737,7 @@ packetbeat.ignore_outgoing: false
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -238,8 +238,7 @@ winlogbeat.event_logs:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -366,8 +366,7 @@ auditbeat.modules:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1554,8 +1554,7 @@ filebeat.inputs:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -581,8 +581,7 @@ functionbeat.provider.gcp.functions:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1237,8 +1237,7 @@ metricbeat.modules:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -241,8 +241,7 @@ winlogbeat.event_logs:
 # The following example enriches each event with host metadata.
 #
 #processors:
-#- add_host_metadata:
-#   netinfo.enabled: false
+#- add_host_metadata: ~
 #
 # The following example enriches each event with process metadata using
 # process IDs included in the event.


### PR DESCRIPTION
Cherry-pick of PR #16077 to 7.x branch. Original message: 

## What does this PR do?

Enable netinfo in add_host_metadata and add_observer_metadata processors by default.

## Why is it important?

This network information metadata is used in observability solutions.

This change shouldn't break backwards compatibility or produce any conflict as the added fields are in ECS. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

* Run a beat with the `add_host_metadata` processor without any options.
* Check that all events contain `host.ip` and `host.mac` fields.

## Related issues

- Superseds elastic/beats#15347