### PR TITLE
[Redis Enterprise] Fix flaky: wait for metrics to be emitted

### DIFF
--- a/x-pack/metricbeat/module/redisenterprise/_meta/healthcheck.sh
+++ b/x-pack/metricbeat/module/redisenterprise/_meta/healthcheck.sh
@@ -18,4 +18,5 @@ if [[ ! -f "${CHECK_DATABASE_CREATED}" ]]; then
   touch ${CHECK_DATABASE_CREATED}
 fi
 
-curl -s --insecure https://127.0.0.1:8070 >/dev/null
+curl -s --insecure https://127.0.0.1:8070 | grep -q "node_cpu" >/dev/null
+curl -s --insecure https://127.0.0.1:8070 | grep -q "listener_egress_bytes" >/dev/null


### PR DESCRIPTION
This PR adjusts `Dockerfile` of `redisentrprise` to wait with announcing "healthy" status until relevant metrics are emitted.

Tests have been failiing because all fetched metrics were filtered (`exclude_metrics`).

Issue: https://github.com/elastic/beats/issues/16718