### PR TITLE
dev-tools/mage: never prefix build vars

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -56,26 +56,9 @@ func DefaultBuildArgs() BuildArgs {
 			"github.com/elastic/beats/libbeat/version.commit":    "{{ commit }}",
 		},
 	}
-
 	if versionQualified {
 		args.Vars["github.com/elastic/beats/libbeat/version.qualifier"] = "{{ .Qualifier }}"
 	}
-
-	repo, err := GetProjectRepoInfo()
-	if err != nil {
-		panic(errors.Wrap(err, "failed to determine project repo info"))
-	}
-
-	if !repo.IsElasticBeats() {
-		// Assume libbeat is vendored and prefix the variables.
-		prefix := repo.RootImportPath + "/vendor/"
-		prefixedVars := map[string]string{}
-		for k, v := range args.Vars {
-			prefixedVars[prefix+k] = v
-		}
-		args.Vars = prefixedVars
-	}
-
 	return args
 }
 


### PR DESCRIPTION
##  What does this PR do?

This PR changes dev-tools/mage build scripts such that the "-X foo=bar" flags passed to "go tool link" are never prefixed with the vendor directory.

## Why is it important?

When using modules, it is not necessary (or correct) to prefix import paths with the vendor path.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

- `mage build` in the filebeat directory
- `mage build` in an external beat (I tested with apm-server, using my [go-modules branch](https://github.com/axw/apm-server/tree/go-modules))

In both cases, the resulting beat's "version" sub-command should include the build time and commit hash.

## Related issues

- Relates #15868
- Relates elastic/apm-server#3296