### PR TITLE
Filebeat monitoring documentation: remove duplicate `ssl` key

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -103,9 +103,9 @@ monitoring:
     hosts: ["https://example.com:9200", "https://example2.com:9200"]
     username: ""
     ssl:
-      ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
-      ssl.certificate: "/etc/pki/client/cert.pem"
-      ssl.key: "/etc/pki/client/cert.key"
+      certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate: "/etc/pki/client/cert.pem"
+      key: "/etc/pki/client/cert.key"
 --------------------
 +
 You must specify the `username` as `""` explicitly so that


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Fixes what I think is a small typo in the SSL settings example for the fileback xpack monitoring. `ssl` is keyed twice in the configuration. See the diff.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The example is wrong, leading to some developer confusion.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ]  ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation 
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~




