### PR TITLE
Cherry-pick #16857 to 7.x: Fix NewContainerMetadataEnricher to use default config for kubernetes module.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix k8s pods annotations broken schema. {pull}16554[16554]
 - Upgrade go-ucfg to latest v0.8.3. {pull}16450{16450}
 - Add `ssl.ca_sha256` option to the supported TLS option, this allow to check that a specific certificate is used as part of the verified chain. {issue}15717[15717]
+- Fix `NewContainerMetadataEnricher` to use default config for kubernetes module. {pull}16857[16857]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata/config.go
+++ b/libbeat/common/kubernetes/metadata/config.go
@@ -38,12 +38,11 @@ type AddResourceMetadataConfig struct {
 	Namespace *common.Config `config:"namespace"`
 }
 
-func defaultConfig() Config {
-	return Config{
-		IncludeCreatorMetadata: true,
-		LabelsDedot:            true,
-		AnnotationsDedot:       true,
-	}
+// InitDefaults initializes the defaults for the config.
+func (c *Config) InitDefaults() {
+	c.IncludeCreatorMetadata = true
+	c.LabelsDedot = true
+	c.AnnotationsDedot = true
 }
 
 // Unmarshal unpacks a Config into the metagen Config

--- a/libbeat/common/kubernetes/metadata/resource.go
+++ b/libbeat/common/kubernetes/metadata/resource.go
@@ -34,7 +34,7 @@ type Resource struct {
 
 // NewResourceMetadataGenerator creates a metadata generator for a generic resource
 func NewResourceMetadataGenerator(cfg *common.Config) *Resource {
-	config := defaultConfig()
+	var config Config
 	config.Unmarshal(cfg)
 
 	return &Resource{

--- a/libbeat/common/kubernetes/metadata/resource_test.go
+++ b/libbeat/common/kubernetes/metadata/resource_test.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/elastic/go-ucfg"
+
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
 )
@@ -109,7 +111,8 @@ func TestResource_Generate(t *testing.T) {
 		},
 	}
 
-	cfg := defaultConfig()
+	var cfg Config
+	ucfg.New().Unpack(&cfg)
 	metagen := &Resource{
 		config: &cfg,
 	}


### PR DESCRIPTION
Cherry-pick of PR #16857 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fix `NewContainerMetadataEnricher` to use default values for `metadata.Config`. `ResourceMetadataEnricher` already used the default config.

This also includes a change to use `InitDefaults` so an new call sites do not need to worry about ensuring the default config is always used before unpacking.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So `labels.dedot` and `annotations.dedot` default to `true`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~ (already was supposed to be default)
- ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->
- Closes elastic/beats#16845

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
