### PR TITLE
Cherry-pick #16971 to 7.x: Make use of prometheus filter settings on IBM-MQ Metricbeat module

### DIFF
--- a/x-pack/metricbeat/module/ibmmq/qmgr/manifest.yml
+++ b/x-pack/metricbeat/module/ibmmq/qmgr/manifest.yml
@@ -4,27 +4,7 @@ input:
   metricset: collector
   defaults:
     metrics_path: /metrics
-
-# The custom processor is responsible for filtering Prometheus metrics
-# not stricly related to the IBM MQ domain, e.g. system load, process,
-# metrics HTTP server.
-processors:
-  - script:
-      lang: javascript
-      source: >
-        function process(event) {
-          var metrics = event.Get("prometheus.metrics");
-          if (metrics == null) {
-            event.Cancel();
-            return;
-          }
-          Object.keys(metrics).forEach(function(key) {
-            if (!(key.match(/^ibmmq_.*$/))) {
-              event.Delete("prometheus.metrics." + key);
-            }
-          });
-          metrics = event.Get("prometheus.metrics");
-          if (Object.keys(metrics).length == 0) {
-            event.Cancel();
-          }
-        }
+    # Filtering out Prometheus metrics that are not strictly related to the
+    # IBM MQ domain, e.g. system load, process, metrics HTTP server.
+    metrics_filters:
+      include: ["ibmmq_.*", "^up$"]

--- a/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
+++ b/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
@@ -37,4 +37,4 @@ class Test(XPackTest):
 
             # Verify if processors are correctly setup.
             for metric in evt["prometheus"]["metrics"].keys():
-                assert metric.startswith("ibmmq_")
+                assert metric.startswith("ibmmq_") or metric == "up"


### PR DESCRIPTION
Cherry-pick of PR #16971 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

Refactoring the manifest file of the qmgr metricset. Previously a processor was used to filter out non ibmmq metrics. This commit replaces the processor with the more elegant metrics_filter that was introduced recently.

## Why is it important?

Using the metrics_filter is cleaner and easier to read.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

- Run the IBM MQ container ("docker-compose up" in x-pack/metricbeat/module/ibmmq) locally.
- Run metricbeats with the ibmmq module enabled. 
- In Kibana look at the imported metric data -> For metricset qmgr, you should see only metrics beginning with "prometheus.metrics.ibmmq_qmgr" 
- Remove the metrics_filter from the manifest file and restart metricbeats
- In Kibana look at the imported metric data -> For metricset qmgr, you should see a number of metrics not beginning with "prometheus.metrics.ibmmq_qmgr" besides metrics beginning with that prefix.

