### PR TITLE
Adding breaking change to 7.6.0 doc

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
@@ -26,10 +26,6 @@ configuration setting. For example:
 setup.ilm.policy_name: "%{[agent.name]}-%{[agent.version]}"
 ----
 
-// end::notable-breaking-changes[]
-
-//tag::notable-breaking-changes[]
-
 [float]
 ==== Two Beat instances can no longer share the same data path
 

--- a/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
@@ -27,3 +27,20 @@ setup.ilm.policy_name: "%{[agent.name]}-%{[agent.version]}"
 ----
 
 // end::notable-breaking-changes[]
+
+//tag::notable-breaking-changes[]
+
+[float]
+==== Two Beat instances can no longer share the same data path
+
+To prevent accidental overwriting of internal state, two instances of the
+same Beat running on the same host can no longer share the same data path.
+To customize the data path for a Beat, use the `path.data` configuration
+setting. For example:
+
+[source,yaml]
+----
+path.data: ${path.home}/data-instance1
+----
+
+// end::notable-breaking-changes[]


### PR DESCRIPTION
## What does this PR do?

Documents a breaking change caused in 7.6.0 by https://github.com/elastic/beats/pull/14069.

## Why is it important?

It's a breaking change, users should know about it, especially since it's in a minor version.

## Checklist

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
