### PR TITLE
[Filebeat] Enhancement Pattern for Cisco Message 734001.

### DIFF
--- a/x-pack/filebeat/module/cisco/asa/_meta/fields.yml
+++ b/x-pack/filebeat/module/cisco/asa/_meta/fields.yml
@@ -85,3 +85,13 @@
     type: short
     description: >
       ICMP code.
+
+  - name: connection_type
+    type: keyword
+    description: >
+      The VPN connection type
+
+  - name: dap_records
+    type: keyword
+    description: ->
+      The assigned DAP records

--- a/x-pack/filebeat/module/cisco/asa/test/dap_records-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/dap_records-expected.json
@@ -1,0 +1,18 @@
+{
+    "source": {
+      "ip": "1.2.3.4"
+    },
+    "user": {
+      "email": "firstname.lastname@domain.net"
+    },
+    "cisco": {
+      "connection_type": "AnyConnect",
+      "dap_records": [
+        "dap_1",
+        "dap_2"
+      ],
+      "asa": {
+        "message_id": "734001"
+      }
+    }
+}

--- a/x-pack/filebeat/module/cisco/asa/test/dap_records.log
+++ b/x-pack/filebeat/module/cisco/asa/test/dap_records.log
@@ -1,0 +1,1 @@
+Feb 20 2020 16:11:11: %ASA-6-734001: DAP: User firsname.lastname@domain.net, Addr 1.2.3.4, Connection AnyConnect: The following DAP records were selected for this connection: dap_1, dap_2

--- a/x-pack/filebeat/module/cisco/ftd/_meta/fields.yml
+++ b/x-pack/filebeat/module/cisco/ftd/_meta/fields.yml
@@ -90,3 +90,13 @@
     type: object
     description:
       Raw fields for Security Events.
+  
+  - name: connection_type
+    type: keyword
+    description: >
+      The VPN connection type
+
+  - name: dap_records
+    type: keyword
+    description: ->
+      The assigned DAP records

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -400,7 +400,14 @@ processors:
      if: "ctx._temp_.cisco.message_id == '338301'"
      field: "server.port"
      value: "{{source.port}}"
-
+ - dissect:
+     if: "ctx._temp_.cisco.message_id == '734001'"
+     field: "message"
+     pattern: "DAP: User %{user.email}, Addr %{source.ip}, Connection %{cisco.connection_type}: The following DAP records were selected for this connection: %{cisco.dap_records->}"
+ - split:
+     field: "cisco.dap_records"
+     separator: ",\\s+"
+     
 #
 # Handle 302xxx messages (Flow expiration a.k.a "Teardown")
 #


### PR DESCRIPTION
    


## What does this PR do?
Adds a new pipeline pattern for the cisci asa/ftd log messages with the event id 734001.
The split part is needed, because one has to be able to search for an
explicit dap_record. As the records order and number can vary a lot,
just saving the whole string makes no sense. I choosed "user.email", "source.ip" based on the ECS and "cisco.connection_type", "cisco.dap_records" as looking to the syslog messages docs,
they also call it like that.

## Why is it important?
We need this filter for troubleshooting VPN Connections

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally
Test Logfile is added 

## Related issues
Closes #16212. 



