### PR TITLE
redisenterprise: Fix metric filter to skip 'up' metric

### DIFF
--- a/x-pack/metricbeat/module/redisenterprise/node/manifest.yml
+++ b/x-pack/metricbeat/module/redisenterprise/node/manifest.yml
@@ -6,4 +6,4 @@ input:
     metrics_path: /
     metrics_filters:
       include: ["node_*"]
-      exclude: ["up"]
+      exclude: ["^up$"]

--- a/x-pack/metricbeat/module/redisenterprise/proxy/manifest.yml
+++ b/x-pack/metricbeat/module/redisenterprise/proxy/manifest.yml
@@ -6,4 +6,4 @@ input:
     metrics_path: /
     metrics_filters:
       include: ["listener_*"]
-      exclude: ["up"]
+      exclude: ["^up$"]


### PR DESCRIPTION
This PR adjusts `redisenterprise` module manifest to skip only `up` metric (need to use metric_filter).

Issue spotted while reviewing https://github.com/elastic/beats/pull/16971