### PR TITLE
[7.x] Adding breaking change to 7.6.0 doc (#16428)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.6.asciidoc
@@ -26,4 +26,17 @@ configuration setting. For example:
 setup.ilm.policy_name: "%{[agent.name]}-%{[agent.version]}"
 ----
 
+[float]
+==== Two Beat instances can no longer share the same data path
+
+To prevent accidental overwriting of internal state, two instances of the
+same Beat running on the same host can no longer share the same data path.
+To customize the data path for a Beat, use the `path.data` configuration
+setting. For example:
+
+[source,yaml]
+----
+path.data: ${path.home}/data-instance1
+----
+
 // end::notable-breaking-changes[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding breaking change to 7.6.0 doc  (#16428)