### PR TITLE
[docs] Restructure and refactor beats documentation

### DIFF
--- a/auditbeat/docs/auditbeat-filtering.asciidoc
+++ b/auditbeat/docs/auditbeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 include::{libbeat-dir}/processors.asciidoc[]
 

--- a/auditbeat/docs/auditbeat-filtering.asciidoc
+++ b/auditbeat/docs/auditbeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/auditbeat/docs/auditbeat-general-options.asciidoc
+++ b/auditbeat/docs/auditbeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}.

--- a/auditbeat/docs/auditbeat-modules-config.asciidoc
+++ b/auditbeat/docs/auditbeat-modules-config.asciidoc
@@ -1,6 +1,10 @@
 [id="configuration-{beatname_lc}"]
 == Specify which modules to run
 
+++++
+<titleabbrev>Modules</titleabbrev>
+++++
+
 To enable specific modules you add entries to the `auditbeat.modules` list in
 the +{beatname_lc}.yml+ config file. Each entry in the list begins with a dash
 (-) and is followed by settings for that module.

--- a/auditbeat/docs/auditbeat-modules-config.asciidoc
+++ b/auditbeat/docs/auditbeat-modules-config.asciidoc
@@ -1,5 +1,5 @@
 [id="configuration-{beatname_lc}"]
-== Specify which modules to run
+== Configure modules
 
 ++++
 <titleabbrev>Modules</titleabbrev>

--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -1,5 +1,5 @@
 [id="configuring-howto-{beatname_lc}"]
-= Configuring {beatname_uc}
+= {beatname_uc} configuration
 
 [partintro]
 --

--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -3,6 +3,10 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<{beatname_lc}-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -21,21 +25,16 @@ The following topics describe how to configure {beatname_uc}:
 
 * <<configuration-{beatname_lc}>>
 * <<configuration-general-options>>
-* <<{beatname_lc}-configuration-reloading>>
 * <<configuring-internal-queue>>
 * <<configuring-output>>
 * <<ilm>>
 * <<configuration-ssl>>
 * <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<configuration-template>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
-* <<yaml-tips>>
 * <<regexp-support>>
 * <<http-endpoint>>
 * <<{beatname_lc}-reference-yml>>
@@ -49,8 +48,6 @@ include::./auditbeat-modules-config.asciidoc[]
 
 include::./auditbeat-general-options.asciidoc[]
 
-include::./reload-configuration.asciidoc[]
-
 include::{libbeat-dir}/queueconfig.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
@@ -61,10 +58,6 @@ include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::./auditbeat-filtering.asciidoc[]
 
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
-
 include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
@@ -72,14 +65,6 @@ include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 include::{libbeat-dir}/setup-config.asciidoc[]
 
 include::{libbeat-dir}/loggingconfig.asciidoc[]
-
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
-
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
 
 include::{libbeat-dir}/regexp.asciidoc[]
 

--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [id="configuring-howto-{beatname_lc}"]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -25,18 +25,19 @@ The following topics describe how to configure {beatname_uc}:
 
 * <<configuration-{beatname_lc}>>
 * <<configuration-general-options>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
 * <<configuration-path>>
+* <<auditbeat-configuration-reloading>>
+* <<configuring-output>>
+* <<configuration-ssl>>
+* <<ilm>>
+* <<configuration-template>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
-* <<configuration-template>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<regexp-support>>
 * <<http-endpoint>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 After changing configuration settings, you need to restart {beatname_uc} to
@@ -48,26 +49,26 @@ include::./auditbeat-modules-config.asciidoc[]
 
 include::./auditbeat-general-options.asciidoc[]
 
-include::{libbeat-dir}/queueconfig.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
+
+include::./reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./auditbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-path-config.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
+include::./auditbeat-filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
 include::{libbeat-dir}/loggingconfig.asciidoc[]
 
-include::{libbeat-dir}/regexp.asciidoc[]
-
 include::{libbeat-dir}/http-endpoint.asciidoc[]
+
+include::{libbeat-dir}/regexp.asciidoc[]
 
 include::{libbeat-dir}/reference-yml.asciidoc[]

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -1,5 +1,9 @@
 [id="{beatname_lc}-getting-started"]
-== Getting started with {beatname_uc}
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/auditbeat/docs/howto/howto.asciidoc
+++ b/auditbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,29 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<{beatname_lc}-geoip>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -39,6 +39,8 @@ include::./upgrading.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::./modules.asciidoc[]
 
 include::./fields.asciidoc[]

--- a/auditbeat/docs/reload-configuration.asciidoc
+++ b/auditbeat/docs/reload-configuration.asciidoc
@@ -2,7 +2,7 @@
 == Reload the configuration dynamically
 
 ++++
-<titleabbrev>Config Reloading</titleabbrev>
+<titleabbrev>Config file reloading</titleabbrev>
 ++++
 
 beta[]

--- a/auditbeat/docs/reload-configuration.asciidoc
+++ b/auditbeat/docs/reload-configuration.asciidoc
@@ -1,6 +1,10 @@
 [id="{beatname_lc}-configuration-reloading"]
 == Reload the configuration dynamically
 
+++++
+<titleabbrev>Config Reloading</titleabbrev>
+++++
+
 beta[]
 
 You can configure {beatname_uc} to dynamically reload configuration files when

--- a/auditbeat/docs/setting-up-running.asciidoc
+++ b/auditbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/auditbeat/docs/troubleshooting.asciidoc
+++ b/auditbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/auditbeat/docs/upgrading.asciidoc
+++ b/auditbeat/docs/upgrading.asciidoc
@@ -1,7 +1,7 @@
 [[upgrading-auditbeat]]
-== Upgrading Auditbeat
+== Upgrade Auditbeat
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
 * {beats-ref}/breaking-changes.html[Breaking Changes]
-* {beats-ref}/upgrading.html[Upgrading]
+* {beats-ref}/upgrading.html[Upgrade]

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [[configuring-howto-filebeat]]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -23,15 +23,16 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Filebeat:
 
+* <<configuration-filebeat-options>>
 * <<configuration-general-options>>
 * <<configuration-path>>
-* <<configuration-filebeat-options>>
+* <<filebeat-configuration-reloading>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
+* <<configuration-template>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
-* <<configuration-template>>
 * <<filtering-and-enhancing-data>>
 * <<configuration-autodiscover>>
 * <<configuring-internal-queue>>
@@ -43,11 +44,13 @@ The following topics describe how to configure Filebeat:
 
 --
 
+include::./filebeat-options.asciidoc[]
+
 include::./filebeat-general-options.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
 
-include::./filebeat-options.asciidoc[]
+include::./reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
@@ -56,8 +59,6 @@ include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 include::../../libbeat/docs/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::./filebeat-filtering.asciidoc[]
 

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -1,5 +1,5 @@
 [[configuring-howto-filebeat]]
-= Configuring Filebeat
+= {beatname_uc} configuration
 
 [partintro]
 --
@@ -19,84 +19,56 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Filebeat:
 
-* <<configuration-filebeat-modules>>
-* <<configuration-filebeat-options>>
-* <<multiline-examples>>
 * <<configuration-general-options>>
-* <<filebeat-configuration-reloading>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<load-balancing>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<{beatname_lc}-deduplication>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
-* <<setup-kibana-endpoint>>
-* <<configuration-dashboards>>
-* <<configuration-template>>
-* <<configuration-logging>>
-* <<using-environ-vars>>
+* <<configuration-filebeat-options>>
+* <<configuring-output>>
+* <<configuration-ssl>>
 * <<configuration-autodiscover>>
-* <<yaml-tips>>
-* <<regexp-support>>
+* <<ilm>>
+* <<configuration-template>>
+* <<configuration-dashboards>>
+* <<setup-kibana-endpoint>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
+* <<load-balancing>>
+* <<configuration-logging>>
 * <<http-endpoint>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
-include::./filebeat-modules-options.asciidoc[]
-
-include::./filebeat-options.asciidoc[]
-
-include::./multiline.asciidoc[]
-
 include::./filebeat-general-options.asciidoc[]
-
-include::./reload-configuration.asciidoc[]
-
-include::{libbeat-dir}/queueconfig.asciidoc[]
-
-include::{libbeat-dir}/outputconfig.asciidoc[]
-
-include::../../libbeat/docs/shared-ilm.asciidoc[]
-
-include::./load-balancing.asciidoc[]
-
-include::{libbeat-dir}/shared-ssl-config.asciidoc[]
-
-include::./filebeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-deduplication.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
 
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+include::./filebeat-options.asciidoc[]
 
-include::{libbeat-dir}/setup-config.asciidoc[]
+include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/loggingconfig.asciidoc[]
-
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
+include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 :autodiscoverJolokia:
 :autodiscoverHints:
 include::{libbeat-dir}/shared-autodiscover.asciidoc[]
 
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
+include::../../libbeat/docs/shared-ilm.asciidoc[]
 
-include::{libbeat-dir}/regexp.asciidoc[]
+include::{libbeat-dir}/setup-config.asciidoc[]
+
+include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+
+include::./filebeat-filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
+include::./load-balancing.asciidoc[]
+
+include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 include::{libbeat-dir}/http-endpoint.asciidoc[]
+
+include::{libbeat-dir}/regexp.asciidoc[]
 
 include::{libbeat-dir}/reference-yml.asciidoc[]

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -3,6 +3,10 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<filebeat-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -24,12 +28,12 @@ The following topics describe how to configure Filebeat:
 * <<configuration-filebeat-options>>
 * <<configuring-output>>
 * <<configuration-ssl>>
-* <<configuration-autodiscover>>
 * <<ilm>>
-* <<configuration-template>>
-* <<configuration-dashboards>>
 * <<setup-kibana-endpoint>>
