### PR TITLE
fix multiline input occasionally leak log when file was removed

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -237,7 +237,7 @@ func (h *Harvester) Run() error {
 		defer h.onTerminate()
 	}
 
-	outlet := channel.CloseOnSignal(h.outletFactory(), h.done)
+	outlet := h.outletFactory()
 	forwarder := harvester.NewForwarder(outlet)
 
 	// This is to make sure a harvester is not started anymore if stop was already
@@ -268,6 +268,9 @@ func (h *Harvester) Run() error {
 
 		// Marks harvester stopping completed
 		h.stopWg.Done()
+
+		// outlet.Close must be after harvester complete
+		outlet.Close()
 	}()
 
 	harvesterStarted.Add(1)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug

-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

fix multiline input occasionally leak log when file was removed




## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

 the log file will be rename, when k8s container panic, at this time, the filebeat may miss a few lines of log

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

create pod in k8s ,that panic after 60 second ，example in go

```
package main

import (
	"fmt"
	"os"
	"time"
)

func panicFunc() {
	panic("panic test after 60 second")
}

func main() {
	go func() {
		for {
			time.Sleep(1 * time.Second)
			fmt.Fprintln(os.Stdout, `{"level":"info","ts":1584010119.8292112,"caller":"v3@v3.1.0/default.go:34","msg":"test log","svcName":"XXX"}`)
		}
	}()
	time.Sleep(60 * time.Second)

}
```

use autodiscover to collect it

```
filebeat.autodiscover:
      providers:
        - type: kubernetes
          templates:
            - condition:
                equals:
                  kubernetes.pod.name: this-pod-name
              config:
                - type: container
                  paths:
                    - /var/log/containers/*-${data.kubernetes.container.id}.log
                  multiline.pattern: "\\Apanic"
                  multiline.negate: true
                  multiline.match: after
                  fields_under_root: true
                  tail_files: false
                  stream: stderr 
                  close_removed: true
                  clean_removed: true 
                  ignore_older: 12m
                  close_inactive: 10m
```


## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

filebeat can collect logs normally when pod stop

![image](https://user-images.githubusercontent.com/12421954/76612510-6f2cf980-6557-11ea-8151-7603cb1bd22f.png)

