### PR TITLE
Cherry-pick #16450 to 7.x: [Filebeat] Update fileset input merging to replaces paths and append processors.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
 - Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
 - Fix loading processors from annotation hints. {pull}16348[16348]
+- Upgrade go-ucfg to latest v0.8.3. {pull}16450{16450}
 
 *Auditbeat*
 
@@ -103,6 +104,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
 - Fix a connection error in httpjson input. {pull}16123[16123]
 - Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
+- Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
 
 *Heartbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1518,8 +1518,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.8.2
-Revision: ab69586e10820006b250d04c98cc3b848e227808
+Version: v0.8.3
+Revision: f3ae3b220df32cfcae011ec6bbf87a711e6bf06b
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/elastic/go-ucfg"
+
 	errw "github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -362,7 +364,7 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error creating config from input overrides: %v", err)
 		}
-		cfg, err = common.MergeConfigs(cfg, overrides)
+		cfg, err = common.MergeConfigsWithOptions([]*common.Config{cfg, overrides}, ucfg.FieldReplaceValues("**.paths"), ucfg.FieldAppendValues("**.processors"))
 		if err != nil {
 			return nil, fmt.Errorf("Error applying config overrides: %v", err)
 		}

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -116,6 +116,16 @@ func MergeConfigs(cfgs ...*Config) (*Config, error) {
 	return config, nil
 }
 
