### PR TITLE
Cherry-pick #16420 to 7.x: Add filtering option for prometheus collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -246,6 +246,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for Dropwizard metrics 4.1. {pull}16332[16332]
 - Add support for NATS 2.1. {pull}16317[16317]
 - Improve the `haproxy` module to support metrics exposed via HTTPS. {issue}14579[14579] {pull}16333[16333]
+- Add filtering option for prometheus collector. {pull}16420[16420]
 - Add metricsets based on Ceph Manager Daemon to the `ceph` module. {issue}7723[7723] {pull}16254[16254]
 - Add Load Balancing metricset to GCP {pull}15559[15559]
 - Release `statsd` module as GA. {pull}16447[16447] {issue}14280[14280]

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -32,6 +32,9 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics
+  #metrics_filters:
+  #  include: []
+  #  exclude: []
   #username: "user"
   #password: "secret"
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -699,6 +699,9 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics
+  #metrics_filters:
+  #  include: []
+  #  exclude: []
   #username: "user"
   #password: "secret"
 

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -2,6 +2,9 @@
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics
+  #metrics_filters:
+  #  include: []
+  #  exclude: []
   #username: "user"
   #password: "secret"
 

--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -41,3 +41,22 @@ metricbeat.modules:
   query:
     'match[]': '{__name__!=""}'
 -------------------------------------------------------------------------------------
+
+[float]
+=== Filtering metrics
+
+In order to filter out/in metrics one can make use of `metrics_filters.include` `metrics_filters.exclude` settings:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+- module: prometheus
+  period: 10s
+  hosts: ["localhost:9092"]
+  metrics_path: /metrics
+  metrics_filters:
+    include: ["node_filesystem_*"]
+    exclude: ["node_filesystem_device_*", "node_filesystem_readonly"]
+-------------------------------------------------------------------------------------
+
+The configuration above will include only metrics that match `node_filesystem_*` pattern and do not match `node_filesystem_device_*`
+and are not `node_filesystem_readonly` metric.

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -22,6 +22,8 @@ package collector
 import (
 	"testing"
 
+	"github.com/elastic/beats/metricbeat/mb"
+
 	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -198,6 +200,164 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		event := getPromEventsFromMetricFamily(test.Family)
 		assert.Equal(t, test.Event, event)
 	}
