### PR TITLE
Rely on automatic -mod=vendor

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -132,14 +132,6 @@ func Build(params BuildArgs) error {
 	}
 	env["CGO_ENABLED"] = cgoEnabled
 
-	var goFlags string
-	goFlags, ok := env["GOFLAGS"]
-	if !ok {
-		env["GOFLAGS"] = "-mod=vendor"
-	} else {
-		env["GOFLAGS"] = strings.Join([]string{goFlags, "-mod=vendor"}, " ")
-	}
-
 	// Spec
 	args := []string{
 		"build",

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -249,7 +249,6 @@ func (b GolangCrossBuilder) Build() error {
 	}
 	args = append(args,
 		"--rm",
-		"--env", "GOFLAGS=-mod=vendor",
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"-v", repoInfo.RootDir+":"+mountPoint,

--- a/dev-tools/mage/dashboard.go
+++ b/dev-tools/mage/dashboard.go
@@ -44,7 +44,7 @@ func ExportDashboard() error {
 		return err
 	}
 
-	dashboardCmd := sh.RunCmd("go", "run", "-mod", "vendor", filepath.Join(beatsDir, "dev-tools/cmd/dashboards/export_dashboards.go"))
+	dashboardCmd := sh.RunCmd("go", "run", filepath.Join(beatsDir, "dev-tools/cmd/dashboards/export_dashboards.go"))
 
 	// TODO: This is currently hardcoded for KB 7, we need to figure out what we do for KB 8 if applicable
 	file := CWD("module", module, "_meta/kibana/7/dashboard", id+".json")

--- a/dev-tools/mage/fields.go
+++ b/dev-tools/mage/fields.go
@@ -101,7 +101,7 @@ func generateFieldsYAML(baseDir, output string, moduleDirs ...string) error {
 		return err
 	}
 
-	globalFieldsCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	globalFieldsCmd := sh.RunCmd("go", "run",
 		filepath.Join(beatsDir, globalFieldsCmdPath),
 		"-es_beats_path", beatsDir,
 		"-beat_path", baseDir,
@@ -125,7 +125,7 @@ func GenerateFieldsGo(fieldsYML, out string) error {
 		return err
 	}
 
-	assetCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	assetCmd := sh.RunCmd("go", "run",
 		filepath.Join(beatsDir, assetCmdPath),
 		"-pkg", "include",
 		"-in", fieldsYML,
@@ -152,7 +152,7 @@ func GenerateModuleFieldsGo(moduleDir string) error {
 		moduleDir = CWD(moduleDir)
 	}
 
-	moduleFieldsCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	moduleFieldsCmd := sh.RunCmd("go", "run",
 		filepath.Join(beatsDir, moduleFieldsCmdPath),
 		"-beat", BeatName,
 		"-license", toLibbeatLicenseName(BeatLicense),
@@ -179,7 +179,7 @@ func GenerateIncludeListGo(options IncludeListOptions) error {
 		return err
 	}
 
-	includeListCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	includeListCmd := sh.RunCmd("go", "run",
 		filepath.Join(beatsDir, moduleIncludeListCmdPath),
 		"-license", toLibbeatLicenseName(BeatLicense),
 		"-out", options.Outfile, "-buildTags", options.BuildTags,

--- a/dev-tools/mage/fmt.go
+++ b/dev-tools/mage/fmt.go
@@ -65,7 +65,6 @@ func GoImports() error {
 
 	fmt.Println(">> fmt - goimports: Formatting Go code")
 	if err := gotool.Install(
-		gotool.Install.Vendored(),
 		gotool.Install.Package(filepath.Join(GoImportsImportPath)),
 	); err != nil {
 		return err

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -48,7 +48,6 @@ func runGoInstall(opts ...ArgOpt) error {
 }
 
 func (goInstall) Package(pkg string) ArgOpt { return posArg(pkg) }
-func (goInstall) Vendored() ArgOpt          { return flagArg("-mod", "vendor") }
 
 type goTest func(opts ...ArgOpt) error
 

--- a/dev-tools/mage/install.go
+++ b/dev-tools/mage/install.go
@@ -26,16 +26,13 @@ var (
 	GoLicenserImportPath = "github.com/elastic/go-licenser"
 )
 
-// InstallVendored uses go get to install a command from its vendored source
-func InstallVendored(importPath string) error {
+// Install uses "go install" to install a command from the module cache or vendor directory.
+func Install(importPath string) error {
 	install := gotool.Install
-	return install(
-		install.Vendored(),
-		install.Package(importPath),
-	)
+	return install(install.Package(importPath))
 }
 
 // InstallGoLicenser target installs go-licenser
 func InstallGoLicenser() error {
-	return InstallVendored(GoLicenserImportPath)
+	return Install(GoLicenserImportPath)
 }

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -192,7 +192,6 @@ func runInIntegTestEnv(mageTarget string, test func() error, passThroughEnvVars 
 		// compose.EnsureUp needs to know the environment type.
 		"-e", "STACK_ENVIRONMENT=" + StackEnvironment,
 		"-e", "TESTING_ENVIRONMENT=" + StackEnvironment,
-		"-e", "GOFLAGS=-mod=vendor",
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/beats
 
-go 1.13
+go 1.14
 
 require (
 	4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,10 @@
 # 4d63.com/embedfiles v0.0.0-20190311033909-995e0740726f
 4d63.com/embedfiles
 # 4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b
+## explicit
 4d63.com/tz
 # cloud.google.com/go v0.49.0
+## explicit
 cloud.google.com/go
 cloud.google.com/go/civil
 cloud.google.com/go/compute/metadata
@@ -14,10 +16,12 @@ cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/monitoring/apiv3
 # cloud.google.com/go/pubsub v1.0.1
+## explicit
 cloud.google.com/go/pubsub
 cloud.google.com/go/pubsub/apiv1
 cloud.google.com/go/pubsub/internal/distribution
 # cloud.google.com/go/storage v1.0.0
+## explicit
 cloud.google.com/go/storage
 # github.com/Azure/azure-amqp-common-go/v3 v3.0.0
 github.com/Azure/azure-amqp-common-go/v3
@@ -31,6 +35,7 @@ github.com/Azure/azure-amqp-common-go/v3/rpc
 github.com/Azure/azure-amqp-common-go/v3/sas
 github.com/Azure/azure-amqp-common-go/v3/uuid
 # github.com/Azure/azure-event-hubs-go/v3 v3.1.0
+## explicit
 github.com/Azure/azure-event-hubs-go/v3
 github.com/Azure/azure-event-hubs-go/v3/atom
 github.com/Azure/azure-event-hubs-go/v3/eph
@@ -39,29 +44,35 @@ github.com/Azure/azure-event-hubs-go/v3/storage
 # github.com/Azure/azure-pipeline-go v0.2.1
 github.com/Azure/azure-pipeline-go/pipeline
 # github.com/Azure/azure-sdk-for-go v37.1.0+incompatible
+## explicit
 github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub
 github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights
 github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-03-01/resources
 github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/azure-storage-blob-go v0.8.0
+## explicit
 github.com/Azure/azure-storage-blob-go/azblob
 # github.com/Azure/go-amqp v0.12.6
 github.com/Azure/go-amqp
 github.com/Azure/go-amqp/internal/testconn
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+## explicit
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
 # github.com/Azure/go-autorest/autorest v0.9.4
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.8.1
 github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
+## explicit
 github.com/Azure/go-autorest/autorest/azure/auth
 # github.com/Azure/go-autorest/autorest/azure/cli v0.3.1
 github.com/Azure/go-autorest/autorest/azure/cli
 # github.com/Azure/go-autorest/autorest/date v0.2.0
+## explicit
 github.com/Azure/go-autorest/autorest/date
 # github.com/Azure/go-autorest/autorest/to v0.3.0
 github.com/Azure/go-autorest/autorest/to
@@ -74,15 +85,19 @@ github.com/Azure/go-autorest/tracing
 # github.com/BurntSushi/toml v0.3.1
 github.com/BurntSushi/toml
 # github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+## explicit
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
 # github.com/Microsoft/hcsshim v0.8.7
 github.com/Microsoft/hcsshim/osversion
 # github.com/Shopify/sarama v0.0.0-00010101000000-000000000000 => github.com/elastic/sarama v0.0.0-20191122160421-355d120d0970
+## explicit
 github.com/Shopify/sarama
 # github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6
+## explicit
 github.com/StackExchange/wmi
 # github.com/aerospike/aerospike-client-go v1.27.1-0.20170612174108-0f3b54da6bdc
+## explicit
 github.com/aerospike/aerospike-client-go
 github.com/aerospike/aerospike-client-go/internal/lua
 github.com/aerospike/aerospike-client-go/internal/lua/resources
@@ -95,15 +110,19 @@ github.com/aerospike/aerospike-client-go/types/particle_type
 github.com/aerospike/aerospike-client-go/types/rand
 github.com/aerospike/aerospike-client-go/utils/buffer
 # github.com/andrewkroh/sys v0.0.0-20151128191922-287798fe3e43
+## explicit
 github.com/andrewkroh/sys/windows/svc/eventlog
 # github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+## explicit
 github.com/armon/go-socks5
 # github.com/aws/aws-lambda-go v1.6.0
+## explicit
 github.com/aws/aws-lambda-go/events
 github.com/aws/aws-lambda-go/lambda
 github.com/aws/aws-lambda-go/lambda/messages
 github.com/aws/aws-lambda-go/lambdacontext
 # github.com/aws/aws-sdk-go-v2 v0.9.0
+## explicit
 github.com/aws/aws-sdk-go-v2/aws
 github.com/aws/aws-sdk-go-v2/aws/arn
 github.com/aws/aws-sdk-go-v2/aws/awserr
@@ -147,6 +166,7 @@ github.com/aws/aws-sdk-go-v2/service/sqs
 github.com/aws/aws-sdk-go-v2/service/sqs/sqsiface
 github.com/aws/aws-sdk-go-v2/service/sts
 # github.com/awslabs/goformation/v4 v4.1.0
+## explicit
 github.com/awslabs/goformation/v4/cloudformation
 github.com/awslabs/goformation/v4/cloudformation/accessanalyzer
 github.com/awslabs/goformation/v4/cloudformation/amazonmq
@@ -260,13 +280,19 @@ github.com/awslabs/goformation/v4/intrinsics
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
+## explicit
 github.com/blakesmith/ar
 # github.com/bsm/sarama-cluster v2.1.14-0.20180625083203-7e67d87a6b3f+incompatible
+## explicit
 github.com/bsm/sarama-cluster
+# github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e
+## explicit
 # github.com/cavaliercoder/go-rpm v0.0.0-20190131055624-7a9c54e3d83e
+## explicit
 github.com/cavaliercoder/go-rpm
 github.com/cavaliercoder/go-rpm/version
 # github.com/cespare/xxhash/v2 v2.1.1
+## explicit
 github.com/cespare/xxhash/v2
 # github.com/containerd/containerd v1.3.3
 github.com/containerd/containerd/errdefs
@@ -276,34 +302,44 @@ github.com/containerd/continuity/pathdriver
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
 # github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
+## explicit
 github.com/containerd/fifo
 # github.com/coreos/bbolt v1.3.1-coreos.6.0.20180318001526-af9db2027c98
+## explicit
 github.com/coreos/bbolt
 # github.com/coreos/go-systemd/v22 v22.0.0
+## explicit
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/internal/dlopen
 github.com/coreos/go-systemd/v22/sdjournal
 # github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea
+## explicit
 github.com/coreos/pkg/dlopen
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892
+## explicit
 github.com/davecgh/go-xdr/xdr2
 # github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f
+## explicit
 github.com/denisenkom/go-mssqldb
 github.com/denisenkom/go-mssqldb/internal/cp
 # github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2
+## explicit
 github.com/devigned/tab
 # github.com/dgrijalva/jwt-go v3.2.1-0.20190620180102-5e25c22bd5d6+incompatible
+## explicit
 github.com/dgrijalva/jwt-go
 # github.com/digitalocean/go-libvirt v0.0.0-20180301200012-6075ea3c39a1
+## explicit
 github.com/digitalocean/go-libvirt
 github.com/digitalocean/go-libvirt/internal/constants
 github.com/digitalocean/go-libvirt/libvirttest
 # github.com/dimchansky/utfbom v1.1.0
 github.com/dimchansky/utfbom
 # github.com/dlclark/regexp2 v1.1.7-0.20171009020623-7632a260cbaf
+## explicit
 github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
 # github.com/docker/distribution v2.7.1+incompatible
@@ -311,6 +347,7 @@ github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
 # github.com/docker/docker v1.4.2-0.20170802015333-8af4db6f002a => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
+## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/backend
@@ -350,25 +387,32 @@ github.com/docker/docker/pkg/system
 github.com/docker/docker/pkg/term
 github.com/docker/docker/pkg/term/windows
 # github.com/docker/go-connections v0.4.0
+## explicit
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-plugins-helpers v0.0.0-20181025120712-1e6269c305b8 => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
+## explicit
 github.com/docker/go-plugins-helpers/sdk
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
 # github.com/dop251/goja v0.0.0-00010101000000-000000000000 => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
+## explicit
 github.com/dop251/goja
 github.com/dop251/goja/ast
 github.com/dop251/goja/file
 github.com/dop251/goja/parser
 github.com/dop251/goja/token
 # github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
+## explicit
 github.com/dop251/goja_nodejs/require
 github.com/dop251/goja_nodejs/util
 # github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
+## explicit
 github.com/dustin/go-humanize
 # github.com/eapache/go-resiliency v1.1.0
 github.com/eapache/go-resiliency/breaker
@@ -377,17 +421,21 @@ github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
 github.com/eapache/queue
 # github.com/elastic/ecs v1.4.0
+## explicit
 github.com/elastic/ecs/code/go/ecs
 # github.com/elastic/go-libaudit v0.4.0
+## explicit
 github.com/elastic/go-libaudit
 github.com/elastic/go-libaudit/aucoalesce
 github.com/elastic/go-libaudit/auparse
 github.com/elastic/go-libaudit/rule
 github.com/elastic/go-libaudit/rule/flags
 # github.com/elastic/go-licenser v0.2.1
+## explicit
 github.com/elastic/go-licenser
 github.com/elastic/go-licenser/licensing
 # github.com/elastic/go-lookslike v0.3.0
+## explicit
 github.com/elastic/go-lookslike
 github.com/elastic/go-lookslike/internal/llreflect
 github.com/elastic/go-lookslike/isdef
@@ -396,6 +444,7 @@ github.com/elastic/go-lookslike/llresult
 github.com/elastic/go-lookslike/testslike
 github.com/elastic/go-lookslike/validator
 # github.com/elastic/go-lumber v0.1.0
+## explicit
 github.com/elastic/go-lumber/client/v2
 github.com/elastic/go-lumber/lj
 github.com/elastic/go-lumber/log
@@ -403,11 +452,14 @@ github.com/elastic/go-lumber/protocol/v2
 github.com/elastic/go-lumber/server/internal
 github.com/elastic/go-lumber/server/v2
 # github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595
+## explicit
 github.com/elastic/go-perf
 # github.com/elastic/go-seccomp-bpf v1.1.0
+## explicit
 github.com/elastic/go-seccomp-bpf
 github.com/elastic/go-seccomp-bpf/arch
 # github.com/elastic/go-structform v0.0.6
+## explicit
 github.com/elastic/go-structform
 github.com/elastic/go-structform/cborl
 github.com/elastic/go-structform/gotype
@@ -416,6 +468,7 @@ github.com/elastic/go-structform/json
 github.com/elastic/go-structform/ubjson
 github.com/elastic/go-structform/visitors
 # github.com/elastic/go-sysinfo v1.3.0
+## explicit
 github.com/elastic/go-sysinfo
 github.com/elastic/go-sysinfo/internal/registry
 github.com/elastic/go-sysinfo/providers/darwin
@@ -424,6 +477,7 @@ github.com/elastic/go-sysinfo/providers/shared
 github.com/elastic/go-sysinfo/providers/windows
 github.com/elastic/go-sysinfo/types
 # github.com/elastic/go-txfile v0.0.7
+## explicit
 github.com/elastic/go-txfile
 github.com/elastic/go-txfile/dev-tools/lib/mage/xbuild
 github.com/elastic/go-txfile/internal/cleanup
@@ -438,6 +492,7 @@ github.com/elastic/go-txfile/pq
 github.com/elastic/go-txfile/txerr
 github.com/elastic/go-txfile/txfiletest
 # github.com/elastic/go-ucfg v0.8.2
+## explicit
 github.com/elastic/go-ucfg
 github.com/elastic/go-ucfg/cfgutil
 github.com/elastic/go-ucfg/flag
@@ -445,44 +500,59 @@ github.com/elastic/go-ucfg/json
 github.com/elastic/go-ucfg/parse
 github.com/elastic/go-ucfg/yaml
 # github.com/elastic/go-windows v1.0.1
+## explicit
 github.com/elastic/go-windows
 # github.com/elastic/gosigar v0.10.5
+## explicit
 github.com/elastic/gosigar
 github.com/elastic/gosigar/cgroup
 github.com/elastic/gosigar/sys
 github.com/elastic/gosigar/sys/linux
 github.com/elastic/gosigar/sys/windows
 # github.com/fatih/color v1.5.0
+## explicit
 github.com/fatih/color
 # github.com/fsnotify/fsevents v0.0.0-00010101000000-000000000000 => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
+## explicit
 github.com/fsnotify/fsevents
 # github.com/fsnotify/fsnotify v1.4.7 => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
+## explicit
 github.com/fsnotify/fsnotify
 # github.com/garyburd/redigo v1.0.1-0.20160525165706-b8dc90050f24
+## explicit
 github.com/garyburd/redigo/internal
 github.com/garyburd/redigo/redis
 # github.com/go-ole/go-ole v1.2.5-0.20190920104607-14974a1cf647
+## explicit
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
 # github.com/go-sourcemap/sourcemap v2.1.2+incompatible
+## explicit
 github.com/go-sourcemap/sourcemap
 github.com/go-sourcemap/sourcemap/internal/base64vlq
 # github.com/go-sql-driver/mysql v1.4.1
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/gocarina/gocsv v0.0.0-20170324095351-ffef3ffc77be
+## explicit
 github.com/gocarina/gocsv
 # github.com/godbus/dbus/v5 v5.0.3
 github.com/godbus/dbus/v5
 # github.com/godror/godror v0.10.4
+## explicit
 github.com/godror/godror
 # github.com/gofrs/flock v0.7.2-0.20190320160742-5135e617513b
+## explicit
 github.com/gofrs/flock
 # github.com/gofrs/uuid v3.2.0+incompatible
+## explicit
 github.com/gofrs/uuid
 # github.com/gogo/protobuf v1.3.1
+## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/protobuf v1.3.2
+## explicit
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go
 github.com/golang/protobuf/protoc-gen-go/descriptor
@@ -498,8 +568,10 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.1
+## explicit
 github.com/golang/snappy
 # github.com/google/flatbuffers v1.7.2-0.20170925184458-7a6b2bf521e9
+## explicit
 github.com/google/flatbuffers/go
 # github.com/google/go-cmp v0.3.1
 github.com/google/go-cmp/cmp
@@ -510,22 +582,29 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
 # github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34
+## explicit
 github.com/google/gopacket
 github.com/google/gopacket/afpacket
 github.com/google/gopacket/layers
 # github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
 # github.com/googleapis/gnostic v0.3.1-0.20190624222214-25d8b0b66985
+## explicit
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gorhill/cronexpr v0.0.0-20161205141322-d520615e531a
+## explicit
 github.com/gorhill/cronexpr
+# github.com/gorilla/mux v1.7.2
+## explicit
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/golang-lru v0.5.2-0.20190520140433-59383c442f7d
+## explicit
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.6
@@ -533,27 +612,34 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/insomniacslk/dhcp v0.0.0-20180716145214-633285ba52b2
+## explicit
 github.com/insomniacslk/dhcp/dhcpv4
 github.com/insomniacslk/dhcp/iana
 # github.com/jcmturner/gofork v1.0.0
+## explicit
 github.com/jcmturner/gofork/encoding/asn1
 github.com/jcmturner/gofork/x/crypto/pbkdf2
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
 # github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5
+## explicit
 github.com/jmoiron/sqlx
 github.com/jmoiron/sqlx/reflectx
 # github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
+## explicit
 github.com/joeshaw/multierror
 # github.com/jpillora/backoff v1.0.0
+## explicit
 github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.7
 github.com/json-iterator/go
 # github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
+## explicit
 github.com/jstemmer/go-junit-report
 github.com/jstemmer/go-junit-report/formatter
 github.com/jstemmer/go-junit-report/parser
 # github.com/klauspost/compress v1.9.3-0.20191122130757-c099ac9f21dd
+## explicit
 github.com/klauspost/compress/flate
 github.com/klauspost/compress/fse
 github.com/klauspost/compress/huff0
@@ -562,12 +648,15 @@ github.com/klauspost/compress/zlib
 github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
+## explicit
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/lib/pq v1.1.2-0.20190507191818-2ff3cb3adc01
+## explicit
 github.com/lib/pq
 github.com/lib/pq/oid
 github.com/lib/pq/scram
 # github.com/magefile/mage v1.9.0
+## explicit
 github.com/magefile/mage
 github.com/magefile/mage/internal
 github.com/magefile/mage/mage
@@ -576,30 +665,40 @@ github.com/magefile/mage/parse
 github.com/magefile/mage/sh
 github.com/magefile/mage/target
 # github.com/mattn/go-colorable v0.0.8
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-ieproxy v0.0.0-20191113090002-7c0f6868bffe
+## explicit
 github.com/mattn/go-ieproxy
 # github.com/mattn/go-isatty v0.0.2
+## explicit
 github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+## explicit
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/dns v1.1.15
+## explicit
 github.com/miekg/dns
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/hashstructure v0.0.0-20170116052023-ab25296c0f51
+## explicit
 github.com/mitchellh/hashstructure
 # github.com/mitchellh/mapstructure v1.1.2
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/morikuni/aec v1.0.0
+## explicit
 github.com/morikuni/aec
 # github.com/opencontainers/go-digest v1.0.0-rc1.0.20190228220655-ac19fd6e7483
+## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.0-rc9
@@ -609,54 +708,72 @@ github.com/opencontainers/runc/libcontainer/user
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pierrre/gotestcover v0.0.0-20160113212533-7b94f124d338
+## explicit
 github.com/pierrre/gotestcover
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
+## explicit
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.1.1-0.20190913103102-20428fa0bffc
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.7.0
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.0.9-0.20191208103036-42f6e295b56f
+## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
+## explicit
 github.com/rcrowley/go-metrics
 # github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e
+## explicit
 github.com/samuel/go-parser/parser
 # github.com/samuel/go-thrift v0.0.0-20140522043831-2187045faa54
+## explicit
 github.com/samuel/go-thrift/parser
 # github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 github.com/sanathkr/go-yaml
 # github.com/sanathkr/yaml v1.0.1-0.20170819201035-0056894fa522
+## explicit
 github.com/sanathkr/yaml
 # github.com/shirou/gopsutil v2.19.11+incompatible
+## explicit
 github.com/shirou/gopsutil/disk
 github.com/shirou/gopsutil/internal/common
 github.com/shirou/gopsutil/net
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v0.0.3
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/objx v0.1.2-0.20180702103455-b8b73a35e983
+## explicit
 github.com/stretchr/objx
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
 # github.com/tsg/go-daemon v0.0.0-20200207173439-e704b93fd89b
+## explicit
 github.com/tsg/go-daemon
 # github.com/tsg/gopacket v0.0.0-20190320122513-dd3d0e41124a
+## explicit
 github.com/tsg/gopacket
 github.com/tsg/gopacket/afpacket
 github.com/tsg/gopacket/layers
@@ -664,12 +781,14 @@ github.com/tsg/gopacket/pcap
 # github.com/urso/go-bin v0.0.0-20180220135811-781c575c9f0e
 github.com/urso/go-bin
 # github.com/urso/magetools v0.0.0-20200106130147-61080ed7b22b
+## explicit
 github.com/urso/magetools/clitool
 github.com/urso/magetools/ctrl
 github.com/urso/magetools/fs
 github.com/urso/magetools/gotool
 github.com/urso/magetools/mgenv
 # github.com/vmware/govmomi v0.0.0-20170802214208-2cad15190b41
+## explicit
 github.com/vmware/govmomi
 github.com/vmware/govmomi/find
 github.com/vmware/govmomi/list
@@ -691,6 +810,7 @@ github.com/vmware/govmomi/vim25/soap
 github.com/vmware/govmomi/vim25/types
 github.com/vmware/govmomi/vim25/xml
 # github.com/yuin/gopher-lua v0.0.0-20170403160031-b402f3114ec7
+## explicit
 github.com/yuin/gopher-lua
 github.com/yuin/gopher-lua/ast
 github.com/yuin/gopher-lua/parse
@@ -714,10 +834,13 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.uber.org/atomic v1.3.1
+## explicit
 go.uber.org/atomic
 # go.uber.org/multierr v1.1.1-0.20170829224307-fb7d312c2c04
+## explicit
 go.uber.org/multierr
 # go.uber.org/zap v1.7.1
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -726,6 +849,7 @@ go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 go.uber.org/zap/zaptest/observer
 # golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
+## explicit
 golang.org/x/crypto/blake2b
 golang.org/x/crypto/cast5
 golang.org/x/crypto/ed25519
@@ -749,6 +873,7 @@ golang.org/x/exp/cmd/apidiff
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -770,15 +895,18 @@ golang.org/x/net/publicsuffix
 golang.org/x/net/trace
 golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20200102141924-c96a22e43c9c
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -787,6 +915,7 @@ golang.org/x/sys/windows/svc
 golang.org/x/sys/windows/svc/debug
 golang.org/x/sys/windows/svc/eventlog
 # golang.org/x/text v0.3.2
+## explicit
 golang.org/x/text/cases
 golang.org/x/text/collate
 golang.org/x/text/encoding
@@ -812,8 +941,10 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+## explicit
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2
+## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/cmd/stringer
 golang.org/x/tools/go/analysis
@@ -838,6 +969,7 @@ golang.org/x/tools/internal/span
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # google.golang.org/api v0.14.0
+## explicit
 google.golang.org/api/cloudfunctions/v1
 google.golang.org/api/compute/v1
 google.golang.org/api/googleapi
@@ -854,6 +986,7 @@ google.golang.org/api/transport/grpc
 google.golang.org/api/transport/http
 google.golang.org/api/transport/http/internal/propagation
 # google.golang.org/appengine v1.6.5
+## explicit
 google.golang.org/appengine
 google.golang.org/appengine/cloudsql
 google.golang.org/appengine/internal
@@ -868,6 +1001,7 @@ google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/socket
 google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
+## explicit
 google.golang.org/genproto/googleapis/api
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/distribution
@@ -931,12 +1065,14 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/inf.v0 v0.9.0
+## explicit
 gopkg.in/inf.v0
 # gopkg.in/jcmturner/aescts.v1 v1.0.1
 gopkg.in/jcmturner/aescts.v1
 # gopkg.in/jcmturner/dnsutils.v1 v1.0.1
 gopkg.in/jcmturner/dnsutils.v1
 # gopkg.in/jcmturner/gokrb5.v7 v7.3.0
+## explicit
 gopkg.in/jcmturner/gokrb5.v7/asn1tools
 gopkg.in/jcmturner/gokrb5.v7/client
 gopkg.in/jcmturner/gokrb5.v7/config
@@ -971,12 +1107,14 @@ gopkg.in/jcmturner/gokrb5.v7/types
 gopkg.in/jcmturner/rpc.v1/mstypes
 gopkg.in/jcmturner/rpc.v1/ndr
 # gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
+## explicit
 gopkg.in/mgo.v2
 gopkg.in/mgo.v2/bson
 gopkg.in/mgo.v2/internal/json
 gopkg.in/mgo.v2/internal/sasl
 gopkg.in/mgo.v2/internal/scram
 # gopkg.in/yaml.v2 v2.2.4
+## explicit
 gopkg.in/yaml.v2
 # honnef.co/go/tools v0.0.1-2019.2.3
 honnef.co/go/tools/arg
@@ -1005,8 +1143,10 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # howett.net/plist v0.0.0-20181124034731-591f970eefbb
+## explicit
 howett.net/plist
 # k8s.io/api v0.0.0-20190722141453-b90922c02518
+## explicit
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
 k8s.io/api/apps/v1beta1
@@ -1044,6 +1184,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.0.0-20190719140911-bfcf53abc9f8
+## explicit
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
@@ -1084,6 +1225,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
@@ -1148,10 +1290,21 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/klog v0.3.4-0.20190719014911-6a023d6d0e09
+## explicit
 k8s.io/klog
 # k8s.io/utils v0.0.0-20190712204705-3dccf664f023
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/trace
 # sigs.k8s.io/yaml v1.1.1-0.20190704183835-4cd0c284b15f
+## explicit
 sigs.k8s.io/yaml
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
+# github.com/Shopify/sarama => github.com/elastic/sarama v0.0.0-20191122160421-355d120d0970
+# github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
+# github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
+# github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
+# github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
+# github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
+# github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c


### PR DESCRIPTION
## What does this PR do?

Remove explicit `-mod=vendor` build flags, and update `go.mod` to specify "go 1.14".

## Why is it important?

This change enables external beats to build without vendoring dependencies. With Go 1.14, when `go.mod` contains "go 1.14" then `-mod=vendor` is automatically applied when there is a vendor directory.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

Tested with Go 1.14rc1: `mage build` in the filebeat directory, with and without the top-level vendor directory removed. I used `GOFLAGS=-x` to verify that dependencies were built from the appropriate location.

## Related issues

- Relates #15868
- Relates elastic/apm-server#3296