### PR TITLE
Improve some logging messages for add_kubernetes_metadata processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix k8s pods labels broken schema. {pull}16480[16480]
 - Fix k8s pods annotations broken schema. {pull}16554[16554]
 - Upgrade go-ucfg to latest v0.8.3. {pull}16450{16450}
+- Improve some logging messages for add_kubernetes_metadata processor {pull}16866{16866}
 
 *Auditbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/matchers.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers.go
@@ -86,7 +86,7 @@ func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 		logp.Debug("kubernetes", "Incoming log.file.path value: %s", source)
 
 		if !strings.Contains(source, f.LogsPath) {
-			logp.Debug("kubernetes", "Error extracting container id - source value does not contain matcher's logs_path '%s'.", f.LogsPath)
+			logp.Err("Error extracting container id - source value does not contain matcher's logs_path '%s'.", f.LogsPath)
 			return ""
 		}
 
@@ -105,7 +105,7 @@ func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 					return podUID
 				}
 
-				logp.Debug("kubernetes", "Error extracting pod uid - source value contains matcher's logs_path, however it is too short to contain a Pod UID.")
+				logp.Err("Error extracting pod uid - source value contains matcher's logs_path, however it is too short to contain a Pod UID.")
 			}
 		} else {
 			// In case of the Kubernetes log path "/var/log/containers/",
@@ -125,7 +125,7 @@ func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 				return cid
 			}
 
-			logp.Debug("kubernetes", "Error extracting container id - source value contains matcher's logs_path, however it is too short to contain a Docker container ID.")
+			logp.Err("Error extracting container id - source value contains matcher's logs_path, however it is too short to contain a Docker container ID.")
 		}
 	}
 

--- a/filebeat/processor/add_kubernetes_metadata/matchers_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers_test.go
@@ -85,8 +85,8 @@ func TestLogsPathMatcher_AnotherLogDir(t *testing.T) {
 	cfgLogsPath := "/var/log/other/"
 	sourcePath := "/var/log/other/%s.log"
 	if runtime.GOOS == "windows" {
-		cfgLogsPath = "C:\\var\\log\\other\\"
-		sourcePath = "C:\\var\\log\\other\\%s.log"
+		cfgLogsPath = "C:\\var\\log\\othere\\"
+		sourcePath = "C:\\var\\log\\othere\\%s.log"
 	}
 
 	source := fmt.Sprintf(sourcePath, cid)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -206,11 +206,14 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 	}
 	index := k.matchers.MetadataIndex(event.Fields)
 	if index == "" {
+		k.log.Debug("No container match string, not adding kubernetes data")
 		return event, nil
 	}
 
+	k.log.Debugf("Using the following index key %s", index)
 	metadata := k.cache.get(index)
 	if metadata == nil {
+		k.log.Debugf("Index key %s did not match any of the cached resources", index)
 		return event, nil
 	}
 
@@ -224,6 +227,7 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 func (k *kubernetesAnnotator) addPod(pod *kubernetes.Pod) {
 	metadata := k.indexers.GetMetadata(pod)
 	for _, m := range metadata {
+		k.log.Debugf("Created index %s for pod %s/%s", m.Index, pod.GetNamespace(), pod.GetName())
 		k.cache.set(m.Index, m.Data)
 	}
 }

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // Test metadata updates don't replace existing pod metrics
@@ -38,6 +39,7 @@ func TestAnnotatorDeepUpdate(t *testing.T) {
 	}
 
 	processor := kubernetesAnnotator{
+		log:   logp.NewLogger(selector),
 		cache: newCache(10 * time.Second),
 		matchers: &Matchers{
 			matchers: []Matcher{matcher},


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Switch from Debug to Error when unrecoveral events happen and add extra debug messages when indexing and matching pods.

I was trying to debug why my configs wouldn't work and I was forced to enable debug to notice that the `add_kubernetes_metadata` processor was failing because my configs were wrong. 

Sadly, my configs weren't working even after I fixed the above and it was a bit painful to figure out what was going on because there weren't enough debug messages to understand what index keys, matches, and metadata was being processed by filebeat.

## Why is it important?

It makes operations and debugging easier

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
