### PR TITLE
[7.6][docs] Backport: Switch to standard ESS trial link (#16504)

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -11,7 +11,7 @@ quickly, see {stack-gs}/get-started-elastic-stack.html[Getting started with the
 You can skip having to install {es} and {kib} by using our
 https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}] on
 {ecloud}. The {ess} is available on AWS, GCP, and Azure.
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {ess}
+{ess-trial}[Try out the {ess}
 for free].
 ==============
 

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -16,7 +16,7 @@ for more information about installing these products.
 You can skip having to install {es} and {kib} by using our
 https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}] on
 {ecloud}. The {ess} is available on AWS, GCP, and Azure.
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {ess}
+{ess-trial}[Try out the {ess}
 for free].
 ==============
 


### PR DESCRIPTION
Backports #16504 to 7.6 branch.