### PR TITLE
Cherry-pick #16466 to 7.6: Rewrite azure filebeat dashboards due to exceptions in the kql kibana filters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 - Fix a connection error in httpjson input. {pull}16123[16123]
 - Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
+- Rewrite azure filebeat dashboards, due to changes in kibana. {pull}16466[16466]
 - Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 
 *Heartbeat*

--- a/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-overview.json
+++ b/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-overview.json
@@ -1,1564 +1,1925 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "This dashboard provides an overview of user activity, alerts and resource in Azure cloud.",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "optionsJSON": {
-          "hidePanelTitles": false,
-          "useMargins": true
-        },
-        "panelsJSON": [
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 4,
-              "i": "6b6e7452-979c-4f78-afc2-cc58fcf105ff",
-              "w": 9,
-              "x": 0,
-              "y": 0
-            },
-            "panelIndex": "6b6e7452-979c-4f78-afc2-cc58fcf105ff",
-            "panelRefName": "panel_0",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 4,
-              "i": "042f777a-5e41-41e8-9d6e-d842473a8aed",
-              "w": 15,
-              "x": 9,
-              "y": 0
-            },
-            "panelIndex": "042f777a-5e41-41e8-9d6e-d842473a8aed",
-            "panelRefName": "panel_1",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Activity Level"
-            },
-            "gridData": {
-              "h": 8,
-              "i": "1e73bca7-8569-41b5-830e-2f762602219a",
-              "w": 24,
-              "x": 24,
-              "y": 0
-            },
-            "panelIndex": "1e73bca7-8569-41b5-830e-2f762602219a",
-            "panelRefName": "panel_2",
-            "title": "Activity Level",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 6,
-              "i": "d9465e9f-49f1-4173-b1a4-fea9ee3120ab",
-              "w": 24,
-              "x": 0,
-              "y": 4
-            },
-            "panelIndex": "d9465e9f-49f1-4173-b1a4-fea9ee3120ab",
-            "panelRefName": "panel_3",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Access Requests"
-            },
-            "gridData": {
-              "h": 7,
-              "i": "18ec1e20-202b-4a40-8d0d-22060ac3e23c",
-              "w": 24,
-              "x": 24,
-              "y": 8
-            },
-            "panelIndex": "18ec1e20-202b-4a40-8d0d-22060ac3e23c",
-            "panelRefName": "panel_4",
-            "title": "Access Requests",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Top Active Users"
-            },
-            "gridData": {
-              "h": 11,
-              "i": "d2bdec0f-dde1-4925-bf7e-afbc430c0eca",
-              "w": 24,
-              "x": 0,
-              "y": 10
-            },
-            "panelIndex": "d2bdec0f-dde1-4925-bf7e-afbc430c0eca",
-            "panelRefName": "panel_5",
-            "title": "Top Active Users",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Alerts Overview"
-            },
-            "gridData": {
-              "h": 7,
-              "i": "3bcc964d-6862-4fdd-9d82-f7510cc02162",
-              "w": 12,
-              "x": 24,
-              "y": 15
-            },
-            "panelIndex": "3bcc964d-6862-4fdd-9d82-f7510cc02162",
-            "panelRefName": "panel_6",
-            "title": "Alerts Overview",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Service Health"
-            },
-            "gridData": {
-              "h": 7,
-              "i": "74436614-9dfc-4c38-bc58-8cb76c348f37",
-              "w": 12,
-              "x": 36,
-              "y": 15
-            },
-            "panelIndex": "74436614-9dfc-4c38-bc58-8cb76c348f37",
-            "panelRefName": "panel_7",
-            "title": "Service Health",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Top Resource Groups",
-              "vis": {
-                "legendOpen": false
-              }
-            },
-            "gridData": {
-              "h": 19,
-              "i": "a6f36dfe-b6d6-4dca-b63c-81f5b4f7c8f8",
-              "w": 24,
-              "x": 0,
-              "y": 21
-            },
-            "panelIndex": "a6f36dfe-b6d6-4dca-b63c-81f5b4f7c8f8",
-            "panelRefName": "panel_8",
-            "title": "Top Resource Groups",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 6,
-              "i": "644c6151-fd05-4b2e-b18e-30843697e932",
-              "w": 12,
-              "x": 24,
-              "y": 22
-            },
-            "panelIndex": "644c6151-fd05-4b2e-b18e-30843697e932",
-            "panelRefName": "panel_9",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 6,
-              "i": "3d5ccff8-6576-4a1c-b3ee-363ae665906e",
-              "w": 12,
-              "x": 36,
-              "y": 22
-            },
-            "panelIndex": "3d5ccff8-6576-4a1c-b3ee-363ae665906e",
-            "panelRefName": "panel_10",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "legendOpen": true,
-              "title": "Resource Changes",
-              "vis": {
-                "legendOpen": false
-              }
-            },
-            "gridData": {
-              "h": 12,
-              "i": "0dce9ac1-3046-4eb5-a57b-ef2cfe61ce1f",
-              "w": 24,
-              "x": 24,
-              "y": 28
-            },
-            "panelIndex": "0dce9ac1-3046-4eb5-a57b-ef2cfe61ce1f",
-            "panelRefName": "panel_11",
-            "title": "Resource Changes",
-            "version": "7.4.0"
-          }
-        ],
-        "timeRestore": false,
-        "title": "[Filebeat Azure] Cloud Overview",
-        "version": 1
-      },
-      "id": "41e84340-ec20-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "dashboard": "7.3.0"
-      },
-      "references": [
+    "objects":[
         {
-          "id": "fe24ac90-f05a-11e9-90ec-112a988266d5",
-          "name": "panel_0",
-          "type": "visualization"
-        },
-        {
-          "id": "097d74d0-f044-11e9-90ec-112a988266d5",
-          "name": "panel_1",
-          "type": "visualization"
-        },
-        {
-          "id": "da67d650-ec14-11e9-90ec-112a988266d5",
-          "name": "panel_2",
-          "type": "visualization"
-        },
-        {
-          "id": "e4c7f4b0-f045-11e9-90ec-112a988266d5",
-          "name": "panel_3",
-          "type": "visualization"
-        },
-        {
-          "id": "709995e0-ec16-11e9-90ec-112a988266d5",
-          "name": "panel_4",
-          "type": "visualization"
-        },
-        {
-          "id": "ffe22180-ec1c-11e9-90ec-112a988266d5",
-          "name": "panel_5",
-          "type": "visualization"
-        },
-        {
-          "id": "52c2a4e0-ec1f-11e9-90ec-112a988266d5",
-          "name": "panel_6",
-          "type": "visualization"
-        },
-        {
-          "id": "bc65e840-ec1e-11e9-90ec-112a988266d5",
-          "name": "panel_7",
-          "type": "visualization"
-        },
-        {
-          "id": "71b62ca0-ec1a-11e9-90ec-112a988266d5",
-          "name": "panel_8",
-          "type": "visualization"
-        },
-        {
-          "id": "f684a750-ec23-11e9-90ec-112a988266d5",
-          "name": "panel_9",
-          "type": "visualization"
-        },
-        {
-          "id": "e37cd3d0-ec23-11e9-90ec-112a988266d5",
-          "name": "panel_10",
-          "type": "visualization"
-        },
-        {
-          "id": "05d39d10-ec1a-11e9-90ec-112a988266d5",
-          "name": "panel_11",
-          "type": "visualization"
-        }
-      ],
-      "type": "dashboard",
-      "updated_at": "2019-10-18T15:20:07.860Z",
-      "version": "WzkyMzcsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Navigation Overview [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "fontSize": 10,
-            "markdown": "### Azure Monitoring\n\n[**Overview**](#/dashboard/41e84340-ec20-11e9-90ec-112a988266d5) | [Users](#/dashboard/87095750-f05a-11e9-90ec-112a988266d5) | [Alerts](#/dashboard/0f559cc0-f0d5-11e9-90ec-112a988266d5) ",
-            "openLinksInNewTab": false
-          },
-          "title": "Navigation Overview [Filebeat Azure]",
-          "type": "markdown"
-        }
-      },
-      "id": "fe24ac90-f05a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:56:32.153Z",
-      "version": "WzQ5MzQsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Subscriptions Filter [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "controls": [
-              {
-                "fieldName": "azure.subscription_id",
-                "id": "1571250866125",
-                "indexPatternRefName": "control_0_index_pattern",
-                "label": "Subscription ID",
-                "options": {
-                  "dynamicOptions": true,
-                  "multiselect": true,
-                  "order": "desc",
-                  "size": 5,
-                  "type": "terms"
+            "attributes":{
+                "description":"This dashboard provides an overview of user activity, alerts and resource in Azure cloud.",
+                "hits":0,
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
                 },
-                "parent": "",
-                "type": "list"
-              }
-            ],
-            "pinFilters": false,
-            "updateFiltersOnChange": true,
-            "useTimeFilter": false
-          },
-          "title": "Subscriptions Filter [Filebeat Azure]",
-          "type": "input_control_vis"
-        }
-      },
-      "id": "097d74d0-f044-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "control_0_index_pattern",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:37:41.917Z",
-      "version": "WzQ0MDEsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Activity Level [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category :\"Administrative\" "
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "bar",
-                "color": "#68BC00",
-                "fill": 0.5,
-                "formatter": "number",
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "everything",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": "",
-            "type": "timeseries"
-          },
-          "title": "Activity Level [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "da67d650-ec14-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:18:42.561Z",
-      "version": "WzQzODYsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset : \"azure.activitylogs\" "
-            }
-          }
-        },
-        "title": "Activity Stats [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {
-                "customLabel": "Resources",
-                "field": "azure.resource.name"
-              },
-              "schema": "metric",
-              "type": "cardinality"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Users",
-                "field": "azure.activitylogs.identity.claims_initiated_by_user.name"
-              },
-              "schema": "metric",
-              "type": "cardinality"
-            },
-            {
-              "enabled": true,
-              "id": "3",
-              "params": {
-                "customLabel": "Resource Groups",
-                "field": "azure.resource.group"
-              },
-              "schema": "metric",
-              "type": "cardinality"
-            },
-            {
-              "enabled": true,
-              "id": "4",
-              "params": {
-                "customLabel": "Subscriptions",
-                "field": "azure.subscription_id"
-              },
-              "schema": "metric",
-              "type": "cardinality"
-            }
-          ],
-          "params": {
-            "addLegend": false,
-            "addTooltip": true,
-            "dimensions": {
-              "metrics": [
-                {
-                  "accessor": 0,
-                  "format": {
-                    "id": "number",
-                    "params": {}
-                  },
-                  "type": "vis_dimension"
+                "optionsJSON":{
+                    "hidePanelTitles":false,
+                    "useMargins":true
                 },
-                {
-                  "accessor": 1,
-                  "format": {
-                    "id": "number",
-                    "params": {}
-                  },
-                  "type": "vis_dimension"
-                },
-                {
-                  "accessor": 2,
-                  "format": {
-                    "id": "number",
-                    "params": {}
-                  },
-                  "type": "vis_dimension"
-                }
-              ]
-            },
-            "metric": {
-              "colorSchema": "Green to Red",
-              "colorsRange": [
-                {
-                  "from": 0,
-                  "to": 10000,
-                  "type": "range"
-                }
-              ],
-              "invertColors": false,
-              "labels": {
-                "show": true
-              },
-              "metricColorMode": "None",
-              "percentageMode": false,
-              "style": {
-                "bgColor": false,
-                "bgFill": "#000",
-                "fontSize": 60,
-                "labelColor": false,
-                "subText": ""
-              },
-              "useRanges": false
-            },
-            "type": "metric"
-          },
-          "title": "Activity Stats [Filebeat Azure]",
-          "type": "metric"
-        }
-      },
-      "id": "e4c7f4b0-f045-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-18T09:14:38.537Z",
-      "version": "WzgwNzYsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Access Requests [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and azure.activitylogs.operation_name : *LISTKEYS*"
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "#68BC00",
-                "fill": "0",
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome : \"success\" or event.outcome : \"Success\" "
-                },
-                "formatter": "number",
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "label": "Success",
-                "line_width": "2",
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              },
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(226,115,0,1)",
-                "fill": "0",
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome : \"Failure\"  or event.outcome : \"failure\"  "
-                },
-                "formatter": "number",
-                "id": "1b5f75a0-ec15-11e9-b6a7-21d19b63822a",
-                "label": "Failure",
-                "line_width": "2",
-                "metrics": [
-                  {
-                    "id": "1b5f75a1-ec15-11e9-b6a7-21d19b63822a",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": "",
-            "type": "timeseries"
-          },
-          "title": "Access Requests [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "709995e0-ec16-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-11T11:01:13.406Z",
-      "version": "WzI3MzYsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "User Tag Cloud [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "field": "azure.activitylogs.identity.claims_initiated_by_user.name",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 10
-              },
-              "schema": "segment",
-              "type": "terms"
-            }
-          ],
-          "params": {
-            "bucket": {
-              "accessor": 0,
-              "format": {
-                "id": "terms",
-                "params": {
-                  "id": "string",
-                  "missingBucketLabel": "Missing",
-                  "otherBucketLabel": "Other"
-                }
-              },
-              "type": "vis_dimension"
-            },
-            "maxFontSize": 32,
-            "metric": {
-              "accessor": 1,
-              "format": {
-                "id": "string",
-                "params": {}
-              },
-              "type": "vis_dimension"
-            },
-            "minFontSize": 12,
-            "orientation": "single",
-            "scale": "linear",
-            "showLabel": true
-          },
-          "title": "User Tag Cloud [Filebeat Azure]",
-          "type": "tagcloud"
-        }
-      },
-      "id": "ffe22180-ec1c-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-18T09:12:32.252Z",
-      "version": "WzgwNzEsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Alerts Overview [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alert\""
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(252,220,0,1)",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome: \"Activated\""
-                },
-                "formatter": "number",
-                "hide_in_legend": 0,
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              },
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "#68BC00",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome: \"Resolved\" or event.outcome: \"Succeeded\""
-                },
-                "formatter": "number",
-                "hide_in_legend": 0,
-                "id": "5a52f170-ec1e-11e9-b6a7-21d19b63822a",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "5a52f171-ec1e-11e9-b6a7-21d19b63822a",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": "",
-            "type": "timeseries"
-          },
-          "title": "Alerts Overview [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "52c2a4e0-ec1f-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:41:58.846Z",
-      "version": "WzQ0MDcsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Service Health Overview [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"ServiceHealth\""
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(252,220,0,1)",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome: \"Active\""
-                },
-                "formatter": "number",
-                "hide_in_legend": 0,
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              },
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "#68BC00",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome: \"Resolved\" "
-                },
-                "formatter": "number",
-                "hide_in_legend": 0,
-                "id": "5a52f170-ec1e-11e9-b6a7-21d19b63822a",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "5a52f171-ec1e-11e9-b6a7-21d19b63822a",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": "",
-            "type": "timeseries"
-          },
-          "title": "Service Health Overview [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "bc65e840-ec1e-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:40:07.894Z",
-      "version": "WzQ0MDQsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Top Resource Groups [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Resource Groups",
-                "field": "azure.resource.group",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 10
-              },
-              "schema": "segment",
-              "type": "terms"
-            }
-          ],
-          "params": {
-            "addLegend": true,
-            "addTimeMarker": false,
-            "addTooltip": true,
-            "categoryAxes": [
-              {
-                "id": "CategoryAxis-1",
-                "labels": {
-                  "filter": false,
-                  "rotate": 0,
-                  "show": true,
-                  "truncate": 200
-                },
-                "position": "left",
-                "scale": {
-                  "type": "linear"
-                },
-                "show": true,
-                "style": {},
-                "title": {},
-                "type": "category"
-              }
-            ],
-            "dimensions": {
-              "x": {
-                "accessor": 0,
-                "aggType": "terms",
-                "format": {
-                  "id": "terms",
-                  "params": {
-                    "id": "string",
-                    "missingBucketLabel": "Missing",
-                    "otherBucketLabel": "Other"
-                  }
-                },
-                "params": {}
-              },
-              "y": [
-                {
-                  "accessor": 1,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "grid": {
-              "categoryLines": false
-            },
-            "labels": {},
-            "legendPosition": "right",
-            "seriesParams": [
-              {
-                "data": {
-                  "id": "1",
-                  "label": "Count"
-                },
-                "drawLinesBetweenPoints": true,
-                "mode": "normal",
-                "show": true,
-                "showCircles": true,
-                "type": "histogram",
-                "valueAxis": "ValueAxis-1"
-              }
-            ],
-            "times": [],
-            "type": "histogram",
-            "valueAxes": [
-              {
-                "id": "ValueAxis-1",
-                "labels": {
-                  "filter": true,
-                  "rotate": 75,
-                  "show": true,
-                  "truncate": 100
-                },
-                "name": "LeftAxis-1",
-                "position": "bottom",
-                "scale": {
-                  "mode": "normal",
-                  "type": "linear"
-                },
-                "show": false,
-                "style": {},
-                "title": {
-                  "text": "Count"
-                },
-                "type": "value"
-              }
-            ]
-          },
-          "title": "Top Resource Groups [Filebeat Azure]",
-          "type": "horizontal_bar"
-        }
-      },
-      "id": "71b62ca0-ec1a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-17T14:50:09.427Z",
-      "version": "WzYxMTUsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"Alert\" "
-            }
-          }
-        },
-        "title": "Alerts Count [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {
-                "customLabel": "Alerts"
-              },
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "filters": [
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "event.outcome : \"Activated\""
+                "panelsJSON":[
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 4,
+                            "i": "6b6e7452-979c-4f78-afc2-cc58fcf105ff",
+                            "w": 9,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "panelIndex": "6b6e7452-979c-4f78-afc2-cc58fcf105ff",
+                        "panelRefName": "panel_0",
+                        "version": "7.4.0"
                     },
-                    "label": "Activated"
-                  },
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "event.outcome : \"Resolved\""
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 4,
+                            "i": "042f777a-5e41-41e8-9d6e-d842473a8aed",
+                            "w": 15,
+                            "x": 9,
+                            "y": 0
+                        },
+                        "panelIndex": "042f777a-5e41-41e8-9d6e-d842473a8aed",
+                        "panelRefName": "panel_1",
+                        "version": "7.4.0"
                     },
