### PR TITLE
Cherry-pick #15926 to 7.x: fixed yml syntax

### DIFF
--- a/libbeat/processors/actions/docs/copy_fields.asciidoc
+++ b/libbeat/processors/actions/docs/copy_fields.asciidoc
@@ -21,11 +21,11 @@ For example, this configuration:
 ------------------------------------------------------------------------------
 processors:
 - copy_fields:
-  fields:
-  - from: message
-    to: event.original
-  fail_on_error: false
-  ignore_missing: true
+    fields:
+    - from: message
+      to: event.original
+    fail_on_error: false
+    ignore_missing: true
 ------------------------------------------------------------------------------
 
 Copies the original `message` field to `event.original`:


### PR DESCRIPTION
Cherry-pick of PR #15926 to 7.x branch. Original message: 

yml example had wrong indentation.
