### PR TITLE
[ci] Make tests pass in Jenkinsfile pipeline

### DIFF
--- a/.ci/scripts/install-go.sh
+++ b/.ci/scripts/install-go.sh
@@ -10,7 +10,7 @@ GVM_CMD="${HOME}/bin/gvm"
 
 mkdir -p "${HOME}/bin"
 
-curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v0.2.1/gvm-${ARCH}-amd64"
+curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-${ARCH}-amd64"
 chmod +x "${GVM_CMD}"
 
 gvm ${GO_VERSION}|cut -d ' ' -f 2|tr -d '\"' > ${PROPERTIES_FILE}

--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -9,8 +9,19 @@ IF ERRORLEVEL 1 (
 mkdir %WORKSPACE%\bin
 where /q gvm
 IF ERRORLEVEL 1 (
- curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.1/gvm-windows-amd64.exe
+ curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-amd64.exe
 )
 FOR /f "tokens=*" %%i IN ('"gvm.exe" use %GO_VERSION% --format=batch') DO %%i
 
+go env
 go install -mod=vendor github.com/magefile/mage
+mage -version
+where mage
+
+if not exist C:\Python38\python.exe (
+    REM Install python 3.8.
+    choco install python -y -r --no-progress --version 3.8.2
+)
+python --version
+where python
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -29,6 +29,10 @@ indent_style = tab
 [*.mk]
 indent_style = tab
 
+[Jenkinsfile]
+indent_size = 2
+indent_style = space
+
 [Vagrantfile]
 indent_size = 2
 indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
     - MACOSX_DEPLOYMENT_TARGET=10.15
+    # Enable verbose output since Travis users cannot access test output that is written to files.
+    # The constant output from tests also prevents time-outs.
+    - MAGEFILE_VERBOSE=true
 
 # Only run CI jobs on specific branches.
 # To keep the number of Travis CI jobs in check, we decided to configure Travis to only kick off CI jobs for the master branch.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')
     booleanParam(name: 'windowsTest', defaultValue: true, description: 'Allow Windows stages.')
+    booleanParam(name: 'macosTest', defaultValue: false, description: 'Allow macOS stages.')
     booleanParam(name: 'debug', defaultValue: false, description: 'Allow debug logging for Jenkins steps')
   }
   stages {
@@ -77,7 +78,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget("Filebeat x-pack Linux", "-C x-pack/filebeat testsuite")
+            mageTarget("Filebeat x-pack Linux", "x-pack/filebeat", "update build test")
           }
         }
         stage('Filebeat Mac OS X'){
@@ -86,7 +87,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_FILEBEAT != "false"
+              return env.BUILD_FILEBEAT != "false" && params.macosTest
             }
           }
           steps {
@@ -103,8 +104,7 @@ pipeline {
             }
           }
           steps {
-            mageTargetWin("Filebeat oss Windows Unit test", "-d filebeat goUnitTest")
-            //mageTargetWin("Filebeat oss Windows Integration test", "-d filebeat goIntegTest")
+            mageTargetWin("Filebeat oss Windows Unit test", "filebeat", "unitTest")
           }
         }
         stage('Heartbeat'){
@@ -125,6 +125,12 @@ pipeline {
             stage('Heartbeat Mac OS X'){
               agent { label 'macosx' }
               options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
               steps {
                 makeTarget("Heartbeat oss Mac OS X", "TEST_ENVIRONMENT=0 -C heartbeat testsuite")
               }
@@ -139,7 +145,7 @@ pipeline {
                 }
               }
               steps {
-                mageTargetWin("Heartbeat oss Windows Unit test", "-d heartbeat goTestUnit")
+                mageTargetWin("Heartbeat oss Windows Unit test", "heartbeat", "unitTest")
               }
             }
           }
@@ -167,6 +173,12 @@ pipeline {
             stage('Auditbeat Mac OS X'){
               agent { label 'macosx' }
               options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
               steps {
                 makeTarget("Auditbeat oss Mac OS X", "TEST_ENVIRONMENT=0 -C auditbeat testsuite")
               }
@@ -181,8 +193,7 @@ pipeline {
                 }
               }
               steps {
-                mageTargetWin("Auditbeat Windows Unit test", "-d auditbeat goUnitTest")
-                //mageTargetWin("Auditbeat Windows Integration test", "-d auditbeat goIntegTest")
+                mageTargetWin("Auditbeat Windows Unit test", "auditbeat", "unitTest")
               }
             }
           }
