### PR TITLE
Fix flaky test test_stats

### DIFF
--- a/libbeat/api/server.go
+++ b/libbeat/api/server.go
@@ -62,8 +62,8 @@ func (s *Server) Start() {
 	s.log.Info("Starting stats endpoint")
 	go func(l net.Listener) {
 		s.log.Infof("Metrics endpoint listening on: %s (configured: %s)", l.Addr().String(), s.config.Host)
-		http.Serve(l, s.mux)
-		s.log.Infof("Finished starting stats endpoint: %s", l.Addr().String())
+		err := http.Serve(l, s.mux)
+		s.log.Infof("Stats endpoint (%s) finished: %v", l.Addr().String(), err)
 	}(s.l)
 }
 

--- a/libbeat/tests/system/test_http.py
+++ b/libbeat/tests/system/test_http.py
@@ -5,17 +5,22 @@ import json
 
 
 class Test(BaseTest):
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        self.render_config_template()
+        self.proc = self.start_beat(extra_args=["-E", "http.enabled=true"])
+        self.wait_until(lambda: self.log_contains("Starting stats endpoint"))
+
+    def tearDown(self):
+        super(BaseTest, self).tearDown()
+        # Wait till the beat is completely started so it can handle SIGTERM
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+        self.proc.check_kill_and_wait()
 
     def test_root(self):
         """
         Test / http endpoint
         """
-        self.render_config_template(
-        )
-
-        proc = self.start_beat(extra_args=["-E", "http.enabled=true"])
-        self.wait_until(lambda: self.log_contains("Starting stats endpoint"))
-
         r = requests.get("http://localhost:5066")
         assert r.status_code == 200
 
@@ -24,18 +29,10 @@ class Test(BaseTest):
         assert data["beat"] == "mockbeat"
         assert data["version"] == "9.9.9"
 
-        proc.check_kill_and_wait()
-
     def test_stats(self):
         """
         Test /stats http endpoint
         """
-        self.render_config_template(
-        )
-
-        proc = self.start_beat(extra_args=["-E", "http.enabled=true"])
-        self.wait_until(lambda: self.log_contains("Starting stats endpoint"))
-
         r = requests.get("http://localhost:5066/stats")
         assert r.status_code == 200
 
@@ -44,19 +41,9 @@ class Test(BaseTest):
         # Test one data point
         assert data["libbeat"]["config"]["scans"] == 0
 
-        proc.check_kill_and_wait()
-
     def test_error(self):
         """
         Test not existing http endpoint
         """
-        self.render_config_template(
-        )
-
-        proc = self.start_beat(extra_args=["-E", "http.enabled=true"])
-        self.wait_until(lambda: self.log_contains("Starting stats endpoint"))
-
         r = requests.get("http://localhost:5066/not-exist")
         assert r.status_code == 404
-
-        proc.check_kill_and_wait()


### PR DESCRIPTION
Tests on stats API can finish even before the mocked beat has completed
its initialization, so it can receive the signal to stop before it can
handle signals, terminating with an status code -15 (killed by SIGTERM),
instead of the expected status code 0.
```
18:30:50 AssertionError: Expected exit code to be 0, but it was -15
```

Check that the beat has been completely started before trying to kill
it, and move common code to setUp/tearDown.

Fix also an incorrect error message.