### PR TITLE
Cherry-pick #16937 to 7.x: Add build tags for cloud tests

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -67,6 +67,7 @@ func makeGoTestArgs(name string) GoTestArgs {
 		Packages:        []string{"./..."},
 		OutputFile:      fileName + ".out",
 		JUnitReportFile: fileName + ".xml",
+		Tags:            testTagsFromEnv(),
 	}
 	if TestCoverage {
 		params.CoverageProfileFile = fileName + ".cov"
@@ -83,11 +84,18 @@ func makeGoTestArgsForModule(name, module string) GoTestArgs {
 		Packages:        []string{fmt.Sprintf("./module/%s/...", module)},
 		OutputFile:      fileName + ".out",
 		JUnitReportFile: fileName + ".xml",
+		Tags:            testTagsFromEnv(),
 	}
 	if TestCoverage {
 		params.CoverageProfileFile = fileName + ".cov"
 	}
 	return params
+}
+
+// testTagsFromEnv gets a list of comma-separated tags from the TEST_TAGS
+// environment variables, e.g: TEST_TAGS=aws,azure.
+func testTagsFromEnv() []string {
+	return strings.Split(strings.Trim(os.Getenv("TEST_TAGS"), ", "), ",")
 }
 
 // DefaultGoTestUnitArgs returns a default set of arguments for running

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -147,6 +147,7 @@ func RunIntegTest(mageTarget string, test func() error, passThroughEnvVars ...st
 	env := []string{
 		"TEST_COVERAGE",
 		"RACE_DETECTOR",
+		"TEST_TAGS",
 		"PYTHON_EXE",
 	}
 	env = append(env, passThroughEnvVars...)

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -172,6 +172,7 @@ func CollectDocs() error {
 // GoIntegTest executes the Go integration tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
+// Use TEST_TAGS=tag1,tag2 to add additional build tags.
 func GoIntegTest(ctx context.Context) error {
 	return devtools.GoTestIntegrationForModule(ctx)
 }

--- a/x-pack/filebeat/input/azureeventhub/azureeventhub_integration_test.go
+++ b/x-pack/filebeat/input/azureeventhub/azureeventhub_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package azureeventhub
 
@@ -23,26 +24,20 @@ import (
 )
 
 var (
-
-	// setup the input config
 	azureConfig = common.MustNewConfigFrom(common.MapStr{
-		"storage_account_key":       os.Getenv("STORAGE_ACCOUNT_NAME"),
-		"storage_account":           os.Getenv("STORAGE_ACCOUNT_KEY"),
+		"storage_account_key":       lookupEnv("STORAGE_ACCOUNT_NAME"),
+		"storage_account":           lookupEnv("STORAGE_ACCOUNT_KEY"),
 		"storage_account_container": ephContainerName,
-		"connection_string":         os.Getenv("EVENTHUB_CONNECTION_STRING"),
-		"consumer_group":            os.Getenv("EVENTHUB_CONSUMERGROUP"),
-		"eventhub":                  os.Getenv("EVENTHUB_NAME"),
+		"connection_string":         lookupEnv("EVENTHUB_CONNECTION_STRING"),
+		"consumer_group":            lookupEnv("EVENTHUB_CONSUMERGROUP"),
+		"eventhub":                  lookupEnv("EVENTHUB_NAME"),
 	})
 
 	message = "{\"records\":[{\"some_field\":\"this is some message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}"
 )
 
 func TestInput(t *testing.T) {
-	if os.Getenv("EVENTHUB_NAME") == "" || os.Getenv("EVENTHUB_CONNECTION_STRING") == "" {
-		t.Skip("EVENTHUB_NAME or/and EVENTHUB_CONSUMERGROUP  are not set in environment.")
-	}
-	err := addEventToHub(os.Getenv("EVENTHUB_CONNECTION_STRING"))
-
+	err := addEventToHub(lookupEnv("EVENTHUB_CONNECTION_STRING"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,6 +92,14 @@ func TestInput(t *testing.T) {
 		t.Fatal("timeout waiting for beat to shut down")
 	case <-didClose:
 	}
+}
+
+func lookupEnv(t *testing.T, varName string) string {
+	value, ok := os.LookupEnv(varName)
+	if !ok {
+		t.Fatalf("Environment variable %s is not set", varName)
+	}
+	return value
 }
 
 func addEventToHub(connStr string) error {

--- a/x-pack/filebeat/input/s3/s3_integration_test.go
+++ b/x-pack/filebeat/input/s3/s3_integration_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build integration
+// +build aws
+
 package s3
 
 import (
@@ -13,14 +16,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3/s3iface"
-	"github.com/aws/aws-sdk-go-v2/service/sqs/sqsiface"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
-	"github.com/stretchr/testify/assert"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/sqsiface"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input"
@@ -38,7 +41,9 @@ const (
 var filePath = filepath.Join("ftest", fileName)
 
 // GetConfigForTest function gets aws credentials for integration tests.
-func getConfigForTest() (config, string) {
+func getConfigForTest(t *testing.T) config {
+	t.Helper()
+
 	awsConfig := awscommon.ConfigAWS{}
 	queueURL := os.Getenv("QUEUE_URL")
 	profileName := os.Getenv("AWS_PROFILE_NAME")
@@ -51,25 +56,25 @@ func getConfigForTest() (config, string) {
 	}
 	switch {
 	case queueURL == "":
-		return config, "Skipping: $QUEUE_URL is not set in environment"
+		t.Fatal("$QUEUE_URL is not set in environment")
 	case profileName == "" && accessKeyID == "":
-		return config, "Skipping: $AWS_ACCESS_KEY_ID or $AWS_PROFILE_NAME not set or set to empty"
+		t.Fatal("$AWS_ACCESS_KEY_ID or $AWS_PROFILE_NAME not set or set to empty")
 	case profileName != "":
 		awsConfig.ProfileName = profileName
 		config.QueueURL = queueURL
 		config.AwsConfig = awsConfig
-		return config, ""
+		return config
 	case secretAccessKey == "":
-		return config, "Skipping: $AWS_SECRET_ACCESS_KEY not set or set to empty"
-	default:
-		awsConfig.AccessKeyID = accessKeyID
-		awsConfig.SecretAccessKey = secretAccessKey
-		if sessionToken != "" {
-			awsConfig.SessionToken = sessionToken
-		}
-		config.AwsConfig = awsConfig
-		return config, ""
+		t.Fatal("$AWS_SECRET_ACCESS_KEY not set or set to empty")
 	}
+
+	awsConfig.AccessKeyID = accessKeyID
+	awsConfig.SecretAccessKey = secretAccessKey
+	if sessionToken != "" {
+		awsConfig.SessionToken = sessionToken
+	}
+	config.AwsConfig = awsConfig
+	return config
 }
 
 func uploadSampleLogFile(t *testing.T, bucketName string, svcS3 s3iface.ClientAPI) {
@@ -160,7 +165,7 @@ func runTest(t *testing.T, cfg *common.Config, run func(t *testing.T, input *s3I
 
 	in, err := NewInput(cfg, connector, inputCtx)
 	if err != nil {
-		t.Skipf("Skipping: %v", err)
+		t.Fatal(err)
 	}
 	s3Input := in.(*s3Input)
 	defer s3Input.Stop()
@@ -224,13 +229,9 @@ func (o *stubOutleter) OnEvent(event beat.Event) bool {
 
 func TestS3Input(t *testing.T) {
 	inputConfig := defaultTestConfig()
+	config := getConfigForTest(t)
 
 	runTest(t, inputConfig, func(t *testing.T, input *s3Input, out *stubOutleter) {
-		config, info := getConfigForTest()
-		if info != "" {
-			t.Skipf("failed to get config for test: %v", info)
-		}
-
 		awsConfig, err := awscommon.GetAWSCredentials(config.AwsConfig)
 		if err != nil {
 

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -132,6 +132,7 @@ func UnitTest() {
 // GoUnitTest executes the Go unit tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
+// Use TEST_TAGS=tag1,tag2 to add additional build tags.
 func GoUnitTest(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
 }
@@ -152,6 +153,7 @@ func IntegTest() {
 // GoIntegTest executes the Go integration tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
+// Use TEST_TAGS=tag1,tag2 to add additional build tags.
 func GoIntegTest(ctx context.Context) error {
 	return devtools.GoTestIntegrationForModule(ctx)
 }

--- a/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package billing
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("billing", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "billing", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package cloudwatch
 
@@ -16,10 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("cloudwatch", "300s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "cloudwatch", "300s")
 
 	config = addCloudwatchMetricsToConfig(config)
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
@@ -32,10 +30,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("cloudwatch", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "cloudwatch", "300s")
 
 	config = addCloudwatchMetricsToConfig(config)
 	metricSet := mbtest.NewFetcher(t, config)

--- a/x-pack/metricbeat/module/aws/dynamodb/dynamodb_integration_test.go
+++ b/x-pack/metricbeat/module/aws/dynamodb/dynamodb_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package dynamodb
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("dynamodb", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "dynamodb", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/ebs/ebs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ebs/ebs_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package ebs
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("ebs", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "ebs", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package ec2
 
@@ -16,10 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("ec2", "300s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "ec2", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
@@ -66,10 +64,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("ec2", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "ec2", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	if err := mbtest.WriteEventsReporterV2Error(metricSet, t, "/"); err != nil {

--- a/x-pack/metricbeat/module/aws/elb/elb_integration_test.go
+++ b/x-pack/metricbeat/module/aws/elb/elb_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package elb
 
@@ -32,10 +33,7 @@ func TestData(t *testing.T) {
 		{"AWS/NetworkELB", "./_meta/data_nlb.json"},
 	}
 
-	config, info := mtest.GetConfigForTest("elb", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "elb", "300s")
 
 	for _, df := range dataFiles {
 		metricSet := mbtest.NewFetcher(t, config)

--- a/x-pack/metricbeat/module/aws/lambda/lambda_integration_test.go
+++ b/x-pack/metricbeat/module/aws/lambda/lambda_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package lambda
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("lambda", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "lambda", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -15,7 +15,9 @@ import (
 )
 
 // GetConfigForTest function gets aws credentials for integration tests.
-func GetConfigForTest(metricSetName string, period string) (map[string]interface{}, string) {
+func GetConfigForTest(t *testing.T, metricSetName string, period string) (map[string]interface{}, string) {
+	t.Helper()
+
 	accessKeyID, okAccessKeyID := os.LookupEnv("AWS_ACCESS_KEY_ID")
 	secretAccessKey, okSecretAccessKey := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
 	sessionToken, okSessionToken := os.LookupEnv("AWS_SESSION_TOKEN")
@@ -27,9 +29,9 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 	info := ""
 	config := map[string]interface{}{}
 	if !okAccessKeyID || accessKeyID == "" {
-		info = "Skipping TestFetch; $AWS_ACCESS_KEY_ID not set or set to empty"
+		t.Fatal("$AWS_ACCESS_KEY_ID not set or set to empty")
 	} else if !okSecretAccessKey || secretAccessKey == "" {
-		info = "Skipping TestFetch; $AWS_SECRET_ACCESS_KEY not set or set to empty"
+		t.Fatal("$AWS_SECRET_ACCESS_KEY not set or set to empty")
 	} else {
 		config = map[string]interface{}{
 			"module":            "aws",
@@ -51,6 +53,8 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 
 // CheckEventField function checks a given field type and compares it with the expected type for integration tests.
 func CheckEventField(metricName string, expectedType string, event mb.Event, t *testing.T) {
+	t.Helper()
+
 	ok1, err1 := event.MetricSetFields.HasKey(metricName)
 	ok2, err2 := event.RootFields.HasKey(metricName)
 	if ok1 || ok2 {

--- a/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
+++ b/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package rds
 
@@ -16,10 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("rds", "60s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "rds", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
@@ -49,10 +47,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("rds", "60s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "rds", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	if err := mbtest.WriteEventsReporterV2Error(metricSet, t, "/"); err != nil {

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package s3_daily_storage
 
@@ -16,10 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("s3_daily_storage", "86400s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "s3_daily_storage", "86400s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
@@ -42,10 +40,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("s3_daily_storage", "86400s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "s3_daily_storage", "86400s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	if err := mbtest.WriteEventsReporterV2Error(metricSet, t, "/"); err != nil {

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package s3_request
 
@@ -16,10 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("s3_request", "86400s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "s3_request", "86400s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
@@ -56,10 +54,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("s3_request", "86400s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "s3_request", "86400s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	if err := mbtest.WriteEventsReporterV2Error(metricSet, t, "/"); err != nil {

--- a/x-pack/metricbeat/module/aws/sns/sns_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sns/sns_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package sns
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("sns", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "sns", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package sqs
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config, info := mtest.GetConfigForTest("sqs", "300s")
-	if info != "" {
-		t.Skip("Skipping TestFetch: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "sqs", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
@@ -49,10 +47,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("sqs", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "sqs", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	if err := mbtest.WriteEventsReporterV2Error(metricSet, t, "/"); err != nil {

--- a/x-pack/metricbeat/module/aws/usage/usage_integration_test.go
+++ b/x-pack/metricbeat/module/aws/usage/usage_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package usage
 
@@ -14,10 +15,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	config, info := mtest.GetConfigForTest("usage", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "usage", "300s")
 
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")

--- a/x-pack/metricbeat/module/aws/vpc/vpc_integration_test.go
+++ b/x-pack/metricbeat/module/aws/vpc/vpc_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build aws
 
 package vpc
 
@@ -32,10 +33,7 @@ func TestData(t *testing.T) {
 		{"AWS/TransitGateway", "./_meta/data_transit_gateway.json"},
 	}
 
-	config, info := mtest.GetConfigForTest("vpc", "300s")
-	if info != "" {
-		t.Skip("Skipping TestData: " + info)
-	}
+	config := mtest.GetConfigForTest(t, "vpc", "300s")
 
 	for _, df := range dataFiles {
 		metricSet := mbtest.NewFetcher(t, config)

--- a/x-pack/metricbeat/module/azure/compute_vm/compute_vm_integration_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/compute_vm_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package compute_vm
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("compute_vm")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "compute_vm")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -30,10 +28,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("compute_vm")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "compute_vm")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_integration_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package compute_vm_scaleset
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("compute_vm_scaleset")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "compute_vm_scaleset")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -30,10 +28,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("compute_vm_scaleset")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "compute_vm_scaleset")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/container_instance/container_instance_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_instance/container_instance_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package container_instance
 
@@ -20,10 +21,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("container_instance")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_instance")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -33,10 +31,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("container_instance")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_instance")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/container_registry/container_registry_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_registry/container_registry_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package container_registry
 
@@ -20,10 +21,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("container_registry")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_registry")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -33,10 +31,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("container_registry")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_registry")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/container_service/container_service_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_service/container_service_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package container_service
 
@@ -20,10 +21,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("container_service")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_service")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -33,10 +31,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("container_service")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "container_service")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/database_account/database_account_integration_test.go
+++ b/x-pack/metricbeat/module/azure/database_account/database_account_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package database_account
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("database_account")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "database_account")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -30,10 +28,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("database_account")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "database_account")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package monitor
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("monitor")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "monitor")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -30,10 +28,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("monitor")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "monitor")
 	config["resources"] = []map[string]interface{}{{
 		"resource_query": "resourceType eq 'Microsoft.DocumentDb/databaseAccounts'",
 		"metrics": []map[string]interface{}{{"namespace": "Microsoft.DocumentDb/databaseAccounts",

--- a/x-pack/metricbeat/module/azure/storage/storage_integration_test.go
+++ b/x-pack/metricbeat/module/azure/storage/storage_integration_test.go
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // +build integration
+// +build azure
 
 package storage
 
@@ -17,10 +18,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	config, err := test.GetConfig("storage")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "storage")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 	events, errs := mbtest.ReportingFetchV2Error(metricSet)
 	if len(errs) > 0 {
@@ -30,10 +28,7 @@ func TestFetchMetricset(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	config, err := test.GetConfig("storage")
-	if err != nil {
-		t.Skip("Skipping TestFetch: " + err.Error())
-	}
+	config := test.GetConfig(t, "storage")
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
 }

--- a/x-pack/metricbeat/module/azure/test/integration.go
+++ b/x-pack/metricbeat/module/azure/test/integration.go
@@ -5,27 +5,29 @@
 package test
 
 import (
-	"errors"
 	"os"
+	"testing"
 )
 
 // GetConfig function gets azure credentials for integration tests.
-func GetConfig(metricSetName string) (map[string]interface{}, error) {
+func GetConfig(t *testing.T, metricSetName string) map[string]interface{} {
+	t.Helper()
+
 	clientId, ok := os.LookupEnv("AZURE_CLIENT_ID")
 	if !ok {
-		return nil, errors.New("could not find var AZURE_CLIENT_ID")
+		t.Fatal("Could not find var AZURE_CLIENT_ID")
 	}
 	clientSecret, ok := os.LookupEnv("AZURE_CLIENT_SECRET")
 	if !ok {
-		return nil, errors.New("could not find var AZURE_CLIENT_SECRET")
+		t.Fatal("Could not find var AZURE_CLIENT_SECRET")
 	}
 	tenantId, ok := os.LookupEnv("AZURE_TENANT_ID")
 	if !ok {
-		return nil, errors.New("could not find var AZURE_TENANT_ID")
+		t.Fatal("Could not find var AZURE_TENANT_ID")
 	}
 	subId, ok := os.LookupEnv("AZURE_SUBSCRIPTION_ID")
 	if !ok {
-		return nil, errors.New("could not find var AZURE_SUBSCRIPTION_ID")
+		t.Fatal("Could not find var AZURE_SUBSCRIPTION_ID")
 	}
 	return map[string]interface{}{
 		"module":                "azure",
@@ -36,5 +38,5 @@ func GetConfig(metricSetName string) (map[string]interface{}, error) {
 		"client_secret":         clientSecret,
 		"tenant_id":             tenantId,
 		"subscription_id":       subId,
-	}, nil
+	}
 }


### PR DESCRIPTION
Cherry-pick of PR #16937 to 7.x branch. Original message: 

## What does this PR do?

Add build tags to AWS and Azure integration tests, and make tests fail if they cannot get a working configuration.

Add support for a `TEST_TAGS` environment variable in mage targets that add additional build tags to `go tests` calls.
When `TEST_TAGS` includes a cloud provider, it is expected that valid credentials to run these tests are available in the environment, if not, tests will fail. This is intentional, to avoid skipping tests by mistake due to some misconfiguration in CI.

## Why is it important?

To add support of integration testing of cloud features in CI we need some way to select what tests to run in a way that can be easily defined in jenkins configuration files. With `TEST_TAGS` we can do this selection of tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~ (We need to review documenation about running tests in general, we also need to review how to document mage targets and supported environment variables)
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Run integration tests for cloud features with `go test`:
* Without corresponding tags, tests shouldn't be run.
* With `go test --tags=integration,aws`, AWS integration tests should be run, with credentials they should work, without credentials they should fail.

Repeat the steps with `mage goIntegTest`:
* Without `TEST_TAGS`, cloud tests shouldn't be run.
* With `TEST_TAGS=aws`, AWS integration tests should be run, with credentials they should work, without credentials they should fail.

## Related issues

- Part of elastic/beats#15891