### PR TITLE
Update RPM packages in Docker image releases

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,6 +144,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `add_cloudfoundry_metadata` processor to annotate events with Cloud Foundry application data. {pull}16621[16621
 - Add support for kubernetes provider to recognize namespace level defaults {pull}16321[16321]
 - Add `translate_sid` processor on Windows for converting Windows security identifier (SID) values to names. {issue}7451[7451] {pull}16013[16013]
+- Update RPM packages contained in Beat Docker images. {issue}17035[17035]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.agent.tmpl
@@ -4,6 +4,9 @@
 
 FROM {{ .from }}
 
+RUN yum -y --setopt=tsflags=nodocs update && \
+    yum clean all
+
 LABEL \
   org.label-schema.build-date="{{ date }}" \
   org.label-schema.schema-version="1.0" \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -4,6 +4,9 @@
 
 FROM {{ .from }}
 
+RUN yum -y --setopt=tsflags=nodocs update && \
+    yum clean all
+
 LABEL \
   org.label-schema.build-date="{{ date }}" \
   org.label-schema.schema-version="1.0" \


### PR DESCRIPTION
## What does this PR do?

Ensure the RPM packages contained in the Docker images that we package and release are updated.

## Why is it important?

It's best to release images with fully patched software even if the Beat itself may not depend on that software. It will limit the number of issues detected on scans.

## How to test this PR locally

`make snapshots`

## Related issues

- Closes #17035
