### PR TITLE
Make usage of vendor folder optional

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -115,12 +115,14 @@ func Build(params BuildArgs) error {
 	}
 	env["CGO_ENABLED"] = cgoEnabled
 
-	var goFlags string
-	goFlags, ok := env["GOFLAGS"]
-	if !ok {
-		env["GOFLAGS"] = "-mod=vendor"
-	} else {
-		env["GOFLAGS"] = strings.Join([]string{goFlags, "-mod=vendor"}, " ")
+	if UseVendor {
+		var goFlags string
+		goFlags, ok := env["GOFLAGS"]
+		if !ok {
+			env["GOFLAGS"] = "-mod=vendor"
+		} else {
+			env["GOFLAGS"] = strings.Join([]string{goFlags, "-mod=vendor"}, " ")
+		}
 	}
 
 	// Spec

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -247,9 +247,12 @@ func (b GolangCrossBuilder) Build() error {
 	if versionQualified {
 		args = append(args, "--env", "VERSION_QUALIFIER="+versionQualifier)
 	}
+	if UseVendor {
+		args = append(args, "--env", "GOFLAGS=-mod=vendor")
+	}
+
 	args = append(args,
 		"--rm",
-		"--env", "GOFLAGS=-mod=vendor",
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"-v", repoInfo.RootDir+":"+mountPoint,

--- a/dev-tools/mage/fields.go
+++ b/dev-tools/mage/fields.go
@@ -101,12 +101,17 @@ func generateFieldsYAML(baseDir, output string, moduleDirs ...string) error {
 		return err
 	}
 
-	globalFieldsCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	cmd := []string{"run"}
+	if UseVendor {
+		cmd = append(cmd, "-mod", "vendor")
+	}
+	cmd = append(cmd,
 		filepath.Join(beatsDir, globalFieldsCmdPath),
 		"-es_beats_path", beatsDir,
 		"-beat_path", baseDir,
 		"-out", CreateDir(output),
 	)
+	globalFieldsCmd := sh.RunCmd("go", cmd...)
 
 	return globalFieldsCmd(moduleDirs...)
 }
@@ -125,7 +130,11 @@ func GenerateFieldsGo(fieldsYML, out string) error {
 		return err
 	}
 
-	assetCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	cmd := []string{"run"}
+	if UseVendor {
+		cmd = append(cmd, "-mod", "vendor")
+	}
+	cmd = append(cmd,
 		filepath.Join(beatsDir, assetCmdPath),
 		"-pkg", "include",
 		"-in", fieldsYML,
@@ -133,6 +142,7 @@ func GenerateFieldsGo(fieldsYML, out string) error {
 		"-license", toLibbeatLicenseName(BeatLicense),
 		BeatName,
 	)
+	assetCmd := sh.RunCmd("go", cmd...)
 
 	return assetCmd()
 }
@@ -152,12 +162,17 @@ func GenerateModuleFieldsGo(moduleDir string) error {
 		moduleDir = CWD(moduleDir)
 	}
 
-	moduleFieldsCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	cmd := []string{"run"}
+	if UseVendor {
+		cmd = append(cmd, "-mod", "vendor")
+	}
+	cmd = append(cmd,
 		filepath.Join(beatsDir, moduleFieldsCmdPath),
 		"-beat", BeatName,
 		"-license", toLibbeatLicenseName(BeatLicense),
 		moduleDir,
 	)
+	moduleFieldsCmd := sh.RunCmd("go", cmd...)
 
 	return moduleFieldsCmd()
 }
@@ -179,12 +194,18 @@ func GenerateIncludeListGo(options IncludeListOptions) error {
 		return err
 	}
 
-	includeListCmd := sh.RunCmd("go", "run", "-mod", "vendor",
+	cmd := []string{"run"}
+	if UseVendor {
+		cmd = append(cmd, "-mod", "vendor")
+	}
+	cmd = append(cmd,
 		filepath.Join(beatsDir, moduleIncludeListCmdPath),
 		"-license", toLibbeatLicenseName(BeatLicense),
 		"-out", options.Outfile, "-buildTags", options.BuildTags,
 		"-pkg", options.Pkg,
 	)
+
+	includeListCmd := sh.RunCmd("go", cmd...)
 
 	var args []string
 	for _, dir := range options.ImportDirs {

--- a/dev-tools/mage/fmt.go
+++ b/dev-tools/mage/fmt.go
@@ -64,11 +64,19 @@ func GoImports() error {
 	}
 
 	fmt.Println(">> fmt - goimports: Formatting Go code")
-	if err := gotool.Install(
-		gotool.Install.Vendored(),
-		gotool.Install.Package(filepath.Join(GoImportsImportPath)),
-	); err != nil {
-		return err
+	if UseVendor {
+		if err := gotool.Install(
+			gotool.Install.Vendored(),
+			gotool.Install.Package(filepath.Join(GoImportsImportPath)),
+		); err != nil {
+			return err
+		}
+	} else {
+		if err := gotool.Get(
+			gotool.Get.Package(filepath.Join(GoImportsImportPath)),
+		); err != nil {
+			return err
+		}
 	}
 
 	args := append(

--- a/dev-tools/mage/install.go
+++ b/dev-tools/mage/install.go
@@ -37,5 +37,10 @@ func InstallVendored(importPath string) error {
 
 // InstallGoLicenser target installs go-licenser
 func InstallGoLicenser() error {
-	return InstallVendored(GoLicenserImportPath)
+	if UseVendor {
+		return InstallVendored(GoLicenserImportPath)
+	}
+	return gotool.Get(
+		gotool.Get.Package(GoLicenserImportPath),
+	)
 }

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -193,7 +193,9 @@ func runInIntegTestEnv(mageTarget string, test func() error, passThroughEnvVars 
 		// compose.EnsureUp needs to know the environment type.
 		"-e", "STACK_ENVIRONMENT=" + StackEnvironment,
 		"-e", "TESTING_ENVIRONMENT=" + StackEnvironment,
-		"-e", "GOFLAGS=-mod=vendor",
+	}
+	if UseVendor {
+		args = append(args, "--env", "GOFLAGS=-mod=vendor")
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -60,6 +60,7 @@ var (
 	XPackDir     = "../x-pack"
 	RaceDetector = false
 	TestCoverage = false
+	UseVendor    = true
 
 	BeatName        = EnvOr("BEAT_NAME", filepath.Base(CWD()))
 	BeatServiceName = EnvOr("BEAT_SERVICE_NAME", BeatName)
@@ -104,6 +105,10 @@ func init() {
 	TestCoverage, err = strconv.ParseBool(EnvOr("TEST_COVERAGE", "false"))
 	if err != nil {
 		panic(errors.Wrap(err, "failed to parse TEST_COVERAGE env value"))
+	}
+	UseVendor, err = strconv.ParseBool(EnvOr("USE_VENDOR", "true"))
+	if err != nil {
+		panic(errors.Wrap(err, "failed to parse USE_VENDOR env value"))
 	}
 
 	Snapshot, err = strconv.ParseBool(EnvOr("SNAPSHOT", "false"))

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -24,6 +24,8 @@ ELASTIC_LICENSE_FILE?=../licenses/ELASTIC-LICENSE.txt
 SECCOMP_BINARY?=${BEAT_NAME}
 SECCOMP_BLACKLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-blacklist.txt
 SECCOMP_ALLOWLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-allow.txt
+USE_VENDOR?=-mod=vendor
+export USE_VENDOR
 MAGE_PRESENT := $(shell command -v mage 2> /dev/null)
 MAGE_IMPORT_PATH?=github.com/magefile/mage
 export MAGE_IMPORT_PATH
@@ -164,7 +166,7 @@ endif
 
 .PHONY: fmt
 fmt: add-headers python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.
-	@go install -mod=vendor $(GOIMPORTS_REPO)
+	@go install ${USE_VENDOR} $(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l -w ${GOFILES_NOVENDOR}
 	@${FIND} -name '*.py' -exec ${PYTHON_ENV}/bin/autopep8 --in-place --max-line-length 120  {} \;
 
@@ -192,9 +194,9 @@ ci:  ## @build Shortcut for continuous integration. This should always run befor
 prepare-tests: update-yacc-vendor
 	mkdir -p ${COVERAGE_DIR}
 	# gotestcover is needed to fetch coverage for multiple packages
-	go install -mod=vendor ${COVERAGE_TOOL_REPO}
+	go install ${USE_VENDOR} ${COVERAGE_TOOL_REPO}
 	# testify is needed for unit and integration tests
-	go install -mod=vendor ${TESTIFY_TOOL_REPO}
+	go install ${USE_VENDOR} ${TESTIFY_TOOL_REPO}
 	# Avoid running yacc to generate a parser for dependency.
 	touch -c ../vendor/github.com/yuin/gopher-lua/parse/parser.go.c
 
@@ -226,7 +228,7 @@ integration-tests-environment: prepare-tests build-image
 	  -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} \
 	  -e TEST_ENVIRONMENT=${TEST_ENVIRONMENT} \
 	  -e BEATS_DOCKER_INTEGRATION_TEST_ENV=${BEATS_DOCKER_INTEGRATION_TEST_ENV} \
-	  -e GOFLAGS=-mod=vendor \
+	  -e GOFLAGS=${USE_VENDOR} \
 	  beat make integration-tests
 
 # Runs the system tests
@@ -245,7 +247,7 @@ system-tests-environment: prepare-tests build-image
 		-e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} \
 		-e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} \
 		-e PYTHON_EXE=${PYTHON_EXE} \
-		-e GOFLAGS=-mod=vendor \
+		-e GOFLAGS=${USE_VENDOR} \
 		beat make system-tests
 
 .PHONY: fast-system-tests
@@ -458,7 +460,7 @@ help_variables: ## @help Show Makefile customizable variables.
 # SECCOMP_BINARY.
 .PHONY: seccomp
 seccomp:
-	@go install -mod=vendor github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler
+	@go install ${USE_VENDOR} github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler
 	@test -f ${SECCOMP_BINARY} || (echo "${SECCOMP_BINARY} binary is not built."; false)
 	seccomp-profiler \
 	-b "$(shell grep -v ^# "${SECCOMP_BLACKLIST}")" \

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -24,8 +24,10 @@ ELASTIC_LICENSE_FILE?=../licenses/ELASTIC-LICENSE.txt
 SECCOMP_BINARY?=${BEAT_NAME}
 SECCOMP_BLACKLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-blacklist.txt
 SECCOMP_ALLOWLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-allow.txt
-USE_VENDOR?=-mod=vendor
-export USE_VENDOR
+INSTALL_FLAG?=-mod=vendor
+INSTALL_CMD?=install ${INSTALL_FLAG}
+export INSTALL_FLAG
+export INSTALL_CMD
 MAGE_PRESENT := $(shell command -v mage 2> /dev/null)
 MAGE_IMPORT_PATH?=github.com/magefile/mage
 export MAGE_IMPORT_PATH
@@ -166,7 +168,7 @@ endif
 
 .PHONY: fmt
 fmt: add-headers python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.
-	@go install ${USE_VENDOR} $(GOIMPORTS_REPO)
+	@go ${INSTALL_CMD} $(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l -w ${GOFILES_NOVENDOR}
 	@${FIND} -name '*.py' -exec ${PYTHON_ENV}/bin/autopep8 --in-place --max-line-length 120  {} \;
 
@@ -194,9 +196,9 @@ ci:  ## @build Shortcut for continuous integration. This should always run befor
 prepare-tests: update-yacc-vendor
 	mkdir -p ${COVERAGE_DIR}
 	# gotestcover is needed to fetch coverage for multiple packages
-	go install ${USE_VENDOR} ${COVERAGE_TOOL_REPO}
+	go ${INSTALL_CMD} ${COVERAGE_TOOL_REPO}
 	# testify is needed for unit and integration tests
-	go install ${USE_VENDOR} ${TESTIFY_TOOL_REPO}
+	go ${INSTALL_CMD} ${TESTIFY_TOOL_REPO}
 	# Avoid running yacc to generate a parser for dependency.
 	touch -c ../vendor/github.com/yuin/gopher-lua/parse/parser.go.c
 
@@ -228,7 +230,7 @@ integration-tests-environment: prepare-tests build-image
 	  -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} \
 	  -e TEST_ENVIRONMENT=${TEST_ENVIRONMENT} \
 	  -e BEATS_DOCKER_INTEGRATION_TEST_ENV=${BEATS_DOCKER_INTEGRATION_TEST_ENV} \
-	  -e GOFLAGS=${USE_VENDOR} \
+	  -e GOFLAGS=${INSTALL_FLAG} \
 	  beat make integration-tests
 
 # Runs the system tests
@@ -247,7 +249,7 @@ system-tests-environment: prepare-tests build-image
 		-e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} \
 		-e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} \
 		-e PYTHON_EXE=${PYTHON_EXE} \
-		-e GOFLAGS=${USE_VENDOR} \
+		-e GOFLAGS=${INSTALL_FLAG} \
 		beat make system-tests
 
 .PHONY: fast-system-tests
@@ -460,7 +462,7 @@ help_variables: ## @help Show Makefile customizable variables.
 # SECCOMP_BINARY.
 .PHONY: seccomp
 seccomp:
-	@go install ${USE_VENDOR} github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler
+	@go ${INSTALL_CMD} github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler
 	@test -f ${SECCOMP_BINARY} || (echo "${SECCOMP_BINARY} binary is not built."; false)
 	seccomp-profiler \
 	-b "$(shell grep -v ^# "${SECCOMP_BLACKLIST}")" \

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -74,9 +74,9 @@ test-module: python-env update metricbeat.test
 
 .PHONY: assets
 assets:
-	go run -mod=vendor ${ES_BEATS}/metricbeat/scripts/assets/assets.go ${ES_BEATS}/metricbeat/module
+	go run ${USE_VENDOR} ${ES_BEATS}/metricbeat/scripts/assets/assets.go ${ES_BEATS}/metricbeat/module
 	mkdir -p include/fields
-	go run -mod=vendor ${ES_BEATS}/libbeat/scripts/cmd/global_fields/main.go -es_beats_path ${ES_BEATS} -beat_path ${PWD} | go run  ${ES_BEATS}/dev-tools/cmd/asset/asset.go -license ${LICENSE} -out ./include/fields/fields.go -pkg include -priority asset.LibbeatFieldsPri ${ES_BEATS}/libbeat/fields.yml $(BEAT_NAME)
+	go run ${USE_VENDOR} ${ES_BEATS}/libbeat/scripts/cmd/global_fields/main.go -es_beats_path ${ES_BEATS} -beat_path ${PWD} | go run  ${ES_BEATS}/dev-tools/cmd/asset/asset.go -license ${LICENSE} -out ./include/fields/fields.go -pkg include -priority asset.LibbeatFieldsPri ${ES_BEATS}/libbeat/fields.yml $(BEAT_NAME)
 
 .PHONY: integration-tests
 integration-tests: ## @testing Run golang integration tests.

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -74,9 +74,9 @@ test-module: python-env update metricbeat.test
 
 .PHONY: assets
 assets:
-	go run ${USE_VENDOR} ${ES_BEATS}/metricbeat/scripts/assets/assets.go ${ES_BEATS}/metricbeat/module
+	go run ${INSTALL_FLAG} ${ES_BEATS}/metricbeat/scripts/assets/assets.go ${ES_BEATS}/metricbeat/module
 	mkdir -p include/fields
-	go run ${USE_VENDOR} ${ES_BEATS}/libbeat/scripts/cmd/global_fields/main.go -es_beats_path ${ES_BEATS} -beat_path ${PWD} | go run  ${ES_BEATS}/dev-tools/cmd/asset/asset.go -license ${LICENSE} -out ./include/fields/fields.go -pkg include -priority asset.LibbeatFieldsPri ${ES_BEATS}/libbeat/fields.yml $(BEAT_NAME)
+	go run ${INSTALL_FLAG} ${ES_BEATS}/libbeat/scripts/cmd/global_fields/main.go -es_beats_path ${ES_BEATS} -beat_path ${PWD} | go run  ${ES_BEATS}/dev-tools/cmd/asset/asset.go -license ${LICENSE} -out ./include/fields/fields.go -pkg include -priority asset.LibbeatFieldsPri ${ES_BEATS}/libbeat/fields.yml $(BEAT_NAME)
 
 .PHONY: integration-tests
 integration-tests: ## @testing Run golang integration tests.

--- a/metricbeat/scripts/mage/docs_collector.go
+++ b/metricbeat/scripts/mage/docs_collector.go
@@ -146,8 +146,12 @@ func getDefaultMetricsets() (map[string][]string, error) {
 		return masterMap, nil
 	}
 
+	cmd := []string{"run"}
+	if mage.UseVendor {
+		cmd = append(cmd, "-mod", "vendor")
+	}
 	for _, dir := range runpaths {
-		rawMap, err := sh.OutCmd("go", "run", "-mod", "vendor", dir)()
+		rawMap, err := sh.OutCmd("go", append(cmd, dir)...)()
 		if err != nil {
 			return nil, errors.Wrap(err, "Error running subcommand to get metricsets")
 		}


### PR DESCRIPTION
## What does this PR do?

This PR introduces two new Makefile variables and a mage option. These options let people configure the way go installs dependencies.

Two new options for `Makefile` from `libbeat/scripts/Makefile`:
1. `INSTALL_FLAG`: This is passed to the `GOFLAGS` of docker envs. It is set to `-mod=vendor`. If you want to avoid using the vendor folder, just leave it blank.
2. `INSTALL_CMD`: This is the command to run when installing dependencies. It is set to `install ${INSTALL_FLAG}`. To use the local module cache, change it to `get`.

New option for `mage` is called `UseVendor`. By default it is set to `true`. If one sets it to `false`, mage uses the modules from the local module cache instead of the vendor folder.

## Why is it important?

`apm-server` decided to not use vendor folder. Until we support Go 1.14, we have to explicitly tell `go` to use the vendor folder. From Go 1.14, `go` will use the local vendor folder automatically if present. So when we migrate these options are going to be removed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works