### PR TITLE
Cherry-pick #16441 to 7.6: [Filebeat] Check expand_event_list_from_field before checking content-type

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 - Fix a connection error in httpjson input. {pull}16123[16123]
 - Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
+- Fix s3 input with cloudtrail fileset reading json file. {issue}16374[16374] {pull}16441[16441]
 - Rewrite azure filebeat dashboards, due to changes in kibana. {pull}16466[16466]
 - Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -59,7 +59,11 @@ If the fileset using this input expects to receive multiple messages bundled
 under a specific field then the config option expand_event_list_from_field value
 can be assigned the name of the field. This setting will be able to split the
 messages under the group value into separate events. For example, CloudTrail logs
-are in JSON format and events are found under the JSON object "Records":
+are in JSON format and events are found under the JSON object "Records".
+
+Note: When `expand_event_list_from_field` parameter is given in the config, s3
+input will assume the logs are in JSON format and decode them as JSON. Content
+type will not be checked.
 
 [float]
 ==== `api_timeout`


### PR DESCRIPTION
Cherry-pick of PR #16441 to 7.6 branch. Original message: 

## What does this PR do?

This PR is to fix s3 input reading json format logs. When `expand_event_list_from_field` config is given, such as cloudtrail fileset, s3 input should use `json.NewDecoder` first. If this `expand_event_list_from_field` is not given, then check content-type and use `gzip.NewReader`.

## Why is it important?

This will fix s3 input when using cloudtrail fileset.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Closes elastic/beats#16374 

## Screenshots
When Metadata is set as below:
<img width="1549" alt="Screen Shot 2020-02-19 at 3 02 48 PM" src="https://user-images.githubusercontent.com/14081635/74885673-5ef87480-5333-11ea-925b-fd1a5c10baba.png">

I was able to read the cloudtrail json.gz file as shown below in Kibana:
<img width="1360" alt="Screen Shot 2020-02-19 at 4 19 52 PM" src="https://user-images.githubusercontent.com/14081635/74885799-b1399580-5333-11ea-9840-de3debb7d333.png">


