### PR TITLE
Fix issue where autodiscover hints default configuration was not being copied.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Adding the var definitions in azure manifest files, fix for errors when executing command setup. {issue}16270[16270] {pull}16468[16468]
 - Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
 - Add queue_url definition in manifest file for aws module. {pull}16640{16640}
+- Fix issue where autodiscover hints default configuration was not being copied. {pull}16987[16987]
 
 *Heartbeat*
 

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -59,7 +59,12 @@ func (c *config) Unpack(from *common.Config) error {
 			}
 		} else {
 			// full config provided, discard default
-			c.DefaultConfig = config
+			//
+			// must be a clone of the default config or the config will be
+			// updated across different hints and causes bad unexpected behaviour;
+			// (https://github.com/elastic/beats/issues/16540) provides more context
+			// on why this is required here
+			c.DefaultConfig = common.MustNewConfigFrom(config)
 		}
 	}
 

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -58,12 +58,8 @@ func (c *config) Unpack(from *common.Config) error {
 				return nil
 			}
 		} else {
-			// full config provided, discard default
-			//
-			// must be a clone of the default config or the config will be
-			// updated across different hints and causes bad unexpected behaviour;
-			// (https://github.com/elastic/beats/issues/16540) provides more context
-			// on why this is required here
+			// full config provided, discard default. It must be a clone of the
+			// given config otherwise it could be updated across multiple inputs.
 			c.DefaultConfig = common.MustNewConfigFrom(config)
 		}
 	}

--- a/filebeat/autodiscover/builder/hints/config_test.go
+++ b/filebeat/autodiscover/builder/hints/config_test.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestUnpackCopiesDefault(t *testing.T) {
+	userCfg := common.MustNewConfigFrom(common.MapStr{
+		"default_config": common.MapStr{
+			"type": "container",
+			"paths": []string{
+				"/var/log/containers/*${data.kubernetes.container.id}.log",
+			},
+		},
+	})
+
+	cfg1 := defaultConfig()
+	assert.NoError(t, userCfg.Unpack(&cfg1))
+
+	cfg2 := defaultConfig()
+	assert.NoError(t, userCfg.Unpack(&cfg2))
+
+	assert.NotEqual(t, cfg1.DefaultConfig, cfg2.DefaultConfig)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

FIxes issue where when a default configuration is provided to autodiscovery in filebeat it would cause the elasticsearch module to have log messages repeated and appear in different datasets.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change log messages would be repeated and reported in different datasets unless `hints.default_config.enabled: false` was set. Which also prevented filebeat from reading the logs of pods that didn't have the annotation of `co.elastic.logs/enabled: true`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build the docker image `cd filebeat && PACKAGES="linux/amd64" mage package`
2. Push it to a registry (I used a personal private registry)
3. Use the image in the filebeat configurations:

```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: filebeat-config
  namespace: kube-system
  labels:
    k8s-app: filebeat
data:
  filebeat.yml: |-
    # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
    filebeat.autodiscover:
      providers:
        - type: kubernetes
          node: ${NODE_NAME}
          hints.enabled: true
          hints.default_config:
            type: container
            paths:
              - /var/log/containers/*${data.kubernetes.container.id}.log

    processors:
      - add_cloud_metadata:
      - add_host_metadata:

    cloud.id: ${ELASTIC_CLOUD_ID}
    cloud.auth: ${ELASTIC_CLOUD_AUTH}

    logging:
      level: debug
      metrics.enabled: false
      selectors:
        - "*"
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: filebeat
  namespace: kube-system
  labels:
    k8s-app: filebeat
spec:
  selector:
    matchLabels:
      k8s-app: filebeat
  template:
    metadata:
      labels:
        k8s-app: filebeat
      annotations:
        co.elastic.logs/enabled: "false"
    spec:
      serviceAccountName: filebeat
      terminationGracePeriodSeconds: 30
      hostNetwork: true
      dnsPolicy: ClusterFirstWithHostNet
      imagePullSecrets:
        - name: blake-creds
      containers:
      - name: filebeat
        image: blakerouse/elastic:filebeat-master
        args: [
          "run", "-c", "/etc/filebeat.yml", "-e"
        ]
        env:
        - name: ELASTIC_CLOUD_ID
          value: "***"
        - name: ELASTIC_CLOUD_AUTH
          value: "***"
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        securityContext:
          runAsUser: 0
        resources:
          limits:
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 100Mi
        volumeMounts:
        - name: config
          mountPath: /etc/filebeat.yml
          readOnly: true
          subPath: filebeat.yml
        - name: data
          mountPath: /usr/share/filebeat/data
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
        - name: varlog
          mountPath: /var/log
          readOnly: true
      volumes:
      - name: config
        configMap:
          defaultMode: 0600
          name: filebeat-config
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
      - name: varlog
        hostPath:
          path: /var/log
      - name: data
        hostPath:
          path: /var/lib/filebeat-data
          type: DirectoryOrCreate
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: filebeat
subjects:
- kind: ServiceAccount
  name: filebeat
  namespace: kube-system
roleRef:
  kind: ClusterRole
  name: filebeat
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: filebeat
  labels:
    k8s-app: filebeat
rules:
- apiGroups: [""] # "" indicates the core API group
  resources:
  - namespaces
  - pods
  verbs:
  - get
  - watch
  - list
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: filebeat
  namespace: kube-system
  labels:
    k8s-app: filebeat
---
```

4. Deploy elasticsearch with the elasticsearch module set in the hints.

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: elasticsearch-data
spec:
  accessModes: [ "ReadWriteOnce" ]
  resources:
    requests:
      storage: 5Gi
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: elasticsearch-config
data:
  elasticsearch.yml: |
    discovery.type: single-node
    xpack.security.enabled: false
    xpack.monitoring.enabled: false
  ES_JAVA_OPTS: -Xms256m -Xmx256m
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: elasticsearch
spec:
  replicas: 1
  selector:
    matchLabels:
      app: elasticsearch
  template:
    metadata:
      labels:
        app: elasticsearch
      annotations:
        co.elastic.logs/enabled: "true"
        co.elastic.logs/module: elasticsearch
    spec:
      securityContext:
        fsGroup: 1000
      containers:
        - name: elasticsearch
          resources:
            requests:
              memory: 500Mi
          securityContext:
            privileged: true
            runAsUser: 1000
            capabilities:
              add:
                - IPC_LOCK
                - SYS_RESOURCE
          image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
          env:
            - name: ES_JAVA_OPTS
              valueFrom:
                configMapKeyRef:
                  name: elasticsearch-config
                  key: ES_JAVA_OPTS
          readinessProbe:
            httpGet:
              scheme: HTTP
              path: /_cluster/health?local=true
              port: 9200
            initialDelaySeconds: 5
          ports:
            - containerPort: 9200
              name: es-http
            - containerPort: 9300
              name: es-transport
          volumeMounts:
            - name: es-data
              mountPath: /usr/share/elasticsearch/data
            - name: elasticsearch-config
              mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
              subPath: elasticsearch.yml
      volumes:
        - name: elasticsearch-config
          configMap:
            name: elasticsearch-config
            items:
              - key: elasticsearch.yml
                path: elasticsearch.yml
        - name: es-data
          persistentVolumeClaim:
            claimName: elasticsearch-data
```

5. Check that the log messages are not repeated and are in the correct `event.dataset`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #16540

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
