### PR TITLE
[7.6][docs] Backport: Fix regexp example (#16694)

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -267,7 +267,7 @@ For example, the following condition checks if the process name starts with
 [source,yaml]
 -----
 regexp:
-  system.process.name: "foo.*"
+  system.process.name: "^foo.*"
 -----
 
 [float]


### PR DESCRIPTION
Backports #16694 to 7.6 branch.