### PR TITLE
[libbeat] rename queue.Eventer -> queue.ACKListener

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -171,11 +171,11 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 		clients = append(clients, client)
 	}
 
-	queueFactory := func(e queue.Eventer) (queue.Queue, error) {
+	queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
 		return memqueue.NewQueue(log,
 			memqueue.Settings{
-				Eventer: e,
-				Events:  20,
+				ACKListener: ackListener,
+				Events:      20,
 			}), nil
 	}
 

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -33,7 +33,7 @@ func TestClient(t *testing.T) {
 	makePipeline := func(settings Settings, qu queue.Queue) *Pipeline {
 		p, err := New(beat.Info{},
 			Monitors{},
-			func(_ queue.Eventer) (queue.Queue, error) {
+			func(_ queue.ACKListener) (queue.Queue, error) {
 				return qu, nil
 			},
 			outputs.Group{},

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -166,7 +166,7 @@ func loadOutput(
 func createQueueBuilder(
 	config common.ConfigNamespace,
 	monitors Monitors,
-) (func(queue.Eventer) (queue.Queue, error), error) {
+) (func(queue.ACKListener) (queue.Queue, error), error) {
 	queueType := defaultQueueType
 	if b := config.Name(); b != "" {
 		queueType = b
@@ -187,7 +187,7 @@ func createQueueBuilder(
 		monitoring.NewString(queueReg, "name").Set(queueType)
 	}
 
-	return func(eventer queue.Eventer) (queue.Queue, error) {
-		return queueFactory(eventer, monitors.Logger, queueConfig)
+	return func(ackListener queue.ACKListener) (queue.Queue, error) {
+		return queueFactory(ackListener, monitors.Logger, queueConfig)
 	}, nil
 }

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -136,7 +136,7 @@ type waitCloser struct {
 	events sync.WaitGroup
 }
 
-type queueFactory func(queue.Eventer) (queue.Queue, error)
+type queueFactory func(queue.ACKListener) (queue.Queue, error)
 
 // New create a new Pipeline instance from a queue instance and a set of outputs.
 // The new pipeline will take ownership of queue and outputs. On Close, the

--- a/libbeat/publisher/queue/memqueue/ackloop.go
+++ b/libbeat/publisher/queue/memqueue/ackloop.go
@@ -112,8 +112,8 @@ func (l *ackLoop) handleBatchSig() int {
 	}
 
 	if count > 0 {
-		if e := l.broker.eventer; e != nil {
-			e.OnACK(count)
+		if listener := l.broker.ackListener; listener != nil {
+			listener.OnACK(count)
 		}
 
 		// report acks to waiting clients

--- a/libbeat/publisher/queue/queue.go
+++ b/libbeat/publisher/queue/queue.go
@@ -27,10 +27,10 @@ import (
 )
 
 // Factory for creating a queue used by a pipeline instance.
-type Factory func(Eventer, *logp.Logger, *common.Config) (Queue, error)
+type Factory func(ACKListener, *logp.Logger, *common.Config) (Queue, error)
 
-// Eventer listens to special events to be send by queue implementations.
-type Eventer interface {
+// ACKListener listens to special events to be send by queue implementations.
+type ACKListener interface {
 	OnACK(int) // number of consecutively published messages, acked by producers
 }
 

--- a/libbeat/publisher/queue/spool/module.go
+++ b/libbeat/publisher/queue/spool/module.go
@@ -39,7 +39,9 @@ func init() {
 	queue.RegisterType("spool", create)
 }
 
-func create(eventer queue.Eventer, logp *logp.Logger, cfg *common.Config) (queue.Queue, error) {
+func create(
+	ackListener queue.ACKListener, logp *logp.Logger, cfg *common.Config,
+) (queue.Queue, error) {
 	cfgwarn.Beta("Spooling to disk is beta")
 
 	config := defaultConfig()
@@ -63,7 +65,7 @@ func create(eventer queue.Eventer, logp *logp.Logger, cfg *common.Config) (queue
 	}
 
 	return NewSpool(log, path, Settings{
-		Eventer:           eventer,
+		ACKListener:       ackListener,
 		Mode:              config.File.Permissions,
 		WriteBuffer:       uint(config.Write.BufferSize),
 		WriteFlushTimeout: config.Write.FlushTimeout,

--- a/libbeat/publisher/queue/spool/spool.go
+++ b/libbeat/publisher/queue/spool/spool.go
@@ -64,7 +64,7 @@ type Settings struct {
 	// buffer be flushed and reset to its original size.
 	WriteBuffer uint
 
-	Eventer queue.Eventer
+	ACKListener queue.ACKListener
 
 	WriteFlushTimeout time.Duration
 	WriteFlushEvents  uint
@@ -134,7 +134,8 @@ func NewSpool(logger logger, path string, settings Settings) (*Spool, error) {
 	if inFlushTimeout < minInFlushTimeout {
 		inFlushTimeout = minInFlushTimeout
 	}
-	inBroker, err := newInBroker(inCtx, settings.Eventer, queue, settings.Codec,
+	inBroker, err := newInBroker(
+		inCtx, settings.ACKListener, queue, settings.Codec,
 		inFlushTimeout, settings.WriteFlushEvents)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

`queue.Eventer` is an interface definition for types that can receive `OnACK(eventCount int)` calls, and is implemented by types that need to listen for incoming event ACKs. This PR renames it `queue.ACKListener` to better convey its purpose.

This PR introduces no user-visible changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
