### PR TITLE
[7.x] Adding missing metricset to list (#16401)

### DIFF
--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -12,8 +12,8 @@ monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
 metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
-`ml_job`, `node_stats`, and `shard`.
+module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
+`index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -5,8 +5,8 @@ monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
 * The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
 metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `index`, `index_recovery`, `index_summary`,
-`ml_job`, `node_stats`, and `shard`.
+module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
+`index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding missing metricset to list  (#16401)