### PR TITLE
Cherry-pick #16448 to 7.x: Include xpack libbeat in the list of projects in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROJECTS_XPACK_PKG=x-pack/auditbeat x-pack/dockerlogbeat x-pack/filebeat x-pack/
 # Mage. For compatibility with CI testing these projects support a subset of the
 # makefile targets. After all Beats converge to primarily using Mage we can
 # remove this and treat all sub-projects the same.
-PROJECTS_XPACK_MAGE=$(PROJECTS_XPACK_PKG)
+PROJECTS_XPACK_MAGE=$(PROJECTS_XPACK_PKG) x-pack/libbeat
 
 #
 # Includes

--- a/x-pack/libbeat/Makefile
+++ b/x-pack/libbeat/Makefile
@@ -8,4 +8,4 @@ TEST_ENVIRONMENT?=true
 # Path to the libbeat Makefile
 include $(ES_BEATS)/libbeat/scripts/Makefile
 
-collect update fields: ;
+collect update fields config: ;

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -5,9 +5,10 @@
 package aws
 
 import (
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetAWSCredentials(t *testing.T) {

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -39,8 +39,3 @@ func Fields() error {
 func GoTestUnit(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
-
-// Config generates example and reference configuration for libbeat.
-func Config() error {
-	return devtools.Config(devtools.ShortConfigType|devtools.ReferenceConfigType, devtools.ConfigFileParams{}, ".")
-}


### PR DESCRIPTION
Cherry-pick of PR #16448 to 7.x branch. Original message: 

## What does this PR do?

Include xpack libbeat in the list of projects in Makefile, and fix format in one of its files.

Remove config generation from x-pack libbeat, these files are not commited and I
guess they are also not used.

## Why is it important?

To include x-pack libbeat in general targets like `make check` or `make clean`. Not having it in `make check` gave less visibility on format errors or other checks.