### PR TITLE
Cherry-pick #16370 to 7.6: libbeat/common/file: fix fsync failure on AIX

### DIFF
--- a/libbeat/common/file/helper_aix.go
+++ b/libbeat/common/file/helper_aix.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !aix,!windows
-
 package file
 
 import (
@@ -35,7 +33,9 @@ func SafeFileRotate(path, tempfile string) error {
 	// best-effort fsync on parent directory. The fsync is required by some
 	// filesystems, so to update the parents directory metadata to actually
 	// contain the new file being rotated in.
-	f, err := os.Open(parent)
+	// On AIX, fsync will fail if the file is opened in read-only mode,
+	// which is the case with os.Open.
+	f, err := os.OpenFile(parent, os.O_RDWR, 0)
 	if err != nil {
 		return nil // ignore error
 	}


### PR DESCRIPTION
Cherry-pick of PR #16370 to 7.6 branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
On AIX, fsync syscall doesn't work with read-only files.
As os.Open is actually opening in read-only mode, it must be changed
for os.OpenFile with O_RDWR flag.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Fix for AIX

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Only for AIX

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Related elastic/beats#15785 
