### PR TITLE
Cherry-pick #16916 to 7.x: [Metricbeat] Remove error message when no metrics are collected from gcp

### DIFF
--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
@@ -109,11 +109,6 @@ func (r *stackdriverMetricsRequester) Metrics(ctx context.Context, ms []string) 
 	}
 
 	wg.Wait()
-
-	if len(results) == 0 {
-		return nil, errors.New("service returned 0 metrics")
-	}
-
 	return results, nil
 }
 

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
@@ -84,7 +84,6 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 
 	responses, err := reqs.Metrics(ctx, m.config.Metrics)
 	if err != nil {
-
 		return errors.Wrapf(err, "error trying to get metrics for project '%s' and zone '%s' or region '%s'", m.config.ProjectID, m.config.Zone, m.config.Region)
 	}
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#16916 to 7.x branch. Original message: 

## What does this PR do?

This PR is to remove error message from Metricbeat when there is no metrics are collected from GCP.

## Why is it important?

It's normal to not have any metrics when there is no instance in a specific region/zone. With the error message might actually confuse users.

closes https://github.com/elastic/beats/issues/16882