### PR TITLE
Omit version selector from module name

### DIFF
--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -20,8 +20,10 @@ package gotool
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
@@ -66,6 +68,25 @@ func GetModuleName() (string, error) {
 		return "", fmt.Errorf("unexpected number of lines")
 	}
 	return lines[0], nil
+}
+
+// GetModuleNameNoVersion returns name of the modules without version suffix.
+func GetModuleNameNoVersion() (string, error) {
+	name, err := GetModuleName()
+	if err != nil {
+		return name, nil
+	}
+
+	return moduleTrimVersion(name), nil
+}
+
+func moduleTrimVersion(module string) string {
+	base := path.Base(module)
+	if _, err := semver.NewVersion(base); strings.HasPrefix(base, "v") && err == nil {
+		return path.Dir(module)
+	}
+
+	return module
 }
 
 // ListProjectPackages lists all packages in the current project

--- a/dev-tools/mage/gotool/go_test.go
+++ b/dev-tools/mage/gotool/go_test.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gotool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimVersion(t *testing.T) {
+	type testCase struct {
+		Source   string
+		Expected string
+	}
+
+	cases := []testCase{
+		testCase{"github.com/elastic/beats", "github.com/elastic/beats"},
+		testCase{"github.com/elastic/beats/v7", "github.com/elastic/beats"},
+		testCase{"github.com/elastic/beats/v7.1", "github.com/elastic/beats"},
+		testCase{"github.com/elastic/beats/v7.1.0", "github.com/elastic/beats"},
+		testCase{"github.com/elastic/beats/7.1", "github.com/elastic/beats/7.1"},
+	}
+
+	for _, tc := range cases {
+		result := moduleTrimVersion(tc.Source)
+		if result != tc.Expected {
+			assert.Fail(t, "unexpected module name", "got '%s' expected '%s'", result, tc.Expected)
+		}
+	}
+}

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -616,7 +616,7 @@ func getProjectRepoInfoWithModules() (*ProjectRepoInfo, error) {
 		return nil, errors.Errorf("failed to find root dir of module file: %v", errs)
 	}
 
-	rootImportPath, err := gotool.GetModuleName()
+	rootImportPath, err := gotool.GetModuleNameNoVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -675,7 +675,7 @@ func getProjectRepoInfoUnderGopath() (*ProjectRepoInfo, error) {
 		return nil, errors.Wrap(err, "failed to get relative path to repo root")
 	}
 
-	rootImportPath, err := gotool.GetModuleName()
+	rootImportPath, err := gotool.GetModuleNameNoVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.1
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/date v0.2.0
+	github.com/Masterminds/semver v1.4.2
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Shopify/sarama v0.0.0-00010101000000-000000000000
 	github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6


### PR DESCRIPTION
## What does this PR do?

Tests are failing on this:
```
failed to determine golang-crossbuild image tag: failed to read go version file=/home/travis/gopath/src/beatpath/testmetricbeat/vendor/github.com/elastic/beats/v7/.go-version: open /home/travis/gopath/src/beatpath/testmetricbeat/vendor/github.com/elastic/beats/v7/.go-version: no such file or directory
```

this is because module version is returned from `go list` command output which contains version selector e.g `github.com/elastic/beats/v7`

This PR introduces GetModuleNameNoVersion which trims version suffix if specified in format starting with `v` e.g. `v7`

## Why is it important?

To get generators tests green

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## 