### PR TITLE
[6.8][docs] Backport: Switch to standard ESS trial link (#16504)

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -9,10 +9,10 @@ quickly, see {stack-gs}/get-started-elastic-stack.html[Getting started with the
 [TIP]
 ==============
 You can skip having to install {es} and {kib} by using our
-https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
-Elastic Cloud. The {es} Service is available on both AWS and GCP.
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
-Service for free].
+https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}] on
+{ecloud}. The {ess} is available on AWS, GCP, and Azure.
+{ess-trial}[Try out the {ess}
+for free].
 ==============
 
 After installing the {stack}, see the {beats} getting started guides: 

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -12,10 +12,10 @@ for more information about installing these products.
 [TIP]
 ==============
 You can skip having to install {es} and {kib} by using our
-https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
-Elastic Cloud. The {es} Service is available on both AWS and GCP.
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
-Service for free].
+https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}] on
+{ecloud}. The {ess} is available on AWS, GCP, and Azure.
+{ess-trial}[Try out the {ess}
+for free].
 ==============
 
 After installing the {stack}, read the following topics to learn how to


### PR DESCRIPTION
Backports #16504 to 6.8 branch.