### PR TITLE
Update add_cloudfoundry_metadata to use debug log, add missing cache_duraction doc

### DIFF
--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/add_cloudfoundry_metadata.go
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/add_cloudfoundry_metadata.go
@@ -72,7 +72,7 @@ func (d *addCloudFoundryMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	}
 	app, err := d.client.GetAppByGuid(val)
 	if err != nil {
-		d.log.Warnf("failed to get application info for GUID(%s): %v", val, err)
+		d.log.Debugf("failed to get application info for GUID(%s): %v", val, err)
 		return event, nil
 	}
 	event.Fields.DeepUpdate(common.MapStr{

--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
@@ -53,4 +53,6 @@ It has the following settings:
 
 `client_secret`:: Client Secret to authenticate with Cloud Foundry.
 
+`cache_duration`:: (Optional) Maximum amount of time to cache an application's metadata.
+
 `ssl`:: (Optional) SSL configuration to use when connecting to Cloud Foundry.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fixes an issue where the `add_cloudfoundry_metadata` process reported missing applications as a warning log. This spammed the logs of metricbeat and filebeat, because PCF has some applications that cannot be references from the API. This changes it to debug log, so its not own by default and can be turned on if the user wanted.

Includes a drive-by fix for the missing `cache_duration` documentation on the `add_cloudfoundry_metadata`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To not spam the logs with warning messages, that will always occur in PCF.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Doesn't spam the logs with warn messages.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