@@ -197,7 +208,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget("Auditbeat x-pack Linux", "-C x-pack/auditbeat testsuite")
+            mageTarget("Auditbeat x-pack Linux", "x-pack/auditbeat", "update build test")
           }
         }
         stage('Libbeat'){
@@ -289,7 +300,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget("Metricbeat x-pack Linux", "-C x-pack/metricbeat testsuite")
+            mageTarget("Metricbeat x-pack Linux", "x-pack/metricbeat", "update build test")
           }
         }
         stage('Metricbeat crosscompile'){
@@ -311,7 +322,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_METRICBEAT != "false"
+              return env.BUILD_METRICBEAT != "false" && params.macosTest
             }
           }
           steps {
@@ -328,8 +339,7 @@ pipeline {
             }
           }
           steps {
-            mageTargetWin("Metricbeat Windows Unit test", "-d metricbeat goUnitTest")
-            //mageTargetWin("Metricbeat Windows Integration test", "-d metricbeat goIntegTest")
+            mageTargetWin("Metricbeat Windows Unit test", "metricbeat", "unitTest")
           }
         }
         stage('Packetbeat'){
@@ -361,7 +371,7 @@ pipeline {
           stages {
             stage('Dockerlogbeat'){
               steps {
-                makeTarget("Elastic Log Plugin unit tests", "-C x-pack/dockerlogbeat testsuite")
+                mageTarget("Elastic Docker Logging Driver Plugin unit tests", "x-pack/dockerlogbeat", "update build test")
               }
             }
           }
@@ -391,7 +401,7 @@ pipeline {
                 }
               }
               steps {
-                mageTargetWin("Winlogbeat Windows Unit test", "-d winlogbeat goUnitTest")
+                mageTargetWin("Winlogbeat Windows Unit test", "winlogbeat", "unitTest")
               }
             }
           }
