### PR TITLE
[docs] Restructure module docs

### DIFF
--- a/filebeat/docs/include/gs-link.asciidoc
+++ b/filebeat/docs/include/gs-link.asciidoc
@@ -1,0 +1,2 @@
+TIP: Read the <<filebeat-modules-quickstart,quick start>> to learn how to set up and
+run modules.

--- a/filebeat/docs/modules/activemq.asciidoc
+++ b/filebeat/docs/modules/activemq.asciidoc
@@ -16,12 +16,12 @@ This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The module has been tested with ActiveMQ 5.13.0 and 5.15.9. Other versions are expected to work.
-
-include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/apache.asciidoc
+++ b/filebeat/docs/modules/apache.asciidoc
@@ -13,9 +13,7 @@ https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
-New to {beatname_uc} modules? Read the
-<<filebeat-modules-quickstart,quick start>> to learn how to setup and run
-modules.
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility
@@ -80,7 +78,6 @@ Add %v config in httpd.conf in log section
     LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 -----
 
-ifndef::hide_for_obs[]
 [float]
 === Example dashboard
 
@@ -88,8 +85,6 @@ This module comes with a sample dashboard. For example:
 
 [role="screenshot"]
 image::./images/kibana-apache.png[]
-
-endif::[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/apache.asciidoc
+++ b/filebeat/docs/modules/apache.asciidoc
@@ -13,6 +13,10 @@ https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
+New to {beatname_uc} modules? Read the
+<<filebeat-modules-quickstart,quick start>> to learn how to setup and run
+modules.
+
 [float]
 === Compatibility
 
@@ -20,16 +24,6 @@ The +{modulename}+ module was tested with logs from versions 2.2.22 and 2.4.23.
 
 On Windows, the module was tested with Apache HTTP Server installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-apache.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -85,6 +79,17 @@ Add %v config in httpd.conf in log section
     # By
     LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 -----
+
+ifndef::hide_for_obs[]
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-apache.png[]
+
+endif::[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -13,6 +13,8 @@ The +{modulename}+ module collects and parses logs from the audit daemon
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -20,18 +22,6 @@ The +{modulename}+ module was tested with logs from `auditd` on OSes like CentOS
 6 and CentOS 7.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing an overview of the audit log
-data. You can build more specific dashboards that are tailored to the audit
-rules that you use on your systems.
-
-[role="screenshot"]
-image::./images/kibana-audit-auditd.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -66,6 +56,16 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing an overview of the audit log
+data. You can build more specific dashboards that are tailored to the audit
+rules that you use on your systems.
+
+[role="screenshot"]
+image::./images/kibana-audit-auditd.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -23,6 +23,8 @@ from network interfaces in AWS VPC. ELB access logs captures detailed informatio
 about requests sent to the load balancer. CloudTrail logs contain events
 that represent actions taken by a user, role or AWS service.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Module configuration
 

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -8,20 +8,18 @@ This file is generated! See scripts/docs_collector.py
 :modulename: azure
 :has-dashboards: false
 
-== azure module
+== Azure module
 
 beta[]
 
-This is the azure module.
-
-The azure module will concentrate on retrieving different types of log data from Azure.
+The azure module retrieves different types of log data from Azure.
 There are several requirements before using the module since the logs will actually be read from azure event hubs.
 
    - the logs have to be exported first to the event hubs https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create-kafka-enabled
    - to export activity logs to event hubs users can follow the steps here https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log-export
    - to export audit and sign-in logs to event hubs users can follow the steps here https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/tutorial-azure-monitor-stream-logs-to-event-hub
 
-The module will contain the following filesets:
+The module contains the following filesets:
 
 `activitylogs` ::
 Will retrieve azure activity logs. Control-plane events on Azure Resource Manager resources. Activity logs provide insight into the operations that were performed on resources in your subscription.
@@ -31,14 +29,6 @@ Will retrieve azure Active Directory sign-in logs. The sign-ins report provides 
 
 `auditlogs` ::
 Will retrieve azure Active Directory audit logs. The audit logs provide traceability through logs for all changes done by various features within Azure AD. Examples of audit logs include changes made to any resources within Azure AD like adding or removing users, apps, groups, roles and policies.
-
-[float]
-=== Dashboards
-
-The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:
-
-image::./images/filebeat-azure-overview.png[]
-
 
 [float]
 === Module configuration
@@ -100,13 +90,21 @@ The name of the storage account the state/offsets will be stored and updated.
 _string_
 The storage account key, this key will be used to authorize access to data in your storage account.
 
-
 include::../include/what-happens.asciidoc[]
+
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility
 
 TODO: document with what versions of the software is this tested
+
+[float]
+=== Dashboards
+
+The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:
+
+image::./images/filebeat-azure-overview.png[]
 
 
 

--- a/filebeat/docs/modules/cef.asciidoc
+++ b/filebeat/docs/modules/cef.asciidoc
@@ -18,7 +18,7 @@ encoded data. The decoded data is written into a `cef` object field. Lastly any
 Elastic Common Schema (ECS) fields that can be populated with the CEF data are
 populated.
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -34,15 +34,7 @@ Check the <<dynamic-script-compilations>> section for more information.
 
 include::../include/what-happens.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard for ASA:
-
-[role="screenshot"]
-image::./images/kibana-cisco-asa.png[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -304,6 +296,14 @@ on your cluster:
 
 - {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
   Increase to at least `200` if using both filesets or other script-heavy modules.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard for ASA:
+
+[role="screenshot"]
+image::./images/kibana-cisco-asa.png[]
 
 :modulename!:
 

--- a/filebeat/docs/modules/coredns.asciidoc
+++ b/filebeat/docs/modules/coredns.asciidoc
@@ -13,19 +13,19 @@ This file is generated! See scripts/docs_collector.py
 This is a filebeat module for CoreDNS. It supports both standalone CoreDNS deployment and
 CoreDNS deployment in Kubernetes.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 Although this module has been developed against Kubernetes v1.13.x, it is expected to work
 with other versions of Kubernetes.
 
-[float]
-=== Example dashboard
+include::../include/configuring-intro.asciidoc[]
 
-This module comes with a sample dashboard.
+:fileset_ex: log
 
-[role="screenshot"]
-image::./images/kibana-coredns.jpg[]
+include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
@@ -46,6 +46,14 @@ include::../include/var-paths.asciidoc[]
 *`var.tags`*::
 
 An array of tags describing the monitored CoreDNS setup.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard.
+
+[role="screenshot"]
+image::./images/kibana-coredns.jpg[]
 
 
 [float]

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -14,14 +14,12 @@ This is the elasticsearch module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The Elasticsearch module is compatible with Elasticsearch 6.2 and newer.
-
-
-include::../include/running-modules.asciidoc[]
-
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/envoyproxy.asciidoc
+++ b/filebeat/docs/modules/envoyproxy.asciidoc
@@ -10,7 +10,9 @@ This file is generated! See scripts/docs_collector.py
 
 == Envoyproxy Module
 
-This is a filebeat module for Envoy proxy access log (https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log). It supports both standalone deployment and Envoy proxy deployment in Kubernetes. 
+This is a Filebeat module for Envoy proxy access log (https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log). It supports both standalone deployment and Envoy proxy deployment in Kubernetes. 
+
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility

--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -18,7 +18,7 @@ Google Pub/Sub topic sink.
 
 include::../include/what-happens.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/haproxy.asciidoc
+++ b/filebeat/docs/modules/haproxy.asciidoc
@@ -12,23 +12,14 @@ The +{modulename}+ module collects and parses logs from a (`haproxy`) process.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from `haproxy` running on AWS Linux as a gateway to a cluster of microservices.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing geolocation, distribution of requests between backends and frontends,
-and status codes over time. For example:
-
-[role="screenshot"]
-image::./images/kibana-haproxy-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -55,6 +46,15 @@ include::../include/config-option-intro.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing geolocation, distribution of requests between backends and frontends,
+and status codes over time. For example:
+
+[role="screenshot"]
+image::./images/kibana-haproxy-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/ibmmq.asciidoc
+++ b/filebeat/docs/modules/ibmmq.asciidoc
@@ -13,24 +13,14 @@ The `ibmmq` module collects and parses the queue manager error logs from IBM MQ 
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 This module has been tested with IBM MQ v9.1.0.0, but it should be compatible with older versions.
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/filebeat-ibmmq.png[]
-
-
 include::../include/configuring-intro.asciidoc[]
-
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
 file to override the default paths for IBM MQ errorlog:
@@ -42,6 +32,7 @@ file to override the default paths for IBM MQ errorlog:
     enabled: true
     var.paths: ["C:/ibmmq/logs/*.log"]
 -----
+
 :fileset_ex: errorlog
 
 include::../include/config-option-intro.asciidoc[]
@@ -50,6 +41,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `errorlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/filebeat-ibmmq.png[]
 
 :fileset_ex!:
 

--- a/filebeat/docs/modules/icinga.asciidoc
+++ b/filebeat/docs/modules/icinga.asciidoc
@@ -13,6 +13,8 @@ https://www.icinga.com/products/icinga-2/[Icinga].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -20,16 +22,6 @@ The +{modulename}+ module was tested with Icinga >= 2.x on various Linux and Win
 systems.
 
 This module is not available for macOS.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-icinga-main.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -80,6 +72,14 @@ include::../include/var-paths.asciidoc[]
 ==== `startup` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-icinga-main.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -13,20 +13,12 @@ Internet Information Services (IIS) HTTP server.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The IIS module was tested with logs from version 7.5 and version 10.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-iis.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -66,6 +58,14 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-iis.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -25,21 +25,7 @@ When you run the module, it performs a few tasks under the hood:
 
 * Deploys dashboards for visualizing the log data.
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards showing geolocation and network
-protocols used. One for all iptables logs:
-
-[role="screenshot"]
-image::./images/kibana-iptables.png[]
-
-and one specific for Ubiquiti Firewall logs:
-
-[role="screenshot"]
-image::./images/kibana-iptables-ubiquiti.png[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -76,6 +62,20 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 NOTE: Ports below 1024 require Filebeat to run as root.
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards showing geolocation and network
+protocols used. One for all iptables logs:
+
+[role="screenshot"]
+image::./images/kibana-iptables.png[]
+
+and one specific for Ubiquiti Firewall logs:
+
+[role="screenshot"]
+image::./images/kibana-iptables-ubiquiti.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -13,20 +13,12 @@ https://kafka.apache.org/[Kafka].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions 0.9, 1.1.0 and 2.0.0.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard to see Kafka logs and stack traces.
-
-[role="screenshot"]
-image::./images/filebeat-kafka-logs-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -78,6 +70,14 @@ The path to your Kafka installation. The default is `/opt`. For example:
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard to see Kafka logs and stack traces.
+
+[role="screenshot"]
+image::./images/filebeat-kafka-logs-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/kibana.asciidoc
+++ b/filebeat/docs/modules/kibana.asciidoc
@@ -14,13 +14,12 @@ This is the Kibana module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The Kibana modules is compatible with Kibana 6.3 and newer.
-
-include::../include/running-modules.asciidoc[]
-
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -13,6 +13,8 @@ and the JSON format (--log.format json). The default is the plain text format.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 The +{modulename}+ module has two filesets:
 
 * The `log` fileset collects and parses the logs that Logstash writes to disk.
@@ -28,19 +30,6 @@ For the `slowlog` fileset, make sure to configure the
 The Logstash `log` fileset was tested with logs from Logstash 5.6 and 6.0.
 
 The Logstash `slowlog` fileset was tested with logs from Logstash 5.6 and 6.0
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-===  Example dashboards
-
-This module comes with two sample dashboards.
-
-[role="screenshot"]
-image::./images/kibana-logstash-log.png[]
-
-[role="screenshot"]
-image::./images/kibana-logstash-slowlog.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -95,6 +84,17 @@ The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+===  Example dashboards
+
+This module comes with two sample dashboards.
+
+[role="screenshot"]
+image::./images/kibana-logstash-log.png[]
+
+[role="screenshot"]
+image::./images/kibana-logstash-slowlog.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/misp.asciidoc
+++ b/filebeat/docs/modules/misp.asciidoc
@@ -19,6 +19,8 @@ The configuration in the config.yml file uses the following format:
  * var.api_key: specifies the API key to access MISP.
  * var.json_objects_array: specifies the array object in MISP response, e.g., "response.Attribute".
  * var.url: URL of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
+ 
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Example dashboard

--- a/filebeat/docs/modules/mongodb.asciidoc
+++ b/filebeat/docs/modules/mongodb.asciidoc
@@ -13,20 +13,12 @@ https://www.mongodb.com/[MongoDB].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions v3.2.11 on Debian.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with one sample dashboard including error and regular logs.
-
-[role="screenshot"]
-image::./images/filebeat-mongodb-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -60,6 +52,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with one sample dashboard including error and regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-mongodb-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -12,10 +12,10 @@ The +{modulename}+ module parses error logs created by MSSQL.
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
+include::../include/gs-link.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
+//[float]
+//=== Compatibility
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -13,6 +13,8 @@ created by https://www.mysql.com/[MySQL].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -21,16 +23,6 @@ MariaDB 10.1, 10.2 and 10.3, and Percona 5.7 and 8.0.
 
 On Windows, the module was tested with MySQL installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-mysql.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -72,6 +64,14 @@ include::../include/var-paths.asciidoc[]
 ==== `slowlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-mysql.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/nats.asciidoc
+++ b/filebeat/docs/modules/nats.asciidoc
@@ -12,21 +12,12 @@ This is the nats module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from version v1.4.0.
-
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Dashboard
-
-The Nats module comes with a predefined dashboard. For example:
-
-image::./images/filebeat_nats_dashboard.png[]
-
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -40,6 +31,13 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Dashboard
+
+The Nats module comes with a predefined dashboard. For example:
+
+image::./images/filebeat_nats_dashboard.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -18,7 +18,7 @@ This module wraps the <<filebeat-input-netflow,netflow input>> to enrich the
 flow records with geolocation information about the IP endpoints by using
 Elasticsearch Ingest Node.
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -14,6 +14,8 @@ http://nginx.org/[Nginx] HTTP server.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -21,16 +23,6 @@ The Nginx module was tested with logs from version 1.10.
 
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-nginx.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -75,6 +67,14 @@ include::../include/var-paths.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-nginx.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -16,6 +16,8 @@ driver (the default). Make sure UTC timestamps are enabled.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Compatibility
@@ -25,16 +27,6 @@ Since the results are written in the JSON format, it is likely that this module
 works with any version of osquery.
 
 This module is available on Linux, macOS, and Windows.
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard for visualizing the data collected by
-the "compliance" pack. To collect this data, enable the `id-compliance` pack in
-the osquery configuration file.
-
-[role="screenshot"]
-image::./images/kibana-osquery-compatibility.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -73,6 +65,16 @@ Set to false to copy the fields in the root of the document. If enabled, this
 setting also disables the renaming of some fields (e.g. `hostIdentifier` to
 `host_identifier`).  Note that if you set this to false, the sample dashboards
 coming with this module won't work correctly. The default is true.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard for visualizing the data collected by
+the "compliance" pack. To collect this data, enable the `id-compliance` pack in
+the osquery configuration file.
+
+[role="screenshot"]
+image::./images/kibana-osquery-compatibility.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -14,6 +14,8 @@ This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -23,7 +25,50 @@ versions 7.1 to 9.0 but limited compatibility is expected for earlier versions.
 The {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugin is required to run this module.
 
-include::../include/running-modules.asciidoc[]
+include::../include/configuring-intro.asciidoc[]
+
+The module is by default configured to run via syslog on port 9001. However
+it can also be configured to read logs from a file. See the following example.
+
+["source","yaml",subs="attributes"]
+-----
+- module: panw
+  panos:
+    enabled: true
+    var.paths: ["/var/log/pan-os.log"]
+    var.input: "file"
+-----
+
+:fileset_ex: panos
+
+include::../include/config-option-intro.asciidoc[]
+
+[float]
+==== `panos` fileset settings
+
+Example config:
+
+[source,yaml]
+----
+  panos:
+    var.syslog_host: 0.0.0.0
+    var.syslog_port: 514
+----
+
+include::../include/var-paths.asciidoc[]
+
+*`var.syslog_host`*::
+
+The interface to listen to UDP based syslog traffic. Defaults to `localhost`.
+Set to `0.0.0.0` to bind to all available interfaces.
+
+*`var.syslog_port`*::
+
+The UDP port to listen for syslog traffic. Defaults to `9001`
+
+NOTE: Ports below 1024 require {beatname_uc} to run as root.
+
+include::../include/timezone-support.asciidoc[]
 
 [float]
 === ECS field mappings
@@ -131,51 +176,6 @@ image::./images/filebeat-panw-traffic.png[]
 
 [role="screenshot"]
 image::./images/filebeat-panw-threat.png[]
-
-include::../include/configuring-intro.asciidoc[]
-
-The module is by default configured to run via syslog on port 9001. However
-it can also be configured to read logs from a file. See the following example.
-
-["source","yaml",subs="attributes"]
------
-- module: panw
-  panos:
-    enabled: true
-    var.paths: ["/var/log/pan-os.log"]
-    var.input: "file"
------
-
-:fileset_ex: panos
-
-include::../include/config-option-intro.asciidoc[]
-
-[float]
-==== `panos` fileset settings
-
-Example config:
-
-[source,yaml]
-----
-  panos:
-    var.syslog_host: 0.0.0.0
-    var.syslog_port: 514
-----
-
-include::../include/var-paths.asciidoc[]
-
-*`var.syslog_host`*::
-
-The interface to listen to UDP based syslog traffic. Defaults to `localhost`.
-Set to `0.0.0.0` to bind to all available interfaces.
-
-*`var.syslog_port`*::
-
-The UDP port to listen for syslog traffic. Defaults to `9001`
-
-NOTE: Ports below 1024 require {beatname_uc} to run as root.
-
-include::../include/timezone-support.asciidoc[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -13,28 +13,13 @@ https://www.postgresql.org/[PostgreSQL].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions 9.5 on Ubuntu and 9.6
 on Debian.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with two sample dashboards.
-
-The first dashboard is for regular logs.
-
-[role="screenshot"]
-image::./images/filebeat-postgresql-overview.png[]
-
-The second one shows the slowlogs of PostgreSQL.
-
-[role="screenshot"]
-image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -69,6 +54,20 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+=== Example dashboards
+
+This module comes with two sample dashboards.
+
+The first dashboard is for regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-overview.png[]
+
+The second one shows the slowlogs of PostgreSQL.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/rabbitmq.asciidoc
+++ b/filebeat/docs/modules/rabbitmq.asciidoc
@@ -12,14 +12,14 @@ This is the module for parsing https://www.rabbitmq.com/logging.html[RabbitMQ lo
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 Parses https://www.rabbitmq.com/logging.html[single file format] introduced in 3.7.0.
 
 Tested with version 3.7.14.
-
-include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -13,6 +13,8 @@ https://redis.io/[Redis].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 The +{modulename}+ module has two filesets:
 
 * The `log` fileset collects and parses the logs that Redis writes to disk.  
@@ -35,16 +37,6 @@ On Windows, the default paths assume that Redis was installed from the Chocolate
 
 The Redis `slowlog` fileset was tested with Redis 3.0.2 and 2.4.6. We expect compatibility with any
 Redis version newer than 2.2.12, when the SLOWLOG command was added.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-redis.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -97,6 +89,14 @@ left empty, `localhost:6379` is assumed.
 
 The password to use to connect to Redis, in case Redis authentication is enabled
 (the `requirepass` option in the Redis configuration).
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-redis.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/santa.asciidoc
+++ b/filebeat/docs/modules/santa.asciidoc
@@ -15,23 +15,14 @@ binaries.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from Santa 0.9.14.
 
 This module is available for MacOS only.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing and overview of the processes
-that are executing.
-
-[role="screenshot"]
-image::./images/kibana-santa-log-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -55,6 +46,15 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing and overview of the processes
+that are executing.
+
+[role="screenshot"]
+image::./images/kibana-santa-log-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -16,24 +16,13 @@ Suricata Eve JSON format].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 This module has been developed against Suricata v4.0.4, but is expected to work
 with other versions of Suricata.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/filebeat-suricata-events.png[]
-
-[role="screenshot"]
-image::./images/filebeat-suricata-alerts.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -55,6 +44,17 @@ include::../include/config-option-intro.asciidoc[]
 ==== `eve` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/filebeat-suricata-events.png[]
+
+[role="screenshot"]
+image::./images/filebeat-suricata-alerts.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -13,6 +13,8 @@ service of common Unix/Linux based distributions.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -20,16 +22,6 @@ This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-system.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -75,6 +67,14 @@ include::../include/var-paths.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboards
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-system.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -13,18 +13,10 @@ https://traefik.io/[Træfik].
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
+include::../include/gs-link.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-traefik.png[]
+//[float]
+//=== Compatibility
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -57,6 +49,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `access` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboards
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-traefik.png[]
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -13,6 +13,8 @@ This file is generated! See scripts/docs_collector.py
 This is a module for Zeek, which used to be called Bro. It parses logs that are in the
 https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 

--- a/filebeat/module/apache/_meta/docs.asciidoc
+++ b/filebeat/module/apache/_meta/docs.asciidoc
@@ -8,6 +8,10 @@ https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
+New to {beatname_uc} modules? Read the
+<<filebeat-modules-quickstart,quick start>> to learn how to set up and run
+modules.
+
 [float]
 === Compatibility
 
@@ -15,16 +19,6 @@ The +{modulename}+ module was tested with logs from versions 2.2.22 and 2.4.23.
 
 On Windows, the module was tested with Apache HTTP Server installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-apache.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -80,6 +74,17 @@ Add %v config in httpd.conf in log section
     # By
     LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 -----
+
+ifndef::hide_for_obs[]
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-apache.png[]
+
+endif::[]
 
 :has-dashboards!:
 

--- a/filebeat/module/apache/_meta/docs.asciidoc
+++ b/filebeat/module/apache/_meta/docs.asciidoc
@@ -8,9 +8,7 @@ https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
-New to {beatname_uc} modules? Read the
-<<filebeat-modules-quickstart,quick start>> to learn how to set up and run
-modules.
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility

--- a/filebeat/module/apache/_meta/docs.asciidoc
+++ b/filebeat/module/apache/_meta/docs.asciidoc
@@ -75,7 +75,6 @@ Add %v config in httpd.conf in log section
     LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 -----
 
-ifndef::hide_for_obs[]
 [float]
 === Example dashboard
 
@@ -83,8 +82,6 @@ This module comes with a sample dashboard. For example:
 
 [role="screenshot"]
 image::./images/kibana-apache.png[]
-
-endif::[]
 
 :has-dashboards!:
 

--- a/filebeat/module/auditd/_meta/docs.asciidoc
+++ b/filebeat/module/auditd/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ The +{modulename}+ module collects and parses logs from the audit daemon
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -15,18 +17,6 @@ The +{modulename}+ module was tested with logs from `auditd` on OSes like CentOS
 6 and CentOS 7.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing an overview of the audit log
-data. You can build more specific dashboards that are tailored to the audit
-rules that you use on your systems.
-
-[role="screenshot"]
-image::./images/kibana-audit-auditd.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -61,6 +51,16 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing an overview of the audit log
+data. You can build more specific dashboards that are tailored to the audit
+rules that you use on your systems.
+
+[role="screenshot"]
+image::./images/kibana-audit-auditd.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -9,14 +9,12 @@ This is the elasticsearch module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The Elasticsearch module is compatible with Elasticsearch 6.2 and newer.
-
-
-include::../include/running-modules.asciidoc[]
-
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/module/haproxy/_meta/docs.asciidoc
+++ b/filebeat/module/haproxy/_meta/docs.asciidoc
@@ -7,23 +7,14 @@ The +{modulename}+ module collects and parses logs from a (`haproxy`) process.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from `haproxy` running on AWS Linux as a gateway to a cluster of microservices.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing geolocation, distribution of requests between backends and frontends,
-and status codes over time. For example:
-
-[role="screenshot"]
-image::./images/kibana-haproxy-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -50,6 +41,15 @@ include::../include/config-option-intro.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing geolocation, distribution of requests between backends and frontends,
+and status codes over time. For example:
+
+[role="screenshot"]
+image::./images/kibana-haproxy-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/icinga/_meta/docs.asciidoc
+++ b/filebeat/module/icinga/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ https://www.icinga.com/products/icinga-2/[Icinga].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -15,16 +17,6 @@ The +{modulename}+ module was tested with Icinga >= 2.x on various Linux and Win
 systems.
 
 This module is not available for macOS.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-icinga-main.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -75,6 +67,14 @@ include::../include/var-paths.asciidoc[]
 ==== `startup` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-icinga-main.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -8,20 +8,12 @@ Internet Information Services (IIS) HTTP server.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The IIS module was tested with logs from version 7.5 and version 10.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-iis.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -61,6 +53,14 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-iis.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -8,20 +8,12 @@ https://kafka.apache.org/[Kafka].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions 0.9, 1.1.0 and 2.0.0.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard to see Kafka logs and stack traces.
-
-[role="screenshot"]
-image::./images/filebeat-kafka-logs-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -73,6 +65,14 @@ The path to your Kafka installation. The default is `/opt`. For example:
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard to see Kafka logs and stack traces.
+
+[role="screenshot"]
+image::./images/filebeat-kafka-logs-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/kibana/_meta/docs.asciidoc
+++ b/filebeat/module/kibana/_meta/docs.asciidoc
@@ -9,13 +9,12 @@ This is the Kibana module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The Kibana modules is compatible with Kibana 6.3 and newer.
-
-include::../include/running-modules.asciidoc[]
-
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ and the JSON format (--log.format json). The default is the plain text format.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 The +{modulename}+ module has two filesets:
 
 * The `log` fileset collects and parses the logs that Logstash writes to disk.
@@ -23,19 +25,6 @@ For the `slowlog` fileset, make sure to configure the
 The Logstash `log` fileset was tested with logs from Logstash 5.6 and 6.0.
 
 The Logstash `slowlog` fileset was tested with logs from Logstash 5.6 and 6.0
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-===  Example dashboards
-
-This module comes with two sample dashboards.
-
-[role="screenshot"]
-image::./images/kibana-logstash-log.png[]
-
-[role="screenshot"]
-image::./images/kibana-logstash-slowlog.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -90,6 +79,17 @@ The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+===  Example dashboards
+
+This module comes with two sample dashboards.
+
+[role="screenshot"]
+image::./images/kibana-logstash-log.png[]
+
+[role="screenshot"]
+image::./images/kibana-logstash-slowlog.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/mongodb/_meta/docs.asciidoc
+++ b/filebeat/module/mongodb/_meta/docs.asciidoc
@@ -8,20 +8,12 @@ https://www.mongodb.com/[MongoDB].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions v3.2.11 on Debian.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with one sample dashboard including error and regular logs.
-
-[role="screenshot"]
-image::./images/filebeat-mongodb-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -55,6 +47,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with one sample dashboard including error and regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-mongodb-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/mysql/_meta/docs.asciidoc
+++ b/filebeat/module/mysql/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ created by https://www.mysql.com/[MySQL].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -16,16 +18,6 @@ MariaDB 10.1, 10.2 and 10.3, and Percona 5.7 and 8.0.
 
 On Windows, the module was tested with MySQL installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-mysql.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -67,6 +59,14 @@ include::../include/var-paths.asciidoc[]
 ==== `slowlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-mysql.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/nats/_meta/docs.asciidoc
+++ b/filebeat/module/nats/_meta/docs.asciidoc
@@ -7,21 +7,12 @@ This is the nats module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from version v1.4.0.
-
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Dashboard
-
-The Nats module comes with a predefined dashboard. For example:
-
-image::./images/filebeat_nats_dashboard.png[]
-
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -35,6 +26,13 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Dashboard
+
+The Nats module comes with a predefined dashboard. For example:
+
+image::./images/filebeat_nats_dashboard.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -9,6 +9,8 @@ http://nginx.org/[Nginx] HTTP server.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -16,16 +18,6 @@ The Nginx module was tested with logs from version 1.10.
 
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-nginx.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -70,6 +62,14 @@ include::../include/var-paths.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-nginx.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/osquery/_meta/docs.asciidoc
+++ b/filebeat/module/osquery/_meta/docs.asciidoc
@@ -11,6 +11,8 @@ driver (the default). Make sure UTC timestamps are enabled.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Compatibility
@@ -20,16 +22,6 @@ Since the results are written in the JSON format, it is likely that this module
 works with any version of osquery.
 
 This module is available on Linux, macOS, and Windows.
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard for visualizing the data collected by
-the "compliance" pack. To collect this data, enable the `id-compliance` pack in
-the osquery configuration file.
-
-[role="screenshot"]
-image::./images/kibana-osquery-compatibility.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -68,6 +60,16 @@ Set to false to copy the fields in the root of the document. If enabled, this
 setting also disables the renaming of some fields (e.g. `hostIdentifier` to
 `host_identifier`).  Note that if you set this to false, the sample dashboards
 coming with this module won't work correctly. The default is true.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard for visualizing the data collected by
+the "compliance" pack. To collect this data, enable the `id-compliance` pack in
+the osquery configuration file.
+
+[role="screenshot"]
+image::./images/kibana-osquery-compatibility.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -8,28 +8,13 @@ https://www.postgresql.org/[PostgreSQL].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from versions 9.5 on Ubuntu and 9.6
 on Debian.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with two sample dashboards.
-
-The first dashboard is for regular logs.
-
-[role="screenshot"]
-image::./images/filebeat-postgresql-overview.png[]
-
-The second one shows the slowlogs of PostgreSQL.
-
-[role="screenshot"]
-image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -64,6 +49,20 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+=== Example dashboards
+
+This module comes with two sample dashboards.
+
+The first dashboard is for regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-overview.png[]
+
+The second one shows the slowlogs of PostgreSQL.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ https://redis.io/[Redis].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 The +{modulename}+ module has two filesets:
 
 * The `log` fileset collects and parses the logs that Redis writes to disk.  
@@ -30,16 +32,6 @@ On Windows, the default paths assume that Redis was installed from the Chocolate
 
 The Redis `slowlog` fileset was tested with Redis 3.0.2 and 2.4.6. We expect compatibility with any
 Redis version newer than 2.2.12, when the SLOWLOG command was added.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/kibana-redis.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -92,6 +84,14 @@ left empty, `localhost:6379` is assumed.
 
 The password to use to connect to Redis, in case Redis authentication is enabled
 (the `requirepass` option in the Redis configuration).
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/kibana-redis.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/santa/_meta/docs.asciidoc
+++ b/filebeat/module/santa/_meta/docs.asciidoc
@@ -10,23 +10,14 @@ binaries.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The +{modulename}+ module was tested with logs from Santa 0.9.14.
 
 This module is available for MacOS only.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard showing and overview of the processes
-that are executing.
-
-[role="screenshot"]
-image::./images/kibana-santa-log-overview.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -50,6 +41,15 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard showing and overview of the processes
+that are executing.
+
+[role="screenshot"]
+image::./images/kibana-santa-log-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -8,6 +8,8 @@ service of common Unix/Linux based distributions.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -15,16 +17,6 @@ This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
 This module is not available for Windows.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-system.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -70,6 +62,14 @@ include::../include/var-paths.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboards
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-system.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -8,18 +8,10 @@ https://traefik.io/[Træfik].
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
+include::../include/gs-link.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboards
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/kibana-traefik.png[]
+//[float]
+//=== Compatibility
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -52,6 +44,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `access` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboards
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/kibana-traefik.png[]
 
 :has-dashboards!:
 

--- a/filebeat/scripts/module/_meta/docs.asciidoc
+++ b/filebeat/scripts/module/_meta/docs.asciidoc
@@ -7,21 +7,12 @@ This is the {module} module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 TODO: document with what versions of the software is this tested
-
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-TODO: include an image of a sample dashboard. If you do not include a dashboard,
-remove this section and set `:has-dashboards: false` at the top of this file.
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -39,6 +30,14 @@ the relevant file. For example:
 ==== `{fileset}` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+TODO: include an image of a sample dashboard. If you do not include a dashboard,
+remove this section and set `:has-dashboards: false` at the top of this file.
 
 :has-dashboards!:
 

--- a/filebeat/tests/system/input/template-test-module/_meta/docs.asciidoc
+++ b/filebeat/tests/system/input/template-test-module/_meta/docs.asciidoc
@@ -7,21 +7,12 @@ This is the template-test-module module.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 TODO: document with what versions of the software is this tested
-
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-TODO: include an image of a sample dashboard. If you do not include a dashboard,
-remove this section and set `:has-dashboards: false` at the top of this file.
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -39,6 +30,14 @@ the relevant file. For example:
 ==== `{fileset}` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+TODO: include an image of a sample dashboard. If you do not include a dashboard,
+remove this section and set `:has-dashboards: false` at the top of this file.
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
@@ -11,12 +11,12 @@ This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 The module has been tested with ActiveMQ 5.13.0 and 5.15.9. Other versions are expected to work.
-
-include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -18,6 +18,8 @@ from network interfaces in AWS VPC. ELB access logs captures detailed informatio
 about requests sent to the load balancer. CloudTrail logs contain events
 that represent actions taken by a user, role or AWS service.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Module configuration
 

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -3,20 +3,18 @@
 :modulename: azure
 :has-dashboards: false
 
-== azure module
+== Azure module
 
 beta[]
 
-This is the azure module.
-
-The azure module will concentrate on retrieving different types of log data from Azure.
+The azure module retrieves different types of log data from Azure.
 There are several requirements before using the module since the logs will actually be read from azure event hubs.
 
    - the logs have to be exported first to the event hubs https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create-kafka-enabled
    - to export activity logs to event hubs users can follow the steps here https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log-export
    - to export audit and sign-in logs to event hubs users can follow the steps here https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/tutorial-azure-monitor-stream-logs-to-event-hub
 
-The module will contain the following filesets:
+The module contains the following filesets:
 
 `activitylogs` ::
 Will retrieve azure activity logs. Control-plane events on Azure Resource Manager resources. Activity logs provide insight into the operations that were performed on resources in your subscription.
@@ -26,14 +24,6 @@ Will retrieve azure Active Directory sign-in logs. The sign-ins report provides 
 
 `auditlogs` ::
 Will retrieve azure Active Directory audit logs. The audit logs provide traceability through logs for all changes done by various features within Azure AD. Examples of audit logs include changes made to any resources within Azure AD like adding or removing users, apps, groups, roles and policies.
-
-[float]
-=== Dashboards
-
-The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:
-
-image::./images/filebeat-azure-overview.png[]
-
 
 [float]
 === Module configuration
@@ -95,13 +85,21 @@ The name of the storage account the state/offsets will be stored and updated.
 _string_
 The storage account key, this key will be used to authorize access to data in your storage account.
 
-
 include::../include/what-happens.asciidoc[]
+
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility
 
 TODO: document with what versions of the software is this tested
+
+[float]
+=== Dashboards
+
+The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:
+
+image::./images/filebeat-azure-overview.png[]
 
 
 

--- a/x-pack/filebeat/module/cef/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cef/_meta/docs.asciidoc
@@ -13,7 +13,7 @@ encoded data. The decoded data is written into a `cef` object field. Lastly any
 Elastic Common Schema (ECS) fields that can be populated with the CEF data are
 populated.
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -29,15 +29,7 @@ Check the <<dynamic-script-compilations>> section for more information.
 
 include::../include/what-happens.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard for ASA:
-
-[role="screenshot"]
-image::./images/kibana-cisco-asa.png[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -299,5 +291,13 @@ on your cluster:
 
 - {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
   Increase to at least `200` if using both filesets or other script-heavy modules.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard for ASA:
+
+[role="screenshot"]
+image::./images/kibana-cisco-asa.png[]
 
 :modulename!:

--- a/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/coredns/_meta/docs.asciidoc
@@ -8,19 +8,19 @@
 This is a filebeat module for CoreDNS. It supports both standalone CoreDNS deployment and
 CoreDNS deployment in Kubernetes.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 Although this module has been developed against Kubernetes v1.13.x, it is expected to work
 with other versions of Kubernetes.
 
-[float]
-=== Example dashboard
+include::../include/configuring-intro.asciidoc[]
 
-This module comes with a sample dashboard.
+:fileset_ex: log
 
-[role="screenshot"]
-image::./images/kibana-coredns.jpg[]
+include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
@@ -41,3 +41,11 @@ include::../include/var-paths.asciidoc[]
 *`var.tags`*::
 
 An array of tags describing the monitored CoreDNS setup.
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard.
+
+[role="screenshot"]
+image::./images/kibana-coredns.jpg[]

--- a/x-pack/filebeat/module/envoyproxy/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/envoyproxy/_meta/docs.asciidoc
@@ -5,7 +5,9 @@
 
 == Envoyproxy Module
 
-This is a filebeat module for Envoy proxy access log (https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log). It supports both standalone deployment and Envoy proxy deployment in Kubernetes. 
+This is a Filebeat module for Envoy proxy access log (https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log). It supports both standalone deployment and Envoy proxy deployment in Kubernetes. 
+
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -13,7 +13,7 @@ Google Pub/Sub topic sink.
 
 include::../include/what-happens.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/ibmmq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/ibmmq/_meta/docs.asciidoc
@@ -8,24 +8,14 @@ The `ibmmq` module collects and parses the queue manager error logs from IBM MQ 
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 This module has been tested with IBM MQ v9.1.0.0, but it should be compatible with older versions.
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with a sample dashboard. For example:
-
-[role="screenshot"]
-image::./images/filebeat-ibmmq.png[]
-
-
 include::../include/configuring-intro.asciidoc[]
-
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
 file to override the default paths for IBM MQ errorlog:
@@ -37,6 +27,7 @@ file to override the default paths for IBM MQ errorlog:
     enabled: true
     var.paths: ["C:/ibmmq/logs/*.log"]
 -----
+
 :fileset_ex: errorlog
 
 include::../include/config-option-intro.asciidoc[]
@@ -45,6 +36,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `errorlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+[role="screenshot"]
+image::./images/filebeat-ibmmq.png[]
 
 :fileset_ex!:
 

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -20,21 +20,7 @@ When you run the module, it performs a few tasks under the hood:
 
 * Deploys dashboards for visualizing the log data.
 
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards showing geolocation and network
-protocols used. One for all iptables logs:
-
-[role="screenshot"]
-image::./images/kibana-iptables.png[]
-
-and one specific for Ubiquiti Firewall logs:
-
-[role="screenshot"]
-image::./images/kibana-iptables-ubiquiti.png[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -71,6 +57,20 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 NOTE: Ports below 1024 require Filebeat to run as root.
 
 include::../include/timezone-support.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards showing geolocation and network
+protocols used. One for all iptables logs:
+
+[role="screenshot"]
+image::./images/kibana-iptables.png[]
+
+and one specific for Ubiquiti Firewall logs:
+
+[role="screenshot"]
+image::./images/kibana-iptables-ubiquiti.png[]
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/module/misp/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/misp/_meta/docs.asciidoc
@@ -14,6 +14,8 @@ The configuration in the config.yml file uses the following format:
  * var.api_key: specifies the API key to access MISP.
  * var.json_objects_array: specifies the array object in MISP response, e.g., "response.Attribute".
  * var.url: URL of the MISP REST API, e.g., "http://x.x.x.x/attributes/restSearch"
+ 
+include::../include/gs-link.asciidoc[]
 
 [float]
 === Example dashboard

--- a/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
@@ -7,10 +7,10 @@ The +{modulename}+ module parses error logs created by MSSQL.
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
+include::../include/gs-link.asciidoc[]
 
-include::../include/running-modules.asciidoc[]
+//[float]
+//=== Compatibility
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -13,7 +13,7 @@ This module wraps the <<filebeat-input-netflow,netflow input>> to enrich the
 flow records with geolocation information about the IP endpoints by using
 Elasticsearch Ingest Node.
 
-include::../include/running-modules.asciidoc[]
+include::../include/gs-link.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -9,6 +9,8 @@ This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
@@ -18,7 +20,50 @@ versions 7.1 to 9.0 but limited compatibility is expected for earlier versions.
 The {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugin is required to run this module.
 
-include::../include/running-modules.asciidoc[]
+include::../include/configuring-intro.asciidoc[]
+
+The module is by default configured to run via syslog on port 9001. However
+it can also be configured to read logs from a file. See the following example.
+
+["source","yaml",subs="attributes"]
+-----
+- module: panw
+  panos:
+    enabled: true
+    var.paths: ["/var/log/pan-os.log"]
+    var.input: "file"
+-----
+
+:fileset_ex: panos
+
+include::../include/config-option-intro.asciidoc[]
+
+[float]
+==== `panos` fileset settings
+
+Example config:
+
+[source,yaml]
+----
+  panos:
+    var.syslog_host: 0.0.0.0
+    var.syslog_port: 514
+----
+
+include::../include/var-paths.asciidoc[]
+
+*`var.syslog_host`*::
+
+The interface to listen to UDP based syslog traffic. Defaults to `localhost`.
+Set to `0.0.0.0` to bind to all available interfaces.
+
+*`var.syslog_port`*::
+
+The UDP port to listen for syslog traffic. Defaults to `9001`
+
+NOTE: Ports below 1024 require {beatname_uc} to run as root.
+
+include::../include/timezone-support.asciidoc[]
 
 [float]
 === ECS field mappings
@@ -126,51 +171,6 @@ image::./images/filebeat-panw-traffic.png[]
 
 [role="screenshot"]
 image::./images/filebeat-panw-threat.png[]
-
-include::../include/configuring-intro.asciidoc[]
-
-The module is by default configured to run via syslog on port 9001. However
-it can also be configured to read logs from a file. See the following example.
-
-["source","yaml",subs="attributes"]
------
-- module: panw
-  panos:
-    enabled: true
-    var.paths: ["/var/log/pan-os.log"]
-    var.input: "file"
------
-
-:fileset_ex: panos
-
-include::../include/config-option-intro.asciidoc[]
-
-[float]
-==== `panos` fileset settings
-
-Example config:
-
-[source,yaml]
-----
-  panos:
-    var.syslog_host: 0.0.0.0
-    var.syslog_port: 514
-----
-
-include::../include/var-paths.asciidoc[]
-
-*`var.syslog_host`*::
-
-The interface to listen to UDP based syslog traffic. Defaults to `localhost`.
-Set to `0.0.0.0` to bind to all available interfaces.
-
-*`var.syslog_port`*::
-
-The UDP port to listen for syslog traffic. Defaults to `9001`
-
-NOTE: Ports below 1024 require {beatname_uc} to run as root.
-
-include::../include/timezone-support.asciidoc[]
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/rabbitmq/_meta/docs.asciidoc
@@ -7,14 +7,14 @@ This is the module for parsing https://www.rabbitmq.com/logging.html[RabbitMQ lo
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 Parses https://www.rabbitmq.com/logging.html[single file format] introduced in 3.7.0.
 
 Tested with version 3.7.14.
-
-include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
@@ -11,24 +11,13 @@ Suricata Eve JSON format].
 
 include::../include/what-happens.asciidoc[]
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 
 This module has been developed against Suricata v4.0.4, but is expected to work
 with other versions of Suricata.
-
-include::../include/running-modules.asciidoc[]
-
-[float]
-=== Example dashboard
-
-This module comes with sample dashboards. For example:
-
-[role="screenshot"]
-image::./images/filebeat-suricata-events.png[]
-
-[role="screenshot"]
-image::./images/filebeat-suricata-alerts.png[]
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -50,6 +39,17 @@ include::../include/config-option-intro.asciidoc[]
 ==== `eve` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with sample dashboards. For example:
+
+[role="screenshot"]
+image::./images/filebeat-suricata-events.png[]
+
+[role="screenshot"]
+image::./images/filebeat-suricata-alerts.png[]
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -8,6 +8,8 @@
 This is a module for Zeek, which used to be called Bro. It parses logs that are in the
 https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 
+include::../include/gs-link.asciidoc[]
+
 [float]
 === Compatibility
 


### PR DESCRIPTION
Fixes elastic/beats#16475 

Summary of changes:

- Remove commands for setting up and running module. Point users to quick start instead.
- Move dashboard examples to the end of the topic to make config info more obvious.
- Fix a few minor nits to make content more consistent.
- Comment out a few compatibility sections because they were empty and would probably result in build errors.

I'll follow up with a separate PR if the module generator needs any updates.