### PR TITLE
Fix path to mage in Docker env for go modules

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -182,7 +182,7 @@ func runInIntegTestEnv(mageTarget string, test func() error, passThroughEnvVars 
 	if err != nil {
 		return err
 	}
-	magePath := filepath.Join("/go/src", repo.ImportPath, "build/mage-linux-amd64")
+	magePath := filepath.Join("/go/src", repo.CanonicalRootImportPath, repo.SubDir, "build/mage-linux-amd64")
 
 	// Build docker-compose args.
 	args := []string{"-p", dockerComposeProjectName(), "run",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the path to `mage` in Docker environment for x-pack tests.

The previously used `repo.ImportPath` included the root import path and the package subdir. Since adding the major version to the root import path, it is not correct. The new path is under `repo.CanonicalImportPath` + `repo.SubDir`.

## Why is it important?

This issue prevented X-Pack tests from running.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Run this command from one of the X-Pack Beats:

```sh
$ mage integTest
```
