### PR TITLE
Cherry-pick #16373 to 7.x: Make k8s meta processor initialisation asynchronous

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -22,22 +22,24 @@ package add_kubernetes_metadata
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
-
-	"github.com/elastic/beats/libbeat/common/kubernetes/metadata"
 
 	k8sclient "k8s.io/client-go/kubernetes"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/kubernetes/metadata"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/libbeat/processors/script/javascript/module/processor"
 )
 
 const (
-	timeout = time.Second * 5
+	timeout                = time.Second * 5
+	selector               = "kubernetes"
+	checkNodeReadyAttempts = 10
 )
 
 type kubernetesAnnotator struct {
@@ -47,9 +49,8 @@ type kubernetesAnnotator struct {
 	matchers            *Matchers
 	cache               *cache
 	kubernetesAvailable bool
+	initOnce            sync.Once
 }
-
-const selector = "kubernetes"
 
 func init() {
 	processors.RegisterPlugin("add_kubernetes_metadata", New)
@@ -64,14 +65,29 @@ func init() {
 	Indexing.AddMatcher(FieldFormatMatcherName, NewFieldFormatMatcher)
 }
 
-func isKubernetesAvailable(client k8sclient.Interface) bool {
+func isKubernetesAvailable(client k8sclient.Interface) (bool, error) {
 	server, err := client.Discovery().ServerVersion()
 	if err != nil {
-		logp.Info("%v: could not detect kubernetes env: %v", "add_kubernetes_metadata", err)
-		return false
+		return false, err
 	}
 	logp.Info("%v: kubernetes env detected, with version: %v", "add_kubernetes_metadata", server)
-	return true
+	return true, nil
+}
+
+func isKubernetesAvailableWithRetry(client k8sclient.Interface) bool {
+	connectionAttempts := 1
+	for {
+		kubernetesAvailable, err := isKubernetesAvailable(client)
+		if kubernetesAvailable {
+			return true
+		}
+		if connectionAttempts > checkNodeReadyAttempts {
+			logp.Info("%v: could not detect kubernetes env: %v", "add_kubernetes_metadata", err)
+			return false
+		}
+		time.Sleep(3 * time.Second)
+		connectionAttempts += 1
+	}
 }
 
 // New constructs a new add_kubernetes_metadata processor.
@@ -108,73 +124,82 @@ func New(cfg *common.Config) (processors.Processor, error) {
 		kubernetesAvailable: false,
 	}
 
-	client, err := kubernetes.GetKubernetesClient(config.KubeConfig)
-	if err != nil {
-		if kubernetes.IsInCluster(config.KubeConfig) {
-			log.Debugf("Could not create kubernetes client using in_cluster config: %+v", err)
-		} else if config.KubeConfig == "" {
-			log.Debugf("Could not create kubernetes client using config: %v: %+v", os.Getenv("KUBECONFIG"), err)
-		} else {
-			log.Debugf("Could not create kubernetes client using config: %v: %+v", config.KubeConfig, err)
-		}
-		return processor, nil
-	}
-
-	if !isKubernetesAvailable(client) {
-		return processor, nil
-	}
-
-	matchers := NewMatchers(config.Matchers)
-
-	if matchers.Empty() {
-		log.Debugf("Could not initialize kubernetes plugin with zero matcher plugins")
-		return processor, nil
-	}
-
-	processor.matchers = matchers
-
-	config.Host = kubernetes.DiscoverKubernetesNode(log, config.Host, kubernetes.IsInCluster(config.KubeConfig), client)
-
-	log.Debug("Initializing a new Kubernetes watcher using host: %s", config.Host)
-
-	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Node:        config.Host,
-		Namespace:   config.Namespace,
-	}, nil)
-	if err != nil {
-		log.Errorf("Couldn't create kubernetes watcher for %T", &kubernetes.Pod{})
-		return nil, err
-	}
-
-	metaGen := metadata.NewPodMetadataGenerator(cfg, watcher.Store(), nil, nil)
-	processor.indexers = NewIndexers(config.Indexers, metaGen)
-	processor.watcher = watcher
-	processor.kubernetesAvailable = true
-
-	watcher.AddEventHandler(kubernetes.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			pod := obj.(*kubernetes.Pod)
-			log.Debugf("Adding kubernetes pod: %s/%s", pod.GetNamespace(), pod.GetName())
-			processor.addPod(pod)
-		},
-		UpdateFunc: func(obj interface{}) {
-			pod := obj.(*kubernetes.Pod)
-			log.Debugf("Updating kubernetes pod: %s/%s", pod.GetNamespace(), pod.GetName())
-			processor.updatePod(pod)
-		},
-		DeleteFunc: func(obj interface{}) {
-			pod := obj.(*kubernetes.Pod)
-			log.Debugf("Removing pod: %s/%s", pod.GetNamespace(), pod.GetName())
-			processor.removePod(pod)
-		},
-	})
-
-	if err := watcher.Start(); err != nil {
-		return nil, err
-	}
+	// complete processor's initialisation asynchronously so as to re-try on failing k8s client initialisations in case
+	// the k8s node is not yet ready.
+	go processor.init(config, cfg)
 
 	return processor, nil
