### PR TITLE
added kafka as input source

### DIFF
--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -13,6 +13,19 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 
+{{ else if eq .input "kafka" }}
+
+type: kafka
+hosts:
+{{ range $i, $host := .hosts }}
+  - {{$host}}
+{{ end }}
+group_id: {{.group_id}}
+topics:
+{{ range $i, $topic := .topics }}
+  - {{$topic}}
+{{ end }}
+
 {{ end }}
 
 tags: {{.tags}}


### PR DESCRIPTION
## What does this PR do?

Adding Kafka as input source for filebeat/panw.

## Why is it important?

Kafka can holds ingress logs while ELK+B is under maintenance. Kafka should be included as a source for almost any beats getting data via syslog.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [X] I have tested under pre production environment

## How to test this PR locally

Tested pipeline includes:

- rsyslog receinving logs from PANW NGFW and storing into kafka
- kafka
 - filebeat getting data from kafka and storing into logstash/elasticsearch

Filbeat is configured as following:

~~~
#/etc/filebeat/modules.d/panw.yml

- module: panw
  panos:
    enabled: true
    var.input: kafka
    var.topics:
      - panw_panos
    var.hosts:
      - localhost:9092
    var.group_id: filebeat
~~~

Mandatory: create pipeline on Elasticsearch as following:
`filebeat setup --pipelines --modules panw -v -e`

## Related issues

## Use cases

Enabling Kafka as input, we can change the ingress pipeline as following:

syslog -(push)> kafka -(pull)> filebeat -(push)> kafka|elasticsearch

## Screenshots

## Logs
