### PR TITLE
Add missing logger init in New() functions

### DIFF
--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -45,7 +45,12 @@ type netClientWorker struct {
 
 func makeClientWorker(observer outputObserver, qu workQueue, client outputs.Client) outputWorker {
 	if nc, ok := client.(outputs.NetworkClient); ok {
-		c := &netClientWorker{observer: observer, qu: qu, client: nc, logger: logp.NewLogger("publisher_pipeline_output")}
+		c := &netClientWorker{
+			observer: observer,
+			qu:       qu,
+			client:   nc,
+			logger:   logp.NewLogger("publisher_pipeline_output"),
+		}
 		go c.run()
 		return c
 	}

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -45,7 +45,7 @@ type netClientWorker struct {
 
 func makeClientWorker(observer outputObserver, qu workQueue, client outputs.Client) outputWorker {
 	if nc, ok := client.(outputs.NetworkClient); ok {
-		c := &netClientWorker{observer: observer, qu: qu, client: nc}
+		c := &netClientWorker{observer: observer, qu: qu, client: nc, logger: logp.NewLogger("publisher_pipeline_output")}
 		go c.run()
 		return c
 	}

--- a/libbeat/reader/multiline/multiline.go
+++ b/libbeat/reader/multiline/multiline.go
@@ -126,6 +126,7 @@ func New(
 		maxLines:     maxLines,
 		separator:    []byte(separator),
 		message:      reader.Message{},
+		logger:       logp.NewLogger("reader_multiline"),
 	}
 	return mlr, nil
 }

--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -67,7 +67,7 @@ func NewLineReader(input io.Reader, config Config) (*LineReader, error) {
 		decodedNl:  terminator,
 		inBuffer:   streambuf.New(nil),
 		outBuffer:  streambuf.New(nil),
-		logger:     logp.NewLogger("readfile_line"),
+		logger:     logp.NewLogger("reader_line"),
 	}, nil
 }
 

--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -67,6 +67,7 @@ func NewLineReader(input io.Reader, config Config) (*LineReader, error) {
 		decodedNl:  terminator,
 		inBuffer:   streambuf.New(nil),
 		outBuffer:  streambuf.New(nil),
+		logger:     logp.NewLogger("readfile_line"),
 	}, nil
 }
 

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -66,6 +66,7 @@ func New(r reader.Reader, stream string, partial bool, format string, CRIFlags b
 		partial:  partial,
 		reader:   r,
 		criflags: CRIFlags,
+		logger:   logp.NewLogger("reader_docker_json"),
 	}
 
 	switch strings.ToLower(format) {

--- a/libbeat/reader/readjson/json.go
+++ b/libbeat/reader/readjson/json.go
@@ -39,7 +39,11 @@ type JSONReader struct {
 
 // NewJSONReader creates a new reader that can decode JSON.
 func NewJSONReader(r reader.Reader, cfg *Config) *JSONReader {
-	return &JSONReader{reader: r, cfg: cfg}
+	return &JSONReader{
+		reader: r,
+		cfg:    cfg,
+		logger: logp.NewLogger("reader_json"),
+	}
 }
 
 // decodeJSON unmarshals the text parameter into a MapStr and

--- a/libbeat/reader/readjson/json_test.go
+++ b/libbeat/reader/readjson/json_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -185,6 +187,7 @@ func TestDecodeJSON(t *testing.T) {
 
 		var p JSONReader
 		p.cfg = &test.Config
+		p.logger = logp.NewLogger("json_test")
 		text, M := p.decode([]byte(test.Text))
 		assert.Equal(t, test.ExpectedText, string(text))
 		assert.Equal(t, test.ExpectedMap, M)


### PR DESCRIPTION
This PR fixes https://github.com/elastic/beats/pull/16886 by adding init loggers in New() functions.