### PR TITLE
Fix _id field in s3 and googlepubsub inputs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -90,6 +90,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
 - Add queue_url definition in manifest file for aws module. {pull}16640{16640}
 - Fix issue where autodiscover hints default configuration was not being copied. {pull}16987[16987]
+- Fix Elasticsearch `_id` field set by S3 and Google Pub/Sub inputs. {pull}17026[17026]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/googlepubsub/input.go
+++ b/x-pack/filebeat/input/googlepubsub/input.go
@@ -193,25 +193,24 @@ func makeTopicID(project, topic string) string {
 func makeEvent(topicID string, msg *pubsub.Message) beat.Event {
 	id := topicID + "-" + msg.ID
 
-	fields := common.MapStr{
-		"event": common.MapStr{
-			"id":      id,
-			"created": time.Now().UTC(),
-		},
-		"message": string(msg.Data),
-	}
-	if len(msg.Attributes) > 0 {
-		fields.Put("labels", msg.Attributes)
-	}
-
-	return beat.Event{
+	event := beat.Event{
 		Timestamp: msg.PublishTime.UTC(),
-		Meta: common.MapStr{
-			"id": id,
+		Fields: common.MapStr{
+			"event": common.MapStr{
+				"id":      id,
+				"created": time.Now().UTC(),
+			},
+			"message": string(msg.Data),
 		},
-		Fields:  fields,
 		Private: msg,
 	}
+	event.SetID(id)
+
+	if len(msg.Attributes) > 0 {
+		event.PutValue("labels", msg.Attributes)
+	}
+
+	return event
 }
 
 func (in *pubsubInput) getOrCreateSubscription(ctx context.Context, client *pubsub.Client) (*pubsub.Subscription, error) {


### PR DESCRIPTION
## What does this PR do?

In #15859 the Elasticsearch output was changed to read from the @metadata._id field when it had been using @metadata.id. The s3 and googlepubsub inputs had both been setting @metadata.id, but were not updated with that change.

This updates the s3 and googlepubsub inputs to use `beat.Event#SetID()` rather than creating the metadata object themselves.

## Why is it important?

These inputs rely on the Elasticsearch `_id` field to prevent duplicate events from being written to Elasticsearch in certain edge cases.

## Related issues

- Relates #15859