### PR TITLE
fix: remove duplicate stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,19 +196,6 @@ pipeline {
             makeTarget("Auditbeat x-pack Linux", "-C x-pack/auditbeat testsuite")
           }
         }
-        stage('Auditbeat x-pack'){
-          agent { label 'ubuntu && immutable' }
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            expression {
-              return env.BUILD_AUDITBEAT_XPACK != "false"
-            }
-          }
-          steps {
-            makeTarget("Auditbeat x-pack Linux", "-C x-pack/auditbeat testsuite")
-          }
-        }
         stage('Libbeat'){
           agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }


### PR DESCRIPTION
## What does this PR do?

Remove a duplicate stage in the pipeline.

## Why is it important?

We have two stages identical, pipelines do not allow stages with the same ID so the pipeline fails with the following error:

```
21:37:36  org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
21:37:36  WorkflowScript: 52: Duplicate stage name: "Auditbeat x-pack" @ line 52, column 7.
21:37:36           parallel {
21:37:36           ^
21:37:36  
21:37:36  WorkflowScript: 52: Duplicate stage name: "Auditbeat x-pack" @ line 52, column 7.
21:37:36           parallel {
21:37:36           ^
21:37:36  
21:37:36  2 errors
```

