### PR TITLE
Increase HTTP client timeout in kubernetes state_deployment tests

### DIFF
--- a/metricbeat/mb/testing/testdata.go
+++ b/metricbeat/mb/testing/testdata.go
@@ -278,7 +278,11 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Dat
 		for _, e := range expectedMap {
 			t.Error(e)
 		}
-		t.Fatal()
+	}
+
+	// If there was some error, fail before trying to write anything.
+	if t.Failed() {
+		t.FailNow()
 	}
 
 	if strings.HasSuffix(file, "docs."+config.Suffix) {

--- a/metricbeat/module/kubernetes/state_deployment/_meta/testdata/config.yml
+++ b/metricbeat/module/kubernetes/state_deployment/_meta/testdata/config.yml
@@ -1,3 +1,5 @@
 type: http
 url: "/metrics"
 suffix: plain
+module:
+  timeout: 30s


### PR DESCRIPTION
Test data for state_deployment metricset is quite big, and the metricset
may need more than the 10 seconds default timeout of HTTP clients,
provoking sporadic failures in CI.
Increase this timeout for this case.

This should fix flaky tests like:
```
10:55:29 --- FAIL: TestData (12.25s)
10:55:29     --- FAIL: TestData/ksm-v1.8.0.plain (11.22s)
10:55:29         testdata.go:272: Event was not expected: {"error":{"message":"decoding of metric family failed: net/http: request canceled (Client.Timeout exceeded while reading body)"},"event":{"dataset":"kubernetes.state_deployment","duration":115000,"module":"kubernetes"},"metricset":{"name":"state_deployment","period":10000},"service":{"address":"127.0.0.1:55555","type":"kubernetes"}}
10:55:29         testdata.go:277: Some events were missing:
...
10:55:29         testdata.go:281: 
10:55:29 FAIL
10:55:29 coverage: 74.1% of statements
10:55:29 FAIL	github.com/elastic/beats/v7/metricbeat/module/kubernetes/state_deployment	12.588s
```