### PR TITLE
[7.x][docs] Backport: Add temporary placeholder ot get doc build working (#16642)

### DIFF
--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/placeholder.asciidoc
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/placeholder.asciidoc
@@ -1,0 +1,1 @@
+Placeholder to get conf.yaml paths working.


### PR DESCRIPTION
Backports #16642 to 7.x branch.