### PR TITLE
Cherry-pick #16735 to 7.x: [Elastic Log Driver] magefile cleanup, fix bug on plugin uninstall

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -62,11 +62,6 @@ func getPluginName() (string, error) {
 
 // createContainer builds the plugin and creates the container that will later become the rootfs used by the plugin
 func createContainer(ctx context.Context, cli *client.Client) error {
-	goVersion, err := mage.GoVersion()
-	if err != nil {
-		return errors.Wrap(err, "error determining go version")
-	}
-
 	dockerLogBeatDir, err := os.Getwd()
 	if err != nil {
 		return errors.Wrap(err, "error getting work dir")
@@ -96,7 +91,6 @@ func createContainer(ctx context.Context, cli *client.Client) error {
 	defer buildContext.Close()
 
 	buildOpts := types.ImageBuildOptions{
-		BuildArgs:  map[string]*string{"versionString": &goVersion},
 		Tags:       []string{rootImageName},
 		Dockerfile: "Dockerfile",
 	}
@@ -209,11 +203,6 @@ func cleanDockerArtifacts(ctx context.Context, containerID string, cli *client.C
 
 // Uninstall removes working objects and containers
 func Uninstall(ctx context.Context) error {
-	name, err := getPluginName()
-	if err != nil {
-		return err
-	}
-
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return errors.Wrap(err, "Error creating docker client")
@@ -224,21 +213,25 @@ func Uninstall(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "error getting list of plugins")
 	}
-	oursExists := false
+
+	toRemoveName := ""
 	for _, plugin := range plugins {
 		if strings.Contains(plugin.Name, logDriverName) {
-			oursExists = true
+			toRemoveName = plugin.Name
+			break
 		}
 	}
-	if oursExists {
-		err = cli.PluginDisable(ctx, name, types.PluginDisableOptions{Force: true})
-		if err != nil {
-			return errors.Wrap(err, "error disabling plugin")
-		}
-		err = cli.PluginRemove(ctx, name, types.PluginRemoveOptions{Force: true})
-		if err != nil {
-			return errors.Wrap(err, "error removing plugin")
-		}
+	if toRemoveName == "" {
+		return nil
+	}
+
+	err = cli.PluginDisable(ctx, toRemoveName, types.PluginDisableOptions{Force: true})
+	if err != nil {
+		return errors.Wrap(err, "error disabling plugin")
+	}
+	err = cli.PluginRemove(ctx, toRemoveName, types.PluginRemoveOptions{Force: true})
+	if err != nil {
+		return errors.Wrap(err, "error removing plugin")
 	}
 
 	return nil


### PR DESCRIPTION
Cherry-pick of PR #16735 to 7.x branch. Original message: 

This is a pretty short bugfix PR. There was an issue where the `Uninstall` step would fail if using a version other than `8.0.0`, as we were pulling the plugin name field from the wrong place. Also removes a vestigial option passed to the build step. 