### PR TITLE
Revert "[metricbeat]Docker: add size flag to docker.container (#15224)"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix skipping protocol scheme by light modules. {pull}16205[pull]
 - Made `logstash-xpack` module once again have parity with internally-collected Logstash monitoring data. {pull}16198[16198]
 - Change sqs metricset to use average as statistic method. {pull}16438[16438]
+- Revert changes in `docker` module: add size flag to docker.container. {pull}16600[16600]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/container/_meta/data.json
+++ b/metricbeat/module/docker/container/_meta/data.json
@@ -38,8 +38,8 @@
                 "org_label-schema_version": "6.5.1"
             },
             "size": {
-                "rw": 193031181,
-                "root_fs": 1290400448
+                "root_fs": 0,
+                "rw": 0
             },
             "status": "Up 7 minutes (healthy)"
         }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -67,7 +67,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // This is based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-containers.
 func (m *MetricSet) Fetch(ctx context.Context, r mb.ReporterV2) error {
 	// Fetch a list of all containers.
-	containers, err := m.dockerClient.ContainerList(ctx, types.ContainerListOptions{Size: true})
+	containers, err := m.dockerClient.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to get docker containers list")
 	}


### PR DESCRIPTION
This PR reverts changes introduced in https://github.com/elastic/beats/pull/15224 due to an issue with hanging API call to `/containers/json?size=1` for some docker versions.

original issue: https://github.com/elastic/beats/issues/14979
original PR: https://github.com/elastic/beats/pull/15224 