+* <<configuration-dashboards>>
+* <<configuration-template>>
 * <<filtering-and-enhancing-data>>
+* <<configuration-autodiscover>>
 * <<configuring-internal-queue>>
 * <<load-balancing>>
 * <<configuration-logging>>
@@ -49,10 +53,6 @@ include::{libbeat-dir}/outputconfig.asciidoc[]
 
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-:autodiscoverJolokia:
-:autodiscoverHints:
-include::{libbeat-dir}/shared-autodiscover.asciidoc[]
-
 include::../../libbeat/docs/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
@@ -60,6 +60,10 @@ include::{libbeat-dir}/setup-config.asciidoc[]
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::./filebeat-filtering.asciidoc[]
+
+:autodiscoverJolokia:
+:autodiscoverHints:
+include::{libbeat-dir}/shared-autodiscover.asciidoc[]
 
 include::{libbeat-dir}/queueconfig.asciidoc[]
 

--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 Your use case might require only a subset of the data exported by {beatname_uc},
 or you might need to enhance the exported data (for example, by adding

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}. This includes:

--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -1,7 +1,7 @@
 :modulename: apache mysql
 
 [id="configuration-{beatname_lc}-modules"]
-== Specify which modules to run
+== Enable and run modules
 
 NOTE: Using {beatname_uc} modules is optional. You may decide to
 <<configuration-{beatname_lc}-options,configure inputs manually>> if you are using

--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -131,7 +131,7 @@ appropriate for your environment. To change the default configurations, you need
 to <<specify-variable-settings,specify variable settings>>.
 
 [[specify-variable-settings]]
-=== Specify variable settings
+=== Configure variable settings
 
 include::./include/set-paths.asciidoc[]
 

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -2,7 +2,7 @@
 == Configure inputs
 
 ++++
-<titleabbrev>Configure inputs</titleabbrev>
+<titleabbrev>Inputs</titleabbrev>
 ++++
 
 TIP: <<{beatname_lc}-modules-overview,{beatname_uc} modules>> provide the
@@ -58,6 +58,8 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-azure-eventhub>>
 * <<{beatname_lc}-input-cloudfoundry>>
 
+
+include::multiline.asciidoc[]
 
 include::inputs/input-log.asciidoc[]
 

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -1,5 +1,9 @@
 [[filebeat-getting-started]]
-== Getting Started With Filebeat
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/filebeat/docs/howto/filebeat-howto.asciidoc
+++ b/filebeat/docs/howto/filebeat-howto.asciidoc
@@ -1,0 +1,38 @@
+[[howto-guides]]
+= How-to guides
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<configuration-filebeat-options>>
+* <<{beatname_lc}-geoip>>
+* <<{beatname_lc}-deduplication>>
+* <<filebeat-configuration-reloading>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{docdir}/../docs/filebeat-modules-options.asciidoc[]
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+include::{libbeat-dir}/shared-deduplication.asciidoc[]
+
+include::{docdir}/../docs/reload-configuration.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -1,0 +1,38 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<configuration-filebeat-options>>
+* <<{beatname_lc}-geoip>>
+* <<{beatname_lc}-deduplication>>
+* <<filebeat-configuration-reloading>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{docdir}/../docs/filebeat-modules-options.asciidoc[]
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+include::{libbeat-dir}/shared-deduplication.asciidoc[]
+
+include::{docdir}/../docs/reload-configuration.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -8,7 +8,6 @@ Learn how to perform common {beatname_uc} configuration tasks.
 * <<configuration-filebeat-options>>
 * <<{beatname_lc}-geoip>>
 * <<{beatname_lc}-deduplication>>
-* <<filebeat-configuration-reloading>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
 * <<yaml-tips>>
@@ -21,8 +20,6 @@ include::{docdir}/../docs/filebeat-modules-options.asciidoc[]
 include::{libbeat-dir}/shared-geoip.asciidoc[]
 
 include::{libbeat-dir}/shared-deduplication.asciidoc[]
-
-include::{docdir}/../docs/reload-configuration.asciidoc[]
 
 :standalone:
 include::{libbeat-dir}/shared-env-vars.asciidoc[]

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -46,7 +46,7 @@ include::./how-filebeat-works.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
-include::{docdir}/howto/filebeat-howto.asciidoc[]
+include::{docdir}/howto/howto.asciidoc[]
 
 include::{libbeat-dir}/shared-central-management.asciidoc[]
 

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -46,6 +46,8 @@ include::./how-filebeat-works.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/filebeat-howto.asciidoc[]
+
 include::{libbeat-dir}/shared-central-management.asciidoc[]
 
 include::./modules.asciidoc[]

--- a/filebeat/docs/load-balancing.asciidoc
+++ b/filebeat/docs/load-balancing.asciidoc
@@ -1,6 +1,10 @@
 [[load-balancing]]
 == Load balance the output hosts
 
+++++
+<titleabbrev>Load balancing</titleabbrev>
+++++
+
 Filebeat provides configuration options that you can use to fine
 tune load balancing when sending events to multiple hosts.
 

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -22,7 +22,7 @@ Can't find a module for your log file type? Follow the numbered steps under
 Before running {beatname_uc} modules:
 
 * Install and configure the Elastic stack. See
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Get started with the {stack}].
 
 * Complete the {beatname_uc} installation instructions described in
 <<filebeat-installation>>. After installing {beatname_uc}, return to this

--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -1,5 +1,9 @@
 [[multiline-examples]]
-== Manage multiline messages
+=== Manage multiline messages
+
+++++
+<titleabbrev>Multiline messages</titleabbrev>
+++++
 
 The files harvested by {beatname_uc} may contain messages that span multiple
 lines of text. For example, multiline messages are common in files that contain
@@ -15,7 +19,7 @@ Also read <<yaml-tips>> and <<regexp-support>> to avoid common mistakes.
 
 [float]
 [[multiline]]
-=== Configuration options
+==== Configuration options
 
 You can specify the following options in the +{beatname_lc}.inputs+ section of
 the +{beatname_lc}.yml+ config file to control how {beatname_uc} deals with messages
@@ -73,7 +77,7 @@ lines are discarded. The default is 500.
 *`multiline.timeout`*:: After the specified timeout, {beatname_uc} sends the multiline event even if no new pattern is found to start a new event. The default is 5s.
 
 
-=== Examples of multiline configuration
+==== Examples of multiline configuration
 
 The examples in this section cover the following use cases:
 
@@ -82,7 +86,7 @@ The examples in this section cover the following use cases:
 * Combining multiple lines from time-stamped events
 
 [float]
-==== Java stack traces
+===== Java stack traces
 
 Java stack traces consist of multiple lines, with each line after the initial line beginning with whitespace, as in
 this example:
@@ -134,7 +138,7 @@ In this example, the pattern matches the following lines:
 * a line that begins with the words `Caused by:`
 
 [float]
