### PR TITLE
Cherry-pick #16772 to 7.6: Fix documentation typo for kafka metricbeat module

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -29,11 +29,11 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 
 This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
 
-The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>>to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
+The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
 
 [float]
 === Usage
-The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>>to fetch JMX metrics. Refer to those Metricsets' documentation about how to use Jolokia.
+The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to those Metricsets' documentation about how to use Jolokia.
 
 
 [float]

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -22,11 +22,11 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 
 This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
 
-The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>>to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
+The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
 
 [float]
 === Usage
-The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>>to fetch JMX metrics. Refer to those Metricsets' documentation about how to use Jolokia.
+The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to those Metricsets' documentation about how to use Jolokia.
 
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #16772 to 7.6 branch. Original message: 

small documentation fix to continue https://github.com/elastic/beats/pull/16261

Co-authored-by: marnikvde <marnikvde@users.noreply.github.com>