### PR TITLE
Cherry-pick #16692 to 7.6: Fix diskio struct alignment for windows 32 bit versions

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -64,9 +64,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Revert changes in `docker` module: add size flag to docker.container. {pull}16600[16600]
 - Convert increments of 100 nanoseconds/ticks to milliseconds for WriteTime and ReadTime in diskio metricset (Windows) for consistency. {issue}14233[14233]
 - Fix diskio issue for windows 32 bit on disk_performance struct alignment. {issue}16680[16680]
-- Fix detection and logging of some error cases with light modules. {pull}14706[14706]
-- Fix imports after PR was merged before rebase. {pull}16756[16756]
-- Add dashboard for `redisenterprise` module. {pull}16752[16752]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change sqs metricset to use average as statistic method. {pull}16438[16438]
 - Revert changes in `docker` module: add size flag to docker.container. {pull}16600[16600]
 - Convert increments of 100 nanoseconds/ticks to milliseconds for WriteTime and ReadTime in diskio metricset (Windows) for consistency. {issue}14233[14233]
+- Fix diskio issue for windows 32 bit on disk_performance struct alignment. {issue}16680[16680]
+- Fix detection and logging of some error cases with light modules. {pull}14706[14706]
+- Fix imports after PR was merged before rebase. {pull}16756[16756]
+- Add dashboard for `redisenterprise` module. {pull}16752[16752]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/diskio/disk_performance_386.go
+++ b/metricbeat/module/system/diskio/disk_performance_386.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build windows
+
+package diskio
+
+// diskPerformance struct provides disk performance information. It is used by the IOCTL_DISK_PERFORMANCE control code.
+// DeviceIoControl() will fail with ERROR_INSUFFICIENT_BUFFER (The data area passed to a system call is too small) on 32 bit systems.
+// The memory layout is different for 32 bit vs 64 bit so an alignment (AlignmentPadding) is necessary in order to increase the buffer size
+type diskPerformance struct {
+	BytesRead    int64
+	BytesWritten int64
+	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	ReadTime int64
+	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	WriteTime int64
+	//Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	IdleTime            int64
+	ReadCount           uint32
+	WriteCount          uint32
+	QueueDepth          uint32
+	SplitCount          uint32
+	QueryTime           int64
+	StorageDeviceNumber uint32
+	StorageManagerName  [8]uint16
+	AlignmentPadding    uint32
+}

--- a/metricbeat/module/system/diskio/disk_performance_amd64.go
+++ b/metricbeat/module/system/diskio/disk_performance_amd64.go
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build windows
+
+package diskio
+
+// diskPerformance struct provides disk performance information. It is used by the IOCTL_DISK_PERFORMANCE control code.
+type diskPerformance struct {
+	BytesRead    int64
+	BytesWritten int64
+	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	ReadTime int64
+	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	WriteTime int64
+	//Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
+	IdleTime            int64
+	ReadCount           uint32
+	WriteCount          uint32
+	QueueDepth          uint32
+	SplitCount          uint32
+	QueryTime           int64
+	StorageDeviceNumber uint32
+	StorageManagerName  [8]uint16
+}

--- a/metricbeat/module/system/diskio/diskstat_windows_helper.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_helper.go
@@ -33,9 +33,11 @@ import (
 )
 
 const (
-	errorSuccess            syscall.Errno = 0
-	ioctlDiskPerformance                  = 0x70020
-	ioctlDiskPerformanceOff               = 0x70060
+	errorSuccess syscall.Errno = 0
+	// ioctlDiskPerformance is used to enable performance counters that provide disk performance information.
+	ioctlDiskPerformance = 0x70020
+	// ioctlDiskPerformanceOff used to disable performance counters that provide disk performance information.
+	ioctlDiskPerformanceOff = 0x70060
 )
 
 var (
@@ -47,24 +49,6 @@ var (
 type logicalDrive struct {
 	Name    string
 	UNCPath string
-}
-
-type diskPerformance struct {
-	BytesRead    int64
-	BytesWritten int64
-	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
-	ReadTime int64
-	// Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
-	WriteTime int64
-	//Contains a cumulative time, expressed in increments of 100 nanoseconds (or ticks).
-	IdleTime            int64
-	ReadCount           uint32
-	WriteCount          uint32
-	QueueDepth          uint32
-	SplitCount          uint32
-	QueryTime           int64
-	StorageDeviceNumber uint32
-	StorageManagerName  [8]uint16
 }
 
 // ioCounters gets the diskio counters and maps them to the list of counterstat objects.


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#16692 to 7.6 branch. Original message:

Shoukd fix https://github.com/elastic/beats/issues/16680.

Added `disk_performance_386.go` and `disk_performance_amd64.go` files to define the struct, chose 2 separate files to clearly separate implementation should we ever want to update / remove the support for 32 bit versions etc.