-                    "label": "Resolved"
-                  },
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "event.outcome : \"Succeeded\""
+                    {
+                        "embeddableConfig": {
+                            "title": "Activity Level"
+                        },
+                        "gridData": {
+                            "h": 8,
+                            "i": "1e73bca7-8569-41b5-830e-2f762602219a",
+                            "w": 24,
+                            "x": 24,
+                            "y": 0
+                        },
+                        "panelIndex": "1e73bca7-8569-41b5-830e-2f762602219a",
+                        "panelRefName": "panel_2",
+                        "title": "Activity Level",
+                        "version": "7.4.0"
                     },
-                    "label": "Succeeded"
-                  }
-                ]
-              },
-              "schema": "group",
-              "type": "filters"
-            }
-          ],
-          "params": {
-            "addLegend": false,
-            "addTooltip": true,
-            "dimensions": {
-              "bucket": {
-                "accessor": 0,
-                "format": {
-                  "id": "string",
-                  "params": {}
-                },
-                "type": "vis_dimension"
-              },
-              "metrics": [
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 6,
+                            "i": "d9465e9f-49f1-4173-b1a4-fea9ee3120ab",
+                            "w": 24,
+                            "x": 0,
+                            "y": 4
+                        },
+                        "panelIndex": "d9465e9f-49f1-4173-b1a4-fea9ee3120ab",
+                        "panelRefName": "panel_3",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Access Requests"
+                        },
+                        "gridData": {
+                            "h": 7,
+                            "i": "18ec1e20-202b-4a40-8d0d-22060ac3e23c",
+                            "w": 24,
+                            "x": 24,
+                            "y": 8
+                        },
+                        "panelIndex": "18ec1e20-202b-4a40-8d0d-22060ac3e23c",
+                        "panelRefName": "panel_4",
+                        "title": "Access Requests",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Top Active Users"
+                        },
+                        "gridData": {
+                            "h": 11,
+                            "i": "d2bdec0f-dde1-4925-bf7e-afbc430c0eca",
+                            "w": 24,
+                            "x": 0,
+                            "y": 10
+                        },
+                        "panelIndex": "d2bdec0f-dde1-4925-bf7e-afbc430c0eca",
+                        "panelRefName": "panel_5",
+                        "title": "Top Active Users",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Alerts Overview"
+                        },
+                        "gridData": {
+                            "h": 7,
+                            "i": "3bcc964d-6862-4fdd-9d82-f7510cc02162",
+                            "w": 12,
+                            "x": 24,
+                            "y": 15
+                        },
+                        "panelIndex": "3bcc964d-6862-4fdd-9d82-f7510cc02162",
+                        "panelRefName": "panel_6",
+                        "title": "Alerts Overview",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Service Health"
+                        },
+                        "gridData": {
+                            "h": 7,
+                            "i": "74436614-9dfc-4c38-bc58-8cb76c348f37",
+                            "w": 12,
+                            "x": 36,
+                            "y": 15
+                        },
+                        "panelIndex": "74436614-9dfc-4c38-bc58-8cb76c348f37",
+                        "panelRefName": "panel_7",
+                        "title": "Service Health",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Top Resource Groups",
+                            "vis": {
+                                "legendOpen": false
+                            }
+                        },
+                        "gridData": {
+                            "h": 19,
+                            "i": "a6f36dfe-b6d6-4dca-b63c-81f5b4f7c8f8",
+                            "w": 24,
+                            "x": 0,
+                            "y": 21
+                        },
+                        "panelIndex": "a6f36dfe-b6d6-4dca-b63c-81f5b4f7c8f8",
+                        "panelRefName": "panel_8",
+                        "title": "Top Resource Groups",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 6,
+                            "i": "644c6151-fd05-4b2e-b18e-30843697e932",
+                            "w": 12,
+                            "x": 24,
+                            "y": 22
+                        },
+                        "panelIndex": "644c6151-fd05-4b2e-b18e-30843697e932",
+                        "panelRefName": "panel_9",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 6,
+                            "i": "3d5ccff8-6576-4a1c-b3ee-363ae665906e",
+                            "w": 12,
+                            "x": 36,
+                            "y": 22
+                        },
+                        "panelIndex": "3d5ccff8-6576-4a1c-b3ee-363ae665906e",
+                        "panelRefName": "panel_10",
+                        "version": "7.4.0"
+                    },
+                    {
+                        "version": "7.4.0",
+                        "gridData": {
+                            "x": 24,
+                            "y": 28,
+                            "w": 12,
+                            "h": 12,
+                            "i": "1a6dce1d-d039-4d18-87c7-1b700da676c2"
+                        },
+                        "panelIndex": "1a6dce1d-d039-4d18-87c7-1b700da676c2",
+                        "embeddableConfig": {
+                            "vis": {
+                                "legendOpen": true
+                            },
+                            "legendOpen": false
+                        },
+                        "panelRefName": "panel_11"
+                    },
+                    {
+                        "version": "7.4.0",
+                        "gridData": {
+                            "x": 36,
+                            "y": 28,
+                            "w": 12,
+                            "h": 12,
+                            "i": "8fddd3bb-c1e6-4533-b075-1ab7361b3af0"
+                        },
+                        "panelIndex": "8fddd3bb-c1e6-4533-b075-1ab7361b3af0",
+                        "embeddableConfig": {
+                            "vis": {
+                                "legendOpen": true
+                            },
+                            "legendOpen": false
+                        },
+                        "panelRefName": "panel_12"
+                    }
+                ],
+                "timeRestore":false,
+                "title":"[Filebeat Azure] Cloud Overview",
+                "version":1
+            },
+            "id":"41e84340-ec20-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "dashboard":"7.3.0"
+            },
+            "references":[
                 {
-                  "accessor": 1,
-                  "format": {
-                    "id": "number",
-                    "params": {}
-                  },
-                  "type": "vis_dimension"
-                }
-              ]
-            },
-            "metric": {
-              "colorSchema": "Green to Red",
-              "colorsRange": [
-                {
-                  "from": 0,
-                  "to": 10000,
-                  "type": "range"
-                }
-              ],
-              "invertColors": false,
-              "labels": {
-                "show": true
-              },
-              "metricColorMode": "None",
-              "percentageMode": false,
-              "style": {
-                "bgColor": false,
-                "bgFill": "#000",
-                "fontSize": 60,
-                "labelColor": false,
-                "subText": ""
-              },
-              "useRanges": false
-            },
-            "type": "metric"
-          },
-          "title": "Alerts Count [Filebeat Azure]",
-          "type": "metric"
-        }
-      },
-      "id": "f684a750-ec23-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:44:12.955Z",
-      "version": "WzQ0MTAsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category : \"ServiceHealth\" "
-            }
-          }
-        },
-        "title": "Service Health Count [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {
-                "customLabel": "Incidents"
-              },
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "filters": [
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "event.outcome : \"Active\""
-                    },
-                    "label": "Active"
-                  },
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "event.outcome : \"Resolved\""
-                    },
-                    "label": "Resolved"
-                  }
-                ]
-              },
-              "schema": "group",
-              "type": "filters"
-            }
-          ],
-          "params": {
-            "addLegend": false,
-            "addTooltip": true,
-            "dimensions": {
-              "bucket": {
-                "accessor": 0,
-                "format": {
-                  "id": "string",
-                  "params": {}
+                    "id": "fe24ac90-f05a-11e9-90ec-112a988266d5",
+                    "name": "panel_0",
+                    "type": "visualization"
                 },
-                "type": "vis_dimension"
-              },
-              "metrics": [
                 {
-                  "accessor": 1,
-                  "format": {
-                    "id": "number",
-                    "params": {}
-                  },
-                  "type": "vis_dimension"
-                }
-              ]
-            },
-            "metric": {
-              "colorSchema": "Green to Red",
-              "colorsRange": [
+                    "id": "097d74d0-f044-11e9-90ec-112a988266d5",
+                    "name": "panel_1",
+                    "type": "visualization"
+                },
                 {
-                  "from": 0,
-                  "to": 10000,
-                  "type": "range"
+                    "id": "da67d650-ec14-11e9-90ec-112a988266d5",
+                    "name": "panel_2",
+                    "type": "visualization"
+                },
+                {
+                    "id": "e4c7f4b0-f045-11e9-90ec-112a988266d5",
+                    "name": "panel_3",
+                    "type": "visualization"
+                },
+                {
+                    "id": "709995e0-ec16-11e9-90ec-112a988266d5",
+                    "name": "panel_4",
+                    "type": "visualization"
+                },
+                {
+                    "id": "ffe22180-ec1c-11e9-90ec-112a988266d5",
+                    "name": "panel_5",
+                    "type": "visualization"
+                },
+                {
+                    "id": "52c2a4e0-ec1f-11e9-90ec-112a988266d5",
+                    "name": "panel_6",
+                    "type": "visualization"
+                },
+                {
+                    "id": "bc65e840-ec1e-11e9-90ec-112a988266d5",
+                    "name": "panel_7",
+                    "type": "visualization"
+                },
+                {
+                    "id": "71b62ca0-ec1a-11e9-90ec-112a988266d5",
+                    "name": "panel_8",
+                    "type": "visualization"
+                },
+                {
+                    "id": "f684a750-ec23-11e9-90ec-112a988266d5",
+                    "name": "panel_9",
+                    "type": "visualization"
+                },
+                {
+                    "id": "e37cd3d0-ec23-11e9-90ec-112a988266d5",
+                    "name": "panel_10",
+                    "type": "visualization"
+                },
+                {
+                    "id": "d91ce8d0-53e8-11ea-b1b7-7de801e1c297",
+                    "name": "panel_11",
+                    "type": "visualization"
+                },
+                {
+                    "id": "6db84660-53e9-11ea-b1b7-7de801e1c297",
+                    "name": "panel_12",
+                    "type": "visualization"
                 }
-              ],
-              "invertColors": false,
-              "labels": {
-                "show": true
-              },
-              "metricColorMode": "None",
-              "percentageMode": false,
-              "style": {
-                "bgColor": false,
-                "bgFill": "#000",
-                "fontSize": 60,
-                "labelColor": false,
-                "subText": ""
-              },
-              "useRanges": false
-            },
-            "type": "metric"
-          },
-          "title": "Service Health Count [Filebeat Azure]",
-          "type": "metric"
-        }
-      },
-      "id": "e37cd3d0-ec23-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-16T18:45:10.848Z",
-      "version": "WzQ0MTEsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" "
-            }
-          }
-        },
-        "title": "Resource Changes [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Resource Type",
-                "field": "azure.resource.provider",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 15
-              },
-              "schema": "segment",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "3",
-              "params": {
-                "filters": [
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "azure.activitylogs.identity.action : *write"
-                    },
-                    "label": "Creations"
-                  },
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "azure.activitylogs.identity.action : *delete"
-                    },
-                    "label": "Deletions"
-                  }
-                ]
-              },
-              "schema": "group",
-              "type": "filters"
-            }
-          ],
-          "params": {
-            "addLegend": true,
-            "addTimeMarker": false,
-            "addTooltip": true,
-            "categoryAxes": [
-              {
-                "id": "CategoryAxis-1",
-                "labels": {
-                  "filter": false,
-                  "rotate": 0,
-                  "show": true,
-                  "truncate": 200
-                },
-                "position": "left",
-                "scale": {
-                  "type": "linear"
-                },
-                "show": true,
-                "style": {},
-                "title": {},
-                "type": "category"
-              }
             ],
-            "dimensions": {
-              "series": [
-                {
-                  "accessor": 1,
-                  "aggType": "filters",
-                  "format": {},
-                  "params": {}
-                }
-              ],
-              "x": {
-                "accessor": 0,
-                "aggType": "terms",
-                "format": {
-                  "id": "terms",
-                  "params": {
-                    "id": "string",
-                    "missingBucketLabel": "Missing",
-                    "otherBucketLabel": "Other"
-                  }
-                },
-                "params": {}
-              },
-              "y": [
-                {
-                  "accessor": 2,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "grid": {
-              "categoryLines": false
-            },
-            "labels": {},
-            "legendPosition": "right",
-            "seriesParams": [
-              {
-                "data": {
-                  "id": "1",
-                  "label": "Count"
-                },
-                "drawLinesBetweenPoints": true,
-                "mode": "stacked",
-                "show": true,
-                "showCircles": true,
-                "type": "histogram",
-                "valueAxis": "ValueAxis-1"
-              }
-            ],
-            "times": [],
-            "type": "histogram",
-            "valueAxes": [
-              {
-                "id": "ValueAxis-1",
-                "labels": {
-                  "filter": true,
-                  "rotate": 75,
-                  "show": true,
-                  "truncate": 100
-                },
-                "name": "LeftAxis-1",
-                "position": "bottom",
-                "scale": {
-                  "mode": "normal",
-                  "type": "linear"
-                },
-                "show": false,
-                "style": {},
-                "title": {
-                  "text": "Count"
-                },
-                "type": "value"
-              }
-            ]
-          },
-          "title": "Resource Changes [Filebeat Azure]",
-          "type": "horizontal_bar"
-        }
-      },
-      "id": "05d39d10-ec1a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
+            "type":"dashboard",
+            "updated_at":"2019-10-18T15:20:07.860Z",
+            "version":"WzkyMzcsMV0="
+        },
         {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Navigation Overview [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "fontSize":10,
+                        "markdown":"### Azure Monitoring\n\n[**Overview**](#/dashboard/41e84340-ec20-11e9-90ec-112a988266d5) | [Users](#/dashboard/87095750-f05a-11e9-90ec-112a988266d5) | [Alerts](#/dashboard/0f559cc0-f0d5-11e9-90ec-112a988266d5) ",
+                        "openLinksInNewTab":false
+                    },
+                    "title":"Navigation Overview [Filebeat Azure]",
+                    "type":"markdown"
+                }
+            },
+            "id":"fe24ac90-f05a-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T11:56:32.153Z",
+            "version":"WzQ5MzQsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Subscriptions Filter [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "controls":[
+                            {
+                                "fieldName":"azure.subscription_id",
+                                "id":"1571250866125",
+                                "indexPatternRefName":"control_0_index_pattern",
+                                "label":"Subscription ID",
+                                "options":{
+                                    "dynamicOptions":true,
+                                    "multiselect":true,
+                                    "order":"desc",
+                                    "size":5,
+                                    "type":"terms"
+                                },
+                                "parent":"",
+                                "type":"list"
+                            }
+                        ],
+                        "pinFilters":false,
+                        "updateFiltersOnChange":true,
+                        "useTimeFilter":false
+                    },
+                    "title":"Subscriptions Filter [Filebeat Azure]",
+                    "type":"input_control_vis"
+                }
+            },
+            "id":"097d74d0-f044-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"control_0_index_pattern",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:37:41.917Z",
+            "version":"WzQ0MDEsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Activity Level [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category :\"Administrative\" "
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"bar",
+                                "color":"#68BC00",
+                                "fill":0.5,
+                                "formatter":"number",
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"everything",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":"",
+                        "type":"timeseries"
+                    },
+                    "title":"Activity Level [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"da67d650-ec14-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:18:42.561Z",
+            "version":"WzQzODYsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset : \"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Activity Stats [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+                                "customLabel":"Resources",
+                                "field":"azure.resource.name"
+                            },
+                            "schema":"metric",
+                            "type":"cardinality"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "customLabel":"Users",
+                                "field":"azure.activitylogs.identity.claims_initiated_by_user.name"
+                            },
+                            "schema":"metric",
+                            "type":"cardinality"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"3",
+                            "params":{
+                                "customLabel":"Resource Groups",
+                                "field":"azure.resource.group"
+                            },
+                            "schema":"metric",
+                            "type":"cardinality"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"4",
+                            "params":{
+                                "customLabel":"Subscriptions",
+                                "field":"azure.subscription_id"
+                            },
+                            "schema":"metric",
+                            "type":"cardinality"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":false,
+                        "addTooltip":true,
+                        "dimensions":{
+                            "metrics":[
+                                {
+                                    "accessor":0,
+                                    "format":{
+                                        "id":"number",
+                                        "params":{
+
+                                        }
+                                    },
+                                    "type":"vis_dimension"
+                                },
+                                {
+                                    "accessor":1,
+                                    "format":{
+                                        "id":"number",
+                                        "params":{
+
+                                        }
+                                    },
+                                    "type":"vis_dimension"
+                                },
+                                {
+                                    "accessor":2,
+                                    "format":{
+                                        "id":"number",
+                                        "params":{
+
+                                        }
+                                    },
+                                    "type":"vis_dimension"
+                                }
+                            ]
+                        },
+                        "metric":{
+                            "colorSchema":"Green to Red",
+                            "colorsRange":[
+                                {
+                                    "from":0,
+                                    "to":10000,
+                                    "type":"range"
+                                }
+                            ],
+                            "invertColors":false,
+                            "labels":{
+                                "show":true
+                            },
+                            "metricColorMode":"None",
+                            "percentageMode":false,
+                            "style":{
+                                "bgColor":false,
+                                "bgFill":"#000",
+                                "fontSize":60,
+                                "labelColor":false,
+                                "subText":""
+                            },
+                            "useRanges":false
+                        },
+                        "type":"metric"
+                    },
+                    "title":"Activity Stats [Filebeat Azure]",
+                    "type":"metric"
+                }
+            },
+            "id":"e4c7f4b0-f045-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T09:14:38.537Z",
+            "version":"WzgwNzYsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Access Requests [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and azure.activitylogs.operation_name : *LISTKEYS*"
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"#68BC00",
+                                "fill":"0",
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome : \"success\" or event.outcome : \"Success\" "
+                                },
+                                "formatter":"number",
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label":"Success",
+                                "line_width":"2",
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            },
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"rgba(226,115,0,1)",
+                                "fill":"0",
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome : \"Failure\"  or event.outcome : \"failure\"  "
+                                },
+                                "formatter":"number",
+                                "id":"1b5f75a0-ec15-11e9-b6a7-21d19b63822a",
+                                "label":"Failure",
+                                "line_width":"2",
+                                "metrics":[
+                                    {
+                                        "id":"1b5f75a1-ec15-11e9-b6a7-21d19b63822a",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":"",
+                        "type":"timeseries"
+                    },
+                    "title":"Access Requests [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"709995e0-ec16-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-11T11:01:13.406Z",
+            "version":"WzI3MzYsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"User Tag Cloud [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "field":"azure.activitylogs.identity.claims_initiated_by_user.name",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":10
+                            },
+                            "schema":"segment",
+                            "type":"terms"
+                        }
+                    ],
+                    "params":{
+                        "bucket":{
+                            "accessor":0,
+                            "format":{
+                                "id":"terms",
+                                "params":{
+                                    "id":"string",
+                                    "missingBucketLabel":"Missing",
+                                    "otherBucketLabel":"Other"
+                                }
+                            },
+                            "type":"vis_dimension"
+                        },
+                        "maxFontSize":32,
+                        "metric":{
+                            "accessor":1,
+                            "format":{
+                                "id":"string",
+                                "params":{
+
+                                }
+                            },
+                            "type":"vis_dimension"
+                        },
+                        "minFontSize":12,
+                        "orientation":"single",
+                        "scale":"linear",
+                        "showLabel":true
+                    },
+                    "title":"User Tag Cloud [Filebeat Azure]",
+                    "type":"tagcloud"
+                }
+            },
+            "id":"ffe22180-ec1c-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T09:12:32.252Z",
+            "version":"WzgwNzEsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Alerts Overview [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category : \"Alert\""
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"rgba(252,220,0,1)",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome: \"Activated\""
+                                },
+                                "formatter":"number",
+                                "hide_in_legend":0,
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            },
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"#68BC00",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome: \"Resolved\" or event.outcome: \"Succeeded\""
+                                },
+                                "formatter":"number",
+                                "hide_in_legend":0,
+                                "id":"5a52f170-ec1e-11e9-b6a7-21d19b63822a",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"5a52f171-ec1e-11e9-b6a7-21d19b63822a",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":"",
+                        "type":"timeseries"
+                    },
+                    "title":"Alerts Overview [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"52c2a4e0-ec1f-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:41:58.846Z",
+            "version":"WzQ0MDcsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Service Health Overview [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category : \"ServiceHealth\""
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"rgba(252,220,0,1)",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome: \"Active\""
+                                },
+                                "formatter":"number",
+                                "hide_in_legend":0,
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            },
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"#68BC00",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome: \"Resolved\" "
+                                },
+                                "formatter":"number",
+                                "hide_in_legend":0,
+                                "id":"5a52f170-ec1e-11e9-b6a7-21d19b63822a",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"5a52f171-ec1e-11e9-b6a7-21d19b63822a",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":"",
+                        "type":"timeseries"
+                    },
+                    "title":"Service Health Overview [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"bc65e840-ec1e-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:40:07.894Z",
+            "version":"WzQ0MDQsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Top Resource Groups [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "customLabel":"Resource Groups",
+                                "field":"azure.resource.group",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":10
+                            },
+                            "schema":"segment",
+                            "type":"terms"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":true,
+                        "addTimeMarker":false,
+                        "addTooltip":true,
+                        "categoryAxes":[
+                            {
+                                "id":"CategoryAxis-1",
+                                "labels":{
+                                    "filter":false,
+                                    "rotate":0,
+                                    "show":true,
+                                    "truncate":200
+                                },
+                                "position":"left",
+                                "scale":{
+                                    "type":"linear"
+                                },
+                                "show":true,
+                                "style":{
+
+                                },
+                                "title":{
+
+                                },
+                                "type":"category"
+                            }
+                        ],
+                        "dimensions":{
+                            "x":{
+                                "accessor":0,
+                                "aggType":"terms",
+                                "format":{
+                                    "id":"terms",
+                                    "params":{
+                                        "id":"string",
+                                        "missingBucketLabel":"Missing",
+                                        "otherBucketLabel":"Other"
+                                    }
+                                },
+                                "params":{
+
+                                }
+                            },
+                            "y":[
+                                {
+                                    "accessor":1,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "grid":{
+                            "categoryLines":false
+                        },
+                        "labels":{
+
+                        },
+                        "legendPosition":"right",
+                        "seriesParams":[
+                            {
+                                "data":{
+                                    "id":"1",
+                                    "label":"Count"
+                                },
+                                "drawLinesBetweenPoints":true,
+                                "mode":"normal",
+                                "show":true,
+                                "showCircles":true,
+                                "type":"histogram",
+                                "valueAxis":"ValueAxis-1"
+                            }
+                        ],
+                        "times":[
+
+                        ],
+                        "type":"histogram",
+                        "valueAxes":[
+                            {
+                                "id":"ValueAxis-1",
+                                "labels":{
+                                    "filter":true,
+                                    "rotate":75,
+                                    "show":true,
+                                    "truncate":100
+                                },
+                                "name":"LeftAxis-1",
+                                "position":"bottom",
+                                "scale":{
+                                    "mode":"normal",
+                                    "type":"linear"
+                                },
+                                "show":false,
+                                "style":{
+
+                                },
+                                "title":{
+                                    "text":"Count"
+                                },
+                                "type":"value"
+                            }
+                        ]
+                    },
+                    "title":"Top Resource Groups [Filebeat Azure]",
+                    "type":"horizontal_bar"
+                }
+            },
+            "id":"71b62ca0-ec1a-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T14:50:09.427Z",
+            "version":"WzYxMTUsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category : \"Alert\" "
+                        }
+                    }
+                },
+                "title":"Alerts Count [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+                                "customLabel":"Alerts"
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "filters":[
+                                    {
+                                        "input":{
+                                            "language":"kuery",
+                                            "query":"event.outcome : \"Activated\""
+                                        },
+                                        "label":"Activated"
+                                    },
+                                    {
+                                        "input":{
+                                            "language":"kuery",
+                                            "query":"event.outcome : \"Resolved\""
+                                        },
+                                        "label":"Resolved"
+                                    },
+                                    {
+                                        "input":{
+                                            "language":"kuery",
+                                            "query":"event.outcome : \"Succeeded\""
+                                        },
+                                        "label":"Succeeded"
+                                    }
+                                ]
+                            },
+                            "schema":"group",
+                            "type":"filters"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":false,
+                        "addTooltip":true,
+                        "dimensions":{
+                            "bucket":{
+                                "accessor":0,
+                                "format":{
+                                    "id":"string",
+                                    "params":{
+
+                                    }
+                                },
+                                "type":"vis_dimension"
+                            },
+                            "metrics":[
+                                {
+                                    "accessor":1,
+                                    "format":{
+                                        "id":"number",
+                                        "params":{
+
+                                        }
+                                    },
+                                    "type":"vis_dimension"
+                                }
+                            ]
+                        },
+                        "metric":{
+                            "colorSchema":"Green to Red",
+                            "colorsRange":[
+                                {
+                                    "from":0,
+                                    "to":10000,
+                                    "type":"range"
+                                }
+                            ],
+                            "invertColors":false,
+                            "labels":{
+                                "show":true
+                            },
+                            "metricColorMode":"None",
+                            "percentageMode":false,
+                            "style":{
+                                "bgColor":false,
+                                "bgFill":"#000",
+                                "fontSize":60,
+                                "labelColor":false,
+                                "subText":""
+                            },
+                            "useRanges":false
+                        },
+                        "type":"metric"
+                    },
+                    "title":"Alerts Count [Filebeat Azure]",
+                    "type":"metric"
+                }
+            },
+            "id":"f684a750-ec23-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:44:12.955Z",
+            "version":"WzQ0MTAsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category : \"ServiceHealth\" "
+                        }
+                    }
+                },
+                "title":"Service Health Count [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+                                "customLabel":"Incidents"
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "filters":[
+                                    {
+                                        "input":{
+                                            "language":"kuery",
+                                            "query":"event.outcome : \"Active\""
+                                        },
+                                        "label":"Active"
+                                    },
+                                    {
+                                        "input":{
+                                            "language":"kuery",
+                                            "query":"event.outcome : \"Resolved\""
+                                        },
+                                        "label":"Resolved"
+                                    }
+                                ]
+                            },
+                            "schema":"group",
+                            "type":"filters"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":false,
+                        "addTooltip":true,
+                        "dimensions":{
+                            "bucket":{
+                                "accessor":0,
+                                "format":{
+                                    "id":"string",
+                                    "params":{
+
+                                    }
+                                },
+                                "type":"vis_dimension"
+                            },
+                            "metrics":[
+                                {
+                                    "accessor":1,
+                                    "format":{
+                                        "id":"number",
+                                        "params":{
+
+                                        }
+                                    },
+                                    "type":"vis_dimension"
+                                }
+                            ]
+                        },
+                        "metric":{
+                            "colorSchema":"Green to Red",
+                            "colorsRange":[
+                                {
+                                    "from":0,
+                                    "to":10000,
+                                    "type":"range"
+                                }
+                            ],
+                            "invertColors":false,
+                            "labels":{
+                                "show":true
+                            },
+                            "metricColorMode":"None",
+                            "percentageMode":false,
+                            "style":{
+                                "bgColor":false,
+                                "bgFill":"#000",
+                                "fontSize":60,
+                                "labelColor":false,
+                                "subText":""
+                            },
+                            "useRanges":false
+                        },
+                        "type":"metric"
+                    },
+                    "title":"Service Health Count [Filebeat Azure]",
+                    "type":"metric"
+                }
+            },
+            "id":"e37cd3d0-ec23-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-16T18:45:10.848Z",
+            "version":"WzQ0MTEsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Resource Creations [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "title":"Resource Creations [Filebeat Azure]",
+                    "type":"horizontal_bar",
+                    "params":{
+                        "addLegend":true,
+                        "addTimeMarker":false,
+                        "addTooltip":true,
+                        "categoryAxes":[
+                            {
+                                "id":"CategoryAxis-1",
+                                "labels":{
+                                    "filter":false,
+                                    "rotate":0,
+                                    "show":true,
+                                    "truncate":200
+                                },
+                                "position":"left",
+                                "scale":{
+                                    "type":"linear"
+                                },
+                                "show":true,
+                                "style":{
+
+                                },
+                                "title":{
+
+                                },
+                                "type":"category"
+                            }
+                        ],
+                        "dimensions":{
+                            "series":[
+                                {
+                                    "accessor":1,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "label":"Creations",
+                                    "params":{
+
+                                    }
+                                }
+                            ],
+                            "x":{
+                                "accessor":0,
+                                "aggType":"terms",
+                                "format":{
+                                    "id":"terms",
+                                    "params":{
+                                        "id":"string",
+                                        "missingBucketLabel":"Missing",
+                                        "otherBucketLabel":"Other"
+                                    }
+                                },
+                                "label":"Resource type",
+                                "params":{
+
+                                }
+                            },
+                            "y":[
+                                {
+                                    "accessor":2,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "label":"Count",
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "grid":{
+                            "categoryLines":false,
+                            "valueAxis":""
+                        },
+                        "labels":{
+
+                        },
+                        "legendPosition":"right",
+                        "seriesParams":[
+                            {
+                                "data":{
+                                    "id":"1",
+                                    "label":"Count"
+                                },
+                                "drawLinesBetweenPoints":true,
+                                "lineWidth":2,
+                                "mode":"stacked",
+                                "show":true,
+                                "showCircles":true,
+                                "type":"histogram",
+                                "valueAxis":"ValueAxis-1"
+                            }
+                        ],
+                        "thresholdLine":{
+                            "color":"#E7664C",
+                            "show":false,
+                            "style":"full",
+                            "value":10,
+                            "width":1
+                        },
+                        "times":[
+
+                        ],
+                        "type":"histogram",
+                        "valueAxes":[
+                            {
+                                "id":"ValueAxis-1",
+                                "labels":{
+                                    "filter":true,
+                                    "rotate":75,
+                                    "show":true,
+                                    "truncate":100
+                                },
+                                "name":"LeftAxis-1",
+                                "position":"bottom",
+                                "scale":{
+                                    "mode":"normal",
+                                    "type":"linear"
+                                },
+                                "show":false,
+                                "style":{
+
+                                },
+                                "title":{
+                                    "text":"Count"
+                                },
+                                "type":"value"
+                            }
+                        ]
+                    },
+                    "aggs":[
+                        {
+                            "id":"1",
+                            "enabled":true,
+                            "type":"count",
+                            "schema":"metric",
+                            "params":{
+
+                            }
+                        },
+                        {
+                            "id":"2",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"segment",
+                            "params":{
+                                "field":"azure.resource.provider",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "customLabel":"Resource type"
+                            }
+                        },
+                        {
+                            "id":"4",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"group",
+                            "params":{
+                                "field":"azure.activitylogs.identity.authorization.action",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "include":".*write",
+                                "customLabel":"Creations"
+                            }
+                        }
+                    ]
+                }
+            },
+            "id":"d91ce8d0-53e8-11ea-b1b7-7de801e1c297",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2020-02-20T13:57:45.235Z",
+            "version":"WzU4OSwxXQ=="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Resource Deletions [Filebeat Azure]",
+                "uiStateJSON": {
+
+                },
+                "version":1,
+                "visState":{
+                    "title": "Resource Deletions [Filebeat Azure]",
+                    "type": "horizontal_bar",
+                    "params": {
+                        "type": "histogram",
+                        "grid": {
+                            "categoryLines": false
+                        },
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1",
+                                "type": "category",
+                                "position": "left",
+                                "show": true,
+                                "style": {},
+                                "scale": {
+                                    "type": "linear"
+                                },
+                                "labels": {
+                                    "show": true,
+                                    "rotate": 0,
+                                    "filter": false,
+                                    "truncate": 200
+                                },
+                                "title": {}
+                            }
+                        ],
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1",
+                                "name": "LeftAxis-1",
+                                "type": "value",
+                                "position": "bottom",
+                                "show": true,
+                                "style": {},
+                                "scale": {
+                                    "type": "linear",
+                                    "mode": "normal"
+                                },
+                                "labels": {
+                                    "show": false,
+                                    "rotate": 75,
+                                    "filter": true,
+                                    "truncate": 100
+                                },
+                                "title": {
+                                    "text": "Count"
+                                }
+                            }
+                        ],
+                        "seriesParams": [
+                            {
+                                "show": true,
+                                "type": "histogram",
+                                "mode": "normal",
+                                "data": {
+                                    "label": "Count",
+                                    "id": "1"
+                                },
+                                "valueAxis": "ValueAxis-1",
+                                "drawLinesBetweenPoints": true,
+                                "lineWidth": 2,
+                                "showCircles": true
+                            }
+                        ],
+                        "addTooltip": true,
+                        "addLegend": true,
+                        "legendPosition": "right",
+                        "times": [],
+                        "addTimeMarker": false,
+                        "labels": {},
+                        "thresholdLine": {
+                            "show": false,
+                            "value": 10,
+                            "width": 1,
+                            "style": "full",
+                            "color": "#E7664C"
+                        },
+                        "dimensions": {
+                            "x": {
+                                "accessor": 0,
+                                "format": {
+                                    "id": "terms",
+                                    "params": {
+                                        "id": "string",
+                                        "otherBucketLabel": "Other",
+                                        "missingBucketLabel": "Missing"
+                                    }
+                                },
+                                "params": {},
+                                "label": "azure.resource.provider: Descending",
+                                "aggType": "terms"
+                            },
+                            "y": [
+                                {
+                                    "accessor": 2,
+                                    "format": {
+                                        "id": "number"
+                                    },
+                                    "params": {},
+                                    "label": "Count",
+                                    "aggType": "count"
+                                }
+                            ],
+                            "series": [
+                                {
+                                    "accessor": 1,
+                                    "format": {
+                                        "id": "terms",
+                                        "params": {
+                                            "id": "string",
+                                            "otherBucketLabel": "Other",
+                                            "missingBucketLabel": "Missing"
+                                        }
+                                    },
+                                    "params": {},
+                                    "label": "Deletions",
+                                    "aggType": "terms"
+                                }
+                            ]
+                        }
+                    },
+                    "aggs": [
+                        {
+                            "id": "1",
+                            "enabled": true,
+                            "type": "count",
+                            "schema": "metric",
+                            "params": {}
+                        },
+                        {
+                            "id": "2",
+                            "enabled": true,
+                            "type": "terms",
+                            "schema": "segment",
+                            "params": {
+                                "field": "azure.resource.provider",
+                                "orderBy": "1",
+                                "order": "desc",
+                                "size": 15,
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "customLabel": "Resource type"
+                            }
+                        },
+                        {
+                            "id": "3",
+                            "enabled": true,
+                            "type": "terms",
+                            "schema": "group",
+                            "params": {
+                                "field": "azure.activitylogs.identity.authorization.action",
+                                "orderBy": "1",
+                                "order": "desc",
+                                "size": 15,
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "include": ".*delete",
+                                "customLabel": "Deletions"
+                            }
+                        }
+                    ]
+                }
+            },
+            "id":"6db84660-53e9-11ea-b1b7-7de801e1c297",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2020-02-20T14:01:02.150Z",
+            "version":"WzU5MiwxXQ=="
         }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:18:44.463Z",
