### PR TITLE
[libbeat/processors/add_docker_metadata] Adding support for custom cgroup prefixes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -250,6 +250,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add backoff configuration options for the Kafka output. {issue}16777[16777] {pull}17808[17808]
 - Add TLS support to Kerberos authentication in Elasticsearch. {pull}18607[18607]
 - Change ownership of files in docker images so they can be used in secured environments. {pull}12905[12905]
+- Add support for custom cgroup prefixes in `add_docker_metadata` {pull}16926[16926]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -27,15 +27,16 @@ import (
 
 // Config for docker processor.
 type Config struct {
-	Host         string            `config:"host"`               // Docker socket (UNIX or TCP socket).
-	TLS          *docker.TLSConfig `config:"ssl"`                // TLS settings for connecting to Docker.
-	Fields       []string          `config:"match_fields"`       // A list of fields to match a container ID.
-	MatchSource  bool              `config:"match_source"`       // Match container ID from a log path present in source field.
-	MatchShortID bool              `config:"match_short_id"`     // Match to container short ID from a log path present in source field.
-	SourceIndex  int               `config:"match_source_index"` // Index in the source path split by / to look for container ID.
-	MatchPIDs    []string          `config:"match_pids"`         // A list of fields containing process IDs (PIDs).
-	HostFS       string            `config:"system.hostfs"`      // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
-	DeDot        bool              `config:"labels.dedot"`       // If set to true, replace dots in labels with `_`.
+	Host           string            `config:"host"`               // Docker socket (UNIX or TCP socket).
+	TLS            *docker.TLSConfig `config:"ssl"`                // TLS settings for connecting to Docker.
+	Fields         []string          `config:"match_fields"`       // A list of fields to match a container ID.
+	MatchSource    bool              `config:"match_source"`       // Match container ID from a log path present in source field.
+	MatchShortID   bool              `config:"match_short_id"`     // Match to container short ID from a log path present in source field.
+	SourceIndex    int               `config:"match_source_index"` // Index in the source path split by / to look for container ID.
+	MatchPIDs      []string          `config:"match_pids"`         // A list of fields containing process IDs (PIDs).
+	HostFS         string            `config:"system.hostfs"`      // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
+	DeDot          bool              `config:"labels.dedot"`       // If set to true, replace dots in labels with `_`.
+	CgroupPrefixes []string          `config:"cgroup_prefixes"`    // CgroupPrefixes specify when the process is inside a container cgroup
 
 	// Annotations are kept after container is killed, until they haven't been
 	// accessed for a full `cleanup_timeout`:
@@ -44,10 +45,11 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		Host:        "unix:///var/run/docker.sock",
-		MatchSource: true,
-		SourceIndex: 4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
-		MatchPIDs:   []string{"process.pid", "process.ppid"},
-		DeDot:       true,
+		Host:           "unix:///var/run/docker.sock",
+		MatchSource:    true,
+		SourceIndex:    4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
+		MatchPIDs:      []string{"process.pid", "process.ppid"},
+		DeDot:          true,
+		CgroupPrefixes: []string{"/docker", "/kubepods"},
 	}
 }

--- a/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
+++ b/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
@@ -48,6 +48,7 @@ processors:
       #  certificate_authority: "/etc/pki/root/ca.pem"
       #  certificate:           "/etc/pki/client/cert.pem"
       #  key:                   "/etc/pki/client/cert.key"
+      #cgroup_prefixes:         ["/docker", "/kubepods"]
 -------------------------------------------------------------------------------
 
 It has the following settings:
@@ -82,3 +83,7 @@ forget metadata for a container, 60s by default.
 
 `labels.dedot`:: (Optional) Default to be false. If set to true, replace dots in
  labels with `_`.
+
+`cgroup_prefixes`:: (Optional) By default, the `cgroup_prefixes` field is set to
+`/docker` and `/kubepods`. This is the prefix used when naming cgroups in containers.
+ To detect different container runtime configurations overwrite the defaults.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change will allow detection of containers orchestrated by Kubernetes

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

Detecting containers running in Kubernetes Cluster

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
