### PR TITLE
[docs] Fix netflow field docs by removing duplicate topic

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -48,7 +48,6 @@ grouped in the following categories:
 * <<exported-fields-mysql>>
 * <<exported-fields-nats>>
 * <<exported-fields-netflow>>
-* <<exported-fields-netflow-module>>
 * <<exported-fields-nginx>>
 * <<exported-fields-o365>>
 * <<exported-fields-okta>>
@@ -26135,12 +26134,6 @@ type: long
 type: short
 
 --
-
-[[exported-fields-netflow-module]]
-== NetFlow fields
-
-Module for receiving NetFlow and IPFIX flow records over UDP. The module does not add fields beyond what the netflow input provides.
-
 
 [[exported-fields-nginx]]
 == Nginx fields

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -6,6 +6,8 @@ import yaml
 
 
 def document_fields(output, section, sections, path):
+    if  "nofields" in section:
+        return
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
 
@@ -136,7 +138,8 @@ grouped in the following categories:
         if "anchor" not in section:
             section["anchor"] = section["key"]
 
-        output.write("* <<exported-fields-{}>>\n".format(section["anchor"]))
+        if  "nofields" not in section:
+            output.write("* <<exported-fields-{}>>\n".format(section["anchor"]))
     output.write("\n--\n")
 
     # Sort alphabetically by key

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -6,7 +6,7 @@ import yaml
 
 
 def document_fields(output, section, sections, path):
-    if  "nofields" in section:
+    if  "skipdocs" in section:
         return
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
@@ -138,7 +138,7 @@ grouped in the following categories:
         if "anchor" not in section:
             section["anchor"] = section["key"]
 
-        if  "nofields" not in section:
+        if  "skipdocs" not in section:
             output.write("* <<exported-fields-{}>>\n".format(section["anchor"]))
     output.write("\n--\n")
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -6,7 +6,7 @@ import yaml
 
 
 def document_fields(output, section, sections, path):
-    if  "skipdocs" in section:
+    if "skipdocs" in section:
         return
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
@@ -138,7 +138,7 @@ grouped in the following categories:
         if "anchor" not in section:
             section["anchor"] = section["key"]
 
-        if  "skipdocs" not in section:
+        if "skipdocs" not in section:
             output.write("* <<exported-fields-{}>>\n".format(section["anchor"]))
     output.write("\n--\n")
 

--- a/x-pack/filebeat/module/netflow/_meta/fields.yml
+++ b/x-pack/filebeat/module/netflow/_meta/fields.yml
@@ -3,4 +3,4 @@
   description: >
     Module for receiving NetFlow and IPFIX flow records over UDP. The module
     does not add fields beyond what the netflow input provides.
-  fields:
+  nofields:

--- a/x-pack/filebeat/module/netflow/_meta/fields.yml
+++ b/x-pack/filebeat/module/netflow/_meta/fields.yml
@@ -3,4 +3,4 @@
   description: >
     Module for receiving NetFlow and IPFIX flow records over UDP. The module
     does not add fields beyond what the netflow input provides.
-  nofields:
+  skipdocs:

--- a/x-pack/filebeat/module/netflow/fields.go
+++ b/x-pack/filebeat/module/netflow/fields.go
@@ -19,5 +19,5 @@ func init() {
 // AssetNetflow returns asset data.
 // This is the base64 encoded gzipped contents of module/netflow.
 func AssetNetflow() string {
-	return "eJw8jjFOw0AQRfs9xbtAcgAXVChSClAKkGhNZoxHLDPW7sRWbo8CSvr3/n87vvU64JpTjW33E3KpWiAtqw68ah5qbAVE+7nZkhY+8FQAXv5gpmg0Paut5l93g9GF4+lw/OA2fAOiSSdWbbw/n/a8zcrjDiS045GMIkymVTqfeg0XtnlMctZ7JebLJVlarCba9wU8/pWh/AYAAP//0XBG/g=="
+	return "eJw8zj1Ow0AQhuF+T/FeIDmACyoUKQUoBUi0xjPGoyw7q92JrdweBcnpn+/nwFXvA0Vjzr4dfl1uWROERdaBd41T9i2BaJ+a1TAvAy8J4O0fM3uj6aS2WvnZE4xFOF9O5y8exQ/gTTq+auPz9XLkY1GecyCuneLBKMJsmqXzrXcvwraMQSy6v8RKvQW1+Wqi/ZigX62KT31IfwEAAP//0cxHCg=="
 }

--- a/x-pack/filebeat/module/netflow/fields.go
+++ b/x-pack/filebeat/module/netflow/fields.go
@@ -19,5 +19,5 @@ func init() {
 // AssetNetflow returns asset data.
 // This is the base64 encoded gzipped contents of module/netflow.
 func AssetNetflow() string {
-	return "eJw8jjFOw0AQRfs9xbtAcoAtqFCkFKAUINGazBiPWHas3Ymt3B4Z4fTv/f8OfOs9UzXG4uvhx+VWNEFYFM28apyKrwlE+7XZHOY185QAXv5gRm80vaotVr92g6EK58vp/ME2vAHepOOLNt6fL0feJuVxB+LaqR4MIoymRTqfevcqrNMQxKR7JVbnWzA3X0y0HxP/Qk6/AQAA//9CcUYh"
+	return "eJw8jjFOw0AQRfs9xbtAcgAXVChSClAKkGhNZoxHLDPW7sRWbo8CSvr3/n87vvU64JpTjW33E3KpWiAtqw68ah5qbAVE+7nZkhY+8FQAXv5gpmg0Paut5l93g9GF4+lw/OA2fAOiSSdWbbw/n/a8zcrjDiS045GMIkymVTqfeg0XtnlMctZ7JebLJVlarCba9wU8/pWh/AYAAP//0XBG/g=="
 }


### PR DESCRIPTION
Right now we have repeated titles in the documentation because we don't want to duplicate the field reference added by the netflow module *and* the netflow input.

I'm wondering if it makes sense to add a `nofields` field to the yml file for those rare occasions when we truly don't want to document the fields.

Here's my attempt at modifying our doc gen script. Someone on the dev team should verify in case there's an impact I don't understand.