### PR TITLE
Rerun mage fmt update for metricbeat

### DIFF
--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -59,8 +59,6 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
-  username : "admin"
-  password : "admin"
   enabled: true
 ----
 


### PR DESCRIPTION
CI is failing because ```Error: some files are not up-to-date. Run 'mage fmt update' then review and commit the changes. Modified: [metricbeat/docs/modules/haproxy.asciidoc]```