+}
+
+func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Config) {
+	k.initOnce.Do(func() {
+		client, err := kubernetes.GetKubernetesClient(config.KubeConfig)
+		if err != nil {
+			if kubernetes.IsInCluster(config.KubeConfig) {
+				k.log.Debugf("Could not create kubernetes client using in_cluster config: %+v", err)
+			} else if config.KubeConfig == "" {
+				k.log.Debugf("Could not create kubernetes client using config: %v: %+v", os.Getenv("KUBECONFIG"), err)
+			} else {
+				k.log.Debugf("Could not create kubernetes client using config: %v: %+v", config.KubeConfig, err)
+			}
+			return
+		}
+
+		if !isKubernetesAvailableWithRetry(client) {
+			return
+		}
+
+		matchers := NewMatchers(config.Matchers)
+
+		if matchers.Empty() {
+			k.log.Debugf("Could not initialize kubernetes plugin with zero matcher plugins")
+			return
+		}
+
+		k.matchers = matchers
+
+		config.Host = kubernetes.DiscoverKubernetesNode(k.log, config.Host, kubernetes.IsInCluster(config.KubeConfig), client)
+
+		k.log.Debugf("Initializing a new Kubernetes watcher using host: %s", config.Host)
+
+		watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
+			SyncTimeout: config.SyncPeriod,
+			Node:        config.Host,
+			Namespace:   config.Namespace,
+		}, nil)
+		if err != nil {
+			k.log.Errorf("Couldn't create kubernetes watcher for %T", &kubernetes.Pod{})
+			return
+		}
+
+		metaGen := metadata.NewPodMetadataGenerator(cfg, watcher.Store(), nil, nil)
+		k.indexers = NewIndexers(config.Indexers, metaGen)
+		k.watcher = watcher
+		k.kubernetesAvailable = true
+
+		watcher.AddEventHandler(kubernetes.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				pod := obj.(*kubernetes.Pod)
+				k.log.Debugf("Adding kubernetes pod: %s/%s", pod.GetNamespace(), pod.GetName())
+				k.addPod(pod)
+			},
+			UpdateFunc: func(obj interface{}) {
+				pod := obj.(*kubernetes.Pod)
+				k.log.Debugf("Updating kubernetes pod: %s/%s", pod.GetNamespace(), pod.GetName())
+				k.updatePod(pod)
+			},
+			DeleteFunc: func(obj interface{}) {
+				pod := obj.(*kubernetes.Pod)
+				k.log.Debugf("Removing pod: %s/%s", pod.GetNamespace(), pod.GetName())
+				k.removePod(pod)
+			},
+		})
+
+		if err := watcher.Start(); err != nil {
+			k.log.Debugf("add_kubernetes_metadata", "Couldn't start watcher: %v", err)
+			return
+		}
+	})
 }
 
 func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {


### PR DESCRIPTION
Cherry-pick of PR #16373 to 7.x branch. Original message: 

## What does this PR do?
This PR changes `add_kubernetes_metadata` processor so as to get initialised asynchronously and being able to handle `node not ready` situations.

## Why is it important?
This will be solve the problem of having to restart Beat in case the processor was not initialised if the node was not ready yet when Beat started. 

## How to test this PR locally
With the use of Minikube:
1. `minikube start`
2. Have a `minikube ssh` in one tab so as to handle k8s health up and down
3. Build Filebeat on the host where Minikube runs
4. Use the kubeconfig of Minikube: `export KUBECONFIG=~/.kube/config`
5. Make sure that `add_kubernetes_metadata` processor is enabled:
```
processors:
  - add_kubernetes_metadata: ~
```
6.  Start filebeat and expect to see `2020-02-18T12:25:12.825+0200	INFO	add_kubernetes_metadata/kubernetes.go:77	add_kubernetes_metadata: kubernetes env detected, with version: v1.17.0` in your logs, meaning that processor was able to reach k8s API.
7. Stop filebeat
8. In the session you have inside Minikube vm run `sudo systemctl stop docker` to bring docker down and make k8s API unreachable
9. Start filebeat again and you should see (after ~30secs) sth like `2020-02-18T12:27:16.958+0200	INFO	add_kubernetes_metadata/kubernetes.go:89	add_kubernetes_metadata: could not detect kubernetes env: Get https://192.168.64.6:8443/version?timeout=32s: dial tcp 192.168.64.6:8443: connect: connection refused`
10. Stop filebeat and start it again.
11. Wait 3-4 seconds and go to Minkube vm and start docker daemon again: `sudo systemctl start` docker.
12. In Filebeat's logs you should expect to see that the processor reached k8s API like in step 6.


## Related issues

- Closes https://github.com/elastic/beats/issues/16064
