### PR TITLE
Kafka module: query each broker all the partitions it is a leader for

### DIFF
--- a/metricbeat/module/kafka/consumergroup/consumergroup.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup.go
@@ -49,7 +49,7 @@ type groupAssignment struct {
 	clientHost string
 }
 
-var debugf = logp.MakeDebug("kafka")
+var log = logp.NewLogger("kafka")
 
 // New creates a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {

--- a/metricbeat/module/kafka/consumergroup/query.go
+++ b/metricbeat/module/kafka/consumergroup/query.go
@@ -53,7 +53,7 @@ func fetchGroupInfo(
 		return nil
 	}
 
-	debugf("known consumer groups: ", groups)
+	log.Debugf("known consumer groups: ", groups)
 
 	assignments, err := fetchGroupAssignments(b, groups)
 	if err != nil {

--- a/metricbeat/module/kafka/kafka.go
+++ b/metricbeat/module/kafka/kafka.go
@@ -20,3 +20,5 @@ package kafka
 import "github.com/elastic/beats/libbeat/logp"
 
 var debugf = logp.MakeDebug("kafka")
+
+var log = logp.NewLogger("kafka")

--- a/metricbeat/module/kafka/kafka.go
+++ b/metricbeat/module/kafka/kafka.go
@@ -19,6 +19,4 @@ package kafka
 
 import "github.com/elastic/beats/libbeat/logp"
 
-var debugf = logp.MakeDebug("kafka")
-
 var log = logp.NewLogger("kafka")

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -175,18 +175,15 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	return nil
 }
 
-func (m *MetricSet) selectPartitionOffsets(topicPartitionPartitionOffsets map[string]map[int32]*kafka.PartitionOffsets,
-	topic *sarama.TopicMetadata, partition *sarama.PartitionMetadata) (*kafka.PartitionOffsets, error) {
-	offsets := topicPartitionPartitionOffsets[topic.Name][partition.ID]
-	if offsets == nil {
-		err := fmt.Errorf("no partition offsets defined (%v:%v)", topic.Name, partition.ID)
-		return nil, err
-	} else if offsets.Err != nil {
-		err := fmt.Errorf("failed to query kafka partition (%v:%v) offsets: %v",
+func (m *MetricSet) selectPartitionOffsets(topicPartitionPartitionOffsets map[string]map[int32]kafka.PartitionOffsets,
+	topic *sarama.TopicMetadata, partition *sarama.PartitionMetadata) (offsets kafka.PartitionOffsets, err error) {
+	offsets = topicPartitionPartitionOffsets[topic.Name][partition.ID]
+	if offsets.Err != nil {
+		err = fmt.Errorf("failed to query kafka partition (%v:%v) offsets: %v",
 			topic.Name, partition.ID, offsets.Err)
-		return nil, err
+		return
 	}
-	return offsets, nil
+	return
 }
 
 func (m *MetricSet) reportPartitionOffsetsError(r mb.ReporterV2, err error) {

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// build integration
+// +build integration
 
 package partition
 

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build integration
+// build integration
 
 package partition
 


### PR DESCRIPTION
This PR addresses issue reported in https://github.com/elastic/beats/issues/13380 .

Briefly - for the partition metricset:
1. Get topics metadata
2. Group partitions per leader broker
3. Query each broker all the partitions it is a leader for

Meta-issue: https://github.com/elastic/beats/issues/14852