### PR TITLE
Update cisco.asciidoc

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -293,11 +293,11 @@ include::../include/timezone-support.asciidoc[]
 [[dynamic-script-compilations]]
 === Dynamic Script Compilations
 
-The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
-use of script processors and painless conditions. This can cause the pipelines
-to fail loading the first time the module is used, due to exceeding the maximum
-script compilation limits. It is recommended to tune the following parameters
-on your cluster:
+The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and 
+make extensive use of script processors and painless conditions. This can cause 
+the pipelines to fail loading the first time the module is used, due to exceeding
+the maximum script compilation limits. It is recommended to tune the following 
+parameters on your Elasticsearch cluster:
 
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -288,11 +288,11 @@ include::../include/timezone-support.asciidoc[]
 [[dynamic-script-compilations]]
 === Dynamic Script Compilations
 
-The `asa` and `ftd` filesets are based on ingest pipelines and make extensive
-use of script processors and painless conditions. This can cause the pipelines
-to fail loading the first time the module is used, due to exceeding the maximum
-script compilation limits. It is recommended to tune the following parameters
-on your cluster:
+The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and 
+make extensive use of script processors and painless conditions. This can cause 
+the pipelines to fail loading the first time the module is used, due to exceeding
+the maximum script compilation limits. It is recommended to tune the following 
+parameters on your Elasticsearch cluster:
 
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.


### PR DESCRIPTION
Replaces https://github.com/elastic/beats/pull/16131

(Because the underlying dev environment has changed, it was easier for me to cherry-pick the commit from 16131.)