### PR TITLE
Improve Prometheus remote_write metricset docs

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -41,5 +41,6 @@ remote_write:
     tls_config:
         cert_file: "/etc/prometheus/my_key.pem"
         key_file: "/etc/prometheus/my_key.key"
-        insecure_skip_verify: true
+        # Disable validation of the server certificate.
+        #insecure_skip_verify: true
 ------------------------------------------------------------------------------

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -7,9 +7,20 @@ remote_write:
   - url: "http://localhost:9201/write"
 ------------------------------------------------------------------------------
 
-
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.
-Also consider using secure settings for the server using TLS/SSL as shown
+A basic configuration would look like:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+- module: prometheus
+  metricsets: ["remote_write"]
+  host: "localhost"
+  port: "9201"
+------------------------------------------------------------------------------
+
+
+
+Also consider using secure settings for the server, configuring the module with TLS/SSL as shown:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
@@ -19,4 +30,16 @@ Also consider using secure settings for the server using TLS/SSL as shown
   ssl.certificate: "/etc/pki/server/cert.pem"
   ssl.key: "/etc/pki/server/cert.key"
   port: "9201"
+------------------------------------------------------------------------------
+
+and on Prometheus side:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+remote_write:
+  - url: "https://localhost:9201/write"
+    tls_config:
+        cert_file: "/etc/prometheus/my_key.pem"
+        key_file: "/etc/prometheus/my_key.key"
+        insecure_skip_verify: true
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up of https://github.com/elastic/beats/pull/16609 to improve the docs of the metricset by:

1. providing a basic configuration without TLS
2. providing configuration samples using TLS support (the manual testing guide was updated with this case too on the initial PR)


