### PR TITLE
[Flaky Test] Skip Auditbeat test_system_socket.py under x-pack

### DIFF
--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -42,6 +42,7 @@ def enable_ipv6_loopback():
     f.close()
 
 
+@unittest.skip("flaky: https://github.com/elastic/beats/issues/16878")
 @unittest.skipUnless(is_platform_supported(), "Requires Linux 2.6.32+ and 386/amd64 arch")
 @unittest.skipUnless(is_root(), "Requires root")
 class Test(AuditbeatXPackTest):


### PR DESCRIPTION
Skip flaky test elastic/beats#16878 for now since it's failing in master branch CI. 