### PR TITLE
Cherry-pick #16563 to 7.x: Fix race condition: use messages.enqueue.count instead of size

### DIFF
--- a/x-pack/metricbeat/module/activemq/test_activemq.py
+++ b/x-pack/metricbeat/module/activemq/test_activemq.py
@@ -66,8 +66,6 @@ class ActiveMqTest(XPackTest):
         for evt in output:
             if self.all_messages_enqueued(evt, destination_type, destination_name):
                 assert 0 < evt['activemq'][destination_type]['messages']['size']['avg']
-                if 'queue' == destination_type:
-                    assert 2 == evt['activemq'][destination_type]['size']
                 self.assert_fields_are_documented(evt)
                 passed = True
 


### PR DESCRIPTION
Cherry-pick of PR #16563 to 7.x branch. Original message: 

This PR eliminates potential flakiness in ActiveMQ module.

QueueSize doesn't need to be immediately changed if Messages.Enqueque.Count changes (they present 2 different values) - these changes are not atomic.
As the system test verifies if metrics have been propagated, there is no need to check this one as well.