### PR TITLE
Cherry-pick #16697 to 7.x: Fixed indentation of 'slowlog.enabled' in 'logstash.yml'

### DIFF
--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -224,6 +224,7 @@ filebeat.modules:
   # Slow logs
   #slowlog:
     #enabled: true
+
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/module/logstash/_meta/config.reference.yml
+++ b/filebeat/module/logstash/_meta/config.reference.yml
@@ -10,6 +10,7 @@
   # Slow logs
   #slowlog:
     #enabled: true
+
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/module/logstash/_meta/config.yml
+++ b/filebeat/module/logstash/_meta/config.yml
@@ -9,7 +9,7 @@
 
   # Slow logs
   slowlog:
-   enabled: true
+    enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/modules.d/logstash.yml.disabled
+++ b/filebeat/modules.d/logstash.yml.disabled
@@ -12,7 +12,7 @@
 
   # Slow logs
   slowlog:
-   enabled: true
+    enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -543,6 +543,7 @@ filebeat.modules:
   # Slow logs
   #slowlog:
     #enabled: true
+
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:


### PR DESCRIPTION
Cherry-pick of PR #16697 to 7.x branch. Original message: 

This PR is to continue https://github.com/elastic/beats/pull/14739 for fixing config typo. 