### PR TITLE
[7.x] Adding integration test for beat Metricbeat module, xpack code path (#15967)

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -49,11 +49,11 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.3.0}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.5.2}-1
     build:
       context: ./module/beat/_meta
       args:
-        BEAT_VERSION: ${BEAT_VERSION:-7.3.0}
+        BEAT_VERSION: ${BEAT_VERSION:-7.5.2}
     command: '-e'
     ports:
       - 5066

--- a/metricbeat/module/beat/_meta/Dockerfile
+++ b/metricbeat/module/beat/_meta/Dockerfile
@@ -4,4 +4,4 @@ FROM docker.elastic.co/beats/metricbeat:${BEAT_VERSION}
 COPY healthcheck.sh /
 HEALTHCHECK --interval=1s --retries=300 CMD sh /healthcheck.sh
 
-ENTRYPOINT [ "metricbeat", "-E", "http.enabled=true", "-E", "http.host=0.0.0.0" ]
+ENTRYPOINT [ "metricbeat", "-E", "http.enabled=true", "-E", "http.host=0.0.0.0", "-E", "monitoring.cluster_uuid=foobar" ]

--- a/metricbeat/module/beat/beat_integration_test.go
+++ b/metricbeat/module/beat/beat_integration_test.go
@@ -60,3 +60,30 @@ func TestData(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestXPackEnabled(t *testing.T) {
+	service := compose.EnsureUpWithTimeout(t, 300, "metricbeat")
+
+	config := getXPackConfig(service.Host())
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	for _, metricSet := range metricSets {
+		events, errs := mbtest.ReportingFetchV2Error(metricSet)
+		require.Empty(t, errs)
+		require.NotEmpty(t, events)
+
+		event := events[0]
+		require.Equal(t, "beats_"+metricSet.Name(), event.RootFields["type"])
+		require.Equal(t, event.RootFields["cluster_uuid"], "foobar")
+		require.Regexp(t, `^.monitoring-beats-\d-mb`, event.Index)
+	}
+}
+
+func getXPackConfig(host string) map[string]interface{} {
+	return map[string]interface{}{
+		"module":        beat.ModuleName,
+		"metricsets":    metricSets,
+		"hosts":         []string{host},
+		"xpack.enabled": true,
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding integration test for beat Metricbeat module, xpack code path  (#15967)