### PR TITLE
Cherry-pick #16795 to 7.x: Get ES password from the correct environment variable during testing

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -325,7 +325,7 @@ func getTestingElasticsearch(t internal.TestLogger) *Client {
 		URL:              internal.GetURL(),
 		Index:            outil.MakeSelector(),
 		Username:         internal.GetUser(),
-		Password:         internal.GetUser(),
+		Password:         internal.GetPass(),
 		Timeout:          60 * time.Second,
 		CompressionLevel: 3,
 	}, nil)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -1,12 +1,13 @@
 ### VARIABLE SETUP ###
 ### Application using libbeat may override the following variables in their Makefile
 BEAT_NAME?=libbeat## @packaging Name of the binary
+BEAT_FULL_NAME?=${BEAT_NAME}
 LICENSE?=ASL2
 BEAT_TITLE?=${BEAT_NAME}## @packaging Title of the application
 BEATS_ROOT?=github.com/elastic/beats
 BEATS_ROOT_IMPORT_PATH?=${BEATS_ROOT}/v7
 BEAT_PATH?=${BEATS_ROOT}/${BEAT_NAME}
-BEAT_IMPORT_PATH?=${BEATS_ROOT_IMPORT_PATH}/${BEAT_NAME}
+BEAT_IMPORT_PATH?=${BEATS_ROOT_IMPORT_PATH}/${BEAT_FULL_NAME}
 BEAT_PACKAGE_NAME?=${BEAT_NAME}
 BEAT_INDEX_PREFIX?=${BEAT_NAME}
 BEAT_URL?=https://www.elastic.co/products/beats/${BEAT_NAME} ## @packaging Link to the homepage of the application

--- a/x-pack/libbeat/Makefile
+++ b/x-pack/libbeat/Makefile
@@ -1,5 +1,6 @@
 BEAT_NAME?=libbeat
-BEAT_PATH?=github.com/elastic/beats/x-pack/${BEAT_NAME}
+BEAT_FULL_NAME?=x-pack/${BEAT_NAME}
+BEAT_PATH?=github.com/elastic/beats/${BEAT_FULL_NAME}
 ES_BEATS?=../..
 LICENSE=Elastic
 SYSTEM_TESTS?=true


### PR DESCRIPTION
Cherry-pick of PR #16795 to 7.x branch. Original message: 

## What does this PR do?

This PR the fixes the minor issues introduced when merging the branch `go-modules`.

## Why is it important?

Make the tests green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works