### PR TITLE
Allowing users to override pipeline ID in fileset input config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -160,6 +160,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `cloudfoundry` input to send events from Cloud Foundry. {pull}16586[16586]
 - Improve ECS categorization field mappings in iis module. {issue}16165[16165] {pull}16618[16618]
 - Improve ECS categorization field mapping in kafka module. {issue}16167[16167] {pull}16645[16645]
+- Allow users to override pipeline ID in fileset input config. {issue}9531[9531] {pull}16561[16561]
 
 *Heartbeat*
 

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -363,14 +363,15 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 		}
 	}
 
-	// force our pipeline ID
-	rootPipelineID := ""
-	if len(fs.pipelineIDs) > 0 {
-		rootPipelineID = fs.pipelineIDs[0]
-	}
-	err = cfg.SetString("pipeline", -1, rootPipelineID)
-	if err != nil {
-		return nil, fmt.Errorf("Error setting the pipeline ID in the input config: %v", err)
+	const pipelineField = "pipeline"
+	if !cfg.HasField(pipelineField) {
+		rootPipelineID := ""
+		if len(fs.pipelineIDs) > 0 {
+			rootPipelineID = fs.pipelineIDs[0]
+		}
+		if err := cfg.SetString(pipelineField, -1, rootPipelineID); err != nil {
+			return nil, errw.Wrap(err, "error setting the fileset pipeline ID in config")
+		}
 	}
 
 	// force our the module/fileset name

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -222,7 +222,6 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 					t.FailNow()
 				}
 
-				require.True(t, c.HasField("pipeline"))
 				v, err := c.String("pipeline", -1)
 				require.NoError(t, err)
 				require.Equal(t, "foobar", v)

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -185,33 +187,76 @@ func TestGetInputConfigNginx(t *testing.T) {
 func TestGetInputConfigNginxOverrides(t *testing.T) {
 	modulesPath, err := filepath.Abs("../module")
 	assert.NoError(t, err)
-	fs, err := New(modulesPath, "access", &ModuleConfig{Module: "nginx"}, &FilesetConfig{
-		Input: map[string]interface{}{
-			"close_eof": true,
+
+	tests := map[string]struct {
+		input      map[string]interface{}
+		expectedFn require.ValueAssertionFunc
+	}{
+		"close_eof": {
+			map[string]interface{}{
+				"close_eof": true,
+			},
+			func(t require.TestingT, cfg interface{}, rest ...interface{}) {
+				c, ok := cfg.(*common.Config)
+				if !ok {
+					t.FailNow()
+				}
+
+				require.True(t, c.HasField("close_eof"))
+				v, err := c.Bool("close_eof", -1)
+				require.NoError(t, err)
+				require.True(t, v)
+
+				pipelineID, err := c.String("pipeline", -1)
+				assert.NoError(t, err)
+				assert.Equal(t, "filebeat-5.2.0-nginx-access-default", pipelineID)
+			},
 		},
-	})
-	assert.NoError(t, err)
+		"pipeline": {
+			map[string]interface{}{
+				"pipeline": "foobar",
+			},
+			func(t require.TestingT, cfg interface{}, rest ...interface{}) {
+				c, ok := cfg.(*common.Config)
+				if !ok {
+					t.FailNow()
+				}
 
-	assert.NoError(t, fs.Read("5.2.0"))
+				require.True(t, c.HasField("pipeline"))
+				v, err := c.String("pipeline", -1)
+				require.NoError(t, err)
+				require.Equal(t, "foobar", v)
+			},
+		},
+	}
 
-	cfg, err := fs.getInputConfig()
-	assert.NoError(t, err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fs, err := New(modulesPath, "access", &ModuleConfig{Module: "nginx"}, &FilesetConfig{
+				Input: test.input,
+			})
+			assert.NoError(t, err)
 
-	assert.True(t, cfg.HasField("paths"))
-	assert.True(t, cfg.HasField("exclude_files"))
-	assert.True(t, cfg.HasField("close_eof"))
-	assert.True(t, cfg.HasField("pipeline"))
-	pipelineID, err := cfg.String("pipeline", -1)
-	assert.NoError(t, err)
-	assert.Equal(t, "filebeat-5.2.0-nginx-access-default", pipelineID)
+			assert.NoError(t, fs.Read("5.2.0"))
 
-	moduleName, err := cfg.String("_module_name", -1)
-	assert.NoError(t, err)
-	assert.Equal(t, "nginx", moduleName)
+			cfg, err := fs.getInputConfig()
+			assert.NoError(t, err)
 
-	filesetName, err := cfg.String("_fileset_name", -1)
-	assert.NoError(t, err)
-	assert.Equal(t, "access", filesetName)
+			assert.True(t, cfg.HasField("paths"))
+			assert.True(t, cfg.HasField("exclude_files"))
+			assert.True(t, cfg.HasField("pipeline"))
+
+			test.expectedFn(t, cfg)
+
+			moduleName, err := cfg.String("_module_name", -1)
+			assert.NoError(t, err)
+			assert.Equal(t, "nginx", moduleName)
+
+			filesetName, err := cfg.String("_fileset_name", -1)
+			assert.NoError(t, err)
+			assert.Equal(t, "access", filesetName)
+		})
+	}
 }
 
 func TestGetPipelineNginx(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR allows users to override the ingest pipeline for a fileset with their custom one. To do this, users must specify the `pipeline` configuration option (common to all Filebeat inputs) in their fileset configuration's `input` section. For example:

```yaml
- module: nginx
  # Access logs
  access:
    enabled: true
    input:
      pipeline: my-custom-pipeline
```

## Why is it important?

Allows users to perform custom processing instead of the default processing provided by the ingest pipelines that come out-of-the-box with module filesets.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->
- Closes #9531.

## Use cases

See https://discuss.elastic.co/t/filebeat-cannot-change-pipeline-in-nginx-module/219360.
