### PR TITLE
Cherry-pick #16906 to 7.x: [Metricbeat] Fix config file name from services => service

### DIFF
--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -12,7 +12,7 @@
     #- core
     #- diskio
     #- socket
-    #- services
+    #- service
     #- users
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -15,7 +15,7 @@
     #- core
     #- diskio
     #- socket
-    #- services
+    #- service
     #- users
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU


### PR DESCRIPTION
Cherry-pick of PR #16906 to 7.x branch. Original message: 

## What does this PR do?
 
This fixes a typo in the default metricbeat config. The metricset is "service" not "services"

## Why is it important?
If you just uncomment this line from the config, metricbeat will choke.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