-      "version": "WzQ4ODIsMV0="
-    }
-  ],
-  "version": "7.4.0"
+    ],
+    "version":"7.4.0"
 }

--- a/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-user-activity.json
+++ b/x-pack/filebeat/module/azure/_meta/kibana/7/dashboard/Filebeat-azure-user-activity.json
@@ -1,1311 +1,1675 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "This dashboard shows expanded user activity in Azure cloud.",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [
-              {
-                "$state": {
-                  "store": "appState"
-                },
-                "exists": {
-                  "field": "azure.activitylogs.identity.claims_initiated_by_user.fullname"
-                },
-                "meta": {
-                  "alias": null,
-                  "disabled": false,
-                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                  "key": "azure.activitylogs.identity.claims_initiated_by_user.fullname",
-                  "negate": false,
-                  "type": "exists",
-                  "value": "exists"
-                }
-              }
-            ],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "optionsJSON": {
-          "hidePanelTitles": false,
-          "useMargins": true
-        },
-        "panelsJSON": [
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 4,
-              "i": "675f172f-dbec-44fe-b45c-fe854a967695",
-              "w": 8,
-              "x": 0,
-              "y": 0
-            },
-            "panelIndex": "675f172f-dbec-44fe-b45c-fe854a967695",
-            "panelRefName": "panel_0",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": ""
-            },
-            "gridData": {
-              "h": 4,
-              "i": "705596b5-db2e-4c45-875d-95d98bfb7ee8",
-              "w": 16,
-              "x": 8,
-              "y": 0
-            },
-            "panelIndex": "705596b5-db2e-4c45-875d-95d98bfb7ee8",
-            "panelRefName": "panel_1",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {},
-            "gridData": {
-              "h": 9,
-              "i": "ace19840-2084-45bd-bf86-9ab31b04a17b",
-              "w": 24,
-              "x": 24,
-              "y": 0
-            },
-            "panelIndex": "ace19840-2084-45bd-bf86-9ab31b04a17b",
-            "panelRefName": "panel_2",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Users List"
-            },
-            "gridData": {
-              "h": 15,
-              "i": "d4d708e1-d179-4688-8005-54e2162a82d2",
-              "w": 11,
-              "x": 0,
-              "y": 4
-            },
-            "panelIndex": "d4d708e1-d179-4688-8005-54e2162a82d2",
-            "panelRefName": "panel_3",
-            "title": "Users List",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Top Caller IPs"
-            },
-            "gridData": {
-              "h": 15,
-              "i": "5774219c-fb45-4480-bdfb-75a69bdc2cfe",
-              "w": 13,
-              "x": 11,
-              "y": 4
-            },
-            "panelIndex": "5774219c-fb45-4480-bdfb-75a69bdc2cfe",
-            "panelRefName": "panel_4",
-            "title": "Top Caller IPs",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {},
-            "gridData": {
-              "h": 10,
-              "i": "5deee186-fe00-4edc-9e5b-86d8d09f6550",
-              "w": 24,
-              "x": 24,
-              "y": 9
-            },
-            "panelIndex": "5deee186-fe00-4edc-9e5b-86d8d09f6550",
-            "panelRefName": "panel_5",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Top Resource Groups",
-              "vis": {
-                "legendOpen": false
-              }
-            },
-            "gridData": {
-              "h": 15,
-              "i": "2fa13b32-c544-45f7-9132-620d09d121eb",
-              "w": 16,
-              "x": 0,
-              "y": 19
-            },
-            "panelIndex": "2fa13b32-c544-45f7-9132-620d09d121eb",
-            "panelRefName": "panel_6",
-            "title": "Top Resource Groups",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Resource Changes",
-              "vis": {
-                "legendOpen": false
-              }
-            },
-            "gridData": {
-              "h": 15,
-              "i": "8dc84199-08e0-4861-b64c-46b1f31482da",
-              "w": 17,
-              "x": 16,
-              "y": 19
-            },
-            "panelIndex": "8dc84199-08e0-4861-b64c-46b1f31482da",
-            "panelRefName": "panel_7",
-            "title": "Resource Changes",
-            "version": "7.4.0"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Top Resource Types"
-            },
-            "gridData": {
-              "h": 15,
-              "i": "84583e62-1aad-4f03-a25a-c4f9eaace8c0",
-              "w": 15,
-              "x": 33,
-              "y": 19
-            },
-            "panelIndex": "84583e62-1aad-4f03-a25a-c4f9eaace8c0",
-            "panelRefName": "panel_8",
-            "title": "Top Resource Types",
-            "version": "7.4.0"
-          }
-        ],
-        "timeRestore": false,
-        "title": "[Filebeat Azure] User Activity",
-        "version": 1
-      },
-      "id": "87095750-f05a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "dashboard": "7.3.0"
-      },
-      "references": [
+    "objects":[
         {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-          "type": "index-pattern"
-        },
-        {
-          "id": "c43855e0-f05a-11e9-90ec-112a988266d5",
-          "name": "panel_0",
-          "type": "visualization"
-        },
-        {
-          "id": "b0471750-f05b-11e9-90ec-112a988266d5",
-          "name": "panel_1",
-          "type": "visualization"
-        },
-        {
-          "id": "e0203fc0-f05f-11e9-90ec-112a988266d5",
-          "name": "panel_2",
-          "type": "visualization"
-        },
-        {
-          "id": "52da1700-f05d-11e9-90ec-112a988266d5",
-          "name": "panel_3",
-          "type": "visualization"
-        },
-        {
-          "id": "6ece76d0-f0cc-11e9-90ec-112a988266d5",
-          "name": "panel_4",
-          "type": "visualization"
-        },
-        {
-          "id": "0dd135c0-f0cc-11e9-90ec-112a988266d5",
-          "name": "panel_5",
-          "type": "visualization"
-        },
-        {
-          "id": "71b62ca0-ec1a-11e9-90ec-112a988266d5",
-          "name": "panel_6",
-          "type": "visualization"
-        },
-        {
-          "id": "05d39d10-ec1a-11e9-90ec-112a988266d5",
-          "name": "panel_7",
-          "type": "visualization"
-        },
-        {
-          "id": "9ed46680-f0ce-11e9-90ec-112a988266d5",
-          "name": "panel_8",
-          "type": "visualization"
-        }
-      ],
-      "type": "dashboard",
-      "updated_at": "2019-10-18T17:27:59.187Z",
-      "version": "WzkyNDUsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Navigation Users [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "fontSize": 10,
-            "markdown": "### Azure Monitoring\n\n[Overview](#/dashboard/41e84340-ec20-11e9-90ec-112a988266d5) | [**Users**](#/dashboard/87095750-f05a-11e9-90ec-112a988266d5) | [Alerts](#/dashboard/0f559cc0-f0d5-11e9-90ec-112a988266d5) ",
-            "openLinksInNewTab": false
-          },
-          "title": "Navigation Users [Filebeat Azure]",
-          "type": "markdown"
-        }
-      },
-      "id": "c43855e0-f05a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:56:56.135Z",
-      "version": "WzQ5MzYsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "User Filters [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "controls": [
-              {
-                "fieldName": "azure.subscription_id",
-                "id": "1517598395667",
-                "indexPatternRefName": "control_0_index_pattern",
-                "label": "Subscription",
-                "options": {
-                  "dynamicOptions": true,
-                  "multiselect": true,
-                  "order": "desc",
-                  "size": 100,
-                  "type": "terms"
-                },
-                "type": "list"
-              },
-              {
-                "fieldName": "azure.activitylogs.identity.claims_initiated_by_user.name",
-                "id": "1518843942322",
-                "indexPatternRefName": "control_1_index_pattern",
-                "label": "User Email",
-                "options": {
-                  "dynamicOptions": true,
-                  "multiselect": true,
-                  "order": "desc",
-                  "size": 100,
-                  "type": "terms"
-                },
-                "type": "list"
-              }
-            ],
-            "pinFilters": false,
-            "updateFiltersOnChange": true,
-            "useTimeFilter": false
-          },
-          "title": "User Filters [Filebeat Azure]",
-          "type": "input_control_vis"
-        }
-      },
-      "id": "b0471750-f05b-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "control_0_index_pattern",
-          "type": "index-pattern"
-        },
-        {
-          "id": "filebeat-*",
-          "name": "control_1_index_pattern",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-18T09:36:45.050Z",
-      "version": "Wzg0NTcsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "User Activity Overview [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and event.category :\"Administrative\" and azure.activitylogs.identity.claims_initiated_by_user.fullname :*"
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "auto",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "bar",
-                "color": "rgba(1,155,143,1)",
-                "fill": "0.4",
-                "filter": "",
-                "formatter": "number",
-                "hide_in_legend": 0,
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "label": "Actions",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "seperate_axis": 0,
-                "split_filters": [
-                  {
-                    "color": "rgba(244,78,59,1)",
-                    "filter": "_exists_:identity.claims.name",
-                    "id": "a5302500-1399-11e8-a699-f390e75f4dd5",
-                    "label": ""
-                  }
-                ],
-                "split_mode": "everything",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": null,
-            "type": "timeseries"
-          },
-          "title": "User Activity Overview [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "e0203fc0-f05f-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-18T17:27:33.254Z",
-      "version": "WzkyNDMsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "lucene",
-              "query": ""
-            }
-          }
-        },
-        "title": "Users List [Filebeat Azure]",
-        "uiStateJSON": {
-          "vis": {
-            "params": {
-              "sort": {
-                "columnIndex": null,
-                "direction": null
-              }
-            }
-          }
-        },
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Email",
-                "field": "azure.activitylogs.identity.claims_initiated_by_user.name",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 20
-              },
-              "schema": "bucket",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "3",
-              "params": {
-                "customLabel": "Name",
-                "field": "azure.activitylogs.identity.claims_initiated_by_user.fullname",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 5
-              },
-              "schema": "bucket",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "5",
-              "params": {
-                "customLabel": "IPs",
-                "field": "source.ip"
-              },
-              "schema": "metric",
-              "type": "cardinality"
-            },
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {
-                "customLabel": "Actions"
-              },
-              "schema": "metric",
-              "type": "count"
-            }
-          ],
-          "params": {
-            "dimensions": {
-              "buckets": [
-                {
-                  "accessor": 0,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "string",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
+            "attributes":{
+                "description":"This dashboard shows expanded user activity in Azure cloud.",
+                "hits":0,
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+                            {
+                                "$state":{
+                                    "store":"appState"
+                                },
+                                "exists":{
+                                    "field":"azure.activitylogs.identity.claims_initiated_by_user.fullname"
+                                },
+                                "meta":{
+                                    "alias":null,
+                                    "disabled":false,
+                                    "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                                    "key":"azure.activitylogs.identity.claims_initiated_by_user.fullname",
+                                    "negate":false,
+                                    "type":"exists",
+                                    "value":"exists"
+                                }
+                            }
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
                     }
-                  },
-                  "params": {}
                 },
-                {
-                  "accessor": 1,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "string",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
-                    }
-                  },
-                  "params": {}
-                }
-              ],
-              "metrics": [
-                {
-                  "accessor": 2,
-                  "aggType": "cardinality",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
+                "optionsJSON":{
+                    "hidePanelTitles":false,
+                    "useMargins":true
                 },
-                {
-                  "accessor": 3,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "perPage": 10,
-            "percentageCol": "",
-            "showMetricsAtAllLevels": false,
-            "showPartialRows": false,
-            "showTotal": false,
-            "sort": {
-              "columnIndex": null,
-              "direction": null
-            },
-            "totalFunc": "sum"
-          },
-          "title": "Users List [Filebeat Azure]",
-          "type": "table"
-        }
-      },
-      "id": "52da1700-f05d-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-18T09:05:04.252Z",
-      "version": "WzgwNjAsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" "
-            }
-          }
-        },
-        "title": "Caller IP [Filebeat Azure]",
-        "uiStateJSON": {
-          "vis": {
-            "params": {
-              "sort": {
-                "columnIndex": null,
-                "direction": null
-              }
-            }
-          }
-        },
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Caller IP",
-                "field": "source.ip",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "5",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 100
-              },
-              "schema": "bucket",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "3",
-              "params": {
-                "customLabel": "Country",
-                "field": "geo.country_name",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "5",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 100
-              },
-              "schema": "bucket",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "4",
-              "params": {
-                "customLabel": "Email",
-                "field": "azure.activitylogs.identity.claims_initiated_by_user.name",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "_key",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 5
-              },
-              "schema": "bucket",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "5",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            }
-          ],
-          "params": {
-            "dimensions": {
-              "buckets": [
-                {
-                  "accessor": 0,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "ip",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
-                    }
-                  },
-                  "params": {}
-                },
-                {
-                  "accessor": 1,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "string",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
-                    }
-                  },
-                  "params": {}
-                },
-                {
-                  "accessor": 2,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "string",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
-                    }
-                  },
-                  "params": {}
-                }
-              ],
-              "metrics": [
-                {
-                  "accessor": 3,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "perPage": 10,
-            "percentageCol": "",
-            "showMetricsAtAllLevels": false,
-            "showPartialRows": false,
-            "showTotal": false,
-            "sort": {
-              "columnIndex": null,
-              "direction": null
-            },
-            "totalFunc": "sum"
-          },
-          "title": "Caller IP [Filebeat Azure]",
-          "type": "table"
-        }
-      },
-      "id": "6ece76d0-f0cc-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-18T09:09:36.555Z",
-      "version": "WzgwNjUsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Authorization Activity User [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "filter": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" and azure.activitylogs.operation_name : *LISTKEYS* "
-            },
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "filebeat-*",
-            "interval": "",
-            "isModelInvalid": false,
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(164,221,0,1)",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome : \"Success\" "
-                },
-                "formatter": "number",
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "label": "Success",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none",
-                "terms_field": "event.outcome"
-              },
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(244,78,59,1)",
-                "fill": 0.5,
-                "filter": {
-                  "language": "kuery",
-                  "query": "event.outcome : \"Fail\" "
-                },
-                "formatter": "number",
-                "id": "78e85470-f0cb-11e9-bf79-0db2fc8554f1",
-                "label": "Failure",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "id": "78e85471-f0cb-11e9-bf79-0db2fc8554f1",
-                    "type": "count"
-                  }
-                ],
-                "point_size": 1,
-                "separate_axis": 0,
-                "split_mode": "filter",
-                "stacked": "none"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 0,
-            "time_field": "",
-            "type": "timeseries"
-          },
-          "title": "Authorization Activity User [Filebeat Azure]",
-          "type": "metrics"
-        }
-      },
-      "id": "0dd135c0-f0cc-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:33:16.437Z",
-      "version": "WzQ4OTksMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Top Resource Groups [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Resource Groups",
-                "field": "azure.resource.group",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 10
-              },
-              "schema": "segment",
-              "type": "terms"
-            }
-          ],
-          "params": {
-            "addLegend": true,
-            "addTimeMarker": false,
-            "addTooltip": true,
-            "categoryAxes": [
-              {
-                "id": "CategoryAxis-1",
-                "labels": {
-                  "filter": false,
-                  "rotate": 0,
-                  "show": true,
-                  "truncate": 200
-                },
-                "position": "left",
-                "scale": {
-                  "type": "linear"
-                },
-                "show": true,
-                "style": {},
-                "title": {},
-                "type": "category"
-              }
-            ],
-            "dimensions": {
-              "x": {
-                "accessor": 0,
-                "aggType": "terms",
-                "format": {
-                  "id": "terms",
-                  "params": {
-                    "id": "string",
-                    "missingBucketLabel": "Missing",
-                    "otherBucketLabel": "Other"
-                  }
-                },
-                "params": {}
-              },
-              "y": [
-                {
-                  "accessor": 1,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "grid": {
-              "categoryLines": false
-            },
-            "labels": {},
-            "legendPosition": "right",
-            "seriesParams": [
-              {
-                "data": {
-                  "id": "1",
-                  "label": "Count"
-                },
-                "drawLinesBetweenPoints": true,
-                "mode": "normal",
-                "show": true,
-                "showCircles": true,
-                "type": "histogram",
-                "valueAxis": "ValueAxis-1"
-              }
-            ],
-            "times": [],
-            "type": "histogram",
-            "valueAxes": [
-              {
-                "id": "ValueAxis-1",
-                "labels": {
-                  "filter": true,
-                  "rotate": 75,
-                  "show": true,
-                  "truncate": 100
-                },
-                "name": "LeftAxis-1",
-                "position": "bottom",
-                "scale": {
-                  "mode": "normal",
-                  "type": "linear"
-                },
-                "show": false,
-                "style": {},
-                "title": {
-                  "text": "Count"
-                },
-                "type": "value"
-              }
-            ]
-          },
-          "title": "Top Resource Groups [Filebeat Azure]",
-          "type": "horizontal_bar"
-        }
-      },
-      "id": "71b62ca0-ec1a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-17T14:50:09.427Z",
-      "version": "WzYxMTUsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" "
-            }
-          }
-        },
-        "title": "Resource Changes [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "customLabel": "Resource Type",
-                "field": "azure.resource.provider",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 15
-              },
-              "schema": "segment",
-              "type": "terms"
-            },
-            {
-              "enabled": true,
-              "id": "3",
-              "params": {
-                "filters": [
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "azure.activitylogs.identity.action : *write"
+                "panelsJSON":[
+                    {
+                        "embeddableConfig":{
+                            "title":""
+                        },
+                        "gridData":{
+                            "h":4,
+                            "i":"675f172f-dbec-44fe-b45c-fe854a967695",
+                            "w":8,
+                            "x":0,
+                            "y":0
+                        },
+                        "panelIndex":"675f172f-dbec-44fe-b45c-fe854a967695",
+                        "panelRefName":"panel_0",
+                        "version":"7.4.0"
                     },
-                    "label": "Creations"
-                  },
-                  {
-                    "input": {
-                      "language": "kuery",
-                      "query": "azure.activitylogs.identity.action : *delete"
+                    {
+                        "embeddableConfig":{
+                            "title":""
+                        },
+                        "gridData":{
+                            "h":4,
+                            "i":"705596b5-db2e-4c45-875d-95d98bfb7ee8",
+                            "w":16,
+                            "x":8,
+                            "y":0
+                        },
+                        "panelIndex":"705596b5-db2e-4c45-875d-95d98bfb7ee8",
+                        "panelRefName":"panel_1",
+                        "version":"7.4.0"
                     },
-                    "label": "Deletions"
-                  }
-                ]
-              },
-              "schema": "group",
-              "type": "filters"
-            }
-          ],
-          "params": {
-            "addLegend": true,
-            "addTimeMarker": false,
-            "addTooltip": true,
-            "categoryAxes": [
-              {
-                "id": "CategoryAxis-1",
-                "labels": {
-                  "filter": false,
-                  "rotate": 0,
-                  "show": true,
-                  "truncate": 200
-                },
-                "position": "left",
-                "scale": {
-                  "type": "linear"
-                },
-                "show": true,
-                "style": {},
-                "title": {},
-                "type": "category"
-              }
-            ],
-            "dimensions": {
-              "series": [
-                {
-                  "accessor": 1,
-                  "aggType": "filters",
-                  "format": {},
-                  "params": {}
-                }
-              ],
-              "x": {
-                "accessor": 0,
-                "aggType": "terms",
-                "format": {
-                  "id": "terms",
-                  "params": {
-                    "id": "string",
-                    "missingBucketLabel": "Missing",
-                    "otherBucketLabel": "Other"
-                  }
-                },
-                "params": {}
-              },
-              "y": [
-                {
-                  "accessor": 2,
-                  "aggType": "count",
-                  "format": {
-                    "id": "number"
-                  },
-                  "params": {}
-                }
-              ]
-            },
-            "grid": {
-              "categoryLines": false
-            },
-            "labels": {},
-            "legendPosition": "right",
-            "seriesParams": [
-              {
-                "data": {
-                  "id": "1",
-                  "label": "Count"
-                },
-                "drawLinesBetweenPoints": true,
-                "mode": "stacked",
-                "show": true,
-                "showCircles": true,
-                "type": "histogram",
-                "valueAxis": "ValueAxis-1"
-              }
-            ],
-            "times": [],
-            "type": "histogram",
-            "valueAxes": [
-              {
-                "id": "ValueAxis-1",
-                "labels": {
-                  "filter": true,
-                  "rotate": 75,
-                  "show": true,
-                  "truncate": 100
-                },
-                "name": "LeftAxis-1",
-                "position": "bottom",
-                "scale": {
-                  "mode": "normal",
-                  "type": "linear"
-                },
-                "show": false,
-                "style": {},
-                "title": {
-                  "text": "Count"
-                },
-                "type": "value"
-              }
-            ]
-          },
-          "title": "Resource Changes [Filebeat Azure]",
-          "type": "horizontal_bar"
-        }
-      },
-      "id": "05d39d10-ec1a-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
-        {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
-        }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:18:44.463Z",
-      "version": "WzQ4ODIsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "query": {
-              "language": "kuery",
-              "query": "event.dataset :\"azure.activitylogs\" "
-            }
-          }
-        },
-        "title": "Resource Type Breakdown [Filebeat Azure]",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [
-            {
-              "enabled": true,
-              "id": "1",
-              "params": {},
-              "schema": "metric",
-              "type": "count"
-            },
-            {
-              "enabled": true,
-              "id": "2",
-              "params": {
-                "field": "azure.resource.provider",
-                "missingBucket": false,
-                "missingBucketLabel": "Missing",
-                "order": "desc",
-                "orderBy": "1",
-                "otherBucket": false,
-                "otherBucketLabel": "Other",
-                "size": 10
-              },
-              "schema": "segment",
-              "type": "terms"
-            }
-          ],
-          "params": {
-            "addLegend": true,
-            "addTooltip": true,
-            "dimensions": {
-              "buckets": [
-                {
-                  "accessor": 0,
-                  "aggType": "terms",
-                  "format": {
-                    "id": "terms",
-                    "params": {
-                      "id": "string",
-                      "missingBucketLabel": "Missing",
-                      "otherBucketLabel": "Other"
+                    {
+                        "embeddableConfig":{
+
+                        },
+                        "gridData":{
+                            "h":9,
+                            "i":"ace19840-2084-45bd-bf86-9ab31b04a17b",
+                            "w":24,
+                            "x":24,
+                            "y":0
+                        },
+                        "panelIndex":"ace19840-2084-45bd-bf86-9ab31b04a17b",
+                        "panelRefName":"panel_2",
+                        "version":"7.4.0"
+                    },
+                    {
+                        "embeddableConfig":{
+                            "title":"Users List"
+                        },
+                        "gridData":{
+                            "h":15,
+                            "i":"d4d708e1-d179-4688-8005-54e2162a82d2",
+                            "w":11,
+                            "x":0,
+                            "y":4
+                        },
+                        "panelIndex":"d4d708e1-d179-4688-8005-54e2162a82d2",
+                        "panelRefName":"panel_3",
+                        "title":"Users List",
+                        "version":"7.4.0"
+                    },
+                    {
+                        "embeddableConfig":{
+                            "title":"Top Caller IPs"
+                        },
+                        "gridData":{
+                            "h":15,
+                            "i":"5774219c-fb45-4480-bdfb-75a69bdc2cfe",
+                            "w":13,
+                            "x":11,
+                            "y":4
+                        },
+                        "panelIndex":"5774219c-fb45-4480-bdfb-75a69bdc2cfe",
+                        "panelRefName":"panel_4",
+                        "title":"Top Caller IPs",
+                        "version":"7.4.0"
+                    },
+                    {
+                        "embeddableConfig":{
+
+                        },
+                        "gridData":{
+                            "h":10,
+                            "i":"5deee186-fe00-4edc-9e5b-86d8d09f6550",
+                            "w":24,
+                            "x":24,
+                            "y":9
+                        },
+                        "panelIndex":"5deee186-fe00-4edc-9e5b-86d8d09f6550",
+                        "panelRefName":"panel_5",
+                        "version":"7.4.0"
+                    },
+                    {
+                        "embeddableConfig":{
+                            "title":"Top Resource Groups",
+                            "vis":{
+                                "legendOpen":false
+                            }
+                        },
+                        "gridData":{
+                            "h":15,
+                            "i":"2fa13b32-c544-45f7-9132-620d09d121eb",
+                            "w":16,
+                            "x":0,
+                            "y":19
+                        },
+                        "panelIndex":"2fa13b32-c544-45f7-9132-620d09d121eb",
+                        "panelRefName":"panel_6",
+                        "title":"Top Resource Groups",
+                        "version":"7.4.0"
+                    },
+                    {
+                        "version":"7.4.0",
+                        "gridData":{
+                            "x":16,
+                            "y":19,
+                            "w":17,
+                            "h":7,
+                            "i":"1a6dce1d-d039-4d18-87c7-1b700da676c2"
+                        },
+                        "panelIndex":"1a6dce1d-d039-4d18-87c7-1b700da676c2",
+                        "embeddableConfig":{
+                            "vis":{
+                                "legendOpen":true
+                            },
+                            "legendOpen":false
+                        },
+                        "panelRefName":"panel_7"
+                    },
+                    {
+                        "version":"7.4.0",
+                        "gridData":{
+                            "x":16,
+                            "y":26,
+                            "w":17,
+                            "h":8,
+                            "i":"8fddd3bb-c1e6-4533-b075-1ab7361b3af0"
+                        },
+                        "panelIndex":"8fddd3bb-c1e6-4533-b075-1ab7361b3af0",
+                        "embeddableConfig":{
+                            "vis":{
+                                "legendOpen":true
+                            },
+                            "legendOpen":false
+                        },
+                        "panelRefName":"panel_8"
+                    },
+                    {
+                        "embeddableConfig":{
+                            "title":"Top Resource Types"
+                        },
+                        "gridData":{
+                            "h":15,
+                            "i":"84583e62-1aad-4f03-a25a-c4f9eaace8c0",
+                            "w":15,
+                            "x":33,
+                            "y":19
+                        },
+                        "panelIndex":"84583e62-1aad-4f03-a25a-c4f9eaace8c0",
+                        "panelRefName":"panel_9",
+                        "title":"Top Resource Types",
+                        "version":"7.4.0"
                     }
-                  },
-                  "params": {}
-                }
-              ],
-              "metric": {
-                "accessor": 1,
-                "aggType": "count",
-                "format": {
-                  "id": "number"
+                ],
+                "timeRestore":false,
+                "title":"[Filebeat Azure] User Activity",
+                "version":1
+            },
+            "id":"87095750-f05a-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "dashboard":"7.3.0"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                    "type":"index-pattern"
                 },
-                "params": {}
-              }
-            },
-            "isDonut": false,
-            "labels": {
-              "last_level": true,
-              "show": false,
-              "truncate": 100,
-              "values": true
-            },
-            "legendPosition": "right",
-            "type": "pie"
-          },
-          "title": "Resource Type Breakdown [Filebeat Azure]",
-          "type": "pie"
-        }
-      },
-      "id": "9ed46680-f0ce-11e9-90ec-112a988266d5",
-      "migrationVersion": {
-        "visualization": "7.3.1"
-      },
-      "references": [
+                {
+                    "id":"c43855e0-f05a-11e9-90ec-112a988266d5",
+                    "name":"panel_0",
+                    "type":"visualization"
+                },
+                {
+                    "id":"b0471750-f05b-11e9-90ec-112a988266d5",
+                    "name":"panel_1",
+                    "type":"visualization"
+                },
+                {
+                    "id":"e0203fc0-f05f-11e9-90ec-112a988266d5",
+                    "name":"panel_2",
+                    "type":"visualization"
+                },
+                {
+                    "id":"52da1700-f05d-11e9-90ec-112a988266d5",
+                    "name":"panel_3",
+                    "type":"visualization"
+                },
+                {
+                    "id":"6ece76d0-f0cc-11e9-90ec-112a988266d5",
+                    "name":"panel_4",
+                    "type":"visualization"
+                },
+                {
+                    "id":"0dd135c0-f0cc-11e9-90ec-112a988266d5",
+                    "name":"panel_5",
+                    "type":"visualization"
+                },
+                {
+                    "id":"71b62ca0-ec1a-11e9-90ec-112a988266d5",
+                    "name":"panel_6",
+                    "type":"visualization"
+                },
+                {
+                    "id":"d91ce8d0-53e8-11ea-b1b7-7de801e1c297",
+                    "name":"panel_7",
+                    "type":"visualization"
+                },
+                {
+                    "id":"6db84660-53e9-11ea-b1b7-7de801e1c297",
+                    "name":"panel_8",
+                    "type":"visualization"
+                },
+                {
+                    "id":"9ed46680-f0ce-11e9-90ec-112a988266d5",
+                    "name":"panel_9",
+                    "type":"visualization"
+                }
+            ],
+            "type":"dashboard",
+            "updated_at":"2019-10-18T17:27:59.187Z",
+            "version":"WzkyNDUsMV0="
+        },
         {
-          "id": "filebeat-*",
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern"
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Navigation Users [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "fontSize":10,
+                        "markdown":"### Azure Monitoring\n\n[Overview](#/dashboard/41e84340-ec20-11e9-90ec-112a988266d5) | [**Users**](#/dashboard/87095750-f05a-11e9-90ec-112a988266d5) | [Alerts](#/dashboard/0f559cc0-f0d5-11e9-90ec-112a988266d5) ",
+                        "openLinksInNewTab":false
+                    },
+                    "title":"Navigation Users [Filebeat Azure]",
+                    "type":"markdown"
+                }
+            },
+            "id":"c43855e0-f05a-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T11:56:56.135Z",
+            "version":"WzQ5MzYsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"User Filters [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "controls":[
+                            {
+                                "fieldName":"azure.subscription_id",
+                                "id":"1517598395667",
+                                "indexPatternRefName":"control_0_index_pattern",
+                                "label":"Subscription",
+                                "options":{
+                                    "dynamicOptions":true,
+                                    "multiselect":true,
+                                    "order":"desc",
+                                    "size":100,
+                                    "type":"terms"
+                                },
+                                "type":"list"
+                            },
+                            {
+                                "fieldName":"azure.activitylogs.identity.claims_initiated_by_user.name",
+                                "id":"1518843942322",
+                                "indexPatternRefName":"control_1_index_pattern",
+                                "label":"User Email",
+                                "options":{
+                                    "dynamicOptions":true,
+                                    "multiselect":true,
+                                    "order":"desc",
+                                    "size":100,
+                                    "type":"terms"
+                                },
+                                "type":"list"
+                            }
+                        ],
+                        "pinFilters":false,
+                        "updateFiltersOnChange":true,
+                        "useTimeFilter":false
+                    },
+                    "title":"User Filters [Filebeat Azure]",
+                    "type":"input_control_vis"
+                }
+            },
+            "id":"b0471750-f05b-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"control_0_index_pattern",
+                    "type":"index-pattern"
+                },
+                {
+                    "id":"filebeat-*",
+                    "name":"control_1_index_pattern",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T09:36:45.050Z",
+            "version":"Wzg0NTcsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"User Activity Overview [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and event.category :\"Administrative\" and azure.activitylogs.identity.claims_initiated_by_user.fullname :*"
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"auto",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"bar",
+                                "color":"rgba(1,155,143,1)",
+                                "fill":"0.4",
+                                "filter":"",
+                                "formatter":"number",
+                                "hide_in_legend":0,
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label":"Actions",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "seperate_axis":0,
+                                "split_filters":[
+                                    {
+                                        "color":"rgba(244,78,59,1)",
+                                        "filter":"_exists_:identity.claims.name",
+                                        "id":"a5302500-1399-11e8-a699-f390e75f4dd5",
+                                        "label":""
+                                    }
+                                ],
+                                "split_mode":"everything",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":null,
+                        "type":"timeseries"
+                    },
+                    "title":"User Activity Overview [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"e0203fc0-f05f-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T17:27:33.254Z",
+            "version":"WzkyNDMsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"lucene",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Users List [Filebeat Azure]",
+                "uiStateJSON":{
+                    "vis":{
+                        "params":{
+                            "sort":{
+                                "columnIndex":null,
+                                "direction":null
+                            }
+                        }
+                    }
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "customLabel":"Email",
+                                "field":"azure.activitylogs.identity.claims_initiated_by_user.name",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":20
+                            },
+                            "schema":"bucket",
+                            "type":"terms"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"3",
+                            "params":{
+                                "customLabel":"Name",
+                                "field":"azure.activitylogs.identity.claims_initiated_by_user.fullname",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":5
+                            },
+                            "schema":"bucket",
+                            "type":"terms"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"5",
+                            "params":{
+                                "customLabel":"IPs",
+                                "field":"source.ip"
+                            },
+                            "schema":"metric",
+                            "type":"cardinality"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+                                "customLabel":"Actions"
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        }
+                    ],
+                    "params":{
+                        "dimensions":{
+                            "buckets":[
+                                {
+                                    "accessor":0,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                },
+                                {
+                                    "accessor":1,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ],
+                            "metrics":[
+                                {
+                                    "accessor":2,
+                                    "aggType":"cardinality",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    }
+                                },
+                                {
+                                    "accessor":3,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "perPage":10,
+                        "percentageCol":"",
+                        "showMetricsAtAllLevels":false,
+                        "showPartialRows":false,
+                        "showTotal":false,
+                        "sort":{
+                            "columnIndex":null,
+                            "direction":null
+                        },
+                        "totalFunc":"sum"
+                    },
+                    "title":"Users List [Filebeat Azure]",
+                    "type":"table"
+                }
+            },
+            "id":"52da1700-f05d-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T09:05:04.252Z",
+            "version":"WzgwNjAsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Caller IP [Filebeat Azure]",
+                "uiStateJSON":{
+                    "vis":{
+                        "params":{
+                            "sort":{
+                                "columnIndex":null,
+                                "direction":null
+                            }
+                        }
+                    }
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "customLabel":"Caller IP",
+                                "field":"source.ip",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"5",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":100
+                            },
+                            "schema":"bucket",
+                            "type":"terms"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"3",
+                            "params":{
+                                "customLabel":"Country",
+                                "field":"geo.country_name",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"5",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":100
+                            },
+                            "schema":"bucket",
+                            "type":"terms"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"4",
+                            "params":{
+                                "customLabel":"Email",
+                                "field":"azure.activitylogs.identity.claims_initiated_by_user.name",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"_key",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":5
+                            },
+                            "schema":"bucket",
+                            "type":"terms"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"5",
+                            "params":{
+
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        }
+                    ],
+                    "params":{
+                        "dimensions":{
+                            "buckets":[
+                                {
+                                    "accessor":0,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"ip",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                },
+                                {
+                                    "accessor":1,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                },
+                                {
+                                    "accessor":2,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ],
+                            "metrics":[
+                                {
+                                    "accessor":3,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "perPage":10,
+                        "percentageCol":"",
+                        "showMetricsAtAllLevels":false,
+                        "showPartialRows":false,
+                        "showTotal":false,
+                        "sort":{
+                            "columnIndex":null,
+                            "direction":null
+                        },
+                        "totalFunc":"sum"
+                    },
+                    "title":"Caller IP [Filebeat Azure]",
+                    "type":"table"
+                }
+            },
+            "id":"6ece76d0-f0cc-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-18T09:09:36.555Z",
+            "version":"WzgwNjUsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Authorization Activity User [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+
+                    ],
+                    "params":{
+                        "axis_formatter":"number",
+                        "axis_position":"left",
+                        "axis_scale":"normal",
+                        "default_index_pattern":"metricbeat-*",
+                        "default_timefield":"@timestamp",
+                        "filter":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" and azure.activitylogs.operation_name : *LISTKEYS* "
+                        },
+                        "id":"61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern":"filebeat-*",
+                        "interval":"",
+                        "isModelInvalid":false,
+                        "series":[
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"rgba(164,221,0,1)",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome : \"Success\" "
+                                },
+                                "formatter":"number",
+                                "id":"61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label":"Success",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none",
+                                "terms_field":"event.outcome"
+                            },
+                            {
+                                "axis_position":"right",
+                                "chart_type":"line",
+                                "color":"rgba(244,78,59,1)",
+                                "fill":0.5,
+                                "filter":{
+                                    "language":"kuery",
+                                    "query":"event.outcome : \"Fail\" "
+                                },
+                                "formatter":"number",
+                                "id":"78e85470-f0cb-11e9-bf79-0db2fc8554f1",
+                                "label":"Failure",
+                                "line_width":1,
+                                "metrics":[
+                                    {
+                                        "id":"78e85471-f0cb-11e9-bf79-0db2fc8554f1",
+                                        "type":"count"
+                                    }
+                                ],
+                                "point_size":1,
+                                "separate_axis":0,
+                                "split_mode":"filter",
+                                "stacked":"none"
+                            }
+                        ],
+                        "show_grid":1,
+                        "show_legend":0,
+                        "time_field":"",
+                        "type":"timeseries"
+                    },
+                    "title":"Authorization Activity User [Filebeat Azure]",
+                    "type":"metrics"
+                }
+            },
+            "id":"0dd135c0-f0cc-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T11:33:16.437Z",
+            "version":"WzQ4OTksMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":""
+                        }
+                    }
+                },
+                "title":"Top Resource Groups [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "customLabel":"Resource Groups",
+                                "field":"azure.resource.group",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":10
+                            },
+                            "schema":"segment",
+                            "type":"terms"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":true,
+                        "addTimeMarker":false,
+                        "addTooltip":true,
+                        "categoryAxes":[
+                            {
+                                "id":"CategoryAxis-1",
+                                "labels":{
+                                    "filter":false,
+                                    "rotate":0,
+                                    "show":true,
+                                    "truncate":200
+                                },
+                                "position":"left",
+                                "scale":{
+                                    "type":"linear"
+                                },
+                                "show":true,
+                                "style":{
+
+                                },
+                                "title":{
+
+                                },
+                                "type":"category"
+                            }
+                        ],
+                        "dimensions":{
+                            "x":{
+                                "accessor":0,
+                                "aggType":"terms",
+                                "format":{
+                                    "id":"terms",
+                                    "params":{
+                                        "id":"string",
+                                        "missingBucketLabel":"Missing",
+                                        "otherBucketLabel":"Other"
+                                    }
+                                },
+                                "params":{
+
+                                }
+                            },
+                            "y":[
+                                {
+                                    "accessor":1,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "grid":{
+                            "categoryLines":false
+                        },
+                        "labels":{
+
+                        },
+                        "legendPosition":"right",
+                        "seriesParams":[
+                            {
+                                "data":{
+                                    "id":"1",
+                                    "label":"Count"
+                                },
+                                "drawLinesBetweenPoints":true,
+                                "mode":"normal",
+                                "show":true,
+                                "showCircles":true,
+                                "type":"histogram",
+                                "valueAxis":"ValueAxis-1"
+                            }
+                        ],
+                        "times":[
+
+                        ],
+                        "type":"histogram",
+                        "valueAxes":[
+                            {
+                                "id":"ValueAxis-1",
+                                "labels":{
+                                    "filter":true,
+                                    "rotate":75,
+                                    "show":true,
+                                    "truncate":100
+                                },
+                                "name":"LeftAxis-1",
+                                "position":"bottom",
+                                "scale":{
+                                    "mode":"normal",
+                                    "type":"linear"
+                                },
+                                "show":false,
+                                "style":{
+
+                                },
+                                "title":{
+                                    "text":"Count"
+                                },
+                                "type":"value"
+                            }
+                        ]
+                    },
+                    "title":"Top Resource Groups [Filebeat Azure]",
+                    "type":"horizontal_bar"
+                }
+            },
+            "id":"71b62ca0-ec1a-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T14:50:09.427Z",
+            "version":"WzYxMTUsMV0="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Resource Creations [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "title":"Resource Creations [Filebeat Azure]",
+                    "type":"horizontal_bar",
+                    "params":{
+                        "addLegend":true,
+                        "addTimeMarker":false,
+                        "addTooltip":true,
+                        "categoryAxes":[
+                            {
+                                "id":"CategoryAxis-1",
+                                "labels":{
+                                    "filter":false,
+                                    "rotate":0,
+                                    "show":true,
+                                    "truncate":200
+                                },
+                                "position":"left",
+                                "scale":{
+                                    "type":"linear"
+                                },
+                                "show":true,
+                                "style":{
+
+                                },
+                                "title":{
+
+                                },
+                                "type":"category"
+                            }
+                        ],
+                        "dimensions":{
+                            "series":[
+                                {
+                                    "accessor":1,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "label":"Creations",
+                                    "params":{
+
+                                    }
+                                }
+                            ],
+                            "x":{
+                                "accessor":0,
+                                "aggType":"terms",
+                                "format":{
+                                    "id":"terms",
+                                    "params":{
+                                        "id":"string",
+                                        "missingBucketLabel":"Missing",
+                                        "otherBucketLabel":"Other"
+                                    }
+                                },
+                                "label":"Resource type",
+                                "params":{
+
+                                }
+                            },
+                            "y":[
+                                {
+                                    "accessor":2,
+                                    "aggType":"count",
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "label":"Count",
+                                    "params":{
+
+                                    }
+                                }
+                            ]
+                        },
+                        "grid":{
+                            "categoryLines":false,
+                            "valueAxis":""
+                        },
+                        "labels":{
+
+                        },
+                        "legendPosition":"right",
+                        "seriesParams":[
+                            {
+                                "data":{
+                                    "id":"1",
+                                    "label":"Count"
+                                },
+                                "drawLinesBetweenPoints":true,
+                                "lineWidth":2,
+                                "mode":"stacked",
+                                "show":true,
+                                "showCircles":true,
+                                "type":"histogram",
+                                "valueAxis":"ValueAxis-1"
+                            }
+                        ],
+                        "thresholdLine":{
+                            "color":"#E7664C",
+                            "show":false,
+                            "style":"full",
+                            "value":10,
+                            "width":1
+                        },
+                        "times":[
+
+                        ],
+                        "type":"histogram",
+                        "valueAxes":[
+                            {
+                                "id":"ValueAxis-1",
+                                "labels":{
+                                    "filter":true,
+                                    "rotate":75,
+                                    "show":true,
+                                    "truncate":100
+                                },
+                                "name":"LeftAxis-1",
+                                "position":"bottom",
+                                "scale":{
+                                    "mode":"normal",
+                                    "type":"linear"
+                                },
+                                "show":false,
+                                "style":{
+
+                                },
+                                "title":{
+                                    "text":"Count"
+                                },
+                                "type":"value"
+                            }
+                        ]
+                    },
+                    "aggs":[
+                        {
+                            "id":"1",
+                            "enabled":true,
+                            "type":"count",
+                            "schema":"metric",
+                            "params":{
+
+                            }
+                        },
+                        {
+                            "id":"2",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"segment",
+                            "params":{
+                                "field":"azure.resource.provider",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "customLabel":"Resource type"
+                            }
+                        },
+                        {
+                            "id":"4",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"group",
+                            "params":{
+                                "field":"azure.activitylogs.identity.authorization.action",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "include":".*write",
+                                "customLabel":"Creations"
+                            }
+                        }
+                    ]
+                }
+            },
+            "id":"d91ce8d0-53e8-11ea-b1b7-7de801e1c297",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2020-02-20T13:57:45.235Z",
+            "version":"WzU4OSwxXQ=="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Resource Deletions [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "title":"Resource Deletions [Filebeat Azure]",
+                    "type":"horizontal_bar",
+                    "params":{
+                        "type":"histogram",
+                        "grid":{
+                            "categoryLines":false
+                        },
+                        "categoryAxes":[
+                            {
+                                "id":"CategoryAxis-1",
+                                "type":"category",
+                                "position":"left",
+                                "show":true,
+                                "style":{
+
+                                },
+                                "scale":{
+                                    "type":"linear"
+                                },
+                                "labels":{
+                                    "show":true,
+                                    "rotate":0,
+                                    "filter":false,
+                                    "truncate":200
+                                },
+                                "title":{
+
+                                }
+                            }
+                        ],
+                        "valueAxes":[
+                            {
+                                "id":"ValueAxis-1",
+                                "name":"LeftAxis-1",
+                                "type":"value",
+                                "position":"bottom",
+                                "show":true,
+                                "style":{
+
+                                },
+                                "scale":{
+                                    "type":"linear",
+                                    "mode":"normal"
+                                },
+                                "labels":{
+                                    "show":false,
+                                    "rotate":75,
+                                    "filter":true,
+                                    "truncate":100
+                                },
+                                "title":{
+                                    "text":"Count"
+                                }
+                            }
+                        ],
+                        "seriesParams":[
+                            {
+                                "show":true,
+                                "type":"histogram",
+                                "mode":"normal",
+                                "data":{
+                                    "label":"Count",
+                                    "id":"1"
+                                },
+                                "valueAxis":"ValueAxis-1",
+                                "drawLinesBetweenPoints":true,
+                                "lineWidth":2,
+                                "showCircles":true
+                            }
+                        ],
+                        "addTooltip":true,
+                        "addLegend":true,
+                        "legendPosition":"right",
+                        "times":[
+
+                        ],
+                        "addTimeMarker":false,
+                        "labels":{
+
+                        },
+                        "thresholdLine":{
+                            "show":false,
+                            "value":10,
+                            "width":1,
+                            "style":"full",
+                            "color":"#E7664C"
+                        },
+                        "dimensions":{
+                            "x":{
+                                "accessor":0,
+                                "format":{
+                                    "id":"terms",
+                                    "params":{
+                                        "id":"string",
+                                        "otherBucketLabel":"Other",
+                                        "missingBucketLabel":"Missing"
+                                    }
+                                },
+                                "params":{
+
+                                },
+                                "label":"azure.resource.provider: Descending",
+                                "aggType":"terms"
+                            },
+                            "y":[
+                                {
+                                    "accessor":2,
+                                    "format":{
+                                        "id":"number"
+                                    },
+                                    "params":{
+
+                                    },
+                                    "label":"Count",
+                                    "aggType":"count"
+                                }
+                            ],
+                            "series":[
+                                {
+                                    "accessor":1,
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "otherBucketLabel":"Other",
+                                            "missingBucketLabel":"Missing"
+                                        }
+                                    },
+                                    "params":{
+
+                                    },
+                                    "label":"Deletions",
+                                    "aggType":"terms"
+                                }
+                            ]
+                        }
+                    },
+                    "aggs":[
+                        {
+                            "id":"1",
+                            "enabled":true,
+                            "type":"count",
+                            "schema":"metric",
+                            "params":{
+
+                            }
+                        },
+                        {
+                            "id":"2",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"segment",
+                            "params":{
+                                "field":"azure.resource.provider",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "customLabel":"Resource type"
+                            }
+                        },
+                        {
+                            "id":"3",
+                            "enabled":true,
+                            "type":"terms",
+                            "schema":"group",
+                            "params":{
+                                "field":"azure.activitylogs.identity.authorization.action",
+                                "orderBy":"1",
+                                "order":"desc",
+                                "size":15,
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "include":".*delete",
+                                "customLabel":"Deletions"
+                            }
+                        }
+                    ]
+                }
+            },
+            "id":"6db84660-53e9-11ea-b1b7-7de801e1c297",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2020-02-20T14:01:02.150Z",
+            "version":"WzU5MiwxXQ=="
+        },
+        {
+            "attributes":{
+                "description":"",
+                "kibanaSavedObjectMeta":{
+                    "searchSourceJSON":{
+                        "filter":[
+
+                        ],
+                        "indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query":{
+                            "language":"kuery",
+                            "query":"event.dataset :\"azure.activitylogs\" "
+                        }
+                    }
+                },
+                "title":"Resource Type Breakdown [Filebeat Azure]",
+                "uiStateJSON":{
+
+                },
+                "version":1,
+                "visState":{
+                    "aggs":[
+                        {
+                            "enabled":true,
+                            "id":"1",
+                            "params":{
+
+                            },
+                            "schema":"metric",
+                            "type":"count"
+                        },
+                        {
+                            "enabled":true,
+                            "id":"2",
+                            "params":{
+                                "field":"azure.resource.provider",
+                                "missingBucket":false,
+                                "missingBucketLabel":"Missing",
+                                "order":"desc",
+                                "orderBy":"1",
+                                "otherBucket":false,
+                                "otherBucketLabel":"Other",
+                                "size":10
+                            },
+                            "schema":"segment",
+                            "type":"terms"
+                        }
+                    ],
+                    "params":{
+                        "addLegend":true,
+                        "addTooltip":true,
+                        "dimensions":{
+                            "buckets":[
+                                {
+                                    "accessor":0,
+                                    "aggType":"terms",
+                                    "format":{
+                                        "id":"terms",
+                                        "params":{
+                                            "id":"string",
+                                            "missingBucketLabel":"Missing",
+                                            "otherBucketLabel":"Other"
+                                        }
+                                    },
+                                    "params":{
+
+                                    }
+                                }
+                            ],
+                            "metric":{
+                                "accessor":1,
+                                "aggType":"count",
+                                "format":{
+                                    "id":"number"
+                                },
+                                "params":{
+
+                                }
+                            }
+                        },
+                        "isDonut":false,
+                        "labels":{
+                            "last_level":true,
+                            "show":false,
+                            "truncate":100,
+                            "values":true
+                        },
+                        "legendPosition":"right",
+                        "type":"pie"
+                    },
+                    "title":"Resource Type Breakdown [Filebeat Azure]",
+                    "type":"pie"
+                }
+            },
+            "id":"9ed46680-f0ce-11e9-90ec-112a988266d5",
+            "migrationVersion":{
+                "visualization":"7.3.1"
+            },
+            "references":[
+                {
+                    "id":"filebeat-*",
+                    "name":"kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type":"index-pattern"
+                }
+            ],
+            "type":"visualization",
+            "updated_at":"2019-10-17T11:32:13.057Z",
+            "version":"WzQ4OTYsMV0="
         }
-      ],
-      "type": "visualization",
-      "updated_at": "2019-10-17T11:32:13.057Z",
-      "version": "WzQ4OTYsMV0="
-    }
-  ],
-  "version": "7.4.0"
+    ],
+    "version":"7.4.0"
 }


### PR DESCRIPTION
Cherry-pick of PR #16466 to 7.6 branch. Original message:

The Resource Changes visualization has been using kql filters which seem to fail in 7.6.0 , opened issue elastic/kibana#57828.
While it is investigating, the visualization has been updated.