### PR TITLE
Move crawler to filebeat/beater

### DIFF
--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -52,11 +52,13 @@ func newCrawler(
 	once bool,
 ) (*crawler, error) {
 	return &crawler{
-		out:          out,
-		inputs:       map[uint64]*input.Runner{},
-		inputConfigs: inputConfigs,
-		once:         once,
-		beatDone:     beatDone,
+		out:            out,
+		inputs:         map[uint64]*input.Runner{},
+		inputsFactory:  inputFactory,
+		modulesFactory: module,
+		inputConfigs:   inputConfigs,
+		once:           once,
+		beatDone:       beatDone,
 	}, nil
 }
 

--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -15,14 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package crawler
+package beater
 
 import (
 	"fmt"
 	"sync"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
-	"github.com/elastic/beats/v7/filebeat/fileset"
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	"github.com/elastic/beats/v7/filebeat/registrar"
@@ -30,43 +29,43 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
-
-	_ "github.com/elastic/beats/v7/filebeat/include"
 )
 
-type Crawler struct {
+type crawler struct {
 	inputs          map[uint64]*input.Runner
 	inputConfigs    []*common.Config
 	out             channel.Factory
 	wg              sync.WaitGroup
-	InputsFactory   cfgfile.RunnerFactory
-	ModulesFactory  cfgfile.RunnerFactory
+	inputsFactory   cfgfile.RunnerFactory
+	modulesFactory  cfgfile.RunnerFactory
 	modulesReloader *cfgfile.Reloader
 	inputReloader   *cfgfile.Reloader
 	once            bool
-	beatVersion     string
 	beatDone        chan struct{}
 }
 
-func New(out channel.Factory, inputConfigs []*common.Config, beatVersion string, beatDone chan struct{}, once bool) (*Crawler, error) {
-	return &Crawler{
+func newCrawler(
+	inputFactory, module cfgfile.RunnerFactory,
+	out channel.Factory,
+	inputConfigs []*common.Config,
+	beatDone chan struct{},
+	once bool,
+) (*crawler, error) {
+	return &crawler{
 		out:          out,
 		inputs:       map[uint64]*input.Runner{},
 		inputConfigs: inputConfigs,
 		once:         once,
-		beatVersion:  beatVersion,
 		beatDone:     beatDone,
 	}, nil
 }
 
 // Start starts the crawler with all inputs
-func (c *Crawler) Start(
+func (c *crawler) Start(
 	pipeline beat.Pipeline,
 	r *registrar.Registrar,
 	configInputs *common.Config,
 	configModules *common.Config,
-	pipelineLoaderFactory fileset.PipelineLoaderFactory,
-	overwritePipelines bool,
 ) error {
 
 	logp.Info("Loading Inputs: %v", len(c.inputConfigs))
@@ -79,27 +78,25 @@ func (c *Crawler) Start(
 		}
 	}
 
-	c.InputsFactory = input.NewRunnerFactory(c.out, r, c.beatDone)
 	if configInputs.Enabled() {
 		c.inputReloader = cfgfile.NewReloader(pipeline, configInputs)
-		if err := c.inputReloader.Check(c.InputsFactory); err != nil {
+		if err := c.inputReloader.Check(c.inputsFactory); err != nil {
 			return err
 		}
 
 		go func() {
-			c.inputReloader.Run(c.InputsFactory)
+			c.inputReloader.Run(c.inputsFactory)
 		}()
 	}
 
-	c.ModulesFactory = fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, overwritePipelines, c.beatDone)
 	if configModules.Enabled() {
 		c.modulesReloader = cfgfile.NewReloader(pipeline, configModules)
-		if err := c.modulesReloader.Check(c.ModulesFactory); err != nil {
+		if err := c.modulesReloader.Check(c.modulesFactory); err != nil {
 			return err
 		}
 
 		go func() {
-			c.modulesReloader.Run(c.ModulesFactory)
+			c.modulesReloader.Run(c.modulesFactory)
 		}()
 	}
 
@@ -108,7 +105,7 @@ func (c *Crawler) Start(
 	return nil
 }
 
-func (c *Crawler) startInput(
+func (c *crawler) startInput(
 	pipeline beat.Pipeline,
 	config *common.Config,
 	states []file.State,
@@ -135,7 +132,7 @@ func (c *Crawler) startInput(
 	return nil
 }
 
-func (c *Crawler) Stop() {
+func (c *crawler) Stop() {
 	logp.Info("Stopping Crawler")
 
 	asyncWaitStop := func(stop func()) {
@@ -165,6 +162,6 @@ func (c *Crawler) Stop() {
 	logp.Info("Crawler stopped")
 }
 
-func (c *Crawler) WaitForCompletion() {
+func (c *crawler) WaitForCompletion() {
 	c.wg.Wait()
 }

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -39,9 +39,11 @@ import (
 	fbautodiscover "github.com/elastic/beats/v7/filebeat/autodiscover"
 	"github.com/elastic/beats/v7/filebeat/channel"
 	cfg "github.com/elastic/beats/v7/filebeat/config"
-	"github.com/elastic/beats/v7/filebeat/crawler"
 	"github.com/elastic/beats/v7/filebeat/fileset"
+	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/filebeat/registrar"
+
+	_ "github.com/elastic/beats/v7/filebeat/include"
 
 	// Add filebeat level processors
 	_ "github.com/elastic/beats/v7/filebeat/processor/add_kubernetes_metadata"
@@ -232,12 +234,26 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	outDone := make(chan struct{}) // outDone closes down all active pipeline connections
-	crawler, err := crawler.New(
-		channel.NewOutletFactory(outDone, wgEvents, b.Info).Create,
-		config.Inputs,
+	pipelineConnector := channel.NewOutletFactory(outDone, wgEvents, b.Info).Create
+
+	// Create a ES connection factory for dynamic modules pipeline loading
+	var pipelineLoaderFactory fileset.PipelineLoaderFactory
+	if b.Config.Output.Name() == "elasticsearch" {
+		pipelineLoaderFactory = newPipelineLoaderFactory(b.Config.Output.Config())
+	} else {
+		logp.Warn(pipelinesWarning)
+	}
+
+	inputLoader := input.NewRunnerFactory(pipelineConnector, registrar, fb.done)
+	moduleLoader := fileset.NewFactory(pipelineConnector,
+		registrar,
 		b.Info.Version,
+		pipelineLoaderFactory,
+		config.OverwritePipelines,
 		fb.done,
-		*once)
+	)
+
+	crawler, err := newCrawler(inputLoader, moduleLoader, pipelineConnector, config.Inputs, fb.done, *once)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)
 		return err
@@ -267,19 +283,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// Wait for all events to be processed or timeout
 	defer waitEvents.Wait()
 
-	// Create a ES connection factory for dynamic modules pipeline loading
-	var pipelineLoaderFactory fileset.PipelineLoaderFactory
-	if b.Config.Output.Name() == "elasticsearch" {
-		pipelineLoaderFactory = newPipelineLoaderFactory(b.Config.Output.Config())
-	} else {
-		logp.Warn(pipelinesWarning)
-	}
-
 	if config.OverwritePipelines {
 		logp.Debug("modules", "Existing Ingest pipelines will be updated")
 	}
 
-	err = crawler.Start(b.Publisher, registrar, config.ConfigInput, config.ConfigModules, pipelineLoaderFactory, config.OverwritePipelines)
+	err = crawler.Start(b.Publisher, registrar, config.ConfigInput, config.ConfigModules)
 	if err != nil {
 		crawler.Stop()
 		return err
@@ -296,15 +304,15 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	// Register reloadable list of inputs and modules
-	inputs := cfgfile.NewRunnerList(management.DebugK, crawler.InputsFactory, b.Publisher)
+	inputs := cfgfile.NewRunnerList(management.DebugK, inputLoader, b.Publisher)
 	reload.Register.MustRegisterList("filebeat.inputs", inputs)
 
-	modules := cfgfile.NewRunnerList(management.DebugK, crawler.ModulesFactory, b.Publisher)
+	modules := cfgfile.NewRunnerList(management.DebugK, moduleLoader, b.Publisher)
 	reload.Register.MustRegisterList("filebeat.modules", modules)
 
 	var adiscover *autodiscover.Autodiscover
 	if fb.config.Autodiscover != nil {
-		adapter := fbautodiscover.NewAutodiscoverAdapter(crawler.InputsFactory, crawler.ModulesFactory)
+		adapter := fbautodiscover.NewAutodiscoverAdapter(inputLoader, moduleLoader)
 		adiscover, err = autodiscover.NewAutodiscover("filebeat", b.Publisher, adapter, config.Autodiscover)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

The Crawler is more or less the main run loop of filebeat. It used to
generate the factories for inputs and modules, yet did expose those via
public interfaces, so we can hook them up with autodiscovery.

The crawler constuctor used to create only a half-instantiated object,
requiring all additional setup to be run after crawler.Start, as start
will finally initialized the shared variables.

This change moves the crawler into filebeat and makes it private (it is
not used anywhere in the Beats codebase).
In addition to this, we now create the factories upfront and pass them
as proper dependencies to autodiscovery and the crawler.

## Why is it important?

Minimize the public interface and reduce dependencies on startup order by injection dependencies on construction time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 

