### PR TITLE
[Metricbeat] Add vpc dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-vpc-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-vpc-overview.json
@@ -1,0 +1,1188 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of AWS VPC Related Metrics, including VPN, TransitGateway and NATGateway.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Account Name Filter"
+            },
+            "gridData": {
+              "h": 5,
+              "i": "fb503d32-2fd2-4669-91ad-477a324b4ee3",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "fb503d32-2fd2-4669-91ad-477a324b4ee3",
+            "panelRefName": "panel_0",
+            "title": "Account Name Filter",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Region Filter"
+            },
+            "gridData": {
+              "h": 5,
+              "i": "e3627422-45ad-43b9-aff9-a14bd3dd181d",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "e3627422-45ad-43b9-aff9-a14bd3dd181d",
+            "panelRefName": "panel_1",
+            "title": "Region Filter",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "61080f59-378a-4959-8522-b90c571bddd8",
+              "w": 24,
+              "x": 0,
+              "y": 5
+            },
+            "panelIndex": "61080f59-378a-4959-8522-b90c571bddd8",
+            "panelRefName": "panel_2",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "19885c8c-b171-4541-821b-aad796ff5cff",
+              "w": 24,
+              "x": 24,
+              "y": 5
+            },
+            "panelIndex": "19885c8c-b171-4541-821b-aad796ff5cff",
+            "panelRefName": "panel_3",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC NATGateway Packets In/Out"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "521a3e01-7664-4448-9071-ae5a2ab35669",
+              "w": 24,
+              "x": 0,
+              "y": 13
+            },
+            "panelIndex": "521a3e01-7664-4448-9071-ae5a2ab35669",
+            "panelRefName": "panel_4",
+            "title": "VPC NATGateway Packets In/Out",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC NATGateway Bytes In/Out"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "a8c79f08-15f3-450c-b4bf-7595773dd457",
+              "w": 24,
+              "x": 24,
+              "y": 13
+            },
+            "panelIndex": "a8c79f08-15f3-450c-b4bf-7595773dd457",
+            "panelRefName": "panel_5",
+            "title": "VPC NATGateway Bytes In/Out",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC TransitGateway Bytes In"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "857e26bf-8f7b-4607-98be-3f869e1cd4ef",
+              "w": 24,
+              "x": 0,
+              "y": 28
+            },
+            "panelIndex": "857e26bf-8f7b-4607-98be-3f869e1cd4ef",
+            "panelRefName": "panel_6",
+            "title": "VPC TransitGateway Bytes In",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC TransitGateway Bytes Out"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "883bb626-57fd-457e-aada-5dc0ce8650f8",
+              "w": 24,
+              "x": 24,
+              "y": 28
+            },
+            "panelIndex": "883bb626-57fd-457e-aada-5dc0ce8650f8",
+            "panelRefName": "panel_7",
+            "title": "VPC TransitGateway Bytes Out",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC TransitGateway Packets In"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "9793bb12-f0f4-4686-adcf-05da009fe0ec",
+              "w": 24,
+              "x": 0,
+              "y": 43
+            },
+            "panelIndex": "9793bb12-f0f4-4686-adcf-05da009fe0ec",
+            "panelRefName": "panel_8",
+            "title": "VPC TransitGateway Packets In",
+            "version": "7.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VPC TransitGateway Packets Out"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "944851ff-2dec-4c3c-9427-024e8813ce85",
+              "w": 24,
+              "x": 24,
+              "y": 43
+            },
+            "panelIndex": "944851ff-2dec-4c3c-9427-024e8813ce85",
+            "panelRefName": "panel_9",
+            "title": "VPC TransitGateway Packets Out",
+            "version": "7.6.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] VPC Overview",
+        "version": 1
+      },
+      "id": "80cc7a50-5dcb-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "b5308940-7347-11e9-816b-07687310a99a",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "a2e0e690-5dc5-11ea-a4f6-717338406083",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "4e150df0-5dc3-11ea-a4f6-717338406083",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "fbd53a90-5dc4-11ea-a4f6-717338406083",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "03bebbf0-5dca-11ea-a4f6-717338406083",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "40ab3340-5dca-11ea-a4f6-717338406083",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "4ac605d0-5dca-11ea-a4f6-717338406083",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "6da3a6c0-5dca-11ea-a4f6-717338406083",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "60dacb30-5dca-11ea-a4f6-717338406083",
+          "name": "panel_9",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2020-03-04T03:55:36.291Z",
+      "version": "Wzc2MCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "AWS Account Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.account.name",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "account name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS Account Filter [Metricbeat AWS]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [
+        {
+          "id": "99198ae0-5a46-11ea-9dd7-5195965709e4",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:51:00.880Z",
+      "version": "Wzc1MSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "AWS Region Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "region name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS Region Filter [Metricbeat AWS]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "b5308940-7347-11e9-816b-07687310a99a",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [
+        {
+          "id": "99198ae0-5a46-11ea-9dd7-5195965709e4",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:51:14.869Z",
+      "version": "Wzc1MiwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC NATGateway Error Port Allocation [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "7d4a8e40-5dc5-11ea-8719-1b98df74d895",
+                "value": 0
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drilldown_url": "",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.ErrorPortAllocation.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "top_n"
+          },
+          "title": "VPC NATGateway Error Port Allocation [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "a2e0e690-5dc5-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:10:01.081Z",
+      "version": "WzcwNCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC NATGateway Active Connection Count [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "214fdf70-5dc3-11ea-8719-1b98df74d895"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "21ffce80-5dc3-11ea-8719-1b98df74d895"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.ActiveConnectionCount.max",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "top_n"
+          },
+          "title": "VPC NATGateway Active Connection Count [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "4e150df0-5dc3-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T02:53:19.823Z",
+      "version": "WzY5MywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC NATGateway Packets In/Out [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Packets In From Destination",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.PacketsInFromDestination.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0",
+                "filter": {
+                  "language": "kuery",
+                  "query": "aws.dimensions.NatGatewayId "
+                },
+                "formatter": "number",
+                "id": "91f28f20-5dc3-11ea-8719-1b98df74d895",
+                "label": "Packets Out To Destination",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.PacketsOutToDestination.sum",
+                    "id": "91f28f21-5dc3-11ea-8719-1b98df74d895",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "91f28f21-5dc3-11ea-8719-1b98df74d895",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "b42429e0-5dc9-11ea-9c37-0776598cee1f",
+                "label": "Packets In From Source",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.PacketsInFromSource.sum",
+                    "id": "b42429e1-5dc9-11ea-9c37-0776598cee1f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "b42429e1-5dc9-11ea-9c37-0776598cee1f",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0",
+                "filter": {
+                  "language": "kuery",
+                  "query": "aws.dimensions.NatGatewayId "
+                },
+                "formatter": "number",
+                "id": "b4c8a740-5dc9-11ea-9c37-0776598cee1f",
+                "label": "Packets Out To Source",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.PacketsOutToSource.sum",
+                    "id": "b4c8a741-5dc9-11ea-9c37-0776598cee1f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "b4c8a741-5dc9-11ea-9c37-0776598cee1f",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC NATGateway Packets In/Out [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "fbd53a90-5dc4-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:39:57.337Z",
+      "version": "Wzc0MSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC NATGateway Bytes In/Out [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes In From Destination",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.BytesInFromDestination.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0",
+                "filter": {
+                  "language": "kuery",
+                  "query": "aws.dimensions.NatGatewayId "
+                },
+                "formatter": "number",
+                "id": "91f28f20-5dc3-11ea-8719-1b98df74d895",
+                "label": "Bytes Out To Destination",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.BytesOutToDestination.sum",
+                    "id": "91f28f21-5dc3-11ea-8719-1b98df74d895",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "91f28f21-5dc3-11ea-8719-1b98df74d895",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "b42429e0-5dc9-11ea-9c37-0776598cee1f",
+                "label": "Bytes In From Source",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.BytesInFromSource.sum",
+                    "id": "b42429e1-5dc9-11ea-9c37-0776598cee1f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "b42429e1-5dc9-11ea-9c37-0776598cee1f",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0",
+                "filter": {
+                  "language": "kuery",
+                  "query": "aws.dimensions.NatGatewayId "
+                },
+                "formatter": "number",
+                "id": "b4c8a740-5dc9-11ea-9c37-0776598cee1f",
+                "label": "Bytes Out To Source",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.natgateway.metrics.BytesOutToSource.sum",
+                    "id": "b4c8a741-5dc9-11ea-9c37-0776598cee1f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.NatGatewayId",
+                "terms_order_by": "b4c8a741-5dc9-11ea-9c37-0776598cee1f",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC NATGateway Bytes In/Out [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "03bebbf0-5dca-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:41:21.583Z",
+      "version": "Wzc0MiwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC TransitGateway Bytes In [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes In",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.transitgateway.metrics.BytesIn.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.TransitGateway",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC TransitGateway Bytes In [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "40ab3340-5dca-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:43:03.796Z",
+      "version": "Wzc0MywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC TransitGateway Bytes Out [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes Out",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.transitgateway.metrics.BytesOut.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.TransitGateway",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC TransitGateway Bytes Out [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "4ac605d0-5dca-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:43:20.749Z",
+      "version": "Wzc0NCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC TransitGateway Packets In [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Packets In",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.transitgateway.metrics.PacketsIn.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.TransitGateway",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC TransitGateway Packets In [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "6da3a6c0-5dca-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:44:19.244Z",
+      "version": "Wzc0NywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "VPC TransitGateway Packets Out [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "03f5bc60-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "02ed7420-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "01e6b280-5dc8-11ea-9c37-0776598cee1f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Packets Out",
+                "line_width": "4",
+                "metrics": [
+                  {
+                    "field": "aws.transitgateway.metrics.PacketsOut.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "4",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.dimensions.TransitGateway",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "VPC TransitGateway Packets Out [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "60dacb30-5dca-11ea-a4f6-717338406083",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-04T03:44:07.841Z",
+      "version": "Wzc0NiwzXQ=="
+    }
+  ],
+  "version": "7.6.0"
+}

--- a/x-pack/metricbeat/module/aws/vpc/_meta/data_transit_gateway.json
+++ b/x-pack/metricbeat/module/aws/vpc/_meta/data_transit_gateway.json
@@ -1,0 +1,53 @@
+{
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "aws": {
+        "cloudwatch": {
+            "namespace": "AWS/TransitGateway"
+        },
+        "dimensions": {
+            "TransitGateway": "tgw-0630672a32f12808a"
+        },
+        "transitgateway": {
+            "metrics": {
+                "BytesIn": {
+                    "sum": 0
+                },
+                "BytesOut": {
+                    "sum": 0
+                },
+                "PacketDropCountBlackhole": {
+                    "sum": 0
+                },
+                "PacketDropCountNoRoute": {
+                    "sum": 0
+                },
+                "PacketsIn": {
+                    "sum": 0
+                },
+                "PacketsOut": {
+                    "sum": 0
+                }
+            }
+        }
+    },
+    "cloud": {
+        "account": {
+            "id": "428152502467",
+            "name": "elastic-beats"
+        },
+        "provider": "aws",
+        "region": "us-west-2"
+    },
+    "event": {
+        "dataset": "aws.vpc",
+        "duration": 115000,
+        "module": "aws"
+    },
+    "metricset": {
+        "name": "vpc",
+        "period": 10000
+    },
+    "service": {
+        "type": "aws"
+    }
+}


### PR DESCRIPTION
This PR is to add overview dashboard for vpc metricset in aws module.
I don't have good data points for VPCs so right now everything is zero in the screenshot.

<img width="1281" alt="Screen Shot 2020-03-03 at 9 01 08 PM" src="https://user-images.githubusercontent.com/14081635/75844043-22e0fd00-5d92-11ea-8a02-0f5e5539845e.png">
