### PR TITLE
[Metricbeat] Add documentation for tags_filter and tags

### DIFF
--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -263,6 +263,9 @@ metricbeat.modules:
   credential_profile_name: test-mb
   metricsets:
     - ec2
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 - module: aws
   period: 300s
   credential_profile_name: test-mb
@@ -292,6 +295,9 @@ metricbeat.modules:
     - namespace: AWS/EBS
     - namespace: AWS/ELB
       tags.resource_type_filter: elasticloadbalancing
+      tags:
+        - key: "Organization"
+          value: "Engineering"
 - module: aws
   period: 60s
   credential_profile_name: test-mb

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -184,6 +184,9 @@ metricbeat.modules:
   credential_profile_name: test-mb
   metricsets:
     - ec2
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 - module: aws
   period: 300s
   credential_profile_name: test-mb
@@ -213,6 +216,9 @@ metricbeat.modules:
     - namespace: AWS/EBS
     - namespace: AWS/ELB
       tags.resource_type_filter: elasticloadbalancing
+      tags:
+        - key: "Organization"
+          value: "Engineering"
 - module: aws
   period: 60s
   credential_profile_name: test-mb

--- a/x-pack/metricbeat/module/aws/_meta/config.reference.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.reference.yml
@@ -3,6 +3,9 @@
   credential_profile_name: test-mb
   metricsets:
     - ec2
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 - module: aws
   period: 300s
   credential_profile_name: test-mb
@@ -32,6 +35,9 @@
     - namespace: AWS/EBS
     - namespace: AWS/ELB
       tags.resource_type_filter: elasticloadbalancing
+      tags:
+        - key: "Organization"
+          value: "Engineering"
 - module: aws
   period: 60s
   credential_profile_name: test-mb

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
@@ -28,6 +28,11 @@ For example, specifying a resource type of ec2 returns all Amazon EC2 resources
 only EC2 instances.
 * *statistic*: Statistics are metric data aggregations over specified periods of time.
 By default, statistic includes Average, Sum, Count, Maximum and Minimum.
+* *tags*: The tags to filter against. If tags are given in config, then only
+collect metrics from resources that have tag key and tag value matches the filter.
+For example, if tags parameter is given as `Organization=Engineering` under
+`AWS/ELB` namespace, then only collect metrics from ELBs with tag name equals to
+`Organization` and tag value equals to `Engineering`.
 
 [float]
 === Configuration examples
@@ -48,6 +53,9 @@ in configurations in order for this metricset to make proper AWS API calls.
     - namespace: AWS/EBS <1>
     - namespace: AWS/ELB <2>
       tags.resource_type_filter: elasticloadbalancing
+      tags:
+        - key: "Organization"
+          value: "Engineering"
     - namespace: AWS/EC2 <3>
       name: CPUUtilization
       statistic: ["Average"]


### PR DESCRIPTION
This PR is to add `tags_filter` in ec2 metricset documentation and `tags` into cloudwatch metricset documentation. The difference in naming here needs to be changed. I'd like to change `tags` in cloudwatch metricset to be `tags_filter` to match ec2 in the future in a separate PR.