### PR TITLE
Cherry-pick #17015 to 7.x: Use max in k8s overview dashboard aggregations

### DIFF
--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/Metricbeat-kubernetes-overview.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/Metricbeat-kubernetes-overview.json
@@ -543,7 +543,7 @@
                                     {
                                         "field": "kubernetes.pod.network.rx.bytes",
                                         "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
-                                        "type": "sum"
+                                        "type": "max"
                                     },
                                     {
                                         "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
@@ -578,7 +578,7 @@
             "id": "16fa4470-2bfd-11e7-859b-f78b612cde28-ecs",
             "type": "visualization",
             "updated_at": "2018-03-01T18:58:07.906Z",
-            "version": 3
+            "version": 4
         },
         {
             "attributes": {
@@ -637,7 +637,7 @@
                                     {
                                         "field": "kubernetes.pod.network.tx.bytes",
                                         "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
-                                        "type": "sum"
+                                        "type": "max"
                                     },
                                     {
                                         "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
@@ -672,7 +672,7 @@
             "id": "294546b0-30d6-11e7-8df8-6d3604a72912-ecs",
             "type": "visualization",
             "updated_at": "2018-03-01T18:58:07.906Z",
-            "version": 3
+            "version": 4
         },
         {
             "attributes": {
@@ -797,7 +797,7 @@
                                     {
                                         "field": "kubernetes.container.cpu.usage.core.ns",
                                         "id": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
-                                        "type": "sum"
+                                        "type": "max"
                                     },
                                     {
                                         "field": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
@@ -834,7 +834,7 @@
             "id": "58e644f0-30d6-11e7-8df8-6d3604a72912-ecs",
             "type": "visualization",
             "updated_at": "2018-03-01T18:58:07.906Z",
-            "version": 3
+            "version": 4
         },
         {
             "attributes": {


### PR DESCRIPTION
Cherry-pick of PR #17015 to 7.x branch. Original message: 

## What does this PR do?
Changes types of aggregations from `sum` to `max` on the following visualisations of Kubernetes Overview:
- Network in by node  [Metricbeat Kubernetes] ECS
- Network out by node  [Metricbeat Kubernetes] ECS
- Top CPU intensive pods  [Metricbeat Kubernetes] ECS 

## Why is it important?
We should not be using a sum on kubernetes.pod.network.rx.bytes,
kubernetes.pod.network.tx.bytes, and kubernetes.container.cpu.usage.core.ns;
these fields are counters. 
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/stats/v1alpha1/types.go#L165
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/stats/v1alpha1/types.go#L198
We should use `max` instead.



## Related issues
- Closes https://github.com/elastic/beats/issues/16625


## Screenshots
![Screenshot 2020-03-16 at 11 40 00](https://user-images.githubusercontent.com/11754898/76745188-1d19ed00-677e-11ea-9b7f-1e0937f49fc7.png)
![Screenshot 2020-03-16 at 11 39 39](https://user-images.githubusercontent.com/11754898/76745200-230fce00-677e-11ea-8c21-9478a821cc3f.png)


