### PR TITLE
[docs] Add skeleton files for 7.7 release highlights and BCs

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -1,0 +1,20 @@
+[[breaking-changes-7.7]]
+
+=== Breaking changes in 7.7
+++++
+<titleabbrev>7.7</titleabbrev>
+++++
+
+{see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+//[float]
+//==== Breaking change
+
+//Description
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.7>>
+
 * <<breaking-changes-7.6>>
 
 * <<breaking-changes-7.5>>
@@ -24,6 +26,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.7.asciidoc[]
 
 include::breaking-7.6.asciidoc[]
 

--- a/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
@@ -1,0 +1,26 @@
+[[release-highlights-7.7.0]]
+=== 7.7 release highlights
+++++
+<titleabbrev>7.7</titleabbrev>
+++++
+
+Each release of {beats} brings new features and product improvements. 
+Following are the most notable features and enhancements in 7.7.
+
+For a complete list of related highlights, see the 
+https://www.elastic.co/blog/elastic-observability-7-6-0-released[Observability 7.7 release blog].
+
+For a list of bug fixes and other changes, see the {beats}
+<<breaking-changes-7.7, Breaking Changes>> and <<release-notes, Release Notes>>.
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+
+//[float]
+//==== highlight
+
+//Description
+
+// end::notable-highlights[]

--- a/libbeat/docs/release-notes/highlights/highlights.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights.asciidoc
@@ -4,6 +4,8 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-7.7.0>>
+
 * <<release-highlights-7.6.0>>
 
 * <<release-highlights-7.5.0>>
@@ -17,6 +19,8 @@ full list, see <<release-notes>> and <<breaking-changes>>.
 * <<release-highlights-7.1.0>>
 
 * <<release-highlights-7.0.0>>
+
+include::highlights-7.7.0.asciidoc[]
 
 include::highlights-7.6.0.asciidoc[]
 


### PR DESCRIPTION
Adds placeholder files where devs and writers can add highlights about the release and point out important BCs.