### PR TITLE
Cherry-pick #16390 to 7.x: Increase max cache size for scripts to try to stabilize Zeek tests

### DIFF
--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
+    environment:
+      script.cache.max_size: "500"
 
   kafka:
     build: ${ES_BEATS}/testing/environments/docker/kafka

--- a/x-pack/filebeat/docker-compose.yml
+++ b/x-pack/filebeat/docker-compose.yml
@@ -32,4 +32,6 @@ services:
     extends:
       file: ${ES_BEATS}/testing/environments/${STACK_ENVIRONMENT}.yml
       service: elasticsearch
+    environment:
+      script.cache.max_size: "500"
 


### PR DESCRIPTION
Cherry-pick of PR #16390 to 7.x branch. Original message: 

## What does this PR do?

Increase max size of cache scripts to avoid recompilations in filebeat tests.

## Why is it important?

Zeek tests are quite flaky since some time ago, the pipeline fails with:
```
[script] Too many dynamic script compilations within, max: [2000/1m]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.max_compilations_rate] setting
```