@@ -406,7 +416,7 @@ pipeline {
             }
           }
           steps {
-            mageTargetWin("Winlogbeat Windows Unit test", "-d x-pack/winlogbeat  update:fields goUnitTest")
+            mageTargetWin("Winlogbeat Windows Unit test", "x-pack/winlogbeat", "unitTest")
           }
         }
         stage('Functionbeat'){
@@ -421,14 +431,20 @@ pipeline {
           stages {
             stage('Functionbeat x-pack'){
               steps {
-                makeTarget("Functionbeat x-pack Linux", "-C x-pack/functionbeat testsuite")
+                mageTarget("Functionbeat x-pack Linux", "x-pack/functionbeat", "update build test")
               }
             }
             stage('Functionbeat Mac OS X x-pack'){
               agent { label 'macosx' }
               options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
               steps {
-                makeTarget("Functionbeat x-pack Mac OS X", "TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite")
+                mageTarget("Functionbeat x-pack Mac OS X", "x-pack/functionbeat", "update build test")
               }
             }
             stage('Functionbeat Windows'){
@@ -441,7 +457,7 @@ pipeline {
                 }
               }
               steps {
-                mageTargetWin("Functionbeat Windows Unit test", "-d x-pack/functionbeat goUnitTest")
+                mageTargetWin("Functionbeat Windows Unit test", "x-pack/functionbeat", "unitTest")
               }
             }
           }
@@ -488,6 +504,12 @@ pipeline {
             stage('Generators Metricbeat Mac OS X'){
               agent { label 'macosx' }
               options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
               steps {
                 makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
               }
@@ -495,6 +517,12 @@ pipeline {
             stage('Generators Beat Mac OS X'){
               agent { label 'macosx' }
               options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
               steps {
                 makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
               }
@@ -530,82 +558,108 @@ pipeline {
   }
 }
 
-def makeTarget(context, target, clean = true){
-  whenTrue(params.debug){
-    dumpFilteredEnvironment()
-    dumpMage()
-  }
+def makeTarget(String context, String target, boolean clean = true) {
   withGithubNotify(context: "${context}") {
-    withBeatsEnv(){
-      sh(label: "Make ${target}", script: """
-        eval "\$(gvm use ${GO_VERSION} --format=bash)"
-        make ${target}
-      """)
-      if(clean) {
+    withBeatsEnv(true) {
+      whenTrue(params.debug) {
+        dumpFilteredEnvironment()
+        dumpMage()
+      }
+      sh(label: "Make ${target}", script: "make ${target}")
+      if (clean) {
         sh(script: 'script/fix_permissions.sh ${HOME}')
       }
     }
   }
 }
 
-def mageTargetWin(context, target){
-  whenTrue(params.debug){
-    dumpFilteredEnvironment()
-    withBeatsEnvWin(){
-      dumpMage()
-    }
-  }
+def mageTarget(String context, String directory, String target) {
   withGithubNotify(context: "${context}") {
-    withBeatsEnvWin(){
-      bat(label: "Mage ${target}", script: """
-        set
-        mage ${target}
-      """)
+    withBeatsEnv(true) {
+      whenTrue(params.debug) {
+        dumpFilteredEnvironment()
+        dumpMage()
+      }
+
+      def verboseFlag = params.debug ? "-v" : ""
+      dir(directory) {
+        sh(label: "Mage ${target}", script: "mage ${verboseFlag} ${target}")
+      }
     }
   }
 }
 
-def withBeatsEnv(Closure body){
+def mageTargetWin(String context, String directory, String target) {
+  withGithubNotify(context: "${context}") {
+    withBeatsEnvWin() {
+      whenTrue(params.debug) {
+        dumpFilteredEnvironment()
+        dumpMageWin()
+      }
+
+      def verboseFlag = params.debug ? "-v" : ""
+      dir(directory) {
+        bat(label: "Mage ${target}", script: "mage ${verboseFlag} ${target}")
+      }
+    }
+  }
+}
+
+def withBeatsEnv(boolean archive, Closure body) {
+  def os = goos()
+  def goRoot = "${env.WORKSPACE}/.gvm/versions/go${GO_VERSION}.${os}.amd64"
+
   withEnv([
     "HOME=${env.WORKSPACE}",
     "GOPATH=${env.WORKSPACE}",
-    "PATH+GO=${env.WORKSPACE}/bin:${env.PATH}",
-    "MAGEFILE_CACHE=${WORKSPACE}\\.magefile",
+    "GOROOT=${goRoot}",
+    "PATH=${env.WORKSPACE}/bin:${goRoot}/bin:${env.PATH}",
+    "MAGEFILE_CACHE=${WORKSPACE}/.magefile",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
     "PYTHON_ENV=${WORKSPACE}/python-env",
     "TEST_TAGS=oracle",
     "DOCKER_PULL=0",
-  ]){
+  ]) {
     deleteDir()
     unstash 'source'
-    dir("${BASE_DIR}"){
+    dir("${env.BASE_DIR}") {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")
       sh(label: "Install docker-compose ${DOCKER_COMPOSE_VERSION}", script: ".ci/scripts/install-docker-compose.sh")
+      sh(label: "Install Mage", script: "make mage")
       try {
         body()
       } finally {
+        if (archive) {
+          catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+            junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/build/TEST*.xml")
+            archiveArtifacts(allowEmptyArchive: true, artifacts: '**/build/TEST*.out')
+          }
+        }
         reportCoverage()
       }
     }
   }
 }
 
-def withBeatsEnvWin(Closure body){
+def withBeatsEnvWin(Closure body) {
+  final String chocoPath = 'C:\\ProgramData\\chocolatey\\bin'
+  final String chocoPython3Path = 'C:\\Python38;C:\\Python38\\Scripts'
   def goRoot = "${env.USERPROFILE}\\.gvm\\versions\\go${GO_VERSION}.windows.amd64"
+
   withEnv([
-    "HOME=${WORKSPACE}",
-    "GOPATH=${WORKSPACE}",
-    "PATH+GO=${WORKSPACE}\\bin;${goRoot}\\bin;C:\\ProgramData\\chocolatey\\bin",
-    "MAGEFILE_CACHE=${WORKSPACE}\\.magefile",
+    "HOME=${env.WORKSPACE}",
+    "GOPATH=${env.WORKSPACE}",
     "GOROOT=${goRoot}",
+    "PATH=${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};${env.PATH}",
+    "MAGEFILE_CACHE=${env.WORKSPACE}\\.magefile",
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
   ]){
     deleteDir()
     unstash 'source'
-    dir("${BASE_DIR}"){
-      bat(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-tools.bat")
+    dir("${env.BASE_DIR}"){
+      bat(label: "Install Go/Mage/Python ${GO_VERSION}", script: ".ci/scripts/install-tools.bat")
       try {
         body()
       } finally {
@@ -618,14 +672,37 @@ def withBeatsEnvWin(Closure body){
   }
 }
 
+def goos(){
+  def labels = env.NODE_LABELS
+
+  if (labels.contains('linux')) {
+    return 'linux'
+  } else if (labels.contains('windows')) {
+    return 'windows'
+  } else if (labels.contains('darwin')) {
+    return 'darwin'
+  }
+
+  throw new IllegalArgumentException("Unhandled OS name in NODE_LABELS: " + labels)
+}
+
 def dumpMage(){
   echo "### MAGE DUMP ###"
   sh(label: "Dump mage variables", script: "mage dumpVariables")
   echo "### END MAGE DUMP ###"
 }
 
+def dumpMageWin(){
+  echo "### MAGE DUMP ###"
+  bat(label: "Dump mage variables", script: "mage dumpVariables")
+  echo "### END MAGE DUMP ###"
+}
+
 def dumpFilteredEnvironment(){
   echo "### ENV DUMP ###"
+  echo "PATH: ${env.PATH}"
+  echo "HOME: ${env.HOME}"
+  echo "USERPROFILE: ${env.USERPROFILE}"
   echo "BUILD_DIR: ${env.BUILD_DIR}"
   echo "COVERAGE_DIR: ${env.COVERAGE_DIR}"
   echo "BEATS: ${env.BEATS}"
@@ -679,7 +756,7 @@ def k8sTest(versions){
     stage("k8s ${v}"){
       withEnv(["K8S_VERSION=${v}"]){
         withGithubNotify(context: "K8s ${v}") {
-          withBeatsEnv(){
+          withBeatsEnv(false) {
             sh(label: "Install k8s", script: """
               eval "\$(gvm use ${GO_VERSION} --format=bash)"
               .ci/scripts/kind-setup.sh
@@ -695,8 +772,6 @@ def k8sTest(versions){
 
 def reportCoverage(){
   catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-*.xml")
-    archiveArtifacts(allowEmptyArchive: true, artifacts: '**/TEST-*.out')
     retry(2){
       sh(label: 'Report to Codecov', script: '''
         curl -sSLo codecov https://codecov.io/bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ if (-Not (Test-Path $gopath_beats)) {
 if (-Not (Get-Command "gvm" -ErrorAction SilentlyContinue)) {
     echo "Installing gvm to manage go version"
     [Net.ServicePointManager]::SecurityProtocol = "tls12"
-    Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v0.2.1/gvm-windows-amd64.exe -Outfile C:\\Windows\\System32\\gvm.exe
+    Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-amd64.exe -Outfile C:\\Windows\\System32\\gvm.exe
     C:\\Windows\\System32\\gvm.exe --format=powershell #{GO_VERSION} | Invoke-Expression
     go version
 
@@ -83,7 +83,7 @@ choco feature disable -n=showDownloadProgress
 
 if (-Not (Get-Command "python" -ErrorAction SilentlyContinue)) {
     echo "Installing python 3"
-    choco install python -y -r --version 3.8.1.20200110
+    choco install python -y -r --version 3.8.2
     refreshenv
     $env:PATH = "$env:PATH;C:\\Python38;C:\\Python38\\Scripts"
 }
@@ -119,7 +119,7 @@ def linuxGvmProvision(arch="amd64")
   return <<SCRIPT
 mkdir -p ~/bin
 if [ ! -e "~/bin/gvm" ]; then
-  curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.2.1/gvm-linux-#{arch}
+  curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-linux-#{arch}
   chmod +x ~/bin/gvm
   ~/bin/gvm #{GO_VERSION}
   echo 'export GOPATH=$HOME/go' >> ~/.bash_profile

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -33,10 +32,15 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
 	common.RegisterCheckDeps(Update)
+	unittest.RegisterGoTestDeps(fieldsYML)
 
 	devtools.BeatDescription = "Audit the activities of users and processes on your system."
 }
@@ -44,7 +48,7 @@ func init() {
 // Aliases provides compatibility with CI while we transition all Beats
 // to having common testing targets.
 var Aliases = map[string]interface{}{
-	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 // Build builds the Beat binary.
@@ -149,23 +153,4 @@ func Dashboards() error {
 // Docs collects the documentation.
 func Docs() {
 	mg.Deps(auditbeat.ModuleDocs, auditbeat.FieldDocs)
-}
-
-// UnitTest executes the unit tests.
-func UnitTest() {
-	mg.SerialDeps(GoUnitTest, PythonUnitTest)
-}
-
-// GoUnitTest executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoUnitTest(ctx context.Context) error {
-	mg.Deps(Fields)
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// PythonUnitTest executes the python system tests.
-func PythonUnitTest() error {
-	mg.Deps(devtools.BuildSystemTestBinary)
-	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
 }

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -200,8 +200,13 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		outputs = append(outputs, fileOutput)
 	}
 	output := io.MultiWriter(outputs...)
-	goTest.Stdout = io.MultiWriter(output, os.Stdout)
-	goTest.Stderr = io.MultiWriter(output, os.Stderr)
+	goTest.Stdout = output
+	goTest.Stderr = output
+
+	if mg.Verbose() {
+		goTest.Stdout = io.MultiWriter(output, os.Stdout)
+		goTest.Stderr = io.MultiWriter(output, os.Stderr)
+	}
 
 	// Execute 'go test' and measure duration.
 	start := time.Now()

--- a/dev-tools/mage/target/integtest/integtest.go
+++ b/dev-tools/mage/target/integtest/integtest.go
@@ -62,7 +62,12 @@ func IntegTest() {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoIntegTest(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
+	if !devtools.IsInIntegTestEnv() {
+		mg.SerialDeps(goTestDeps...)
+	}
+	return devtools.RunIntegTest("goIntegTest", func() error {
+		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
+	}, whitelistedEnvVars...)
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -33,10 +33,15 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import generate
 	_ "github.com/elastic/beats/v7/filebeat/scripts/mage/generate"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
 	common.RegisterCheckDeps(Update)
+	test.RegisterDeps(IntegTest)
 
 	devtools.BeatDescription = "Filebeat sends log files to Logstash or directly to Elasticsearch."
 }
@@ -44,7 +49,7 @@ func init() {
 // Aliases provides compatibility with CI while we transition all Beats
 // to having common testing targets.
 var Aliases = map[string]interface{}{
-	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 // Build builds the Beat binary.
@@ -182,29 +187,11 @@ func IntegTest() {
 	mg.SerialDeps(GoIntegTest, PythonIntegTest)
 }
 
-// UnitTest executes the unit tests.
-func UnitTest() {
-	mg.SerialDeps(GoUnitTest, PythonUnitTest)
-}
-
-// GoUnitTest executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoUnitTest(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
 // GoIntegTest executes the Go integration tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoIntegTest(ctx context.Context) error {
 	return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
-}
-
-// PythonUnitTest executes the python system tests.
-func PythonUnitTest() error {
-	mg.Deps(devtools.BuildSystemTestBinary)
-	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).

--- a/filebeat/tests/system/test_tcp.py
+++ b/filebeat/tests/system/test_tcp.py
@@ -35,7 +35,7 @@ class Test(BaseTest):
 """
 
         # Use default of \n and stripping \r
-        if delimiter is not "":
+        if delimiter != "":
             input_raw += "\n  line_delimiter: {}".format(delimiter)
 
         input_raw = input_raw.format(host, port)

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -32,7 +32,7 @@ import (
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
 
 	// mage:import
-	build "github.com/elastic/beats/v7/dev-tools/mage/target/build"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
@@ -42,18 +42,28 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/pkg"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
-	update "github.com/elastic/beats/v7/dev-tools/mage/target/update"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/update"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 )
 
 func init() {
 	common.RegisterCheckDeps(update.Update)
+	test.RegisterDeps(GoIntegTest)
+	unittest.RegisterGoTestDeps(Fields)
+	unittest.RegisterPythonTestDeps(Fields)
+
 	devtools.BeatDescription = "Metricbeat is a lightweight shipper for metrics."
+}
+
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 //CollectAll generates the docs and the fields.
@@ -134,13 +144,6 @@ func Fields() error {
 	return devtools.GenerateFieldsYAML("module")
 }
 
-// GoTestUnit executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestUnit(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
 // ExportDashboard exports a dashboard and writes it into the correct directory
 //
 // Required ENV variables:
@@ -174,5 +177,6 @@ func CollectDocs() error {
 // Use RACE_DETECTOR=true to enable the race detector.
 // Use TEST_TAGS=tag1,tag2 to add additional build tags.
 func GoIntegTest(ctx context.Context) error {
+	mg.Deps(Fields)
 	return devtools.GoTestIntegrationForModule(ctx)
 }

--- a/metricbeat/module/system/diskio/diskstat_windows_test.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_test.go
@@ -31,6 +31,9 @@ import (
 )
 
 func TestCDriveFilterOnWindowsTestEnv(t *testing.T) {
+	// Test if flakey.
+	t.Skip("See https://github.com/elastic/beats/issues/17126")
+
 	conf := map[string]interface{}{
 		"module":                 "system",
 		"metricsets":             []string{"diskio"},

--- a/winlogbeat/magefile.go
+++ b/winlogbeat/magefile.go
@@ -43,6 +43,7 @@ import (
 )
 
 func init() {
+	unittest.RegisterGoTestDeps(winlogbeat.Update.Fields)
 	winlogbeat.SelectLogic = devtools.OSSProject
 }
 

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -21,7 +20,11 @@ import (
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
+	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
@@ -35,7 +38,7 @@ func init() {
 // Aliases provides compatibility with CI while we transition all Beats
 // to having common testing targets.
 var Aliases = map[string]interface{}{
-	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 // Build builds the Beat binary.
@@ -125,24 +128,6 @@ func ExportDashboard() error {
 // Dashboards collects all the dashboards and generates index patterns.
 func Dashboards() error {
 	return devtools.KibanaDashboards(devtools.OSSBeatDir("module"), "module")
-}
-
-// UnitTest executes the unit tests.
-func UnitTest() {
-	mg.SerialDeps(GoUnitTest, PythonUnitTest)
-}
-
-// GoUnitTest executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoUnitTest(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// PythonUnitTest executes the python system tests.
-func PythonUnitTest() error {
-	mg.SerialDeps(Fields, devtools.BuildSystemTestBinary)
-	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
 }
 
 // -----------------------------------------------------------------------------

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -28,6 +28,8 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 
 	"github.com/docker/docker/api/types"
@@ -335,11 +337,6 @@ func Package() {
 // BuildAndInstall builds and installs the plugin
 func BuildAndInstall() {
 	mg.SerialDeps(Build, Install)
-}
-
-// IntegTest is currently a dummy test for the `testsuite` target
-func IntegTest() {
-	fmt.Printf("There are no Integration tests for The Elastic Log Plugin\n")
 }
 
 // Update is currently a dummy test for the `testsuite` target

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -21,10 +21,15 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import generate
 	_ "github.com/elastic/beats/v7/filebeat/scripts/mage/generate"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
 	common.RegisterCheckDeps(Update)
+	test.RegisterDeps(IntegTest)
 
 	devtools.BeatDescription = "Filebeat sends log files to Logstash or directly to Elasticsearch."
 	devtools.BeatLicense = "Elastic License"
@@ -33,7 +38,7 @@ func init() {
 // Aliases provides compatibility with CI while we transition all Beats
 // to having common testing targets.
 var Aliases = map[string]interface{}{
-	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 // Build builds the Beat binary.
@@ -154,18 +159,6 @@ func IntegTest() {
 	mg.SerialDeps(GoIntegTest, PythonIntegTest)
 }
 
-// UnitTest executes the unit tests.
-func UnitTest() {
-	mg.SerialDeps(GoUnitTest, PythonUnitTest)
-}
-
-// GoUnitTest executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoUnitTest(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
 // GoIntegTest executes the Go integration tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
@@ -173,12 +166,6 @@ func GoIntegTest(ctx context.Context) error {
 	return devtools.RunIntegTest("goIntegTest", func() error {
 		return devtools.GoTest(ctx, devtools.DefaultGoTestIntegrationArgs())
 	})
-}
-
-// PythonUnitTest executes the python system tests.
-func PythonUnitTest() error {
-	mg.Deps(devtools.BuildSystemTestBinary)
-	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
 }
 
 // PythonIntegTest executes the python system tests in the integration environment (Docker).

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -24,6 +24,8 @@ import (
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
+	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 	functionbeat "github.com/elastic/beats/v7/x-pack/functionbeat/scripts/mage"

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -109,11 +109,9 @@ class Test(BaseTest):
                 f.write("my dummy functionbeat binary\n")
 
     def _get_generated_function_template(self):
-        logs = self.get_log_lines()
-        skipped_lines = -1
-        if os.sys.platform.startswith("win"):
-            skipped_lines = -2
-        function_template_lines = logs[:skipped_lines]
-        raw_function_temaplate = "".join(function_template_lines)
-        function_template = json.loads(raw_function_temaplate)
+        log = self.get_log()
+        # Trim the extra output from the Go test wrapper (like PASS/FAIL and
+        # coverage information).
+        log = log[:log.rindex('}')+1]
+        function_template = json.loads(log)
         return function_template

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -4,8 +4,11 @@ services:
     build: ${PWD}/.
     depends_on:
       - proxy_dep
-    env_file:
-      - ${PWD}/build/test.env
+    environment:
+      - ES_BEATS=/go/src/github.com/elastic/beats
+      - BEAT_STRICT_PERMS=false
+      - ES_HOST=elasticsearch
+      - ES_PORT=9200
     working_dir: /go/src/github.com/elastic/beats/x-pack/libbeat
     volumes:
       - ${PWD}/../..:/go/src/github.com/elastic/beats/

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -7,8 +7,6 @@
 package main
 
 import (
-	"context"
-
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 
 	// mage:import
@@ -16,7 +14,9 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
@@ -33,9 +33,8 @@ func Fields() error {
 	return devtools.GenerateFieldsYAML()
 }
 
-// GoTestUnit executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-func GoTestUnit(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -21,10 +21,15 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 func init() {
 	common.RegisterCheckDeps(Update)
+	test.RegisterDeps(IntegTest)
 
 	devtools.BeatDescription = "Metricbeat is a lightweight shipper for metrics."
 	devtools.BeatLicense = "Elastic License"
@@ -33,7 +38,7 @@ func init() {
 // Aliases provides compatibility with CI while we transition all Beats
 // to having common testing targets.
 var Aliases = map[string]interface{}{
-	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+	"goTestUnit": unittest.GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
 }
 
 // Build builds the Beat binary.
@@ -128,25 +133,6 @@ func Update() {
 	mg.SerialDeps(Fields, Dashboards, Config,
 		metricbeat.PrepareModulePackagingXPack,
 		devtools.GenerateModuleIncludeListGo)
-}
-
-// UnitTest executes the unit tests.
-func UnitTest() {
-	mg.SerialDeps(GoUnitTest, PythonUnitTest)
-}
-
-// GoUnitTest executes the Go unit tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
-// Use RACE_DETECTOR=true to enable the race detector.
-// Use TEST_TAGS=tag1,tag2 to add additional build tags.
-func GoUnitTest(ctx context.Context) error {
-	return devtools.GoTest(ctx, devtools.DefaultGoTestUnitArgs())
-}
-
-// PythonUnitTest executes the python system tests.
-func PythonUnitTest() error {
-	mg.Deps(devtools.BuildSystemTestBinary)
-	return devtools.PythonNoseTest(devtools.DefaultPythonTestUnitArgs())
 }
 
 // IntegTest executes integration tests (it uses Docker to run the tests).

--- a/x-pack/winlogbeat/magefile.go
+++ b/x-pack/winlogbeat/magefile.go
@@ -28,6 +28,8 @@ import (
 )
 
 func init() {
+	unittest.RegisterGoTestDeps(winlogbeat.Update.Fields)
+
 	winlogbeat.SelectLogic = devtools.XPackProject
 	devtools.BeatLicense = "Elastic License"
 }


### PR DESCRIPTION
## What does this PR do?

- Fix/skip two failing tests. One in functionbeat and one in metricbeat.
- Use `mage unitTest` on Windows. Make sure each project where mage is invoked directly has this in their magefile.go.
- Fix up some of the environment variables in the Jenkinsfile.
- Disable macOS stages because we're missing python3 for the moment.

## Why is it important?

This will get the Jenkins pipeline build to green. After that we can enable it for all master branch changes and all PRs to master. And then continue to iterate on improving it as we migrate all projects to have a mage build.