### PR TITLE
[Libbeat] Add v7 into libbeat/logp when importing

### DIFF
--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -20,12 +20,11 @@ package actions
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/logp"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestCopyFields(t *testing.T) {

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -21,12 +21,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/logp"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestRenameRun(t *testing.T) {

--- a/libbeat/processors/actions/truncate_fields_test.go
+++ b/libbeat/processors/actions/truncate_fields_test.go
@@ -20,12 +20,11 @@ package actions
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/logp"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestTruncateFields(t *testing.T) {


### PR DESCRIPTION
This PR is to fix problem caused by adding version when importing `libbeat/logp`.

```
(python-env) kaiyansheng@KaiyanMacBookPro:~/go/src/github.com/elastic/beats/libbeat/processors/actions (fix_logp)$ go vet ./...
# github.com/elastic/beats/v7/libbeat/processors/actions
vet: ./rename_test.go:240:13: cannot use log (variable of type *logp.Logger) as *logp.Logger value in struct literal
```