### PR TITLE
[Metricbeat]Fix MySQL default dashboard

### DIFF
--- a/metricbeat/module/mysql/_meta/kibana/7/dashboard/Metricbeat-mysql-overview.json
+++ b/metricbeat/module/mysql/_meta/kibana/7/dashboard/Metricbeat-mysql-overview.json
@@ -1,648 +1,1655 @@
 {
-    "objects": [
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of MySQL server",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Open Tables, Files, Streams"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "14",
+              "w": 24,
+              "x": 24,
+              "y": 38
+            },
+            "panelIndex": "14",
+            "panelRefName": "panel_0",
+            "title": "Open Tables, Files, Streams",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Rate of Questions"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "050b110b-0b4d-404a-86c0-fa97f7eed2a0",
+              "w": 16,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "050b110b-0b4d-404a-86c0-fa97f7eed2a0",
+            "panelRefName": "panel_1",
+            "title": "Rate of Questions",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Rate of SELECT statements"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "988a61d7-ac3e-481e-a6ae-aa75aaa32a3a",
+              "w": 16,
+              "x": 16,
+              "y": 0
+            },
+            "panelIndex": "988a61d7-ac3e-481e-a6ae-aa75aaa32a3a",
+            "panelRefName": "panel_2",
+            "title": "Rate of SELECT statements",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Rate of INSERT, UPDATE, DELETE"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "a1f8fa38-a62f-4e05-adde-e995dae9ad83",
+              "w": 16,
+              "x": 32,
+              "y": 0
+            },
+            "panelIndex": "a1f8fa38-a62f-4e05-adde-e995dae9ad83",
+            "panelRefName": "panel_3",
+            "title": "Rate of INSERT, UPDATE, DELETE",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Connected Threads"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "d126fb61-605f-43af-b5d5-3fa3c128f726",
+              "w": 6,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "d126fb61-605f-43af-b5d5-3fa3c128f726",
+            "panelRefName": "panel_4",
+            "title": "Connected Threads",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Connections"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "59586d96-3abd-48a3-a258-cfd620826ec2",
+              "w": 14,
+              "x": 6,
+              "y": 12
+            },
+            "panelIndex": "59586d96-3abd-48a3-a258-cfd620826ec2",
+            "panelRefName": "panel_5",
+            "title": "Connections",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Aborted Connections Rate"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "dd0cf202-fe22-4daf-8f25-09c64d412bf3",
+              "w": 14,
+              "x": 20,
+              "y": 12
+            },
+            "panelIndex": "dd0cf202-fe22-4daf-8f25-09c64d412bf3",
+            "panelRefName": "panel_6",
+            "title": "Aborted Connections Rate",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Thread Activity"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "ead16a55-a2d3-49ae-a09b-a0b03560e9a0",
+              "w": 14,
+              "x": 34,
+              "y": 12
+            },
+            "panelIndex": "ead16a55-a2d3-49ae-a09b-a0b03560e9a0",
+            "panelRefName": "panel_7",
+            "title": "Thread Activity",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Buffer Pool Pages"
+            },
+            "gridData": {
+              "h": 14,
+              "i": "24fc2926-610d-4910-8f3e-eb63ca69788c",
+              "w": 15,
+              "x": 0,
+              "y": 24
+            },
+            "panelIndex": "24fc2926-610d-4910-8f3e-eb63ca69788c",
+            "panelRefName": "panel_8",
+            "title": "Buffer Pool Pages",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Buffer Pool Utilization"
+            },
+            "gridData": {
+              "h": 14,
+              "i": "33c10c95-be67-492e-afb5-863f375cffc2",
+              "w": 16,
+              "x": 15,
+              "y": 24
+            },
+            "panelIndex": "33c10c95-be67-492e-afb5-863f375cffc2",
+            "panelRefName": "panel_9",
+            "title": "Buffer Pool Utilization",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Network Traffic"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
+              "w": 24,
+              "x": 0,
+              "y": 38
+            },
+            "panelIndex": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
+            "panelRefName": "panel_10",
+            "title": "Network Traffic",
+            "version": "7.3.1"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Buffer Pool Efficiency"
+            },
+            "gridData": {
+              "h": 14,
+              "i": "d35d7c5e-8832-40e2-8c77-953ad320c853",
+              "w": 17,
+              "x": 31,
+              "y": 24
+            },
+            "panelIndex": "d35d7c5e-8832-40e2-8c77-953ad320c853",
+            "panelRefName": "panel_11",
+            "title": "Buffer Pool Efficiency",
+            "version": "7.3.1"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat MySQL] Database Overview",
+        "version": 1
+      },
+      "id": "57b3fb50-6309-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Connections rate [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "#68BC00", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Connections rate", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.connections", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "id": "aee9bbf0-f1f3-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Connections rate [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 2
-        }, 
+          "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs",
+          "name": "panel_0",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Command rates [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "#68BC00", 
-                                "fill": "0.2", 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "SELECT", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.command.select", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "id": "2d149f90-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }, 
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(104,204,202,1)", 
-                                "fill": "0.2", 
-                                "formatter": "number", 
-                                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99", 
-                                "label": "INSERT", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.command.insert", 
-                                        "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
-                                        "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }, 
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(252,220,0,1)", 
-                                "fill": "0.2", 
-                                "formatter": "number", 
-                                "id": "485ce050-f1f4-11e7-a752-236fe3270d99", 
-                                "label": "UPDATE", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.command.update", 
-                                        "id": "485ce051-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "485ce051-f1f4-11e7-a752-236fe3270d99", 
-                                        "id": "485ce052-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }, 
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(244,78,59,1)", 
-                                "fill": "0.2", 
-                                "formatter": "number", 
-                                "id": "543a4a70-f1f4-11e7-a752-236fe3270d99", 
-                                "label": "DELETE", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.command.delete", 
-                                        "id": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
-                                        "id": "543a4a72-f1f4-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Command rates [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 2
-        }, 
+          "id": "4fa69a10-630b-11ea-a83e-25b8612d00cc",
+          "name": "panel_1",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Running threads [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(174,161,255,1)", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Running threads", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.threads.running", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Running threads [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 2
-        }, 
+          "id": "7ea77d30-630a-11ea-a83e-25b8612d00cc",
+          "name": "panel_2",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Opened tables rate [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(252,196,0,1)", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Opened tables rate", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.opened_tables", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Opened tables rate [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 3
-        }, 
+          "id": "779ee920-6309-11ea-a83e-25b8612d00cc",
+          "name": "panel_3",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Threads created rate [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(123,100,255,1)", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Threads created rate", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.threads.created", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Threads created rate [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 2
-        }, 
+          "id": "fc6b5a40-630d-11ea-a83e-25b8612d00cc",
+          "name": "panel_4",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Open files [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(22,165,165,1)", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Open files", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.open.files", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Open files [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 2
-        }, 
+          "id": "493e8460-630d-11ea-a83e-25b8612d00cc",
+          "name": "panel_5",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {}
-                }, 
-                "title": "Sent and received bytes rates [Metricbeat MySQL] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [], 
-                    "params": {
-                        "axis_formatter": "number", 
-                        "axis_position": "left", 
-                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
-                        "index_pattern": "metricbeat-*", 
-                        "interval": "auto", 
-                        "legend_position": "bottom", 
-                        "series": [
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "rgba(0,98,177,1)", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99", 
-                                "label": "Received bytes", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.bytes.received", 
-                                        "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
-                                        "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }, 
-                            {
-                                "axis_position": "right", 
-                                "chart_type": "line", 
-                                "color": "#68BC00", 
-                                "fill": 0.5, 
-                                "formatter": "number", 
-                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
-                                "label": "Sent bytes", 
-                                "line_width": 1, 
-                                "metrics": [
-                                    {
-                                        "field": "mysql.status.bytes.sent", 
-                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
-                                    }, 
-                                    {
-                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "id": "23cfda50-f1f7-11e7-a752-236fe3270d99", 
-                                        "type": "derivative", 
-                                        "unit": ""
-                                    }
-                                ], 
-                                "point_size": 1, 
-                                "seperate_axis": 0, 
-                                "split_mode": "everything", 
-                                "stacked": "none"
-                            }
-                        ], 
-                        "show_grid": 1, 
-                        "show_legend": 1, 
-                        "time_field": "@timestamp", 
-                        "type": "timeseries"
-                    }, 
-                    "title": "Sent and received bytes rates [Metricbeat MySQL] ECS", 
-                    "type": "metrics"
-                }
-            }, 
-            "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1-ecs", 
-            "type": "visualization", 
-            "updated_at": "2018-01-05T09:15:49.714Z", 
-            "version": 3
-        }, 
+          "id": "bf60bc10-639b-11ea-a83e-25b8612d00cc",
+          "name": "panel_6",
+          "type": "visualization"
+        },
         {
-            "attributes": {
-                "description": "Overview of MySQL server",
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "query": {
-                            "language": "kuery",
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "optionsJSON": {
-                    "darkTheme": false, 
-                    "useMargins": false
-                }, 
-                "panelsJSON": [
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "10", 
-                            "w": 6, 
-                            "x": 0, 
-                            "y": 3
-                        }, 
-                        "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "10", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "11", 
-                            "w": 12, 
-                            "x": 0, 
-                            "y": 0
-                        }, 
-                        "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "11", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "13", 
-                            "w": 6, 
-                            "x": 6, 
-                            "y": 3
-                        }, 
-                        "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "13", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "14", 
-                            "w": 6, 
-                            "x": 0, 
-                            "y": 6
-                        }, 
-                        "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "14", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "15", 
-                            "w": 6, 
-                            "x": 6, 
-                            "y": 6
-                        }, 
-                        "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "15", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "16", 
-                            "w": 6, 
-                            "x": 6, 
-                            "y": 9
-                        }, 
-                        "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "16", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }, 
-                    {
-                        "gridData": {
-                            "h": 3, 
-                            "i": "17", 
-                            "w": 6, 
-                            "x": 0, 
-                            "y": 9
-                        }, 
-                        "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1-ecs", 
-                        "panelIndex": "17", 
-                        "type": "visualization", 
-                        "version": "6.2.4"
-                    }
-                ], 
-                "timeRestore": false, 
-                "title": "[Metricbeat MySQL] Overview ECS", 
-                "version": 1
-            }, 
-            "id": "66881e90-0006-11e7-bf7f-c9acc3d3e306-ecs", 
-            "type": "dashboard", 
-            "updated_at": "2018-01-05T09:14:45.934Z", 
-            "version": 3
+          "id": "822df290-630f-11ea-a83e-25b8612d00cc",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "98c7bca0-63a2-11ea-a83e-25b8612d00cc",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "96d46630-63a4-11ea-a83e-25b8612d00cc",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "a1e00160-63a4-11ea-a83e-25b8612d00cc",
+          "name": "panel_11",
+          "type": "visualization"
         }
