### PR TITLE
[7.x] Generate haproxy module docs (#16776)

### DIFF
--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -59,6 +59,8 @@ metricbeat.modules:
   metricsets: ["info", "stat"]
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  username : "admin"
+  password : "admin"
   enabled: true
 ----
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Generate haproxy module docs  (#16776)