### PR TITLE
Cherry-pick #16952 to 7.x: Temporarily disable generator jobs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,14 +154,15 @@ jobs:
       stage: test
 
     # Generators
-    - os: linux
-      env: TARGETS="-C generator/_templates/metricbeat test test-package"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C generator/_templates/beat test test-package"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # https://github.com/elastic/beats/issues/16951
+    #- os: linux
+    #  env: TARGETS="-C generator/_templates/metricbeat test test-package"
+    #  go: $TRAVIS_GO_VERSION
+    #  stage: test
+    #- os: linux
+    #  env: TARGETS="-C generator/_templates/beat test test-package"
+    #  go: $TRAVIS_GO_VERSION
+    #  stage: test
 
     - os: osx
       env: TARGETS="-C generator/_templates/metricbeat test"


### PR DESCRIPTION
Cherry-pick of PR #16952 to 7.x branch. Original message: 

Jobs are disabled temporarily.
An issue is opened to make sure it is fixed: https://github.com/elastic/beats/issues/16951