### PR TITLE
Cherry-pick #16402 to 7.x: [libbeat] Change aws_elb autodiscover provider field name to aws.elb.*

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update to ECS 1.4.0. {pull}14844[14844]
 - The document id fields has been renamed from @metadata.id to @metadata._id {pull}15859[15859]
 - Variable substitution from environment variables is not longer supported. {pull}15937{15937}
+- Change aws_elb autodiscover provider field name from elb_listener.* to aws.elb.*. {issue}16219[16219] {pull}16402{16402}
 
 *Auditbeat*
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -315,22 +315,28 @@ configs are the same only one will actually run.
 
 This provider will load AWS credentials using the standard AWS environment variables and shared credentials files see https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html[Best Practices for Managing AWS Access Keys] for more information. If you do not wish to use these, you may explicitly set the `access_key_id` and `secret_access_key` variables.
 
-These are the available fields during within config templating. The `elb_listener.*` fields will be available on each emitted event.
+These are the available fields during within config templating. The `aws.elb.*` fields will be available on each emitted event.
 
   * host
   * port
-  * elb_listener.listener_arn
-  * elb_listener.load_balancer_arn
-  * elb_listener.protocol
-  * elb_listener.type
-  * elb_listener.scheme
-  * elb_listener.availability_zones
-  * elb_listener.created
-  * elb_listener.state
-  * elb_listener.ip_address_type
-  * elb_listener.security_groups
-  * elb_listener.vpc_id
-  * elb_listener.ssl_policy
+
+  * cloud.availability_zone
+  * cloud.provider
+  * cloud.region
+
+  * aws.elb.listener_arn
+  * aws.elb.load_balancer_arn
+  * aws.elb.protocol
+  * aws.elb.type
+  * aws.elb.scheme
+  * aws.elb.availability_zones
+  * aws.elb.created
+  * aws.elb.state.code
+  * aws.elb.state.reason
+  * aws.elb.ip_address_type
+  * aws.elb.security_groups
+  * aws.elb.vpc_id
+  * aws.elb.ssl_policy
 
 include::../../{beatname_lc}/docs/autodiscover-aws-elb-config.asciidoc[]
 

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/_meta/fields.yml
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/_meta/fields.yml
@@ -1,11 +1,11 @@
-- key: elb_listener
+- key: aws.elb
   title: "ELB Listener"
   description: >
     AWS ELB Listeners
   short_config: false
   release: experimental
   fields:
-    - name: elb_listener
+    - name: aws.elb
       type: group
       description: >
           Represents an AWS ELB Listener, e.g. a port on an ELB.

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -131,9 +131,15 @@ func (p *Provider) onWatcherStart(arn string, lbl *lbListener) {
 		"id":       arn,
 		"host":     lblMap["host"],
 		"port":     lblMap["port"],
+		"aws": common.MapStr{
+			"elb": lbl.toMap(),
+		},
+		"cloud": lbl.toCloudMap(),
 		"meta": common.MapStr{
-			"elb_listener": lbl.toMap(),
-			"cloud":        lbl.toCloudMap(),
+			"aws": common.MapStr{
+				"elb": lbl.toMap(),
+			},
+			"cloud": lbl.toCloudMap(),
 		},
 	}
 

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
@@ -110,9 +110,15 @@ func Test_internalBuilder(t *testing.T) {
 		"start":    true,
 		"host":     *lbl.lb.DNSName,
 		"port":     *lbl.listener.Port,
+		"aws": common.MapStr{
+			"elb": lbl.toMap(),
+		},
+		"cloud": lbl.toCloudMap(),
 		"meta": common.MapStr{
-			"elb_listener": lbl.toMap(),
-			"cloud":        lbl.toCloudMap(),
+			"aws": common.MapStr{
+				"elb": lbl.toMap(),
+			},
+			"cloud": lbl.toCloudMap(),
 		},
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #16402 to 7.x branch. Original message: 

## What does this PR do?

This PR is to change `aws_elb` autodiscover provider fields from `elb_listener.*` to `aws.elb.*`.  For example, the output event will look like below from unit test:
```
map[aws:{"elb":{"availability_zones":["strVal"],"created":"2020-02-18T13:58:30.569437-07:00","host":"fake.example.net","ip_address_type":"dualstack","listener_arn":"listen_arn","load_balancer_arn":"lb_arn","port":1234,"protocol":"HTTPS","scheme":"internet-facing","security_groups":["foo-security-group"],"ssl_policy":"strVal","state":{"code":"active","reason":"strVal"},"type":"application","vpc_id":"strVal"}} cloud:{"availability_zone":["strVal"],"provider":"aws","region":"strV"} host:fake.example.net id:listen_arn meta:{"aws":{"elb":{"availability_zones":["strVal"],"created":"2020-02-18T13:58:30.569437-07:00","host":"fake.example.net","ip_address_type":"dualstack","listener_arn":"listen_arn","load_balancer_arn":"lb_arn","port":1234,"protocol":"HTTPS","scheme":"internet-facing","security_groups":["foo-security-group"],"ssl_policy":"strVal","state":{"code":"active","reason":"strVal"},"type":"application","vpc_id":"strVal"}},"cloud":{"availability_zone":["strVal"],"provider":"aws","region":"strV"}} port:1234 provider:39021adf-6e56-4c6a-8a3c-b12bf9317c06 start:true]
```

`meta` represents what will end up as metadata in the output of modules that get launched.  This PR also updated `aws_elb` provider to have all the meta fields into autodiscover template by adding it to the root of the event. Please see https://github.com/elastic/beats/pull/14823#discussion_r375714303 for more details.

## Why is it important?

With this change, fields from `aws_elb` and `aws_ec2` autodiscover providers  will match.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Closes elastic/beats#16219