### PR TITLE
Bug with DeviceIoControl function call on Windows

### DIFF
--- a/metricbeat/module/system/diskio/diskstat_windows_helper.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_helper.go
@@ -65,6 +65,7 @@ type diskPerformance struct {
 	QueryTime           int64
 	StorageDeviceNumber uint32
 	StorageManagerName  [8]uint16
+	AlignmentPadding    uint32
 }
 
 // ioCounters gets the diskio counters and maps them to the list of counterstat objects.


### PR DESCRIPTION
## What does this PR do?
PR is fixing issue with DISKIO ioCounter function, as it is constantly failing with error "The parameter is incorrect" during DeviceIoControl call on Windows environment.

Issue is reproducible on both Windows 7/ Windows 10 x32/x64. Other Windows platforms are not tested.

Changed:
- Added padding to diskPerformance structure to make it aligned with WinAPI DISK_PERFORMANCE structure. GoLang is not performing alignment and pass structure as is (84 bytes), but WinAPI DeviceIoControl expects aligned structure(88 bytes)

## Why is it important?
Currently DiskIO functionality for ioCounter is not working, and produce a lot of errors during run.

## Checklist
- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

## How to test this PR locally
Run metricbeats service and configure it to get DiskIO counters. Check if no error occurs and returned data is valid

## Related issues

## Use cases

## Screenshots

## Logs
