### PR TITLE
Cherry-pick #16640 to 7.x: [Filebeat] Add missing queue_url var definition in manifest.yml (#16640)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rewrite azure filebeat dashboards, due to changes in kibana. {pull}16466[16466]
 - Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 - Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
+- Add queue_url definition in manifest file for aws module. {pull}16640{16640}
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -3,6 +3,7 @@ module_version: 1.0
 var:
   - name: input
     default: s3
+  - name: queue_url
   - name: shared_credential_file
   - name: credential_profile_name
   - name: visibility_timeout


### PR DESCRIPTION
* Missing queue_url in aws module manifest.yml

* update changelog

(cherry picked from commit 3a764e634cf11642cc718f14844f487669140120)
