### PR TITLE
Cherry-pick #16476 to 7.x: match reference.yml to code default

### DIFF
--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -973,10 +973,10 @@ setup.template.settings:
 # to load your own lifecycle policy.
 #setup.ilm.policy_file:
 
-# Disable the check for an existing lifecycle policy. The default is false. If
+# Disable the check for an existing lifecycle policy. The default is true. If
 # you disable this check, set setup.ilm.overwrite: true so the lifecycle policy
 # can be installed.
-#setup.ilm.check_exists: false
+#setup.ilm.check_exists: true
 
 # Overwrite the lifecycle policy at startup. The default is false.
 #setup.ilm.overwrite: false


### PR DESCRIPTION
Cherry-pick of PR #16476 to 7.x branch. Original message: 

What does this PR do?
Changes the default for `setup.ilm.check_exists` from false to true to match the code defaults.  Closes issue https://github.com/elastic/beats/issues/16474

The code defaults are in https://github.com/elastic/beats/blob/7.6/libbeat/_meta/config.reference.yml.tmpl#L978-L981


## Why is it important?

Users depend on <beatname>.reference.yml to be correct as they use it as a template for their own config files.  

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

(the code defaults and docs are already correct, just the reference.yml files are wrong).  The code checks are already there.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Someone should verify that the template file I modified is used to generate all of the <beatname>.reference.yml files, I do not know how to do this.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues



- Closes https://github.com/elastic/beats/issues/16474



