### PR TITLE
Cherry-pick #16063 to 7.6: Make use of secure port when accessing Kubelet API

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Metricbeat*
 
+- Make use of secure port when accessing Kubelet API {pull}16063[16063]
 
 *Packetbeat*
 

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -76,11 +76,11 @@ data:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and 
+      hosts: ["https://${HOSTNAME}:10250"]
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl.verification_mode: "none"
+      # If using Red Hat OpenShift remove ssl.verification_mode entry and
       # uncomment these settings:
-      #hosts: ["https://${HOSTNAME}:10250"]
-      #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       #ssl.certificate_authorities:
         #- /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
     - module: kubernetes

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -76,11 +76,11 @@ data:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and 
+      hosts: ["https://${HOSTNAME}:10250"]
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl.verification_mode: "none"
+      # If using Red Hat OpenShift remove ssl.verification_mode entry and
       # uncomment these settings:
-      #hosts: ["https://${HOSTNAME}:10250"]
-      #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       #ssl.certificate_authorities:
         #- /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
     - module: kubernetes

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -67,9 +67,10 @@ metricbeat.modules:
     - system
     - volume
   period: 10s
-  hosts: ["localhost:10255"]
   enabled: true
-  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  hosts: ["https://${HOSTNAME}:10250"]
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ssl.verification_mode: "none"
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
   #ssl.certificate: "/etc/pki/client/cert.pem"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -452,9 +452,10 @@ metricbeat.modules:
     - system
     - volume
   period: 10s
-  hosts: ["localhost:10255"]
   enabled: true
-  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  hosts: ["https://${HOSTNAME}:10250"]
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ssl.verification_mode: "none"
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
   #ssl.certificate: "/etc/pki/client/cert.pem"

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -7,9 +7,10 @@
     - system
     - volume
   period: 10s
-  hosts: ["localhost:10255"]
   enabled: true
-  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  hosts: ["https://${HOSTNAME}:10250"]
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ssl.verification_mode: "none"
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
   #ssl.certificate: "/etc/pki/client/cert.pem"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -613,9 +613,10 @@ metricbeat.modules:
     - system
     - volume
   period: 10s
-  hosts: ["localhost:10255"]
   enabled: true
-  #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  hosts: ["https://${HOSTNAME}:10250"]
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ssl.verification_mode: "none"
   #ssl.certificate_authorities:
   #  - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
   #ssl.certificate: "/etc/pki/client/cert.pem"


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#16063 to 7.6 branch. Original message: 

## What does this PR do?

This PR switches Metricbeat k8s manifests and docs to point to Kubelet secure port over https instead of the insecure port.

## Why is it important?

Insecure port of Kubelet (10255/TCP) is now less common and discouraged and also in most cases it is not enabled by default (requiring to restart `kubelet` with `--read-only-port` flag)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Closes https://github.com/elastic/beats/issues/14420


