### PR TITLE
[Metricbeat] Update performance metricset in the Oracle module docs to include required permissions

### DIFF
--- a/x-pack/metricbeat/module/oracle/performance/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/oracle/performance/_meta/docs.asciidoc
@@ -1,5 +1,6 @@
 `performance` Metricset includes performance related events that might be correlated between them. It contains mainly cursor and cache based data and can generate 3 types of events.
 
+[float]
 === Required database access
 
 To ensure that the module has access to the appropriate metrics, the module requires that you configure a user with access to the following tables:

--- a/x-pack/metricbeat/module/oracle/performance/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/oracle/performance/_meta/docs.asciidoc
@@ -1,4 +1,15 @@
-`performance` Metricset includes performance related events that might be correlated between them. It contains mainly cursor and cache based data and can generate 3 types of events:
+`performance` Metricset includes performance related events that might be correlated between them. It contains mainly cursor and cache based data and can generate 3 types of events.
+
+=== Required database access
+
+To ensure that the module has access to the appropriate metrics, the module requires that you configure a user with access to the following tables:
+
+* V$BUFFER_POOL_STATISTICS
+* v$sesstat
+* v$statname
+* v$session
+* v$sysstat
+* V$LIBRARYCACHE
 
 [float]
 === Description of fields


### PR DESCRIPTION
Replaces https://github.com/elastic/beats/pull/14496

(cherry-picking the commit was easier than getting the PR to pass tests because the dev environment has changed)