+}
+
+func TestSkipMetricFamily(t *testing.T) {
+	testFamilies := []*dto.MetricFamily{
+		{
+			Name: proto.String("http_request_duration_microseconds_a_a_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_COUNTER.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Label: []*dto.LabelPair{
+						{
+							Name:  proto.String("handler"),
+							Value: proto.String("query"),
+						},
+					},
+					Counter: &dto.Counter{
+						Value: proto.Float64(10),
+					},
+				},
+			},
+		},
+		{
+			Name: proto.String("http_request_duration_microseconds_a_b_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_COUNTER.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Label: []*dto.LabelPair{
+						{
+							Name:  proto.String("handler"),
+							Value: proto.String("query"),
+						},
+					},
+					Counter: &dto.Counter{
+						Value: proto.Float64(10),
+					},
+				},
+			},
+		},
+		{
+			Name: proto.String("http_request_duration_microseconds_b_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Gauge: &dto.Gauge{
+						Value: proto.Float64(10),
+					},
+				},
+			},
+		},
+		{
+			Name: proto.String("http_request_duration_microseconds_c_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_SUMMARY.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Summary: &dto.Summary{
+						SampleCount: proto.Uint64(10),
+						SampleSum:   proto.Float64(10),
+						Quantile: []*dto.Quantile{
+							{
+								Quantile: proto.Float64(0.99),
+								Value:    proto.Float64(10),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: proto.String("http_request_duration_microseconds_d_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_HISTOGRAM.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Histogram: &dto.Histogram{
+						SampleCount: proto.Uint64(10),
+						SampleSum:   proto.Float64(10),
+						Bucket: []*dto.Bucket{
+							{
+								UpperBound:      proto.Float64(0.99),
+								CumulativeCount: proto.Uint64(10),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: proto.String("http_request_duration_microseconds_e_in"),
+			Help: proto.String("foo"),
+			Type: dto.MetricType_UNTYPED.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Label: []*dto.LabelPair{
+						{
+							Name:  proto.String("handler"),
+							Value: proto.String("query"),
+						},
+					},
+					Untyped: &dto.Untyped{
+						Value: proto.Float64(10),
+					},
+				},
+			},
+		},
+	}
+
+	ms := &MetricSet{
+		BaseMetricSet: mb.BaseMetricSet{},
+	}
+
+	// test with no filters
+	ms.includeMetrics, _ = compilePatternList(&[]string{})
+	ms.excludeMetrics, _ = compilePatternList(&[]string{})
+	metricsToKeep := 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep += 1
+		}
+	}
+	assert.Equal(t, metricsToKeep, len(testFamilies))
+
+	// test with only one include filter
+	ms.includeMetrics, _ = compilePatternList(&[]string{"http_request_duration_microseconds_a_*"})
+	ms.excludeMetrics, _ = compilePatternList(&[]string{})
+	metricsToKeep = 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep += 1
+		}
+	}
+	assert.Equal(t, metricsToKeep, 2)
+
+	// test with only one exclude filter
+	ms.includeMetrics, _ = compilePatternList(&[]string{""})
+	ms.excludeMetrics, _ = compilePatternList(&[]string{"http_request_duration_microseconds_a_*"})
+	metricsToKeep = 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep += 1
+		}
+	}
+	assert.Equal(t, len(testFamilies)-2, metricsToKeep)
+
+	// test with ine include and one exclude
+	ms.includeMetrics, _ = compilePatternList(&[]string{"http_request_duration_microseconds_a_*"})
+	ms.excludeMetrics, _ = compilePatternList(&[]string{"http_request_duration_microseconds_a_b_*"})
+	metricsToKeep = 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep += 1
+		}
+	}
+	assert.Equal(t, 1, metricsToKeep)
+
 }
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/prometheus/collector/config.go
+++ b/metricbeat/module/prometheus/collector/config.go
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package collector
+
+type metricsetConfig struct {
+	MetricsFilters MetricFilters `config:"metrics_filters" yaml:"metrics_filters,omitempty"`
+}
+
+type MetricFilters struct {
+	IncludeMetrics *[]string `config:"include" yaml:"include,omitempty"`
+	ExcludeMetrics *[]string `config:"exclude" yaml:"exclude,omitempty"`
+}
+
+var defaultConfig = metricsetConfig{
+	MetricsFilters: MetricFilters{
+		IncludeMetrics: nil,
+		ExcludeMetrics: nil},
+}
+
+func (c *metricsetConfig) Validate() error {
+	// validate configuration here
+	return nil
+}

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -5,6 +5,9 @@
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics
+  #metrics_filters:
+  #  include: []
+  #  exclude: []
   #username: "user"
   #password: "secret"
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -898,6 +898,9 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics
+  #metrics_filters:
+  #  include: []
+  #  exclude: []
   #username: "user"
   #password: "secret"
 


### PR DESCRIPTION
Cherry-pick of PR #16420 to 7.x branch. Original message: 

Drafting what was discussed on https://github.com/elastic/beats/issues/15493 to start implementation specific discussions.For the time being only filters are implemented, but mappings will be added if we agree on this.
@jsoriano I preferred to add the processing on collector layer to avoid touching `GetFamilies` since it is used by many other places like the `state_*` metricsets of k8s module. Not sure if we would like to have it in there (in the helper method).


## What does this PR do?
This PR introduces filtering options for prometheus collector metricset. 

## Why is it important?
This is important when someone want to filter out metrics that come in a single response for instance in case of prometheus exporters. 

This will be useful in light-modules like `ibmmq` module where currently we use script processor to filter out metrics as well as in [OpenMetrics](https://github.com/elastic/beats/issues/14982) module where a user may want to explicitly define which metrics want to keep.

## How to test this PR locally
1. One can use a nodexporter as an example Prometheus app to collect from. For instance this forked project should be enough: https://github.com/ChrsMark/dockprom. Download and `docker-compose up`. Then metrics should be exported at `http://localhost:9100/metrics`.
2. Configuration:
```
- module: prometheus
  period: 10s
  hosts: ["localhost:9092"]
  metrics_path: /metrics
  metrics_filters:
    include: ["node_filesystem_*"]
    exclude: ["node_filesystem_device_*", "node_filesystem_readonly"]
```
And expect to see only events that match `node_filesystem_*` but also not `node_filesystem_device_*` and are not `node_filesystem_readonly`. 
3. Try to remove `node_filesystem_readonly` from `exclude` filters and see that this metric is included in events. One can try different combinations.

## Related issues

- Relates https://github.com/elastic/beats/issues/15493, https://github.com/elastic/beats/issues/14982


