### PR TITLE
Cherry-pick #16468 to 7.x: Add missing var definitions in the manifest files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
 - Fix a connection error in httpjson input. {pull}16123[16123]
 - Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
+- Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 - Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
 
 *Heartbeat*

--- a/x-pack/filebeat/module/azure/activitylogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/manifest.yml
@@ -7,6 +7,9 @@ var:
     default: "insights-operational-logs"
   - name: consumer_group
     default: "$Default"
+  - name: connection_string
+  - name: storage_account
+  - name: storage_account_key
 
 ingest_pipeline:
   - ingest/pipeline.json

--- a/x-pack/filebeat/module/azure/auditlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/manifest.yml
@@ -7,6 +7,9 @@ var:
     default: "insights-logs-auditlogs"
   - name: consumer_group
     default: "$Default"
+  - name: connection_string
+  - name: storage_account
+  - name: storage_account_key
 
 ingest_pipeline:
   - ingest/pipeline.json

--- a/x-pack/filebeat/module/azure/signinlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/manifest.yml
@@ -7,6 +7,9 @@ var:
     default: "insights-logs-signinlogs"
   - name: consumer_group
     default: "$Default"
+  - name: connection_string
+  - name: storage_account
+  - name: storage_account_key
 
 ingest_pipeline:
   - ingest/pipeline.json


### PR DESCRIPTION
Cherry-pick of PR #16468 to 7.x branch. Original message:

Should fix https://github.com/elastic/beats/issues/16270.

Due to new checks on the configuration file keys in v7.6.0,  when running:
```
filebeat setup --module azure
```
users get:
```
Exiting: Error getting config for fileset azure/activitylogs: Error interpreting the template of the input: template: text:2:22: executing "text" at <.connection_string>: map has no entry for key "connection_string"
```
due to missing to define some of the vars in the manifest file.
This PR does this.