### PR TITLE
Adding missing metricset to list

### DIFF
--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -12,8 +12,8 @@ monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
 metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
-`ml_job`, `node_stats`, and `shard`.
+module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
+`index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -5,8 +5,8 @@ monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
 metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
-`ml_job`, `node_stats`, and `shard`.
+module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
+`index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility


### PR DESCRIPTION
## What does this PR do?

Adds the `enrich` metricset to the list of default metricsets in the Elasticsearch X-Pack module.

## Why is it important?

The list of metricsets was outdated.

## Checklist

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
