### PR TITLE
dev-tools/mage: use "go list -m" to locate beats

### DIFF
--- a/dev-tools/mage/gomod.go
+++ b/dev-tools/mage/gomod.go
@@ -80,13 +80,10 @@ func Vendor() error {
 		if err != nil {
 			return err
 		}
-		if len(path) != 1 {
-			return fmt.Errorf("unexpected number of paths")
-		}
 		fmt.Println(path)
 
 		for _, f := range p.filesToCopy {
-			from := filepath.Join(path[0], f)
+			from := filepath.Join(path, f)
 			to := filepath.Join(vendorFolder, p.name, f)
 			copyTask := &CopyTask{Source: from, Dest: to, DirMode: os.ModeDir | 0750}
 			err = copyTask.Execute()

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -94,14 +94,20 @@ func ListTestFiles(pkg string) ([]string, error) {
 }
 
 // ListModulePath returns the path to the module in the cache.
-func ListModulePath(pkg string) ([]string, error) {
+func ListModulePath(pkg string) (string, error) {
 	const tmpl = `{{.Dir}}`
-
-	// make sure to look in the module cache
 	env := map[string]string{
+		// make sure to look in the module cache
 		"GOFLAGS": "",
 	}
-	return getLines(callGo(env, "list", "-f", tmpl, pkg))
+	lines, err := getLines(callGo(env, "list", "-m", "-f", tmpl, pkg))
+	if err != nil {
+		return "", err
+	}
+	if n := len(lines); n != 1 {
+		return "", fmt.Errorf("expected 1 line, got %d", n)
+	}
+	return lines[0], nil
 }
 
 // HasTests returns true if the given package contains test files.


### PR DESCRIPTION
## What does this PR do?

This PR updates the dev-tools/mage code to use "go list" to locate the root directory of the elastic/beats module.

## Why is it important?

This removes some assumptions about the use of vendoring, and hard-coded knowledge of the apm-server directory structure. When we move to modules, the apm-server project will not be vendoring, and won't have a "_beats" top-level directory.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Run `mage build` in the filebeat directory.

## Related issues

- Relates https://github.com/elastic/beats/issues/15868
- Relates https://github.com/elastic/apm-server/issues/3296