### PR TITLE
[Uptime] Backport 16393 7.6

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
+- Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misues. {pull}16397[16397]
 
 *Journalbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,7 +49,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misues. {pull}16397[16397]
 
 *Journalbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,7 +49,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misues. {pull}16397[16397]
+- Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misuse. {pull}16397[16397]
 
 *Journalbeat*
 

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -247,8 +247,15 @@ func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *
 	s.stats.waitingTasks.Inc()
 
 	// Acquire an execution slot in keeping with heartbeat.scheduler.limit
-	s.limitSem.Acquire(s.ctx, 1)
-	defer s.limitSem.Release(1)
+	// this should block until resources are available.
+	// In the case where the semaphore has free resources immediately
+	// it will not block and will not check the cancelled status of the
+	// context, which is OK, because we check it later anyway.
+	limitErr := s.limitSem.Acquire(jobCtx, 1)
+	s.stats.waitingTasks.Dec()
+	if limitErr == nil {
+		defer s.limitSem.Release(1)
+	}
 
 	// Record the time this task started now that we have a resource to execute with
 	startedAt = time.Now()
@@ -259,7 +266,6 @@ func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *
 		return startedAt
 	default:
 		s.stats.activeTasks.Inc()
-		s.stats.waitingTasks.Dec()
 
 		continuations := task(jobCtx)
 		s.stats.activeTasks.Dec()

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/monitoring"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	batomic "github.com/elastic/beats/libbeat/common/atomic"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 // The runAt in the island of tarawa 🏝. Good test TZ because it's pretty rare for a local box
@@ -172,6 +173,71 @@ func TestScheduler_Stop(t *testing.T) {
 	}))
 
 	assert.Equal(t, ErrAlreadyStopped, err)
+}
+
+func TestScheduler_runRecursiveTask(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	testCases := []struct {
+		name          string
+		jobCtx        context.Context
+		overLimit     bool
+		shouldRunTask bool
+	}{
+		{
+			"context not cancelled",
+			context.Background(),
+			false,
+			true,
+		},
+		{
+			"context cancelled",
+			cancelledCtx,
+			false,
+			false,
+		},
+		{
+			"context cancelled over limit",
+			cancelledCtx,
+			true,
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			limit := int64(100)
+			s := NewWithLocation(limit, monitoring.NewRegistry(), tarawaTime())
+
+			if testCase.overLimit {
+				s.limitSem.Acquire(context.Background(), limit)
+			}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			executed := batomic.MakeBool(false)
+
+			tf := func(ctx context.Context) []TaskFunc {
+				executed.Store(true)
+				return nil
+			}
+
+			beforeStart := time.Now()
+			startedAt := s.runRecursiveTask(testCase.jobCtx, tf, wg)
+
+			// This will panic in the case where we don't check s.limitSem.Acquire
+			// for an error value and released an unacquired resource in scheduler.go.
+			// In that case this will release one more resource than allowed causing
+			// the panic.
+			if testCase.overLimit {
+				s.limitSem.Release(limit)
+			}
+
+			require.Equal(t, testCase.shouldRunTask, executed.Load())
+			require.True(t, startedAt.Equal(beforeStart) || startedAt.After(beforeStart))
+		})
+	}
 }
 
 func BenchmarkScheduler(b *testing.B) {


### PR DESCRIPTION
Backport of https://github.com/elastic/beats/pull/16393 to 7.6