-    ], 
-    "version": "6.2.4"
+      ],
+      "type": "dashboard",
+      "updated_at": "2020-03-16T13:01:34.528Z",
+      "version": "WzQ2NzAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Open tables, files, streams [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Open Tables",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.open.tables",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "615a2400-6312-11ea-99e6-b5eed31db613",
+                "label": "Open Files",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.open.files",
+                    "id": "615a2401-6312-11ea-99e6-b5eed31db613",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(226,115,0,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "15d7bcd0-6313-11ea-99e6-b5eed31db613",
+                "label": "Open Streams",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.open.streams",
+                    "id": "15d7bcd1-6313-11ea-99e6-b5eed31db613",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Open tables, files, streams [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:01:07.859Z",
+      "version": "WzQ2NjksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Question rates [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "d61928d0-6309-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "right",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0.3",
+                "formatter": "'0.0a'",
+                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99",
+                "label": "SELECT",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.questions",
+                    "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "id": "82f59710-6309-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 0,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Question rates [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "4fa69a10-630b-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T12:58:09.873Z",
+      "version": "WzQ2NTQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SELECT rates [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "d61928d0-6309-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "right",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0.3",
+                "formatter": "'0.0a'",
+                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99",
+                "label": "SELECT",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.select",
+                    "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "id": "82f59710-6309-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 0,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "SELECT rates [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "7ea77d30-630a-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T12:59:11.517Z",
+      "version": "WzQ2NTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Insert, Update, Delete rates [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "d61928d0-6309-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99",
+                "label": "INSERT",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.insert",
+                    "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3c2a2a42-f1f4-11e7-a752-236fe3270d99",
+                    "id": "82f59710-6309-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "485ce050-f1f4-11e7-a752-236fe3270d99",
+                "label": "UPDATE",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.update",
+                    "id": "485ce051-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "485ce051-f1f4-11e7-a752-236fe3270d99",
+                    "id": "485ce052-f1f4-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "485ce052-f1f4-11e7-a752-236fe3270d99",
+                    "id": "a4092660-6309-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "543a4a70-f1f4-11e7-a752-236fe3270d99",
+                "label": "DELETE",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.delete",
+                    "id": "543a4a71-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "543a4a71-f1f4-11e7-a752-236fe3270d99",
+                    "id": "543a4a72-f1f4-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "543a4a72-f1f4-11e7-a752-236fe3270d99",
+                    "id": "bae29b50-6309-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Insert, Update, Delete rates [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "779ee920-6309-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T12:59:32.603Z",
+      "version": "WzQ2NTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Connected Threads [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "d5fcf170-630d-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "gauge_color_rules": [
+              {
+                "id": "f1321f60-630d-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,0.89)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "fe9af660-630b-11ea-99e6-b5eed31db613",
+                "label": "Connections",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.threads.connected",
+                    "id": "fe9af661-630b-11ea-99e6-b5eed31db613",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "gauge"
+          },
+          "title": "Connected Threads [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "fc6b5a40-630d-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T12:59:47.044Z",
+      "version": "WzQ2NTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Connections [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(198,135,31,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Connection rate",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.connections",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "caee3e70-630c-11ea-99e6-b5eed31db613",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "caee3e70-630c-11ea-99e6-b5eed31db613",
+                    "id": "d4eb4fd0-630c-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,0.89)",
+                "fill": "0.3",
+                "formatter": "number",
+                "id": "fe9af660-630b-11ea-99e6-b5eed31db613",
+                "label": "Connected",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.threads.connected",
+                    "id": "fe9af661-630b-11ea-99e6-b5eed31db613",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "e3d46bf0-630f-11ea-99e6-b5eed31db613",
+                "label": "Max Used Connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.max_used_connections",
+                    "id": "e3d46bf1-630f-11ea-99e6-b5eed31db613",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Connections [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "493e8460-630d-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:08.292Z",
+      "version": "WzQ2NTgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Aborted Connections Rate [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "d61928d0-6309-11ea-99e6-b5eed31db613"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": "0.3",
+                "formatter": "'0.0a'",
+                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99",
+                "label": "Aborted Connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.aborted.clients",
+                    "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99",
+                    "id": "6d053540-639b-11ea-83d6-4f7a6fe5aed4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "6d053540-639b-11ea-83d6-4f7a6fe5aed4",
+                    "id": "7548afc0-639b-11ea-83d6-4f7a6fe5aed4",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(251,158,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "d6572ee0-639b-11ea-83d6-4f7a6fe5aed4",
+                "label": "Failed Attempts to Connect ",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.aborted.connects",
+                    "id": "d6572ee1-639b-11ea-83d6-4f7a6fe5aed4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "d6572ee1-639b-11ea-83d6-4f7a6fe5aed4",
+                    "id": "e4a63540-639b-11ea-83d6-4f7a6fe5aed4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "id": "ec492a00-639b-11ea-83d6-4f7a6fe5aed4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Aborted Connections Rate [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "bf60bc10-639b-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:17.572Z",
+      "version": "WzQ2NTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Thread Activity [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(226,115,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Avg Threads Running",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.threads.running",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "895f0820-630e-11ea-99e6-b5eed31db613",
+                "label": "Peak Threads Running",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.threads.running",
+                    "id": "895f0821-630e-11ea-99e6-b5eed31db613",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(77,77,77,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "f8752460-630e-11ea-99e6-b5eed31db613",
+                "label": "Peak Threads Connected",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.threads.connected",
+                    "id": "f8752461-630e-11ea-99e6-b5eed31db613",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Thread Activity [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "822df290-630f-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:25.480Z",
+      "version": "WzQ2NjAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buffer Pool Pages [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "515b9dd0-639f-11ea-96d8-1943b9bb65d9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "'0.0a'",
+                "id": "37f2d600-63a0-11ea-90a2-c51229c5db5f",
+                "label": "Buffer Pool Pages Data",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pages.data",
+                    "id": "37f2d601-63a0-11ea-90a2-c51229c5db5f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": "0",
+                "formatter": "'0.0a'",
+                "id": "57ae9d80-63a0-11ea-90a2-c51229c5db5f",
+                "label": "Buffer Pool Pages Free",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pages.free",
+                    "id": "57ae9d81-63a0-11ea-90a2-c51229c5db5f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(102,102,102,1)",
+                "fill": "0",
+                "formatter": "'0.0a'",
+                "id": "c86cc470-63a0-11ea-90a2-c51229c5db5f",
+                "label": "Buffer Pool Pages Total",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pages.total",
+                    "id": "c86ceb80-63a0-11ea-90a2-c51229c5db5f",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buffer Pool Pages [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "98c7bca0-63a2-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:34.413Z",
+      "version": "WzQ2NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buffer Pool Utilization [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "0f20fa60-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "0e1ecca0-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "07c08ce0-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "515b9dd0-639f-11ea-96d8-1943b9bb65d9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(226,115,0,1)",
+                "fill": "0.1",
+                "formatter": "percent",
+                "id": "256f1f40-63a3-11ea-90a2-c51229c5db5f",
+                "label": "Utilization",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pages.total",
+                    "id": "256f1f41-63a3-11ea-90a2-c51229c5db5f",
+                    "type": "max"
+                  },
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pages.free",
+                    "id": "256f1f43-63a3-11ea-90a2-c51229c5db5f",
+                    "type": "max"
+                  },
+                  {
+                    "id": "256f1f45-63a3-11ea-90a2-c51229c5db5f",
+                    "script": "params.total != null \u0026\u0026 params.total \u003e 0 ? (params.total - params.free)/params.total : null",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "256f1f41-63a3-11ea-90a2-c51229c5db5f",
+                        "id": "256f1f42-63a3-11ea-90a2-c51229c5db5f",
+                        "name": "total"
+                      },
+                      {
+                        "field": "256f1f43-63a3-11ea-90a2-c51229c5db5f",
+                        "id": "256f1f44-63a3-11ea-90a2-c51229c5db5f",
+                        "name": "free"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buffer Pool Utilization [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "96d46630-63a4-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:42.999Z",
+      "version": "WzQ2NjUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Network Traffic [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,98,177,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99",
+                "label": "Received bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.bytes.received",
+                    "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
+                    "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
+                    "id": "788d3c90-6310-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  },
+                  {
+                    "id": "88f8e160-6310-11ea-99e6-b5eed31db613",
+                    "script": "params.received != null \u0026\u0026 params.received \u003e 0 ? params.received * -1 : null",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "788d3c90-6310-11ea-99e6-b5eed31db613",
+                        "id": "8beb4660-6310-11ea-99e6-b5eed31db613",
+                        "name": "received"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Sent bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.bytes.sent",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "23cfda50-f1f7-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "23cfda50-f1f7-11e7-a752-236fe3270d99",
+                    "id": "ad26a900-6310-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Network Traffic [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:59.606Z",
+      "version": "WzQ2NjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buffer Pool Efficiency [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "0f20fa60-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "0e1ecca0-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "07c08ce0-63a3-11ea-90a2-c51229c5db5f"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "515b9dd0-639f-11ea-96d8-1943b9bb65d9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(87,177,211,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "hidden": false,
+                "id": "a397d570-63a2-11ea-90a2-c51229c5db5f",
+                "label": "Effeciency (lower is better)",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.pool.reads",
+                    "id": "a397d571-63a2-11ea-90a2-c51229c5db5f",
+                    "type": "max"
+                  },
+                  {
+                    "field": "mysql.status.innodb.buffer_pool.read.requests",
+                    "id": "ad177970-63a2-11ea-90a2-c51229c5db5f",
+                    "type": "max"
+                  },
+                  {
+                    "id": "af58ddf0-63a2-11ea-90a2-c51229c5db5f",
+                    "script": "params.pool_read_requests != null \u0026\u0026 params.pool_read_requests \u003e 0 ? (params.pool_reads/params.pool_read_requests) * 100: null",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "a397d571-63a2-11ea-90a2-c51229c5db5f",
+                        "id": "b1b6cb20-63a2-11ea-90a2-c51229c5db5f",
+                        "name": "pool_reads"
+                      },
+                      {
+                        "field": "ad177970-63a2-11ea-90a2-c51229c5db5f",
+                        "id": "c3fe5be0-63a2-11ea-90a2-c51229c5db5f",
+                        "name": "pool_read_requests"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buffer Pool Efficiency [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "a1e00160-63a4-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.4.2"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-03-16T13:00:51.577Z",
+      "version": "WzQ2NjYsMV0="
+    }
+  ],
+  "version": "7.3.1"
 }


### PR DESCRIPTION
This PR resolves: https://github.com/elastic/beats/issues/16582 and completely revisits the default MySQL dashboard:
![image](https://user-images.githubusercontent.com/1685068/76761205-5575f700-678f-11ea-85fa-ca073dbfb01d.png)
