### PR TITLE
Follow-up return value change in Winlogbeat

### DIFF
--- a/winlogbeat/sys/eventlogging/eventlogging_windows.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows.go
@@ -413,11 +413,10 @@ func parseSID(record eventLogRecord, buffer []byte) (*sys.SID, error) {
 	}
 
 	sid := (*windows.SID)(unsafe.Pointer(&buffer[record.userSidOffset]))
-	identifier, err := sid.String()
-	if err != nil {
-		return nil, err
+	identifier := sid.String()
+	if identifier == "" {
+		return nil, fmt.Errorf("unable to convert SID to string: %v", sid)
 	}
-
 	return &sys.SID{Identifier: identifier}, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

`golang.org/x/sys` was updated which contained a breaking change. This PR fixes the code to return correct number of values.

```
# github.com/elastic/beats/v7/winlogbeat/sys/eventlogging
sys/eventlogging/eventlogging_windows.go:416:18: assignment mismatch: 2 variables but sid.String returns 1 values
make: *** [crosscompile] Error 1
```

## Why is it important?

The issue prevents winlogbeat from being compiled on Windows.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works