### PR TITLE
Cherry-pick #17013 to 7.x: Remove Makefile which ruins builds from vendor

### DIFF
--- a/dev-tools/mage/gomod.go
+++ b/dev-tools/mage/gomod.go
@@ -46,6 +46,9 @@ var (
 			},
 		},
 	}
+	filesToRemove = []string{
+		filepath.Join("vendor", "github.com", "yuin", "gopher-lua", "parse", "Makefile"),
+	}
 )
 
 // Vendor cleans up go.mod and copies the files not carried over from modules cache.
@@ -75,7 +78,7 @@ func Vendor() error {
 
 	// copy packages which require the whole tree
 	for _, p := range copyAll {
-		path, err := gotool.ListModuleVendorDir(p.name)
+		path, err := gotool.ListModuleCacheDir(p.name)
 		if err != nil {
 			return err
 		}
@@ -88,6 +91,14 @@ func Vendor() error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	for _, p := range filesToRemove {
+		p = filepath.Join(repo.RootDir, p)
+		err = os.RemoveAll(p)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -129,18 +129,13 @@ include $(ES_BEATS)/dev-tools/make/mage.mk
 
 .DEFAULT_GOAL := ${BEAT_NAME}
 
-${BEAT_NAME}: $(GOFILES_ALL) update-yacc-vendor ## @build build the beat application
+${BEAT_NAME}: $(GOFILES_ALL) ## @build build the beat application
 	go build $(GOBUILD_FLAGS)
 
 # Create test coverage binary
-${BEAT_NAME}.test: $(GOFILES_ALL) update-yacc-vendor
+${BEAT_NAME}.test: $(GOFILES_ALL)
 	@go build -o /dev/null
 	@go test $(RACE) -c -coverpkg ${GOPACKAGES_COMMA_SEP}
-
-# Avoid running yacc to generate a parser for dependency.
-.PHONY: update-yacc-vendor
-update-yacc-vendor:
-	touch -c ../vendor/github.com/yuin/gopher-lua/parse/parser.go
 
 .PHONY: crosscompile
 crosscompile: ## @build Cross-compile beat for the OS'es specified in GOX_OS variable. The binaries are placed in the build/bin directory.
@@ -194,7 +189,7 @@ ci:  ## @build Shortcut for continuous integration. This should always run befor
 
 # Preparation for tests
 .PHONY: prepare-tests
-prepare-tests: update-yacc-vendor
+prepare-tests:
 	mkdir -p ${COVERAGE_DIR}
 	# gotestcover is needed to fetch coverage for multiple packages
 	go ${INSTALL_CMD} ${COVERAGE_TOOL_REPO}

--- a/vendor/github.com/yuin/gopher-lua/parse/Makefile
+++ b/vendor/github.com/yuin/gopher-lua/parse/Makefile
@@ -1,4 +1,0 @@
-all : parser.go
-
-parser.go : parser.go.y
-	go tool yacc -o $@ parser.go.y; [ -f y.output ] && ( rm -f y.output )


### PR DESCRIPTION
Cherry-pick of PR #17013 to 7.x branch. Original message: 

## What does this PR do?

This PR adds the option to remove files from the vendor folder during `mage update`.

## Why is it important?

`yacc` is triggered from time to time when `mage vendor` copies files in a particular order. It leads to build failures unexpectedly.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~