### PR TITLE
[Agent] Fix ACK to fleet

### DIFF
--- a/x-pack/agent/pkg/agent/application/action_store.go
+++ b/x-pack/agent/pkg/agent/application/action_store.go
@@ -134,7 +134,7 @@ func (a *actionStoreAcker) Ack(ctx context.Context, action fleetapi.Action) erro
 }
 
 func (a *actionStoreAcker) Commit(ctx context.Context) error {
-	return nil
+	return a.acker.Commit(ctx)
 }
 
 func newActionStoreAcker(acker fleetAcker, store *actionStore) *actionStoreAcker {

--- a/x-pack/agent/pkg/agent/application/fleet_acker.go
+++ b/x-pack/agent/pkg/agent/application/fleet_acker.go
@@ -40,7 +40,6 @@ func (f *actionAcker) Ack(ctx context.Context, action fleetapi.Action) error {
 	// checkin
 	cmd := fleetapi.NewAckCmd(f.agentInfo, f.client)
 	req := &fleetapi.AckRequest{
-		AgentID: f.agentInfo.AgentID(),
 		Actions: []string{
 			action.ID(),
 		},

--- a/x-pack/agent/pkg/fleetapi/ack_cmd.go
+++ b/x-pack/agent/pkg/fleetapi/ack_cmd.go
@@ -23,7 +23,6 @@ const ackPath = "/api/ingest_manager/fleet/agents/%s/acks"
 //   "action_ids": ["id1"]
 // }
 type AckRequest struct {
-	AgentID string   `json:"agent_id"`
 	Actions []string `json:"action_ids"`
 }
 


### PR DESCRIPTION
Two things were broken with ACK
- we were not calling ackers Commit in Action Store Commit, which in combination with lazy acker results in collection Acks in memory without sending it out
- Additional field AgentID in AckRequest caused fleet to reject Ack 