### PR TITLE
[Filebeat] Add missing queue_url var definition in manifest.yml

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rewrite azure filebeat dashboards, due to changes in kibana. {pull}16466[16466]
 - Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 - Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
+- Add queue_url definition in manifest file for aws module. {pull}16640{16640}
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout


### PR DESCRIPTION
## What does this PR do?

This PR is to add `queue_url` definition in all manifest.yml for all aws Filebeat filesets.

## Why is it important?

When running `./filebeat setup --modules aws` command, this error showed up:
```
Exiting: Error getting config for fileset aws/cloudtrail: Error interpreting the template of the input: template: text:4:14: executing "text" at <.queue_url>: map has no entry for key "queue_url"
```

With this PR, rerun the same command:
```
(python-env) kaiyansheng@KaiyanMacBookPro:~/go/src/github.com/elastic/beats/x-pack/filebeat (aws_var)$ ./filebeat setup --modules aws
Overwriting ILM policy is disabled. Set `setup.ilm.overwrite:true` for enabling.

Index setup finished.
Loading dashboards (Kibana must be running and reachable)
Skipping loading dashboards, No directory /Users/kaiyansheng/go/src/github.com/elastic/beats/x-pack/filebeat/kibana/7
Loaded Ingest pipelines

```