### PR TITLE
Improve remote_write handler

### DIFF
--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
@@ -74,10 +73,7 @@ func getDefaultHttpServer(mb mb.BaseMetricSet) (*HttpServer, error) {
 	}
 
 	httpServer := &http.Server{
-		Addr:         net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port))),
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Addr: net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port))),
 	}
 	if tlsConfig != nil {
 		httpServer.TLSConfig = tlsConfig.BuildModuleConfig(config.Host)
@@ -156,7 +152,6 @@ func (h *HttpServer) handleFunc(writer http.ResponseWriter, req *http.Request) {
 			http.Error(writer, "Unexpected error reading request payload", http.StatusBadRequest)
 			return
 		}
-		defer req.Body.Close()
 
 		payload := common.MapStr{
 			server.EventDataKey: body,

--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
@@ -74,6 +75,9 @@ func getDefaultHttpServer(mb mb.BaseMetricSet) (*HttpServer, error) {
 
 	httpServer := &http.Server{
 		Addr: net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port))),
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 	if tlsConfig != nil {
 		httpServer.TLSConfig = tlsConfig.BuildModuleConfig(config.Host)
@@ -152,6 +156,7 @@ func (h *HttpServer) handleFunc(writer http.ResponseWriter, req *http.Request) {
 			http.Error(writer, "Unexpected error reading request payload", http.StatusBadRequest)
 			return
 		}
+		defer req.Body.Close()
 
 		payload := common.MapStr{
 			server.EventDataKey: body,

--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -74,7 +74,7 @@ func getDefaultHttpServer(mb mb.BaseMetricSet) (*HttpServer, error) {
 	}
 
 	httpServer := &http.Server{
-		Addr: net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port))),
+		Addr:         net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port))),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  120 * time.Second,

--- a/metricbeat/module/prometheus/remote_write/remote_write.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write.go
@@ -108,7 +108,6 @@ func (m *MetricSet) handleFunc(writer http.ResponseWriter, req *http.Request) {
 
 	select {
 	case <-req.Context().Done():
-		writer.WriteHeader(http.StatusAccepted)
 		return
 	case m.events <- protoReq:
 	}

--- a/metricbeat/module/prometheus/remote_write/remote_write.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write.go
@@ -109,7 +109,7 @@ func (m *MetricSet) handleFunc(writer http.ResponseWriter, req *http.Request) {
 
 	for _, e := range events {
 		select {
-		case <- m.stopCh:
+		case <-m.stopCh:
 			return
 		case m.events <- e:
 		}

--- a/metricbeat/module/prometheus/remote_write/remote_write.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write.go
@@ -41,8 +41,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	server serverhelper.Server
-	events chan prompb.WriteRequest
-	stopCh chan struct{}
+	events chan mb.Event
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
@@ -53,8 +52,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 	m := &MetricSet{
 		BaseMetricSet: base,
-		events:        make(chan prompb.WriteRequest),
-		stopCh:        make(chan struct{}),
+		events:        make(chan mb.Event),
 	}
 	svc, err := httpserver.NewHttpServerWithHandler(base, m.handleFunc)
 	if err != nil {
@@ -72,14 +70,9 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 		select {
 		case <-reporter.Done():
 			m.server.Stop()
-			close(m.stopCh)
 			return
-		case protoReq := <-m.events:
-			samples := protoToSamples(&protoReq)
-			events := samplesToEvents(samples)
-			for _, e := range events {
-				reporter.Event(e)
-			}
+		case e := <-m.events:
+			reporter.Event(e)
 		}
 	}
 }
@@ -106,12 +99,16 @@ func (m *MetricSet) handleFunc(writer http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	select {
-	case <-req.Context().Done():
-		return
-	case m.events <- protoReq:
-	}
+	samples := protoToSamples(&protoReq)
+	events := samplesToEvents(samples)
 
+	for _, e := range events {
+		select {
+		case <-req.Context().Done():
+			return
+		case m.events <- e:
+		}
+	}
 	writer.WriteHeader(http.StatusAccepted)
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR improves `remote_write` handlers by:

~~- adding `defer req.Body.Close()`~~
~~- setting timeouts on httpServer~~
- Gracefully handling channel on Metricbeat stop, by avoid closing events channel and have the writers to be notified by the server that they should stop writing.
~~- remove metrics processing from handlerFunc to avoid having blocking connections~~

## Why is it important?

To void having panics on Metricbeat stopping:
```
2020-03-16T16:04:17.503+0200	DEBUG	[module]	module/wrapper.go:214	Stopped metricSetWrapper[module=prometheus, name=remote_write, host=]
2020-03-16T16:04:17.503+0200	DEBUG	[module]	module/wrapper.go:155	Stopped Wrapper[name=prometheus, len(metricSetWrappers)=1]
2020/03/16 16:04:17 http: panic serving 127.0.0.1:59319: send on closed channel
goroutine 2337 [running]:
net/http.(*conn).serve.func1(0xc002927e00)
	/usr/local/opt/go/libexec/src/net/http/server.go:1767 +0x139
panic(0x5ee0200, 0x67cbfe0)
	/usr/local/opt/go/libexec/src/runtime/panic.go:679 +0x1b2
github.com/elastic/beats/v7/metricbeat/module/prometheus/remote_write.(*MetricSet).handleFunc(0xc0002f0f00, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/Users/chrismark/go/src/github.com/elastic/beats/metricbeat/module/prometheus/remote_write/remote_write.go:108 +0x44e
net/http.HandlerFunc.ServeHTTP(0xc0003dba40, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/usr/local/opt/go/libexec/src/net/http/server.go:2007 +0x44
net/http.serverHandler.ServeHTTP(0xc000272000, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/usr/local/opt/go/libexec/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc002927e00, 0x6890dc0, 0xc00011b4c0)
	/usr/local/opt/go/libexec/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/opt/go/libexec/src/net/http/server.go:2927 +0x38e
2020/03/16 16:04:17 http: panic serving 127.0.0.1:59172: send on closed channel
```

~~To avoid reaching out of resources with the following error: `write accept: too many open files; retrying in 1s`~~
