### PR TITLE
(Enhancement)Add redis stream output

### DIFF
--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1522,6 +1522,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
+  # If set to stream, Redis will use Redis streams https://redis.io/topics/streams-intro
   #datatype: list
 
   # The number of workers to use for each host configured to publish events to

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -254,6 +254,7 @@ func (c *client) publishEventsBulk(conn redis.Conn, command string) publishFn {
 func (c *client) publishEventsPipeline(conn redis.Conn, command string) publishFn {
 	return func(key outil.Selector, data []publisher.Event) ([]publisher.Event, error) {
 		var okEvents []publisher.Event
+		var commandArgs redis.Args
 		serialized := make([]interface{}, 0, len(data))
 		okEvents, serialized = serializeEvents(serialized, 0, data, c.index, c.codec)
 		c.observer.Dropped(len(data) - len(okEvents))
@@ -271,17 +272,18 @@ func (c *client) publishEventsPipeline(conn redis.Conn, command string) publishF
 				continue
 			}
 
+
 			data = append(data, okEvents[i])
 			if command == "XADD" {
-				if err := conn.Send(command, eventKey, "*", "payload", serializedEvent); err != nil {
-					logp.Err("Failed to execute %v: %v", command, err)
-				}
+				commandArgs = commandArgs.Add(eventKey).Add("*").Add("payload").Add(serializedEvent)
 			} else {
-				if err := conn.Send(command, eventKey, serializedEvent); err != nil {
-					logp.Err("Failed to execute %v: %v", command, err)
-				}
+				commandArgs = commandArgs.Add(eventKey).Add(serializedEvent)
 			}
-			return okEvents, err
+
+			if err := conn.Send(command, commandArgs...); err != nil {
+				logp.Err("Failed to execute %v: %v", command, err)
+				return okEvents, err
+			}
 		}
 		c.observer.Dropped(dropped)
 

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -254,7 +254,6 @@ func (c *client) publishEventsBulk(conn redis.Conn, command string) publishFn {
 func (c *client) publishEventsPipeline(conn redis.Conn, command string) publishFn {
 	return func(key outil.Selector, data []publisher.Event) ([]publisher.Event, error) {
 		var okEvents []publisher.Event
-		var commandArgs redis.Args
 		serialized := make([]interface{}, 0, len(data))
 		okEvents, serialized = serializeEvents(serialized, 0, data, c.index, c.codec)
 		c.observer.Dropped(len(data) - len(okEvents))
@@ -265,6 +264,7 @@ func (c *client) publishEventsPipeline(conn redis.Conn, command string) publishF
 		data = okEvents[:0]
 		dropped := 0
 		for i, serializedEvent := range serialized {
+			commandArgs := redis.Args{}
 			eventKey, err := key.Select(&okEvents[i].Content)
 			if err != nil {
 				logp.Err("Failed to set redis key: %v", err)

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -65,7 +65,7 @@ var (
 
 func (c *redisConfig) Validate() error {
 	switch c.DataType {
-	case "", "list", "channel":
+	case "", "list", "channel", "stream":
 	default:
 		return fmt.Errorf("redis data type %v not supported", c.DataType)
 	}

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -91,6 +91,8 @@ func makeRedis(
 		dataType = redisListType
 	case "channel":
 		dataType = redisChannelType
+	case "stream":
+		dataType = redisStreamType
 	default:
 		return outputs.Fail(errors.New("Bad Redis data type"))
 	}


### PR DESCRIPTION
- Feature additions

## What does this PR do?

Added Redis streams output to filebeat

## Why is it important?


Redis outputs are already supported and streams is a new feature enabled in Redis 5+
Streams allow for an ordered persistent queue in Redis and is often used in data processing pipelines in more modern applications

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

Check out the redis streams docs https://redis.io/topics/streams-intro

## How to test this PR locally

1. create an example filebeat config

```
filebeat.modules:
filebeat.inputs:
- type: log
  enabled: true
  paths:
    - /tmp/*.log
output.redis:
  enabled: true
  hosts: ["localhost:6379"]
  datatype: stream     
```

2. Startup a redis container with a version greater than 5.0 (when Streams was introduced)

```
docker run -p 6379:6379 redis:5.0.7
```

3. Add some logfile entries

```
echo "TEST1" >> /tmp/example.log
echo "TEST2" >> /tmp/example.log
```

4. Ensure the entries are added to the redis stream

```
$ redis-cli XRANGE filebeat - +
1) 1) "1583164104376-0"
   2) 1) "payload"
      2) "{\"@timestamp\":\"2020-03-02T15:48:23.372Z\",\"@metadata\":{\"beat\":\"filebeat\",\"type\":\"_doc\",\"version\":\"8.0.0\"},\"log\":{\"offset\":0,\"file\":{\"path\":\"/tmp/example.log\"}},\"message\":\"TEST1\",\"input\":{\"type\":\"log\"},\"host\":{\"name\":\"tamarin\"},\"agent\":{\"type\":\"filebeat\",\"ephemeral_id\":\"94339c8e-4da8-4c16-b9f1-bf9f0c9a6592\",\"hostname\":\"tamarin\",\"id\":\"309ecbd4-2704-4843-ba2c-dc1ffe230566\",\"version\":\"8.0.0\"},\"ecs\":{\"version\":\"1.4.0\"}}"
2) 1) "1583164104376-1"
   2) 1) "payload"
      2) "{\"@timestamp\":\"2020-03-02T15:48:23.372Z\",\"@metadata\":{\"beat\":\"filebeat\",\"type\":\"_doc\",\"version\":\"8.0.0\"},\"host\":{\"name\":\"tamarin\"},\"agent\":{\"id\":\"309ecbd4-2704-4843-ba2c-dc1ffe230566\",\"version\":\"8.0.0\",\"type\":\"filebeat\",\"ephemeral_id\":\"94339c8e-4da8-4c16-b9f1-bf9f0c9a6592\",\"hostname\":\"tamarin\"},\"log\":{\"offset\":6,\"file\":{\"path\":\"/tmp/example.log\"}},\"message\":\"TEST2\",\"input\":{\"type\":\"log\"},\"ecs\":{\"version\":\"1.4.0\"}}"
```


## Related issues

- Supersedes elastic/beats#10703

- 

## Use cases

- Use a persistent ordered stream to store logs
- Ingest logs for processing with Redis Gears (http://redisgears.io) 

## Logs

You can see the addition using redis-cli MONITOR command

```
1583020615.597469 [0 172.17.42.1:41816] "XADD" "filebeat" "*" "payload" "{\"@timestamp\":\"2020-02-29T23:56:54.596Z\",\"@metadata\":{\"beat\":\"filebeat\",\"type\":\"_doc\",\"version\":\"8.0.0\"},\"log\":{\"offset\":46,\"file\":{\"path\":\"/tmp/fml.log\"}},\"message\":\"test4\",\"input\":{\"type\":\"log\"},\"ecs\":{\"version\":\"1.4.0\"},\"host\":{\"name\":\"tamarin\"},\"agent\":{\"type\":\"filebeat\",\"ephemeral_id\":\"e247baf1-fed2-47e9-a6ce-73fbd4a4ea3e\",\"hostname\":\"tamarin\",\"id\":\"309ecbd4-2704-4843-ba2c-dc1ffe230566\",\"version\":\"8.0.0\"}}"
```
