### PR TITLE
[7.6] [docs] Add username and password to haproxy example (#16703)

### DIFF
--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -59,6 +59,8 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  username : "admin"
+  password : "admin"
   enabled: true
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -315,6 +315,8 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  username : "admin"
+  password : "admin"
   enabled: true
 
 #--------------------------------- HTTP Module ---------------------------------

--- a/metricbeat/module/haproxy/_meta/config.reference.yml
+++ b/metricbeat/module/haproxy/_meta/config.reference.yml
@@ -2,4 +2,6 @@
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  username : "admin"
+  password : "admin"
   enabled: true

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -476,6 +476,8 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  username : "admin"
+  password : "admin"
   enabled: true
 
 #--------------------------------- HTTP Module ---------------------------------


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [docs] Add username and password to haproxy example  (#16703)