+func MergeConfigsWithOptions(cfgs []*Config, options ...ucfg.Option) (*Config, error) {
+	config := NewConfig()
+	for _, c := range cfgs {
+		if err := config.MergeWithOpts(c, options...); err != nil {
+			return nil, err
+		}
+	}
+	return config, nil
+}
+
 func NewConfigWithYAML(in []byte, source string) (*Config, error) {
 	opts := append(
 		[]ucfg.Option{
@@ -162,6 +172,14 @@ func LoadFiles(paths ...string) (*Config, error) {
 
 func (c *Config) Merge(from interface{}) error {
 	return c.access().Merge(from, configOpts...)
+}
+
+func (c *Config) MergeWithOpts(from interface{}, opts ...ucfg.Option) error {
+	o := configOpts
+	if opts != nil {
+		o = append(o, opts...)
+	}
+	return c.access().Merge(from, o...)
 }
 
 func (c *Config) Unpack(to interface{}) error {

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.8.3]
+
+### Added
+- Added ability to adjust merging behavior based on field names in configuration. Using `ucfg.FieldMergeValues`, `ucfg.FieldReplaceValues`, `ucfg.FieldAppendValues`, and `ucfg.FieldPrependValues`. #151
+
 ## [0.8.2]
 
 ### Fixed
@@ -263,7 +268,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/elastic/go-ucfg/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/elastic/go-ucfg/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/elastic/go-ucfg/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/elastic/go-ucfg/compare/v0.7.0...v0.8.0

--- a/vendor/github.com/elastic/go-ucfg/opts.go
+++ b/vendor/github.com/elastic/go-ucfg/opts.go
@@ -18,7 +18,9 @@
 package ucfg
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/elastic/go-ucfg/parse"
 )
@@ -38,6 +40,7 @@ type options struct {
 	noParse      bool
 
 	configValueHandling configHandling
+	fieldHandlingTree   *fieldHandlingTree
 
 	// temporary cache of parsed splice values for lifetime of call to
 	// Unpack/Pack/Get/...
@@ -47,6 +50,9 @@ type options struct {
 }
 
 type valueCache map[string]spliceValue
+
+// specific API on top of Config to handle adjusting merging behavior per fields
+type fieldHandlingTree Config
 
 // id used to store intermediate parse results in current execution context.
 // As parsing results might differ between multiple calls due to:
@@ -162,6 +168,57 @@ func makeOptValueHandling(h configHandling) Option {
 	}
 }
 
+var (
+	// FieldMergeValues option configures all merging and unpacking operations to use
+	// the default merging behavior for the specified field. This overrides the any struct
+	// tags during unpack for the field. Nested field names can be defined using dot
+	// notation.
+	FieldMergeValues = makeFieldOptValueHandling(cfgMergeValues)
+
+	// FieldReplaceValues option configures all merging and unpacking operations to
+	// replace old dictionaries and arrays while merging for the specified field. This
+	// overrides the any struct tags during unpack for the field. Nested field names
+	// can be defined using dot notation.
+	FieldReplaceValues = makeFieldOptValueHandling(cfgReplaceValue)
+
+	// FieldAppendValues option configures all merging and unpacking operations to
+	// merge dictionaries and append arrays to existing arrays while merging for the
+	// specified field. This overrides the any struct tags during unpack for the field.
+	// Nested field names can be defined using dot notation.
+	FieldAppendValues = makeFieldOptValueHandling(cfgArrAppend)
+
+	// FieldPrependValues option configures all merging and unpacking operations to
+	// merge dictionaries and prepend arrays to existing arrays while merging for the
+	// specified field. This overrides the any struct tags during unpack for the field.
+	// Nested field names can be defined using dot notation.
+	FieldPrependValues = makeFieldOptValueHandling(cfgArrPrepend)
+)
+
+func makeFieldOptValueHandling(h configHandling) func(...string) Option {
+	return func(fieldName ...string) Option {
+		if len(fieldName) == 0 {
+			return func(_ *options) {}
+		}
+
+		table := make(map[string]configHandling)
+		for _, name := range fieldName {
+			// field value config options are rendered into a Config; the '*' represents the handling method
+			// for everything nested under this field.
+			if !strings.HasSuffix(name, ".*") {
+				name = fmt.Sprintf("%s.*", name)
+			}
+			table[name] = h
+		}
+
+		return func(o *options) {
+			if o.fieldHandlingTree == nil {
+				o.fieldHandlingTree = newFieldHandlingTree()
+			}
+			o.fieldHandlingTree.merge(table, PathSep(o.pathSep))
+		}
+	}
+}
+
 // VarExp option enables support for variable expansion. Resolve and Env options will only be effective if  VarExp is set.
 var VarExp Option = doVarExp
 
@@ -199,4 +256,60 @@ func (cache valueCache) cachedValue(
 		cache[string(id)] = spliceValue{err, v}
 	}
 	return v, err
+}
+
+func newFieldHandlingTree() *fieldHandlingTree {
+	return (*fieldHandlingTree)(New())
+}
+
+func (t *fieldHandlingTree) merge(other interface{}, opts ...Option) error {
+	cfg := (*Config)(t)
+	return cfg.Merge(other, opts...)
+}
+
+func (t *fieldHandlingTree) child(fieldName string, idx int) (*fieldHandlingTree, error) {
+	cfg := (*Config)(t)
+	child, err := cfg.Child(fieldName, idx)
+	if err != nil {
+		return nil, err
+	}
+	return (*fieldHandlingTree)(child), nil
+}
+
+func (t *fieldHandlingTree) configHandling(fieldName string, idx int) (configHandling, error) {
+	cfg := (*Config)(t)
+	handling, err := cfg.Uint(fieldName, idx)
+	if err != nil {
+		return cfgDefaultHandling, err
+	}
+	return configHandling(handling), nil
+}
+
+func (t *fieldHandlingTree) wildcard() (*fieldHandlingTree, error) {
+	return t.child("**", -1)
+}
+
+func (t *fieldHandlingTree) setWildcard(wildcard *fieldHandlingTree) error {
+	cfg := (*Config)(t)
+	return cfg.SetChild("**", -1, (*Config)(wildcard))
+}
+
+func (t *fieldHandlingTree) fieldHandling(fieldName string, idx int) (configHandling, *fieldHandlingTree, bool) {
+	child, err := t.child(fieldName, idx)
+	if err == nil {
+		cfgHandling, err := child.configHandling("*", -1)
+		if err == nil {
+			return cfgHandling, child, true
+		}
+	}
+	// try wildcard match
+	wildcard, err := t.wildcard()
+	if err != nil {
+		return cfgDefaultHandling, child, false
+	}
+	cfgHandling, cfg, ok := wildcard.fieldHandling(fieldName, idx)
+	if ok {
+		return cfgHandling, cfg, ok
+	}
+	return cfgDefaultHandling, child, ok
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3285,76 +3285,76 @@
 			"versionExact": "v0.0.7"
 		},
 		{
-			"checksumSHA1": "VPcK6uPDligSrbdi1yVeGivPvno=",
+			"checksumSHA1": "6EwlkLbm/yUYgLddYEiQRZioMNM=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "B58nBBiUIstpkXfr9yaYN9GzdLE=",
 			"path": "github.com/elastic/go-ucfg/diff",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "E6k6DWkpI+LOKDIFRqRmNH9GORc=",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "NhiQQjYMs/ViCbmEq9tll2uCaYo=",
 			"path": "github.com/elastic/go-ucfg/hjson",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
 			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
 			"revisionTime": "2019-01-28T11:18:48Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "cfMNsyQm0gZOV0hRJrBSdKDQSBo=",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "ZISq+zzSb0OLzvwLlf1ObdgnFmM=",
 			"path": "github.com/elastic/go-ucfg/parse",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "cnJVnptTvXNLzxVhd266k19/pQg=",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "ab69586e10820006b250d04c98cc3b848e227808",
-			"revisionTime": "2020-02-07T21:56:35Z",
-			"version": "v0.8.2",
-			"versionExact": "v0.8.2"
+			"revision": "f3ae3b220df32cfcae011ec6bbf87a711e6bf06b",
+			"revisionTime": "2020-02-20T11:45:39Z",
+			"version": "v0.8.3",
+			"versionExact": "v0.8.3"
 		},
 		{
 			"checksumSHA1": "iI1JCWsrAPpoKcEo/i6G3lRLIVs=",


### PR DESCRIPTION
Cherry-pick of PR #16450 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Updates vendored package of go-ucfg to 0.8.3, needed to use the new field merging adjustments. Updates fileset input merging to replaces paths and append processors when merging configurations.

## Why is it important?

Allows a container to define modules that contain processors at the same time as adding extra processors during autodiscovery.

`docker run -l 'co.elastic.logs/processors.add_fields={"fields":{"foo":"bar"}}' -l co.elastic.logs/module=elasticsearch busybox echo hello` 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run filebeat with configuration:

```
filebeat.autodiscover:
  providers:
    - type: docker
      hints.enabled: true

output.console:
  pretty: true
```

Start container:

`docker run -l 'co.elastic.logs/processors.add_fields={"fields":{"foo":"bar"}}' -l co.elastic.logs/module=elasticsearch busybox echo hello` 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #16190 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
2020-02-20T06:39:46.264-0500    DEBUG   [autodiscover]  autodiscover/autodiscover.go:190        Generated config: map[audit:map[enabled:true input:map[paths:[/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log] processors:[map[add_fields:map[fields:map[foo:bar]]]] stream:all type:container]] deprecation:map[enabled:true input:map[paths:[/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log] processors:[map[add_fields:map[fields:map[foo:bar]]]] stream:all type:container]] gc:map[enabled:true input:map[paths:[/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log] processors:[map[add_fields:map[fields:map[foo:bar]]]] stream:all type:container]] module:elasticsearch server:map[enabled:true input:map[paths:[/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log] processors:[map[add_fields:map[fields:map[foo:bar]]]] stream:all type:container]] slowlog:map[enabled:true input:map[paths:[/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log] processors:[map[add_fields:map[fields:map[foo:bar]]]] stream:all type:container]]]
2020-02-20T06:39:46.264-0500    DEBUG   [autodiscover]  autodiscover/autodiscover.go:252        Got a meta field in the event
2020-02-20T06:39:46.265-0500    DEBUG   [autodiscover]  cfgfile/list.go:62      Starting reload procedure, current runners: 0
2020-02-20T06:39:46.265-0500    DEBUG   [autodiscover]  cfgfile/list.go:80      Start list: 1, Stop list: 0
2020-02-20T06:39:46.271-0500    DEBUG   [processors]    processors/processor.go:101     Generated new processors: add_locale=[format=offset], add_fields={"fields":{"foo":"bar"}}
2020-02-20T06:39:46.271-0500    DEBUG   [input] log/config.go:204       recursive glob enabled
2020-02-20T06:39:46.271-0500    DEBUG   [input] log/input.go:164        exclude_files: [(?-s:.)gz(?-m:$)]. Number of stats: 0
2020-02-20T06:39:46.271-0500    DEBUG   [input] log/input.go:185        input with previous states loaded: 0
2020-02-20T06:39:46.271-0500    INFO    log/input.go:152        Configured paths: [/var/lib/docker/containers/fe58462fbaec77346b02d431375b39508c386bc31ef930320a4e82643ca02e93/*-json.log]
```
