### PR TITLE
Fix wording in dev guide

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -457,7 +457,7 @@ make create-fields MODULE={module} FILESET={fileset}
 ----
 
 Please, always check the generated file and make sure the fields are correct.
-Documentation of fields must be added manually.
+You must add field documentation manually.
 
 If the fields are correct, it is time to generate documentation, configuration
 and Kibana index patterns.


### PR DESCRIPTION
Remove passive voice.

I was backporting a typo fix and figured I might as well fix the whole sentence.