### PR TITLE
[Agent] Docker image for integration tests

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -160,7 +160,7 @@ shared:
     <<: *agent_binary_spec
     extra_vars:
       from: 'centos:7'
-      user: '{{ .BeatName }}'
+      user: 'root'
       linux_capabilities: ''
     files:
       'agent.yml':

--- a/dev-tools/packaging/templates/docker/Dockerfile.agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.agent.tmpl
@@ -1,0 +1,52 @@
+{{- $beatHome := printf "%s/%s" "/usr/share" .BeatName }}
+{{- $beatBinary := printf "%s/%s" $beatHome .BeatName }}
+{{- $repoInfo := repo }}
+
+FROM {{ .from }}
+
+LABEL \
+  org.label-schema.build-date="{{ date }}" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="{{ .BeatVendor }}" \
+  org.label-schema.license="{{ .License }}" \
+  org.label-schema.name="{{ .BeatName }}" \
+  org.label-schema.version="{{ beat_version }}" \
+  org.label-schema.url="{{ .BeatURL }}" \
+  org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
+  org.label-schema.vcs-ref="{{ commit }}" \
+  license="{{ .License }}" \
+  description="{{ .BeatDescription }}"
+
+ENV ELASTIC_CONTAINER "true"
+ENV PATH={{ $beatHome }}:$PATH
+
+COPY beat {{ $beatHome }}
+COPY docker-entrypoint /usr/local/bin/docker-entrypoint
+RUN chmod 755 /usr/local/bin/docker-entrypoint
+
+RUN groupadd --gid 1000 {{ .BeatName }}
+
+RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
+    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
+    find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
+    find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
+    chmod 0750 {{ $beatBinary }} && \
+{{- if .linux_capabilities }}
+    setcap {{ .linux_capabilities }} {{ $beatBinary }} && \
+{{- end }}
+{{- range $i, $modulesd := .ModulesDirs }}
+    chmod 0770 {{ $beatHome}}/{{ $modulesd }} && \
+{{- end }}
+    chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
+
+{{- if ne .user "root" }}
+RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
+{{- end }}
+USER {{ .user }}
+
+{{- range $i, $port := .ExposePorts }}
+EXPOSE {{ $port }}
+{{- end }}
+
+WORKDIR {{ $beatHome }}
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.agent.tmpl
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function setup(){
+  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/setup -H 'kbn-xsrf: true' -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
+  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/setup \
+    -H 'Content-Type: application/json' \
+    -H 'kbn-xsrf: true' \
+    -d '{"admin_username":"elastic","admin_password":"changeme"}' \
+    -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
+}
+
+function enroll(){
+    # enroll agent to kibana
+    local enrollResp
+    enrollResp=$(curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \
+      -H 'Content-Type: application/json' \
+      -H 'kbn-xsrf: true' \
+      -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} \
+      -d '{"name":"demotoken","config_id":"default"}')
+
+    local exitCode=$?
+    if [ $exitCode -ne 0 ]; then
+      exit $exitCode
+    fi
+
+    apikey=$(echo $enrollResp | jq -r '.item.api_key')
+    ./{{ .BeatName }} enroll ${KIBANA_HOST:-http://localhost:5601} $apikey -f
+}
+yum install -y epel-release
+yum install -y jq
+
+setup
+enroll
+
+exec {{ .BeatName }} run "$@"

--- a/x-pack/agent/.gitignore
+++ b/x-pack/agent/.gitignore
@@ -1,6 +1,9 @@
 # agent
 build/
 agent.dev.yml
+cmd/agent/agent
+cmd/agent/agent.yml
+cmd/agent/fleet.yml
 pkg/agent/operation/tests/scripts/short--1.0.yml
 pkg/agent/operation/tests/scripts/configurable-1.0-darwin-x86/configurable
 pkg/agent/operation/tests/scripts/configurablebyfile-1.0-darwin-x86/configurablebyfile

--- a/x-pack/agent/_meta/agent.docker.yml
+++ b/x-pack/agent/_meta/agent.docker.yml
@@ -4,9 +4,9 @@
 outputs:
   default:
     type: elasticsearch
-    hosts: [127.0.0.1:9200, 127.0.0.1:9300]
-    username: elastic
-    password: changeme
+    hosts: '${ELASTICSEARCH_HOSTS:http://elasticsearch:9200}'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
 
 streams:
   - type: event/file
@@ -14,6 +14,14 @@ streams:
     paths:
       - /var/log/hello1.log
       - /var/log/hello2.log
+  - type: metric/system
+    metricsets:
+      - cpu
+      - memory
+    enabled: true
+    period: 10s
+    processes: ['.*']
+    cpu.metrics:  ["percentages"]
 
 management:
   # Mode of management, the agent support two modes of operation:

--- a/x-pack/agent/agent.docker.yml
+++ b/x-pack/agent/agent.docker.yml
@@ -4,9 +4,9 @@
 outputs:
   default:
     type: elasticsearch
-    hosts: [127.0.0.1:9200, 127.0.0.1:9300]
-    username: elastic
-    password: changeme
+    hosts: '${ELASTICSEARCH_HOSTS:http://elasticsearch:9200}'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
 
 streams:
   - type: event/file
@@ -14,6 +14,14 @@ streams:
     paths:
       - /var/log/hello1.log
       - /var/log/hello2.log
+  - type: metric/system
+    metricsets:
+      - cpu
+      - memory
+    enabled: true
+    period: 10s
+    processes: ['.*']
+    cpu.metrics:  ["percentages"]
 
 management:
   # Mode of management, the agent support two modes of operation:


### PR DESCRIPTION
Newly created container definition for agent enrolls to kibana first and then runs and waits for kibana to provide configuration. 

Configuration uses variables to connect to services with fallbacks to localhost on standard ports. This enables you to spin up kibana/es and start agent in a container running 

```
docker build -t agent .  
docker run --network host agent
```