-==== Line continuations
+===== Line continuations
 
 Several programming languages use the backslash (`\`) character at the end of a line to denote that the line continues,
 as in this example:
@@ -157,7 +161,7 @@ multiline.match: before
 This configuration merges any line that ends with the `\` character with the line that follows.
 
 [float]
-==== Timestamps
+===== Timestamps
 
 Activity logs from services such as Elasticsearch typically begin with a timestamp, followed by information on the
 specific activity, as in this example:
@@ -181,7 +185,7 @@ This configuration uses the `negate: true` and `match: after` settings to specif
 specified pattern belongs to the previous line.
 
 [float]
-==== Application events
+===== Application events
 
 Sometimes your application logs contain events, that begin and end with custom markers, such as the following example:
 
@@ -204,7 +208,7 @@ multiline.flush_pattern: 'End event'
 
 The `flush_pattern` option, specifies a regex at which the current multiline will be flushed. If you think of the `pattern` option specifying the beginning of an event, the `flush_pattern` option will specify the end or last line of the event.
 
-=== Test your regexp pattern for multiline
+==== Test your regexp pattern for multiline
 
 To make it easier for you to test the regexp patterns in your multiline config, we've created a
 https://play.golang.org/p/uAd5XHxscu[Go Playground]. You can simply plug in the regexp pattern along with

--- a/filebeat/docs/reload-configuration.asciidoc
+++ b/filebeat/docs/reload-configuration.asciidoc
@@ -1,6 +1,10 @@
 [[filebeat-configuration-reloading]]
 == Load external configuration files
 
+++++
+<titleabbrev>Config file loading</titleabbrev>
+++++
+
 {beatname_uc} can load external configuration files for inputs and modules,
 allowing you to separate your configuration into multiple smaller
 configuration files. See the <<load-input-config>> and the

--- a/filebeat/docs/setting-up-running.asciidoc
+++ b/filebeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/filebeat/docs/troubleshooting.asciidoc
+++ b/filebeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/filebeat/docs/upgrading.asciidoc
+++ b/filebeat/docs/upgrading.asciidoc
@@ -1,5 +1,9 @@
 [[upgrading-filebeat]]
-== Upgrade Filebeat
+== Upgrade {beatname_uc}
+
+++++
+<titleabbrev>Upgrade</titleabbrev>
+++++
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 

--- a/filebeat/docs/upgrading.asciidoc
+++ b/filebeat/docs/upgrading.asciidoc
@@ -1,7 +1,7 @@
 [[upgrading-filebeat]]
-== Upgrading Filebeat
+== Upgrade Filebeat
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
 * {beats-ref}/breaking-changes.html[Breaking Changes]
-* {beats-ref}/upgrading.html[Upgrading]
+* {beats-ref}/upgrading.html[Upgrade]

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [[configuring-howto-heartbeat]]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -32,13 +32,12 @@ The following topics describe how to configure Heartbeat:
 * <<configuration-ssl>>
 * <<ilm>>
 * <<configuration-template>>
-* <<setup-kibana-endpoint>>
 * <<filtering-and-enhancing-data>>
+* <<configuration-autodiscover>>
 * <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<configuration-autodiscover>>
-* <<regexp-support>>
 * <<http-endpoint>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 --
@@ -57,13 +56,7 @@ include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
-
 include::./heartbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/queueconfig.asciidoc[]
-
-include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 :autodiscoverAWSELB:
 :autodiscoverHints:
@@ -71,8 +64,12 @@ include::{libbeat-dir}/shared-autodiscover.asciidoc[]
 :autodiscoverHints!:
 :autodiscoverAWSELB!:
 
-include::{libbeat-dir}/regexp.asciidoc[]
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
+include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 include::{libbeat-dir}/http-endpoint.asciidoc[]
+
+include::{libbeat-dir}/regexp.asciidoc[]
 
 include::{libbeat-dir}/reference-yml.asciidoc[]

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -3,6 +3,10 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<heartbeat-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -23,20 +27,16 @@ The following topics describe how to configure Heartbeat:
 
 * <<configuration-heartbeat-options>>
 * <<configuration-general-options>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
-* <<setup-kibana-endpoint>>
+* <<configuring-output>>
+* <<configuration-ssl>>
+* <<ilm>>
 * <<configuration-template>>
+* <<setup-kibana-endpoint>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
 * <<configuration-autodiscover>>
-* <<yaml-tips>>
 * <<regexp-support>>
 * <<http-endpoint>>
 * <<{beatname_lc}-reference-yml>>
@@ -47,43 +47,29 @@ include::./heartbeat-options.asciidoc[]
 
 include::./heartbeat-general-options.asciidoc[]
 
-include::./heartbeat-observer-options.asciidoc[]
-
-include::{libbeat-dir}/queueconfig.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./heartbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-path-config.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
-include::{libbeat-dir}/loggingconfig.asciidoc[]
+include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
+include::./heartbeat-filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
+include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 :autodiscoverAWSELB:
 :autodiscoverHints:
 include::{libbeat-dir}/shared-autodiscover.asciidoc[]
 :autodiscoverHints!:
 :autodiscoverAWSELB!:
-
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
 
 include::{libbeat-dir}/regexp.asciidoc[]
 

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -1,5 +1,5 @@
 [[configuring-howto-heartbeat]]
-= Configuring {beatname_uc}
+= {beatname_uc} configuration
 
 [partintro]
 --

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -1,5 +1,5 @@
 [[heartbeat-getting-started]]
-== Getting Started With Heartbeat
+== Get started With Heartbeat
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -1,5 +1,9 @@
 [[heartbeat-getting-started]]
-== Get started With Heartbeat
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/heartbeat/docs/heartbeat-filtering.asciidoc
+++ b/heartbeat/docs/heartbeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/heartbeat/docs/heartbeat-filtering.asciidoc
+++ b/heartbeat/docs/heartbeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and Enhance the exported data
+== Filter and enhance the exported data
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 include::{libbeat-dir}/processors.asciidoc[]
 

--- a/heartbeat/docs/heartbeat-general-options.asciidoc
+++ b/heartbeat/docs/heartbeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}.

--- a/heartbeat/docs/heartbeat-observer-options.asciidoc
+++ b/heartbeat/docs/heartbeat-observer-options.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-observer-options]]
-== Specify Observer and Geo Options
+== Add observer and geo metadata
 
 It is often useful to view and query various attributes of the instance Heartbeat is running on. This data is attached to events via the <<add-observer-metadata,`add_observer_metadata`>> processor. This processor populates the ECS `observer.*` fields. One field of particular utility is the `observer.geo.name` field, which you can configure via this processor. Use this field to create distinctive geographic regions for your uptime checks. You might label your regions by datacenter name or geographic region, e.g. `virginia-dc-1`, or `us-east-1a`, or `virginia-us`.
 

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -1,8 +1,8 @@
 [[configuration-heartbeat-options]]
-== Set up {beatname_uc} monitors
+== Configure {beatname_uc} monitors
 
 ++++
-<titleabbrev>Set up monitors</titleabbrev>
+<titleabbrev>Monitors</titleabbrev>
 ++++
 
 To configure {beatname_uc} define a set of `monitors` to check your remote hosts.

--- a/heartbeat/docs/howto/howto.asciidoc
+++ b/heartbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,32 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<configuration-observer-options>>
+* <<{beatname_lc}-geoip>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{docdir}/heartbeat-observer-options.asciidoc[]
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -38,6 +38,8 @@ include::./setting-up-running.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::./fields.asciidoc[]
 
 include::{libbeat-dir}/monitoring/monitoring-beats.asciidoc[]

--- a/heartbeat/docs/setting-up-running.asciidoc
+++ b/heartbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/heartbeat/docs/troubleshooting.asciidoc
+++ b/heartbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/journalbeat/docs/config-options.asciidoc
+++ b/journalbeat/docs/config-options.asciidoc
@@ -2,7 +2,7 @@
 == Configure inputs
 
 ++++
-<titleabbrev>Configure inputs</titleabbrev>
+<titleabbrev>Inputs</titleabbrev>
 ++++
 
 By default, {beatname_uc} reads log events from the default systemd journals. To

--- a/journalbeat/docs/configuring-howto.asciidoc
+++ b/journalbeat/docs/configuring-howto.asciidoc
@@ -3,6 +3,9 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
 
 Before modifying configuration settings, make sure you've completed the
 <<{beatname_lc}-configuration,configuration steps>> in the Getting Started.
@@ -12,63 +15,47 @@ include::{libbeat-dir}/shared-configuring.asciidoc[]
 
 The following topics describe how to configure {beatname_uc}:
 
-* <<configuration-{beatname_lc}-options>>
 * <<configuration-general-options>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
-* <<setup-kibana-endpoint>>
+* <<configuration-{beatname_lc}-options>>
+* <<configuring-output>>
+* <<configuration-ssl>>
+* <<ilm>>
 * <<configuration-template>>
+* <<setup-kibana-endpoint>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
-* <<yaml-tips>>
-* <<regexp-support>>
 * <<http-endpoint>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
-include::./config-options.asciidoc[]
-
 include::./general-options.asciidoc[]
-
-include::{libbeat-dir}/queueconfig.asciidoc[]
-
-include::{libbeat-dir}/outputconfig.asciidoc[]
-
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-include::{libbeat-dir}/shared-ssl-config.asciidoc[]
-
-include::./filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
 
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+include::./config-options.asciidoc[]
+
+include::{libbeat-dir}/outputconfig.asciidoc[]
+
+include::{libbeat-dir}/shared-ssl-config.asciidoc[]
+
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
+include::{libbeat-dir}/shared-kibana-config.asciidoc[]
+
+include::./filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
 include::{libbeat-dir}/loggingconfig.asciidoc[]
 
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
-
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
+include::{libbeat-dir}/http-endpoint.asciidoc[]
 
 include::{libbeat-dir}/regexp.asciidoc[]
-
-include::{libbeat-dir}/http-endpoint.asciidoc[]
 
 include::{libbeat-dir}/reference-yml.asciidoc[]

--- a/journalbeat/docs/configuring-howto.asciidoc
+++ b/journalbeat/docs/configuring-howto.asciidoc
@@ -1,5 +1,5 @@
 [id="configuring-howto-{beatname_lc}"]
-= Configuring {beatname_uc}
+= {beatname_uc} configuration
 
 [partintro]
 --

--- a/journalbeat/docs/configuring-howto.asciidoc
+++ b/journalbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [id="configuring-howto-{beatname_lc}"]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -15,14 +15,13 @@ include::{libbeat-dir}/shared-configuring.asciidoc[]
 
 The following topics describe how to configure {beatname_uc}:
 
+* <<configuration-{beatname_lc}-options>>
 * <<configuration-general-options>>
 * <<configuration-path>>
-* <<configuration-{beatname_lc}-options>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
 * <<configuration-template>>
-* <<setup-kibana-endpoint>>
 * <<filtering-and-enhancing-data>>
 * <<configuring-internal-queue>>
 * <<configuration-logging>>
@@ -32,11 +31,11 @@ The following topics describe how to configure {beatname_uc}:
 
 --
 
+include::./config-options.asciidoc[]
+
 include::./general-options.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
-
-include::./config-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
@@ -45,8 +44,6 @@ include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::./filtering.asciidoc[]
 

--- a/journalbeat/docs/filtering.asciidoc
+++ b/journalbeat/docs/filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/journalbeat/docs/filtering.asciidoc
+++ b/journalbeat/docs/filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 Your use case might require only a subset of the data exported by {beatname_uc},
 or you might need to enhance the exported data (for example, by adding

--- a/journalbeat/docs/general-options.asciidoc
+++ b/journalbeat/docs/general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}. This includes:

--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -1,5 +1,9 @@
 [id="{beatname_lc}-getting-started"]
-== Getting started with {beatname_uc}
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/journalbeat/docs/howto/howto.asciidoc
+++ b/journalbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,30 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<{beatname_lc}-geoip>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -33,6 +33,8 @@ include::./setting-up-running.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::./fields.asciidoc[]
 
 include::{libbeat-dir}/monitoring/monitoring-beats.asciidoc[]

--- a/journalbeat/docs/setting-up-running.asciidoc
+++ b/journalbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/journalbeat/docs/troubleshooting.asciidoc
+++ b/journalbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/libbeat/docs/contributing-to-beats.asciidoc
+++ b/libbeat/docs/contributing-to-beats.asciidoc
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 ["appendix",id="contributing-to-beats"]
-= Contributing to Beats
+= Contribute to Beats
 
 The Beats are open source and we love to receive contributions from our
 community — you!

--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -10,7 +10,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-dashboards]]
-== Load the Kibana dashboards
+== Set up Kibana dashboards
+
+++++
+<titleabbrev>Kibana dashboards</titleabbrev>
+++++
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana.

--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-dashboards]]
-== Set up Kibana dashboards
+== Configure Kibana dashboard loading
 
 ++++
 <titleabbrev>Kibana dashboards</titleabbrev>

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -15,7 +15,7 @@
 === General configuration options
 
 ++++
-<titleabbrev>General</titleabbrev>
+<titleabbrev>General settings</titleabbrev>
 ++++
 
 These options are supported by all Elastic Beats. Because they are common

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -14,6 +14,10 @@
 [[configuration-general]]
 === General configuration options
 
+++++
+<titleabbrev>General</titleabbrev>
+++++
+
 These options are supported by all Elastic Beats. Because they are common
 options, they are not namespaced.
 

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -1,9 +1,9 @@
 [[getting-started]]
-== Getting started with {beats}
+== Get started with {beats}
 
 Each Beat is a separately installable product. Before installing Beats, you need
 to install and configure the {stack}. To learn how to get up and running
-quickly, see {stack-gs}/get-started-elastic-stack.html[Getting started with the
+quickly, see {stack-gs}/get-started-elastic-stack.html[Get started with the
 {stack}].
 
 [TIP]

--- a/libbeat/docs/http-endpoint.asciidoc
+++ b/libbeat/docs/http-endpoint.asciidoc
@@ -10,7 +10,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[http-endpoint]]
-== HTTP Endpoint
+== Configure an HTTP endpoint for metrics
+
+++++
+<titleabbrev>HTTP endpoint</titleabbrev>
+++++
 
 experimental[]
 

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -13,6 +13,10 @@
 [[configuration-logging]]
 == Configure logging
 
+++++
+<titleabbrev>Logging</titleabbrev>
+++++
+
 The `logging` section of the +{beatname_lc}.yml+ config file contains options
 for configuring the logging output.
 ifndef::serverless[]

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -1,9 +1,12 @@
 [role="xpack"]
 [[monitoring]]
-= Monitoring {beatname_uc}
+= Monitor {beatname_uc}
 
 [partintro]
 --
+++++
+<titleabbrev>Monitor</titleabbrev>
+++++
 
 You can use the {stack} {monitor-features} to gain insight into the health of
 ifndef::apm-server[]

--- a/libbeat/docs/monitoring/monitoring-internal-collection-legacy.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection-legacy.asciidoc
@@ -13,7 +13,7 @@
 [[monitoring-internal-collection-legacy]]
 == Use legacy internal collection to send monitoring data
 ++++
-<titleabbrev>Legacy internal collection (deprecated)</titleabbrev>
+<titleabbrev>Use legacy internal collection (deprecated)</titleabbrev>
 ++++
 
 deprecated[7.2.0]

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -13,7 +13,7 @@
 [[monitoring-internal-collection]]
 == Use internal collection to send monitoring data
 ++++
-<titleabbrev>Internal collection</titleabbrev>
+<titleabbrev>Use internal collection</titleabbrev>
 ++++
 
 Use internal collectors to send {beats} monitoring data directly to your

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -3,7 +3,7 @@
 == Use {metricbeat} to send monitoring data
 [subs="attributes"]
 ++++
-<titleabbrev>{metricbeat} collection</titleabbrev>
+<titleabbrev>Use {metricbeat} collection</titleabbrev>
 ++++
 
 In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc} 

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -123,7 +123,7 @@ metricbeat modules enable beat-xpack
 ----------------------------------------------------------------------
 
 For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/configuration-metricbeat.html[Configure modules] and 
 {metricbeat-ref}/metricbeat-module-beat.html[beat module]. 
 // end::enable-beat-module[]
 --

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -14,6 +14,10 @@
 [[configuring-output]]
 == Configure the output
 
+++++
+<titleabbrev>Output</titleabbrev>
+++++
+
 You configure {beatname_uc} to write to a specific output by setting options
 in the Outputs section of the +{beatname_lc}.yml+ config file. Only a single
 output may be defined.

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -1,6 +1,9 @@
 [[configuring-internal-queue]]
 == Configure the internal queue
 
+++++
+<titleabbrev>Internal queue</titleabbrev>
+++++
 {beatname_uc} uses an internal queue to store events before publishing them. The
 queue is responsible for buffering and combining events into batches that can
 be consumed by the outputs. The outputs will use bulk operations to send a

--- a/libbeat/docs/setup-config.asciidoc
+++ b/libbeat/docs/setup-config.asciidoc
@@ -1,6 +1,7 @@
 
+include::./template-config.asciidoc[]
+
 ifndef::no_dashboards[]
 include::./dashboardsconfig.asciidoc[]
 endif::no_dashboards[]
 
-include::./template-config.asciidoc[]

--- a/libbeat/docs/setup-config.asciidoc
+++ b/libbeat/docs/setup-config.asciidoc
@@ -2,6 +2,8 @@
 include::./template-config.asciidoc[]
 
 ifndef::no_dashboards[]
+include::./shared-kibana-config.asciidoc[]
+
 include::./dashboardsconfig.asciidoc[]
 endif::no_dashboards[]
 

--- a/libbeat/docs/shared-deduplication.asciidoc
+++ b/libbeat/docs/shared-deduplication.asciidoc
@@ -1,5 +1,5 @@
 [id="{beatname_lc}-deduplication"]
-== Data deduplication
+== Deduplicate data
 
 The {beats} framework guarantees at-least-once delivery to ensure that no data
 is lost when events are sent to outputs that support acknowledgement, such as

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -1,5 +1,5 @@
 [[running-on-docker]]
-=== Running {beatname_uc} on Docker
+=== Run {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/centos/[centos:7].
@@ -14,7 +14,7 @@ paid commercial features. See the
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.
 
-==== Pulling the image
+==== Pull the image
 
 Obtaining {beatname_uc} for Docker is as simple as issuing a +docker pull+ command
 against the Elastic Docker registry.

--- a/libbeat/docs/shared-download-and-install.asciidoc
+++ b/libbeat/docs/shared-download-and-install.asciidoc
@@ -1,6 +1,6 @@
 
 *Before you begin*: If you haven't installed the {stack}, do that now. See
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Get started with the {stack}].
 
 To download and install {beatname_uc}, use the commands that work with your
 system.

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -8,7 +8,7 @@ ifndef::no-output-logstash[]
 * {ls} (optional) for parsing and enhancing the data.
 endif::[]
 
-See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
+See {stack-gs}/get-started-elastic-stack.html[Get started with the {stack}]
 for more information about installing these products.
 
 [TIP]

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -2,6 +2,10 @@
 [role="xpack"]
 == Configure index lifecycle management
 
+++++
+<titleabbrev>Index lifecycle management (ILM)</titleabbrev>
+++++
+
 Use the {ref}/getting-started-index-lifecycle-management.html[index lifecycle
 management] (ILM) feature in {es} to manage your {beatname_uc} indices as they age.
 For example, instead of creating daily indices where index size can vary based

--- a/libbeat/docs/shared-kibana-config.asciidoc
+++ b/libbeat/docs/shared-kibana-config.asciidoc
@@ -12,6 +12,10 @@
 [[setup-kibana-endpoint]]
 == Configure the Kibana endpoint
 
+++++
+<titleabbrev>Kibana endpoint</titleabbrev>
+++++
+
 Starting with {beatname_uc} 6.0.0, the Kibana dashboards are loaded into Kibana
 via the Kibana API. This requires a Kibana endpoint configuration.
 

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -13,6 +13,10 @@
 [[configuration-path]]
 == Configure project paths
 
+++++
+<titleabbrev>Project paths</titleabbrev>
+++++
+
 The `path` section of the +{beatname_lc}.yml+ config file contains configuration
 options that define where {beatname_uc} looks for its files. For example, {beatname_uc}
 looks for the Elasticsearch template file in the configuration path and writes

--- a/libbeat/docs/shared-securing-beat.asciidoc
+++ b/libbeat/docs/shared-securing-beat.asciidoc
@@ -1,9 +1,13 @@
 [id="securing-{beatname_lc}"]
-= Securing {beatname_uc}
+= Secure {beatname_uc}
 
 [partintro]
 
 --
+++++
+<titleabbrev>Secure</titleabbrev>
+++++
+
 The following topics provide information about securing the {beatname_uc}
 process and securing communication between {beatname_uc} and other products in
 the Elastic stack:

--- a/libbeat/docs/shared-shutdown.asciidoc
+++ b/libbeat/docs/shared-shutdown.asciidoc
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[shutdown]]
-=== Stopping {beatname_uc}
+=== Stop {beatname_uc}
 
 An orderly shutdown of {beatname_uc} ensures that it has a chance to clean up 
 and close outstanding resources. You can help ensure an orderly shutdown by 

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -1,6 +1,10 @@
 [[configuration-ssl]]
 ifndef::apm-server[]
 == Specify SSL settings
+
+++++
+<titleabbrev>SSL</titleabbrev>
+++++
 endif::apm-server[]
 ifdef::apm-server[]
 == SSL output settings

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -1,6 +1,6 @@
 [[configuration-ssl]]
 ifndef::apm-server[]
-== Specify SSL settings
+== Configure SSL
 
 ++++
 <titleabbrev>SSL</titleabbrev>
@@ -16,7 +16,9 @@ ifndef::apm-server[]
 You can specify SSL options when you configure:
 
 * <<configuring-output,outputs>> that support SSL
+ifndef::no_dashboards[]
 * the <<setup-kibana-endpoint,Kibana endpoint>>
+endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -1,6 +1,6 @@
 [[configuration-template]]
 
-== Set up the Elasticsearch index template
+== Configure Elasticsearch index template loading
 
 ++++
 <titleabbrev>Elasticsearch index template</titleabbrev>

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -1,6 +1,10 @@
 [[configuration-template]]
 
-== Load the Elasticsearch index template
+== Set up the Elasticsearch index template
+
+++++
+<titleabbrev>Elasticsearch index template</titleabbrev>
+++++
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
 the {ref}/indices-templates.html[index template] to use for setting

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -1,5 +1,5 @@
 [[upgrading]]
-== Upgrading
+== Upgrade
 
 This section gives general recommendations for upgrading {beats} shippers:
 
@@ -292,7 +292,7 @@ If you want to disable index lifecycle management, set
 `setup.ilm.enabled: false` in the {beats} configuration file.
 
 [[troubleshooting-upgrade]]
-=== Troubleshooting {beats} upgrade issues
+=== Troubleshoot {beats} upgrade issues
 
 This section describes common problems you might encounter when upgrading to
 {beats} 7.x.

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -15,7 +15,7 @@
 ifdef::standalone[]
 
 [[yaml-tips]]
-== YAML tips and gotchas
+== Avoid YAML formatting problems
 
 endif::[]
 

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -26,6 +26,7 @@ The following topics describe how to configure {beatname_uc}:
 * <<configuration-metricbeat>>
 * <<configuration-general-options>>
 * <<configuration-path>>
+* <<metricbeat-configuration-reloading>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
@@ -47,6 +48,8 @@ include::./metricbeat-options.asciidoc[]
 include::./metricbeat-general-options.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
+
+include::{docdir}/../docs/reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -3,6 +3,10 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<metricbeat-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -19,61 +23,43 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure {beatname_uc}:
 
-* <<configuration-metricbeat>>
 * <<configuration-general-options>>
-* <<metricbeat-configuration-reloading>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
+* <<configuration-metricbeat>>
+* <<configuring-output>>
+* <<configuration-ssl>>
+* <<ilm>>
 * <<setup-kibana-endpoint>>
-* <<configuration-dashboards>>
 * <<configuration-template>>
-* <<configuration-logging>>
-* <<using-environ-vars>>
+* <<configuration-dashboards>>
+* <<filtering-and-enhancing-data>>
 * <<configuration-autodiscover>>
-* <<yaml-tips>>
-* <<regexp-support>>
+* <<configuring-internal-queue>>
+* <<configuring-ingest-node>>
+* <<configuration-logging>>
 * <<http-endpoint>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
-include::./metricbeat-options.asciidoc[]
-
 include::./metricbeat-general-options.asciidoc[]
 
-include::./reload-configuration.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
 
-include::{libbeat-dir}/queueconfig.asciidoc[]
+include::./metricbeat-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./metricbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-path-config.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
-include::{libbeat-dir}/loggingconfig.asciidoc[]
-
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
+include::./metricbeat-filtering.asciidoc[]
 
 :autodiscoverJolokia:
 :autodiscoverHints:
@@ -81,12 +67,12 @@ include::{libbeat-dir}/shared-env-vars.asciidoc[]
 include::{libbeat-dir}/shared-autodiscover.asciidoc[]
 :autodiscoverAWSEC2!:
 
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
+include::{libbeat-dir}/queueconfig.asciidoc[]
 
-include::{libbeat-dir}/regexp.asciidoc[]
+include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 include::{libbeat-dir}/http-endpoint.asciidoc[]
+
+include::{libbeat-dir}/regexp.asciidoc[]
 
 include::{libbeat-dir}/reference-yml.asciidoc[]

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -1,5 +1,5 @@
 [[configuring-howto-metricbeat]]
-= Configuring {beatname_uc}
+= {beatname_uc} configuration
 
 [partintro]
 --

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [[configuring-howto-metricbeat]]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -23,19 +23,18 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure {beatname_uc}:
 
+* <<configuration-metricbeat>>
 * <<configuration-general-options>>
 * <<configuration-path>>
-* <<configuration-metricbeat>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
-* <<setup-kibana-endpoint>>
 * <<configuration-template>>
+* <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<filtering-and-enhancing-data>>
 * <<configuration-autodiscover>>
 * <<configuring-internal-queue>>
-* <<configuring-ingest-node>>
 * <<configuration-logging>>
 * <<http-endpoint>>
 * <<regexp-support>>
@@ -43,19 +42,17 @@ The following topics describe how to configure {beatname_uc}:
 
 --
 
+include::./metricbeat-options.asciidoc[]
+
 include::./metricbeat-general-options.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
-
-include::./metricbeat-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -1,5 +1,9 @@
 [id="{beatname_lc}-getting-started"]
-== Getting started with {beatname_uc}
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 {beatname_uc} helps you monitor your servers and the services they host by
 collecting metrics from the operating system and services.

--- a/metricbeat/docs/howto/howto.asciidoc
+++ b/metricbeat/docs/howto/howto.asciidoc
@@ -6,7 +6,6 @@
 Learn how to perform common {beatname_uc} configuration tasks.
 
 * <<{beatname_lc}-geoip>>
-* <<metricbeat-configuration-reloading>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
 * <<yaml-tips>>
@@ -15,8 +14,6 @@ Learn how to perform common {beatname_uc} configuration tasks.
 --
 
 include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{docdir}/../docs/reload-configuration.asciidoc[]
 
 :standalone:
 include::{libbeat-dir}/shared-env-vars.asciidoc[]

--- a/metricbeat/docs/howto/howto.asciidoc
+++ b/metricbeat/docs/howto/howto.asciidoc
@@ -6,7 +6,6 @@
 Learn how to perform common {beatname_uc} configuration tasks.
 
 * <<{beatname_lc}-geoip>>
-* <<{beatname_lc}-deduplication>>
 * <<metricbeat-configuration-reloading>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
@@ -16,8 +15,6 @@ Learn how to perform common {beatname_uc} configuration tasks.
 --
 
 include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-deduplication.asciidoc[]
 
 include::{docdir}/../docs/reload-configuration.asciidoc[]
 

--- a/metricbeat/docs/howto/howto.asciidoc
+++ b/metricbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,35 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<{beatname_lc}-geoip>>
+* <<{beatname_lc}-deduplication>>
+* <<metricbeat-configuration-reloading>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+include::{libbeat-dir}/shared-deduplication.asciidoc[]
+
+include::{docdir}/../docs/reload-configuration.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -46,6 +46,8 @@ include::./how-metricbeat-works.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::{libbeat-dir}/shared-central-management.asciidoc[]
 
 include::./modules.asciidoc[]

--- a/metricbeat/docs/metricbeat-filtering.asciidoc
+++ b/metricbeat/docs/metricbeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 include::{libbeat-dir}/processors.asciidoc[]
 

--- a/metricbeat/docs/metricbeat-filtering.asciidoc
+++ b/metricbeat/docs/metricbeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/metricbeat/docs/metricbeat-general-options.asciidoc
+++ b/metricbeat/docs/metricbeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}. This includes:

--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-metricbeat]]
-== Specify which modules to run
+== Configure modules
+
+++++
+<titleabbrev>Modules</titleabbrev>
+++++
 
 Metricbeat provides a couple different ways to enable modules and metricsets:
 

--- a/metricbeat/docs/reload-configuration.asciidoc
+++ b/metricbeat/docs/reload-configuration.asciidoc
@@ -1,6 +1,10 @@
 [[metricbeat-configuration-reloading]]
 == Load external configuration files
 
+++++
+<titleabbrev>Config file loading</titleabbrev>
+++++
+
 Metricbeat can load external configuration files for modules, which allows you
 to separate your configuration into multiple smaller configuration files. To use
 this, you specify the `path` option under `metricbeat.config.modules` in the

--- a/metricbeat/docs/setting-up-running.asciidoc
+++ b/metricbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/metricbeat/docs/troubleshooting.asciidoc
+++ b/metricbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/metricbeat/docs/upgrading.asciidoc
+++ b/metricbeat/docs/upgrading.asciidoc
@@ -1,7 +1,7 @@
 [[upgrading-metricbeat]]
-== Upgrading Metricbeat
+== Upgrade Metricbeat
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
 * {beats-ref}/breaking-changes.html[Breaking Changes]
-* {beats-ref}/upgrading.html[Upgrading]
+* {beats-ref}/upgrading.html[Upgrade]

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [[configuring-howto-packetbeat]]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -23,18 +23,18 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Packetbeat:
 
-* <<configuration-path>>
-* <<configuration-general-options>>
-* <<configuration-interfaces>>
 * <<configuration-flows>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
+* <<configuration-general-options>>
+* <<configuration-path>>
+* <<configuration-interfaces>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
+* <<configuration-template>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
-* <<configuration-template>>
 * <<filtering-and-enhancing-data>>
 * <<configuring-internal-queue>>
 * <<configuration-logging>>
@@ -43,19 +43,17 @@ The following topics describe how to configure Packetbeat:
 
 --
 
-include::{libbeat-dir}/shared-path-config.asciidoc[]
+include::./packetbeat-options.asciidoc[]
 
 include::./packetbeat-general-options.asciidoc[]
 
-include::./packetbeat-options.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -1,8 +1,12 @@
 [[configuring-howto-packetbeat]]
-= Configuring Packetbeat
+= {beatname_uc} configuration
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<packetbeat-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -19,63 +23,47 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Packetbeat:
 
+* <<configuration-path>>
+* <<configuration-general-options>>
 * <<configuration-interfaces>>
 * <<configuration-flows>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
-* <<configuration-general-options>>
-* <<configuring-internal-queue>>
 * <<configuring-output>>
-* <<ilm>>
 * <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
-* <<configuration-path>>
+* <<ilm>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<configuration-template>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
-* <<yaml-tips>>
 * <<http-endpoint>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
-include::./packetbeat-options.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::./packetbeat-general-options.asciidoc[]
 
-include::{libbeat-dir}/queueconfig.asciidoc[]
+include::./packetbeat-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./packetbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-path-config.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
+include::./packetbeat-filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
 include::{libbeat-dir}/loggingconfig.asciidoc[]
-
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
-
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
 
 include::{libbeat-dir}/http-endpoint.asciidoc[]
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -1,5 +1,9 @@
 [[packetbeat-getting-started]]
-== Getting started with Packetbeat
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 The best way to understand the value of a network packet analytics system like
 Packetbeat is to try it on your own traffic.

--- a/packetbeat/docs/howto/howto.asciidoc
+++ b/packetbeat/docs/howto/howto.asciidoc
@@ -1,14 +1,11 @@
 [[howto-guides]]
-= How-to guides
+= How to
 
 [partintro]
 --
 Learn how to perform common {beatname_uc} configuration tasks.
 
-* <<configuration-filebeat-options>>
 * <<{beatname_lc}-geoip>>
-* <<{beatname_lc}-deduplication>>
-* <<filebeat-configuration-reloading>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
 * <<yaml-tips>>
@@ -16,23 +13,24 @@ Learn how to perform common {beatname_uc} configuration tasks.
 
 --
 
-include::{docdir}/../docs/filebeat-modules-options.asciidoc[]
-
+[role="xpack"]
 include::{libbeat-dir}/shared-geoip.asciidoc[]
 
-include::{libbeat-dir}/shared-deduplication.asciidoc[]
-
-include::{docdir}/../docs/reload-configuration.asciidoc[]
-
 :standalone:
+[role="xpack"]
 include::{libbeat-dir}/shared-env-vars.asciidoc[]
 :standalone!:
 
+[role="xpack"]
 include::{libbeat-dir}/shared-config-ingest.asciidoc[]
 
 :standalone:
+:allplatforms:
+[role="xpack"]
 include::{libbeat-dir}/yaml.asciidoc[]
 :standalone!:
+:allplatforms!:
+
 
 
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -41,6 +41,8 @@ include::./upgrading.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::./fields.asciidoc[]
 
 include::{libbeat-dir}/monitoring/monitoring-beats.asciidoc[]

--- a/packetbeat/docs/packetbeat-filtering.asciidoc
+++ b/packetbeat/docs/packetbeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 include::{libbeat-dir}/processors.asciidoc[]
 

--- a/packetbeat/docs/packetbeat-filtering.asciidoc
+++ b/packetbeat/docs/packetbeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/packetbeat/docs/packetbeat-general-options.asciidoc
+++ b/packetbeat/docs/packetbeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}.

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -1,6 +1,12 @@
 [[configuration-interfaces]]
 == Set traffic capturing options
 
+//TODO: Break this file down into multiple source files (one for each html page)
+
+++++
+<titleabbrev>Network traffic</titleabbrev>
+++++
+
 There are two main ways of deploying Packetbeat:
 
 * On dedicated servers, getting the traffic from mirror ports or tap devices.
@@ -268,6 +274,10 @@ see the following published transactions (when `ignore_outgoing` is true):
 [[configuration-flows]]
 == Set up flows to monitor network traffic
 
+++++
+<titleabbrev>Network flows</titleabbrev>
+++++
+
 You can configure Packetbeat to collect and report statistics on network flows.
 A _flow_ is a group of packets sent over the same time period that share
 common properties, such as the same source and destination address and protocol.
@@ -423,6 +433,10 @@ the output document. By default, `keep_null` is set to `false`.
 
 [[configuration-protocols]]
 == Specify which transaction protocols to monitor
+
+++++
+<titleabbrev>Protocols</titleabbrev>
+++++
 
 The `packetbeat.protocols` section of the +{beatname_lc}.yml+ config file
 contains configuration options for each supported protocol, including common
@@ -1481,6 +1495,10 @@ of memory consumed by replication sessions.
 
 [[configuration-processes]]
 == Specify which processes to monitor
+
+++++
+<titleabbrev>Processes</titleabbrev>
+++++
 
 This section of the +{beatname_lc}.yml+ config file is optional, but configuring
 the processes enables Packetbeat to show you not only the servers that the

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -1,10 +1,10 @@
 [[configuration-interfaces]]
-== Set traffic capturing options
+== Configure traffic capturing options
 
 //TODO: Break this file down into multiple source files (one for each html page)
 
 ++++
-<titleabbrev>Network traffic</titleabbrev>
+<titleabbrev>Traffic sniffing</titleabbrev>
 ++++
 
 There are two main ways of deploying Packetbeat:
@@ -272,7 +272,7 @@ see the following published transactions (when `ignore_outgoing` is true):
 
 
 [[configuration-flows]]
-== Set up flows to monitor network traffic
+== Configure flows to monitor network traffic
 
 ++++
 <titleabbrev>Network flows</titleabbrev>
@@ -432,7 +432,7 @@ If this option is set to true, fields with `null` values will be published in
 the output document. By default, `keep_null` is set to `false`.
 
 [[configuration-protocols]]
-== Specify which transaction protocols to monitor
+== Configure which transaction protocols to monitor
 
 ++++
 <titleabbrev>Protocols</titleabbrev>
@@ -1494,7 +1494,7 @@ allows to use request pipelining while at the same time limiting the amount
 of memory consumed by replication sessions.
 
 [[configuration-processes]]
-== Specify which processes to monitor
+== Configure which processes to monitor
 
 ++++
 <titleabbrev>Processes</titleabbrev>

--- a/packetbeat/docs/setting-up-running.asciidoc
+++ b/packetbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/packetbeat/docs/troubleshooting.asciidoc
+++ b/packetbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/packetbeat/docs/upgrading.asciidoc
+++ b/packetbeat/docs/upgrading.asciidoc
@@ -1,7 +1,7 @@
 [[upgrading-packetbeat]]
-== Upgrading Packetbeat
+== Upgrade Packetbeat
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
 * {beats-ref}/breaking-changes.html[Breaking Changes]
-* {beats-ref}/upgrading.html[Upgrading]
+* {beats-ref}/upgrading.html[Upgrade]

--- a/packetbeat/docs/visualizing-data-packetbeat.asciidoc
+++ b/packetbeat/docs/visualizing-data-packetbeat.asciidoc
@@ -1,5 +1,5 @@
 [[visualizing-data-packetbeat]]
-= Visualizing Packetbeat data in Kibana
+= Visualize Packetbeat data in Kibana
 
 [partintro]
 --

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -1,10 +1,10 @@
 [[configuring-howto-winlogbeat]]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
 ++++
-<titleabbrev>Configuration</titleabbrev>
+<titleabbrev>Configure</titleabbrev>
 ++++
 
 Before modifying configuration settings, make sure you've completed the
@@ -21,15 +21,15 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Winlogbeat:
 
-* <<configuration-path>>
-* <<configuration-general-options>>
 * <<configuration-winlogbeat-options>>
+* <<configuration-general-options>>
+* <<configuration-path>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
+* <<configuration-template>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
-* <<configuration-template>>
 * <<filtering-and-enhancing-data>>
 * <<configuring-internal-queue>>
 * <<configuration-logging>>
@@ -38,19 +38,17 @@ The following topics describe how to configure Winlogbeat:
 
 --
 
+include::./winlogbeat-options.asciidoc[]
+
 include::./winlogbeat-general-options.asciidoc[]
 
 include::{libbeat-dir}/shared-path-config.asciidoc[]
-
-include::./winlogbeat-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -1,8 +1,12 @@
 [[configuring-howto-winlogbeat]]
-= Configuring Winlogbeat
+= {beatname_uc} configuration
 
 [partintro]
 --
+++++
+<titleabbrev>Configuration</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<winlogbeat-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -17,60 +21,44 @@ _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Winlogbeat:
 
-* <<configuration-winlogbeat-options>>
-* <<configuration-general-options>>
-* <<configuring-internal-queue>>
-* <<configuring-output>>
-* <<ilm>>
-* <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
 * <<configuration-path>>
+* <<configuration-general-options>>
+* <<configuration-winlogbeat-options>>
+* <<configuring-output>>
+* <<configuration-ssl>>
+* <<ilm>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<configuration-template>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
-* <<yaml-tips>>
 * <<http-endpoint>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
-include::./winlogbeat-options.asciidoc[]
-
 include::./winlogbeat-general-options.asciidoc[]
 
-include::{libbeat-dir}/queueconfig.asciidoc[]
+include::{libbeat-dir}/shared-path-config.asciidoc[]
+
+include::./winlogbeat-options.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./winlogbeat-filtering.asciidoc[]
-
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-path-config.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/setup-config.asciidoc[]
 
+include::./winlogbeat-filtering.asciidoc[]
+
+include::{libbeat-dir}/queueconfig.asciidoc[]
+
 include::{libbeat-dir}/loggingconfig.asciidoc[]
-
-:standalone:
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
-
-:standalone:
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
 
 include::{libbeat-dir}/http-endpoint.asciidoc[]
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -1,5 +1,9 @@
 [[winlogbeat-getting-started]]
-== Getting Started With Winlogbeat
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 
@@ -15,7 +19,7 @@ include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 === Step 1: Install Winlogbeat
 
 *Before you begin*: If you haven't installed the {stack}, do that now. See
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Get started with the {stack}].
 
 . Download the Winlogbeat zip file from the
 https://www.elastic.co/downloads/beats/winlogbeat[downloads page].

--- a/winlogbeat/docs/howto/howto.asciidoc
+++ b/winlogbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,32 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<{beatname_lc}-geoip>>
+* <<{beatname_lc}-deduplication>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+include::{libbeat-dir}/shared-deduplication.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/winlogbeat/docs/howto/howto.asciidoc
+++ b/winlogbeat/docs/howto/howto.asciidoc
@@ -6,7 +6,6 @@
 Learn how to perform common {beatname_uc} configuration tasks.
 
 * <<{beatname_lc}-geoip>>
-* <<{beatname_lc}-deduplication>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
 * <<yaml-tips>>
@@ -15,8 +14,6 @@ Learn how to perform common {beatname_uc} configuration tasks.
 --
 
 include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-include::{libbeat-dir}/shared-deduplication.asciidoc[]
 
 :standalone:
 include::{libbeat-dir}/shared-env-vars.asciidoc[]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -34,6 +34,8 @@ include::./upgrading.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 include::./modules.asciidoc[]
 
 include::./fields.asciidoc[]

--- a/winlogbeat/docs/setting-up-running.asciidoc
+++ b/winlogbeat/docs/setting-up-running.asciidoc
@@ -5,7 +5,11 @@
 /////
 
 [[setting-up-and-running]]
-== Setting up and running {beatname_uc}
+== Set up and run {beatname_uc}
+
+++++
+<titleabbrev>Set up and run</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/winlogbeat/docs/troubleshooting.asciidoc
+++ b/winlogbeat/docs/troubleshooting.asciidoc
@@ -1,5 +1,5 @@
 [[troubleshooting]]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --

--- a/winlogbeat/docs/upgrading.asciidoc
+++ b/winlogbeat/docs/upgrading.asciidoc
@@ -1,7 +1,11 @@
 [[upgrading-winlogbeat]]
-== Upgrading Winlogbeat
+== Upgrade Winlogbeat
+
+++++
+<titleabbrev>Upgrade</titleabbrev>
+++++
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
 * {beats-ref}/breaking-changes.html[Breaking Changes]
-* {beats-ref}/upgrading.html[Upgrading]
+* {beats-ref}/upgrading.html[Upgrade]

--- a/winlogbeat/docs/winlogbeat-filtering.asciidoc
+++ b/winlogbeat/docs/winlogbeat-filtering.asciidoc
@@ -1,5 +1,5 @@
 [[filtering-and-enhancing-data]]
-== Filter and enhance the exported data
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/winlogbeat/docs/winlogbeat-filtering.asciidoc
+++ b/winlogbeat/docs/winlogbeat-filtering.asciidoc
@@ -1,5 +1,9 @@
 [[filtering-and-enhancing-data]]
-== Filter and Enhance the exported data
+== Filter and enhance the exported data
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 include::{libbeat-dir}/processors.asciidoc[]
 

--- a/winlogbeat/docs/winlogbeat-general-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-general-options.asciidoc
@@ -1,5 +1,9 @@
 [[configuration-general-options]]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}.

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -2,9 +2,13 @@
   supporting the Windows Event Log API (Microsoft Windows Vista and newer).
 
 [[configuration-winlogbeat-options]]
-== Set up Winlogbeat
+== Configure {beatname_uc}
 
-The `winlogbeat` section of the +{beatname_lc}.yml+ config file specifies all options that are specific to Winlogbeat.
+++++
+<titleabbrev>{beatname_uc}</titleabbrev>
+++++
+
+The `winlogbeat` section of the +{beatname_lc}.yml+ config file specifies all options that are specific to {beatname_uc}.
 Most importantly, it contains the list of event logs to monitor.
 
 Here is a sample configuration:
@@ -26,7 +30,7 @@ You can specify the following options in the `winlogbeat` section of the +{beatn
 [float]
 ==== `registry_file`
 
-The name of the file where Winlogbeat stores information that it uses to resume
+The name of the file where {beatname_uc} stores information that it uses to resume
 monitoring after a restart. By default the file is stored as `.winlogbeat.yml`
 in the directory where the Beat was started. When you run the process as a
 Windows service, it's recommended that you set the value to
@@ -46,7 +50,7 @@ need to escape them.
 ==== `shutdown_timeout`
 
 The amount of time to wait for all events to be published when shutting down.
-By default there is no shutdown timeout so Winlogbeat will stop without waiting.
+By default there is no shutdown timeout so {beatname_uc} will stop without waiting.
 When you restart it will resume from the last successfully published event in
 each event log.
 
@@ -83,7 +87,7 @@ The maximum number of event log records to read from the Windows API in a single
 batch. The default batch size is 100. Most Windows versions return an error if
 the value is larger than 1024. *{vista_and_newer}*
 
-Winlogbeat starts a goroutine (a lightweight thread) to read from each
+{beatname_uc} starts a goroutine (a lightweight thread) to read from each
 individual event log. The goroutine reads a batch of event log records using the
 Windows API, applies any processors to the events, publishes them to the
 configured outputs, and waits for an acknowledgement from the outputs before
@@ -157,7 +161,7 @@ winlogbeat.event_logs:
 [float]
 ==== `event_logs.ignore_older`
 
-If this option is specified, Winlogbeat filters events that are older than the
+If this option is specified, {beatname_uc} filters events that are older than the
 specified amount of time. Valid time units are "ns", "us" (or "µs"), "ms", "s",
 "m", "h". This option is useful when you are beginning to monitor an event log
 that contains older records that you would like to ignore. This field is
@@ -177,8 +181,8 @@ A boolean flag to indicate that the log contains only events collected from
 remote hosts using the Windows Event Collector. The value defaults to true for
 the ForwardedEvents log and false for any other log. *{vista_and_newer}*
 
-This settings allows Winlogbeat to optimize reads for forwarded events that are
-already rendered. When the value is true Winlogbeat does not attempt to render
+This settings allows {beatname_uc} to optimize reads for forwarded events that are
+already rendered. When the value is true {beatname_uc} does not attempt to render
 the event using message files from the host computer. The Windows Event
 Collector subscription should be configured to use the "RenderedText" format
 (this is the default) to ensure that the events are distributed with messages
@@ -202,9 +206,9 @@ winlogbeat.event_logs:
 [WARNING]
 =======================================
 If you specify more that 22 event IDs to include or 22 event IDs to exclude,
-Windows will prevent Winlogbeat from reading the event log because it limits the
+Windows will prevent {beatname_uc} from reading the event log because it limits the
 number of conditions that can be used in an event log query. If this occurs a similar
-warning as shown below will be logged by Winlogbeat, and it will continue
+warning as shown below will be logged by {beatname_uc}, and it will continue
 processing data from other event logs. For more information, see
 https://support.microsoft.com/en-us/kb/970453.
 
@@ -213,7 +217,7 @@ source. The specified query is invalid.`
 
 If you have more than 22 event IDs, you can workaround this Windows limitation
 by using a drop_event[drop-event] processor to do the filtering after
-Winlogbeat has received the events from Windows. The filter shown below is
+{beatname_uc} has received the events from Windows. The filter shown below is
 equivalent to `event_id: 903, 1024, 4624` but can be expanded beyond 22
 event IDs.
 
@@ -305,11 +309,11 @@ Microsoft-Windows-Eventlog
 ==== `event_logs.include_xml`
 
 Boolean option that controls if the raw XML representation of an event is
-included in the data sent by Winlogbeat. The default is false.
+included in the data sent by {beatname_uc}. The default is false.
 *{vista_and_newer}*
 
 The XML representation of the event is useful for troubleshooting purposes. The
-data in the fields reported by Winlogbeat can be compared to the data in the XML
+data in the fields reported by {beatname_uc} can be compared to the data in the XML
 to diagnose problems.
 
 Example:
@@ -365,7 +369,7 @@ winlogbeat.event_logs:
 If this option is set to true, the custom <<winlogbeat-configuration-fields,fields>>
 are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
-field names added by Winlogbeat, then the custom fields overwrite the other
+field names added by {beatname_uc}, then the custom fields overwrite the other
 fields.
 
 [float]
@@ -400,7 +404,7 @@ the output document. By default, `keep_null` is set to `false`.
 The action that the event log reader should take when it receives a signal from
 Windows that there are no more events to read. It can either `wait` for more
 events to be written (the default behavior) or it can `stop`. The overall
-Winlogbeat process will stop when all of the individual event log readers have
+{beatname_uc} process will stop when all of the individual event log readers have
 stopped. *{vista_and_newer}*
 
 Setting `no_more_events` to `stop` is useful when reading from archived event

--- a/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
@@ -1,6 +1,6 @@
 [[log-driver-troubleshooting]]
 [role="xpack"]
-== Troubleshooting
+== Troubleshoot
 
 experimental[]
 

--- a/x-pack/functionbeat/docs/config-options-aws.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-aws.asciidoc
@@ -3,7 +3,7 @@
 == Configure AWS functions
 
 ++++
-<titleabbrev>Configure AWS functions</titleabbrev>
+<titleabbrev>AWS functions</titleabbrev>
 ++++
 
 {beatname_uc} runs as a function in your serverless environment.

--- a/x-pack/functionbeat/docs/config-options-gcp.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-gcp.asciidoc
@@ -3,7 +3,7 @@
 == Configure Google Functions
 
 ++++
-<titleabbrev>Configure Google functions</titleabbrev>
+<titleabbrev>Google functions</titleabbrev>
 ++++
 
 beta[]

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -1,6 +1,6 @@
 [id="configuring-howto-{beatname_lc}"]
 [role="xpack"]
-= {beatname_uc} configuration
+= Configure {beatname_uc}
 
 [partintro]
 --
@@ -16,13 +16,12 @@ include::{libbeat-dir}/shared-configuring.asciidoc[]
 
 The following topics describe how to configure {beatname_uc}:
 
-* <<configuration-general-options>>
 * <<configuration-{beatname_lc}-options>>
 * <<configuration-{beatname_lc}-gcp-options>>
+* <<configuration-general-options>>
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<ilm>>
-* <<setup-kibana-endpoint>>
 * <<configuration-template>>
 * <<filtering-and-enhancing-data>>
 * <<configuring-internal-queue>>
@@ -32,11 +31,11 @@ The following topics describe how to configure {beatname_uc}:
 
 --
 
-include::./general-options.asciidoc[]
-
 include::./config-options-aws.asciidoc[]
 
 include::./config-options-gcp.asciidoc[]
+
+include::./general-options.asciidoc[]
 
 [role="xpack"]
 include::{libbeat-dir}/outputconfig.asciidoc[]
@@ -46,9 +45,6 @@ include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 [role="xpack"]
 include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-[role="xpack"]
-include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 
 [role="xpack"]
 include::{libbeat-dir}/setup-config.asciidoc[]

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -4,6 +4,10 @@
 
 [partintro]
 --
+++++
+<titleabbrev>Configure</titleabbrev>
+++++
+
 Before modifying configuration settings, make sure you've completed the
 <<{beatname_lc}-configuration,configuration steps>> in the Getting Started.
 This section describes some common use cases for changing configuration options.
@@ -12,53 +16,36 @@ include::{libbeat-dir}/shared-configuring.asciidoc[]
 
 The following topics describe how to configure {beatname_uc}:
 
+* <<configuration-general-options>>
 * <<configuration-{beatname_lc}-options>>
 * <<configuration-{beatname_lc}-gcp-options>>
-* <<configuration-general-options>>
-* <<configuring-internal-queue>>
 * <<configuring-output>>
-* <<ilm>>
 * <<configuration-ssl>>
-* <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
-* <<{beatname_lc}-geoip>>
+* <<ilm>>
 * <<setup-kibana-endpoint>>
 * <<configuration-template>>
+* <<filtering-and-enhancing-data>>
+* <<configuring-internal-queue>>
 * <<configuration-logging>>
-* <<using-environ-vars>>
-* <<yaml-tips>>
 * <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 --
 
+include::./general-options.asciidoc[]
+
 include::./config-options-aws.asciidoc[]
 
 include::./config-options-gcp.asciidoc[]
-
-include::./general-options.asciidoc[]
-
-:allplatforms:
-[role="xpack"]
-include::{libbeat-dir}/queueconfig.asciidoc[]
-:allplatforms!:
 
 [role="xpack"]
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
 [role="xpack"]
-include::{libbeat-dir}/shared-ilm.asciidoc[]
-
-[role="xpack"]
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
-include::./filtering.asciidoc[]
-
 [role="xpack"]
-include::{libbeat-dir}/shared-config-ingest.asciidoc[]
-
-[role="xpack"]
-include::{libbeat-dir}/shared-geoip.asciidoc[]
+include::{libbeat-dir}/shared-ilm.asciidoc[]
 
 [role="xpack"]
 include::{libbeat-dir}/shared-kibana-config.asciidoc[]
@@ -67,19 +54,15 @@ include::{libbeat-dir}/shared-kibana-config.asciidoc[]
 include::{libbeat-dir}/setup-config.asciidoc[]
 
 [role="xpack"]
-include::{libbeat-dir}/loggingconfig.asciidoc[]
+include::./filtering.asciidoc[]
 
-:standalone:
-[role="xpack"]
-include::{libbeat-dir}/shared-env-vars.asciidoc[]
-:standalone!:
-
-:standalone:
 :allplatforms:
 [role="xpack"]
-include::{libbeat-dir}/yaml.asciidoc[]
-:standalone!:
+include::{libbeat-dir}/queueconfig.asciidoc[]
 :allplatforms!:
+
+[role="xpack"]
+include::{libbeat-dir}/loggingconfig.asciidoc[]
 
 [role="xpack"]
 include::{libbeat-dir}/regexp.asciidoc[]

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -1,6 +1,6 @@
 [id="configuring-howto-{beatname_lc}"]
 [role="xpack"]
-= Configuring {beatname_uc}
+= {beatname_uc} configuration
 
 [partintro]
 --

--- a/x-pack/functionbeat/docs/filtering.asciidoc
+++ b/x-pack/functionbeat/docs/filtering.asciidoc
@@ -1,6 +1,10 @@
 [[filtering-and-enhancing-data]]
 [role="xpack"]
-== Filter and enhance the exported data
+== Filter and enhance data by using processors
+
+++++
+<titleabbrev>Processors</titleabbrev>
+++++
 
 Your use case might require only a subset of the data exported by {beatname_uc},
 or you might need to enhance the exported data (for example, by adding

--- a/x-pack/functionbeat/docs/filtering.asciidoc
+++ b/x-pack/functionbeat/docs/filtering.asciidoc
@@ -1,6 +1,6 @@
 [[filtering-and-enhancing-data]]
 [role="xpack"]
-== Filter and enhance data by using processors
+== Filter and enhance data with processors
 
 ++++
 <titleabbrev>Processors</titleabbrev>

--- a/x-pack/functionbeat/docs/general-options.asciidoc
+++ b/x-pack/functionbeat/docs/general-options.asciidoc
@@ -1,6 +1,10 @@
 [[configuration-general-options]]
 [role="xpack"]
-== Specify general settings
+== Configure general settings
+
+++++
+<titleabbrev>General settings</titleabbrev>
+++++
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the
 general behavior of {beatname_uc}.

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -1,6 +1,10 @@
 [id="{beatname_lc}-getting-started"]
 [role="xpack"]
-== Getting Started With {beatname_uc}
+== Get started with {beatname_uc}
+
+++++
+<titleabbrev>Get started</titleabbrev>
+++++
 
 include::{libbeat-dir}/shared-getting-started-intro.asciidoc[]
 

--- a/x-pack/functionbeat/docs/howto/howto.asciidoc
+++ b/x-pack/functionbeat/docs/howto/howto.asciidoc
@@ -1,4 +1,5 @@
 [[howto-guides]]
+[role="xpack"]
 = How to
 
 [partintro]
@@ -14,17 +15,22 @@ Learn how to perform common {beatname_uc} configuration tasks.
 
 --
 
+[role="xpack"]
 include::{libbeat-dir}/shared-geoip.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/shared-deduplication.asciidoc[]
 
 :standalone:
+[role="xpack"]
 include::{libbeat-dir}/shared-env-vars.asciidoc[]
 :standalone!:
 
+[role="xpack"]
 include::{libbeat-dir}/shared-config-ingest.asciidoc[]
 
 :standalone:
+[role="xpack"]
 include::{libbeat-dir}/yaml.asciidoc[]
 :standalone!:
 

--- a/x-pack/functionbeat/docs/howto/howto.asciidoc
+++ b/x-pack/functionbeat/docs/howto/howto.asciidoc
@@ -1,0 +1,32 @@
+[[howto-guides]]
+= How to
+
+[partintro]
+--
+Learn how to perform common {beatname_uc} configuration tasks.
+
+* <<{beatname_lc}-geoip>>
+* <<{beatname_lc}-deduplication>>
+* <<using-environ-vars>>
+* <<configuring-ingest-node>>
+* <<yaml-tips>>
+
+
+--
+
+include::{libbeat-dir}/shared-geoip.asciidoc[]
+
+include::{libbeat-dir}/shared-deduplication.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/shared-env-vars.asciidoc[]
+:standalone!:
+
+include::{libbeat-dir}/shared-config-ingest.asciidoc[]
+
+:standalone:
+include::{libbeat-dir}/yaml.asciidoc[]
+:standalone!:
+
+
+

--- a/x-pack/functionbeat/docs/howto/howto.asciidoc
+++ b/x-pack/functionbeat/docs/howto/howto.asciidoc
@@ -7,7 +7,6 @@
 Learn how to perform common {beatname_uc} configuration tasks.
 
 * <<{beatname_lc}-geoip>>
-* <<{beatname_lc}-deduplication>>
 * <<using-environ-vars>>
 * <<configuring-ingest-node>>
 * <<yaml-tips>>
@@ -17,9 +16,6 @@ Learn how to perform common {beatname_uc} configuration tasks.
 
 [role="xpack"]
 include::{libbeat-dir}/shared-geoip.asciidoc[]
-
-[role="xpack"]
-include::{libbeat-dir}/shared-deduplication.asciidoc[]
 
 :standalone:
 [role="xpack"]

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -44,6 +44,8 @@ include::./setting-up-running.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::{docdir}/howto/howto.asciidoc[]
+
 [role="xpack"]
 include::./fields.asciidoc[]
 

--- a/x-pack/functionbeat/docs/setting-up-running.asciidoc
+++ b/x-pack/functionbeat/docs/setting-up-running.asciidoc
@@ -6,7 +6,11 @@
 
 [[setting-up-and-running]]
 [role="xpack"]
-== Setting up and deploying {beatname_uc}
+== Set up and deploy {beatname_uc}
+
+++++
+<titleabbrev>Set up and deploy</titleabbrev>
+++++
 
 Before reading this section, see the
 <<{beatname_lc}-getting-started,getting started documentation>> for basic

--- a/x-pack/functionbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/functionbeat/docs/troubleshooting.asciidoc
@@ -1,6 +1,6 @@
 [[troubleshooting]]
 [role="xpack"]
-= Troubleshooting
+= Troubleshoot
 
 [partintro]
 --


### PR DESCRIPTION
Breaks the configuration section down into two separate sections. Also adds abbreviated titles to make the TOC easier to scan.

To do:

- [x] Apply structural changes to all Beats books.
- [x] Make config section order. consistent across all the books
- [x] Make titles consistent (use configure instead of set up in config section).
- [x] Make sure functionbeat sections are correctly flagged as xpack.
- [x] Do diff across all books to verify that nothing was dropped.
- [x] Do final check on files for consistency, etc.
- [x] Hold on merging until Brandon M. approves.

Assuming the build succeeds, you can preview the new navigation structure here:

http://beats_16825.docs-preview.app.elstc.co/diff
