### PR TITLE
Skip flaky docker watcher tests

### DIFF
--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -358,6 +358,8 @@ func TestWatcherUpdateEventShortID(t *testing.T) {
 }
 
 func TestWatcherDie(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/7906")
+
 	watcher := runWatcher(t, false,
 		[][]types.Container{
 			[]types.Container{
@@ -402,6 +404,8 @@ func TestWatcherDie(t *testing.T) {
 }
 
 func TestWatcherDieShortID(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/7906")
+
 	watcher := runWatcherShortID(t, false,
 		[][]types.Container{
 			[]types.Container{


### PR DESCRIPTION
Skip tests reported as flaky in elastic/beats#7906

I have only seen them failing in Windows, but they are time-sensitive, so
I think they could fail for the same reasons in any platform so I am completely
skipping them.