### PR TITLE
Cherry-pick #15903 to 7.x: Separated period configuration for system/package dataset updates

### DIFF
--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -123,9 +123,14 @@ auditbeat.modules:
 # or stops).
 - module: system
   datasets:
+    - package # Installed, updated, and removed packages
+
+  period: 2m # The frequency at which the datasets check for changes
+
+- module: system
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - login   # User logins, logouts, and system boots.
-    - package # Installed, updated, and removed packages
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -49,9 +49,14 @@ auditbeat.modules:
 
 - module: system
   datasets:
+    - package # Installed, updated, and removed packages
+
+  period: 2m # The frequency at which the datasets check for changes
+
+- module: system
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - login   # User logins, logouts, and system boots.
-    - package # Installed, updated, and removed packages
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information

--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -130,9 +130,14 @@ is an example configuration:
 auditbeat.modules:
 - module: system
   datasets:
+    - package # Installed, updated, and removed packages
+
+  period: 2m # The frequency at which the datasets check for changes
+
+- module: system
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - login   # User logins, logouts, and system boots.
-    - package # Installed, updated, and removed packages
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -4,14 +4,20 @@
 # running processes) and real-time changes (e.g. when a new process starts
 # or stops).
 {{ end -}}
+
+{{- if ne .GOOS "windows" -}}
+- module: system
+  datasets:
+    - package # Installed, updated, and removed packages
+
+  period: 2m # The frequency at which the datasets check for changes
+{{- end }}
+
 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
     {{- if eq .GOOS "linux" }}
     - login   # User logins, logouts, and system boots.
-    {{- end -}}
-    {{- if ne .GOOS "windows" }}
-    - package # Installed, updated, and removed packages
     {{- end }}
     - process # Started and stopped processes
     {{- if eq .GOOS "linux" }}


### PR DESCRIPTION
Cherry-pick of PR #15903 to 7.x branch. Original message: 

## What does this PR do?

Add a separated configuration for dataset that scan for newly installed packages in module system.

## Why is it important?

Because currently the `system/package` dataset fetches every 10 seconds which causes unnecessary cpu usage when scanning a large number of newly installed packages. The 10 seconds correspond to `system.period` so changing this value is not an option since it is used by others datasets.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## Related issues
- Closes #15877

