### PR TITLE
Revert "Update haproxy.asciidoc (#16324)"

### DIFF
--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -59,8 +59,6 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
-  username : "admin"
-  password : "admin"
   enabled: true
 ----
 


### PR DESCRIPTION
The PR #16324 did unfortunately break the build, because it was updating a
generated file. Reverting this for now.

This reverts commit a45f12509629251b58bf9e33f9eb3a9fe3cfed2f.

@dedemorton will try to get the fix done later :)