### PR TITLE
Install mage and goimports from vendor folder

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -13,4 +13,4 @@ IF ERRORLEVEL 1 (
 )
 FOR /f "tokens=*" %%i IN ('"gvm.exe" use %GO_VERSION% --format=batch') DO %%i
 
-go install github.com/elastic/beats/vendor/github.com/magefile/mage
+go install -mod=vendor github.com/magefile/mage

--- a/auditbeat/make.bat
+++ b/auditbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/filebeat/make.bat
+++ b/filebeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/heartbeat/make.bat
+++ b/heartbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/libbeat/make.bat
+++ b/libbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -72,7 +72,7 @@ TESTIFY_TOOL_REPO?=github.com/stretchr/testify/assert
 NOW=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GOBUILD_FLAGS?=-ldflags "-X github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 GOIMPORTS=goimports
-GOIMPORTS_REPO?=github.com/elastic/beats/vendor/golang.org/x/tools/cmd/goimports
+GOIMPORTS_REPO?=golang.org/x/tools/cmd/goimports
 GOIMPORTS_LOCAL_PREFIX?=github.com/elastic
 GOLINT=golint
 GOLINT_REPO?=golang.org/x/lint/golint

--- a/make.bat
+++ b/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/metricbeat/make.bat
+++ b/metricbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/packetbeat/make.bat
+++ b/packetbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/winlogbeat/make.bat
+++ b/winlogbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/x-pack/filebeat/make.bat
+++ b/x-pack/filebeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*

--- a/x-pack/winlogbeat/make.bat
+++ b/x-pack/winlogbeat/make.bat
@@ -6,6 +6,6 @@ REM
 REM After running this once you may invoke mage.exe directly.
 
 WHERE mage
-IF %ERRORLEVEL% NEQ 0 go install github.com/elastic/beats/vendor/github.com/magefile/mage
+IF %ERRORLEVEL% NEQ 0 go install -mod=vendor github.com/magefile/mage
 
 mage %*


### PR DESCRIPTION
## What does this PR do?

This PR removes all outdated install paths from Makefiles.

## Why is it important?

ATM running `make fmt` fails with the following error:

```
2020/03/05 13:47:25 exec: go list -m
2020/03/05 13:47:25 Found Elastic Beats dir at /Users/chrismark/go/src/github.com/elastic/beats
>> fmt - go-licenser: Adding missing headers
can't load package: package github.com/elastic/beats/vendor/golang.org/x/tools/cmd/goimports: cannot find package "." in:
	/Users/chrismark/go/src/github.com/elastic/beats/vendor/github.com/elastic/beats/vendor/golang.org/x/tools/cmd/goimports
make: *** [fmt] Error 1
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~