### PR TITLE
Bug fix for issue with disk IO on windows platform

### DIFF
--- a/metricbeat/module/system/diskio/diskstat_windows_helper.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_helper.go
@@ -65,6 +65,7 @@ type diskPerformance struct {
 	QueryTime           int64
 	StorageDeviceNumber uint32
 	StorageManagerName  [8]uint16
+	ReservedAlignment   uint32
 }
 
 // ioCounters gets the diskio counters and maps them to the list of counterstat objects.


### PR DESCRIPTION
Bug fix for issue with disk IO on windows platform

In Windows, script is calling WINAPI function DeviceIoControl. It is accepting structure DISK_PERFORMANCE. GoLang doesn't have alignment as C/C++ structures, therefore actual sizes are mismatched with expected (GoLang size -> 84, C/C++ -> 88). This is causing failure of DeviceIoControl with error "The parameter is incorrect". This can easily be reproduced, just by running metricbeats service on windows, and enable diskio.
Fix is to add alignment padding of 4 bytes to the end of structure, as it is done in C/C++ structure analog. This will make structure valid, and DeviceIoControl will be able to return request information.
