### PR TITLE
mage: optionally mount module cache for crossbuild

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -49,6 +49,8 @@ import (
 	"github.com/magefile/mage/sh"
 	"github.com/magefile/mage/target"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/dev-tools/mage/gotool"
 )
 
 // Expand expands the given Go text/template string.
@@ -790,4 +792,14 @@ func ParseVersion(version string) (major, minor, patch int, err error) {
 	minor, _ = strconv.Atoi(data["minor"])
 	patch, _ = strconv.Atoi(data["patch"])
 	return
+}
+
+// listModuleDir calls gotool.ListModuleVendorDir or
+// gotool.ListModuleCacheDir, depending on the value of
+// UseVendor.
+func listModuleDir(modpath string) (string, error) {
+	if UseVendor {
+		return gotool.ListModuleVendorDir(modpath)
+	}
+	return gotool.ListModuleCacheDir(modpath)
 }

--- a/dev-tools/mage/config.go
+++ b/dev-tools/mage/config.go
@@ -38,21 +38,6 @@ var (
 	shortTemplate     = filepath.Join("build", BeatName+".yml.tmpl")
 	referenceTemplate = filepath.Join("build", BeatName+".reference.yml.tmpl")
 	dockerTemplate    = filepath.Join("build", BeatName+".docker.yml.tmpl")
-
-	defaultConfigFileParams = ConfigFileParams{
-		ShortParts: []string{
-			OSSBeatDir("_meta/beat.yml"),
-			LibbeatDir("_meta/config.yml.tmpl"),
-		},
-		ReferenceParts: []string{
-			OSSBeatDir("_meta/beat.reference.yml"),
-			LibbeatDir("_meta/config.reference.yml.tmpl"),
-		},
-		DockerParts: []string{
-			OSSBeatDir("_meta/beat.docker.yml"),
-			LibbeatDir("_meta/config.docker.yml"),
-		},
-	}
 )
 
 // ConfigFileType is a bitset that indicates what types of config files to
@@ -97,7 +82,20 @@ func (c ConfigFileParams) Empty() bool {
 // host for the generated configs. Defaults to linux/amd64.
 func Config(types ConfigFileType, args ConfigFileParams, targetDir string) error {
 	if args.Empty() {
-		args = defaultConfigFileParams
+		args = ConfigFileParams{
+			ShortParts: []string{
+				OSSBeatDir("_meta/beat.yml"),
+				LibbeatDir("_meta/config.yml.tmpl"),
+			},
+			ReferenceParts: []string{
+				OSSBeatDir("_meta/beat.reference.yml"),
+				LibbeatDir("_meta/config.reference.yml.tmpl"),
+			},
+			DockerParts: []string{
+				OSSBeatDir("_meta/beat.docker.yml"),
+				LibbeatDir("_meta/config.docker.yml"),
+			},
+		}
 	}
 
 	if err := makeConfigTemplates(types, args); err != nil {

--- a/dev-tools/mage/godaemon.go
+++ b/dev-tools/mage/godaemon.go
@@ -22,8 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-
-	"github.com/elastic/beats/v7/dev-tools/mage/gotool"
 )
 
 var (
@@ -44,19 +42,13 @@ func BuildGoDaemon() error {
 			"only be executed within the golang-crossbuild docker environment.")
 	}
 
-	// Locate tsg/go-daemon.
-	var args []string
-	if UseVendor {
-		args = append(args, "-mod=vendor")
-	}
-	godaemonDir, err := gotool.ListModulePath("github.com/tsg/go-daemon", args...)
+	// Test if binaries are up-to-date.
+	godaemonDir, err := listModuleDir("github.com/tsg/go-daemon")
 	if err != nil {
 		return err
 	}
-
-	// Test if binaries are up-to-date.
-	output := MustExpand("build/golang-crossbuild/god-{{.Platform.GOOS}}-{{.Platform.Arch}}")
 	input := filepath.Join(godaemonDir, "src", "god.c")
+	output := MustExpand("build/golang-crossbuild/god-{{.Platform.GOOS}}-{{.Platform.Arch}}")
 	if IsUpToDate(output, input) {
 		log.Println(">>> buildGoDaemon is up-to-date for", Platform.Name)
 		return nil

--- a/dev-tools/mage/gomod.go
+++ b/dev-tools/mage/gomod.go
@@ -75,7 +75,7 @@ func Vendor() error {
 
 	// copy packages which require the whole tree
 	for _, p := range copyAll {
-		path, err := gotool.ListModulePath(p.name)
+		path, err := gotool.ListModuleVendorDir(p.name)
 		if err != nil {
 			return err
 		}

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -93,14 +93,19 @@ func ListTestFiles(pkg string) ([]string, error) {
 	return getLines(callGo(nil, "list", "-f", tmpl, pkg))
 }
 
-// ListModulePath returns the path to the module in the cache.
-func ListModulePath(pkg string) (string, error) {
-	const tmpl = `{{.Dir}}`
+// ListModulePath returns the path to the specified module.
+//
+// Additional parameters like "-mod=vendor" may be passed
+// to control behaviour.
+func ListModulePath(pkg string, args ...string) (string, error) {
 	env := map[string]string{
-		// make sure to look in the module cache
+		// make sure to look in the module cache,
+		// unless otherwise configured in args.
 		"GOFLAGS": "",
 	}
-	lines, err := getLines(callGo(env, "list", "-m", "-f", tmpl, pkg))
+	args = append([]string{"-m", "-f", "{{.Dir}}"}, args...)
+	args = append(args, pkg)
+	lines, err := getLines(callGo(env, "list", args...))
 	if err != nil {
 		return "", err
 	}

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -112,10 +112,11 @@ func listModuleDir(pkg string, vendor bool) (string, error) {
 		// Make sure GOFLAGS does not influence behaviour.
 		"GOFLAGS": "",
 	}
-	args := []string{"-m", "-f", "{{.Dir}}", pkg}
+	args := []string{"-m", "-f", "{{.Dir}}"}
 	if vendor {
 		args = append(args, "-mod=vendor")
 	}
+	args = append(args, pkg)
 	lines, err := getLines(callGo(env, "list", args...))
 	if err != nil {
 		return "", err

--- a/dev-tools/mage/gotool/modules.go
+++ b/dev-tools/mage/gotool/modules.go
@@ -19,10 +19,11 @@ package gotool
 
 // Mod is the command go mod.
 var Mod = goMod{
-	Init:   modCommand{"init"}.run,
-	Tidy:   modCommand{"tidy"}.run,
-	Verify: modCommand{"verify"}.run,
-	Vendor: modCommand{"vendor"}.run,
+	Download: modCommand{"download"}.run,
+	Init:     modCommand{"init"}.run,
+	Tidy:     modCommand{"tidy"}.run,
+	Verify:   modCommand{"verify"}.run,
+	Vendor:   modCommand{"vendor"}.run,
 }
 
 type modCommand struct {
@@ -40,11 +41,15 @@ func (cmd modCommand) run(opts ...ArgOpt) error {
 }
 
 type goMod struct {
-	Init   modInit
-	Tidy   modTidy
-	Verify modVerify
-	Vendor modVendor
+	Download modDownload
+	Init     modInit
+	Tidy     modTidy
+	Verify   modVerify
+	Vendor   modVendor
 }
+
+// modDownload cleans the go.mod file
+type modDownload func(opts ...ArgOpt) error
 
 // modInit initializes a new go module in folder.
 type modInit func(opts ...ArgOpt) error

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -60,6 +60,10 @@ var (
 	TestCoverage = false
 	UseVendor    = true
 
+	// CrossBuildMountModcache, if true, mounts $GOPATH/pkg/mod into
+	// the crossbuild images at /go/pkg/mod, read-only.
+	CrossBuildMountModcache = false
+
 	BeatName        = EnvOr("BEAT_NAME", filepath.Base(CWD()))
 	BeatServiceName = EnvOr("BEAT_SERVICE_NAME", BeatName)
 	BeatIndexPrefix = EnvOr("BEAT_INDEX_PREFIX", BeatName)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -284,11 +284,7 @@ func findElasticBeatsDir() (string, error) {
 	if repo.IsElasticBeats() {
 		return repo.RootDir, nil
 	}
-	var args []string
-	if UseVendor {
-		args = append(args, "-mod=vendor")
-	}
-	return gotool.ListModulePath("github.com/elastic/beats/v7")
+	return listModuleDir("github.com/elastic/beats/v7")
 }
 
 var (

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -284,7 +284,10 @@ func findElasticBeatsDir() (string, error) {
 	if repo.IsElasticBeats() {
 		return repo.RootDir, nil
 	}
-
+	var args []string
+	if UseVendor {
+		args = append(args, "-mod=vendor")
+	}
 	return gotool.ListModulePath("github.com/elastic/beats/v7")
 }
 

--- a/generator/common/beatgen/beatgen.go
+++ b/generator/common/beatgen/beatgen.go
@@ -101,6 +101,12 @@ func Generate() error {
 		return err
 	}
 
+	// Make sure the ElasticBeatsDir value is cached
+	// before changing directory below.
+	if _, err := devtools.ElasticBeatsDir(); err != nil {
+		return err
+	}
+
 	err = setup.GenNewBeat(cfg)
 	if err != nil {
 		return errors.Wrap(err, "error generating new beat")

--- a/generator/common/beatgen/setup/setup.go
+++ b/generator/common/beatgen/setup/setup.go
@@ -112,7 +112,7 @@ func CopyVendor() error {
 		return err
 	}
 
-	path, err := gotool.ListModulePath("github.com/elastic/beats/v7")
+	path, err := gotool.ListModuleCacheDir("github.com/elastic/beats/v7")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

Introduce another mage variable, `CrossBuildMountModcache`,
which defaults to false. When set to true, the host's
module cache (`$GOPATH/pkg/mod`) will be mounted into the
crossbuild Docker containers, read-only. To ensure the
cache is up-to-date, we run `go mod download` on the host
before starting the Docker containers.

Also, fix `mage buildGoDaemon` to stop assuming that
tsg/go-daemon is vendored. Instead, use
`go list -m github.com/tsg/go-daemon` to find the module
directory in either the vendor directory or the module cache.

## Why is it important?

This is necessary to support beats that do not use vendoring, such as apm-server.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

`cd filebeat && PLATFORMS=linux/amd64 mage package`