### PR TITLE
Check ES for CCR feature availability

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,6 +117,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dashboard for `redisenterprise` module. {pull}16752[16752]
 - Dynamically choose a method for the system/service metricset to support older linux distros. {pull}16902[16902]
 - Reduce memory usage in `elasticsearch/index` metricset. {issue}16503[16503] {pull}16538[16538]
+- Check if CCR feature is available on Elasticsearch cluster before attempting to call CCR APIs from `elasticsearch/ccr` metricset. {issue}16511[16511] {pull}17073[17073]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/ccr/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/ccr/_meta/docs.asciidoc
@@ -1,8 +1,8 @@
-This is the `ccr` metricset of the Elasticsearch module. It interrogates the
+This is the `ccr` metricset of the {es} module. It uses the
 Cross-Cluster Replication Stats API endpoint to fetch metrics about cross-cluster
-replication from the Elasticsearch clusters that are participating in cross-cluster
+replication from the {es} clusters that are participating in cross-cluster
 replication.
 
-If the Elasticserach cluster does not have the cross-cluster replication feature
-enabled, this metricset will not collect any metrics. A DEBUG log message about this
-will be emitted in the Metricbeat log.
+If the {es} cluster does not have cross-cluster replication enabled, this metricset
+will not collect metrics. A DEBUG log message about this will be emitted in the
+Metricbeat log.

--- a/metricbeat/module/elasticsearch/ccr/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/ccr/_meta/docs.asciidoc
@@ -1,3 +1,8 @@
 This is the `ccr` metricset of the Elasticsearch module. It interrogates the
-Cross Cluster Replication Stats API endpoint to fetch information about shards
-in the Elasticsearch cluster that are participating in cross-cluster replication.
+Cross-Cluster Replication Stats API endpoint to fetch metrics about cross-cluster
+replication from the Elasticsearch clusters that are participating in cross-cluster
+replication.
+
+If the Elasticserach cluster does not have the cross-cluster replication feature
+enabled, this metricset will not collect any metrics. A DEBUG log message about this
+will be emitted in the Metricbeat log.

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -126,7 +126,12 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Ver
 		return "", errors.Wrap(err, "error determining xpack features")
 	}
 
-	isAvailable := xpack.Features.CCR.Available && elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
+	if !xpack.Features.CCR.Available {
+		message = "the CCR feature not available on your Elasticsearch cluster."
+		return
+	}
+
+	isAvailable := elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isAvailable {
 		metricsetName := m.FullyQualifiedName()

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -121,6 +121,8 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Ver
 		return
 	}
 
+	// TODO: Check feature availability in ES: GET _xpack, check .features.ccr.available
+
 	isAvailable := elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isAvailable {

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -121,9 +121,12 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Ver
 		return
 	}
 
-	// TODO: Check feature availability in ES: GET _xpack, check .features.ccr.available
+	xpack, err := elasticsearch.GetXPack(m.HTTP, m.GetServiceURI())
+	if err != nil {
+		return "", errors.Wrap(err, "error determining xpack features")
+	}
 
-	isAvailable := elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
+	isAvailable := xpack.Features.CCR.Available && elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isAvailable {
 		metricsetName := m.FullyQualifiedName()

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -126,8 +126,8 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Ver
 		return "", errors.Wrap(err, "error determining xpack features")
 	}
 
-	if !xpack.Features.CCR.Available {
-		message = "the CCR feature not available on your Elasticsearch cluster."
+	if !xpack.Features.CCR.Enabled {
+		message = "the CCR feature is not enabled on your Elasticsearch cluster."
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -1,0 +1,1 @@
+package ccr

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -1,1 +1,99 @@
 package ccr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+)
+
+func startESServer(esVersion, license string, ccrAvailable bool) *httptest.Server {
+
+	nodesLocalHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"nodes": { "foobar": {}}}`))
+	}
+	clusterStateMasterHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"master_node": "foobar"}`))
+	}
+	rootHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+		}
+		w.Write([]byte(`{"version": { "number": "` + esVersion + `" } }`))
+	}
+	licenseHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{ "license": { "type": "` + license + `" } }`))
+	}
+	xpackHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{ "features": { "ccr": { "available": ` + strconv.FormatBool(ccrAvailable) + `}}}`))
+	}
+	ccrStatsHandler := func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "this should never have been called", 418)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/_nodes/_local/nodes", http.HandlerFunc(nodesLocalHandler))
+	mux.Handle("/_cluster/state/master_node", http.HandlerFunc(clusterStateMasterHandler))
+	mux.Handle("/", http.HandlerFunc(rootHandler))
+	mux.Handle("/_license", http.HandlerFunc(licenseHandler))       // for 7.0 and above
+	mux.Handle("/_xpack/license", http.HandlerFunc(licenseHandler)) // for before 7.0
+	mux.Handle("/_xpack", http.HandlerFunc(xpackHandler))
+	mux.Handle("/_ccr/stats", http.HandlerFunc(ccrStatsHandler))
+
+	return httptest.NewServer(mux)
+}
+
+func TestCCRNotAvailable(t *testing.T) {
+	tests := map[string]struct {
+		esVersion    string
+		license      string
+		ccrAvailable bool
+	}{
+		"old_version": {
+			"6.4.0",
+			"platinum",
+			true,
+		},
+		"low_license": {
+			"7.6.0",
+			"basic",
+			true,
+		},
+		"feature_unavailable": {
+			"7.6.0",
+			"platinum",
+			false,
+		},
+	}
+
+	// Disable license caching for these tests
+	elasticsearch.LicenseEnableCaching = false
+	defer func() { elasticsearch.LicenseEnableCaching = true }()
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := startESServer(test.esVersion, test.license, test.ccrAvailable)
+			defer server.Close()
+
+			ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
+			events, errs := mbtest.ReportingFetchV2Error(ms)
+
+			require.Empty(t, errs)
+			require.Empty(t, events)
+		})
+	}
+}
+
+func getConfig(host string) map[string]interface{} {
+	return map[string]interface{}{
+		"module":     elasticsearch.ModuleName,
+		"metricsets": []string{"ccr"},
+		"hosts":      []string{host},
+	}
+}

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ccr
 
 import (

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -90,8 +90,8 @@ func TestCCRNotAvailable(t *testing.T) {
 	}
 
 	// Disable license caching for these tests
-	elasticsearch.LicenseEnableCaching = false
-	defer func() { elasticsearch.LicenseEnableCaching = true }()
+	elasticsearch.LicenseCacheEnabled = false
+	defer func() { elasticsearch.LicenseCacheEnabled = true }()
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -30,7 +30,7 @@ import (
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 )
 
-func startESServer(esVersion, license string, ccrAvailable bool) *httptest.Server {
+func startESServer(esVersion, license string, ccrEnabled bool) *httptest.Server {
 
 	nodesLocalHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"nodes": { "foobar": {}}}`))
@@ -48,7 +48,7 @@ func startESServer(esVersion, license string, ccrAvailable bool) *httptest.Serve
 		w.Write([]byte(`{ "license": { "type": "` + license + `" } }`))
 	}
 	xpackHandler := func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{ "features": { "ccr": { "available": ` + strconv.FormatBool(ccrAvailable) + `}}}`))
+		w.Write([]byte(`{ "features": { "ccr": { "enabled": ` + strconv.FormatBool(ccrEnabled) + `}}}`))
 	}
 	ccrStatsHandler := func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "this should never have been called", 418)
@@ -68,9 +68,9 @@ func startESServer(esVersion, license string, ccrAvailable bool) *httptest.Serve
 
 func TestCCRNotAvailable(t *testing.T) {
 	tests := map[string]struct {
-		esVersion    string
-		license      string
-		ccrAvailable bool
+		esVersion  string
+		license    string
+		ccrEnabled bool
 	}{
 		"old_version": {
 			"6.4.0",
@@ -95,7 +95,7 @@ func TestCCRNotAvailable(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			server := startESServer(test.esVersion, test.license, test.ccrAvailable)
+			server := startESServer(test.esVersion, test.license, test.ccrEnabled)
 			defer server.Close()
 
 			ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -458,8 +458,13 @@ func MergeClusterSettings(clusterSettings common.MapStr) (common.MapStr, error) 
 	return settings, nil
 }
 
-// Global cache for license information. Assumption is that license information changes infrequently.
-var licenseCache = &_licenseCache{}
+var (
+	// Global cache for license information. Assumption is that license information changes infrequently.
+	licenseCache = &_licenseCache{}
+
+	// LicenseEnableCaching controls whether license caching is enabled or not. Intended for test use.
+	LicenseEnableCaching = true
+)
 
 type _licenseCache struct {
 	sync.RWMutex
@@ -481,6 +486,10 @@ func (c *_licenseCache) get() *License {
 }
 
 func (c *_licenseCache) set(license *License, ttl time.Duration) {
+	if !LicenseEnableCaching {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -366,7 +366,7 @@ func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 type XPack struct {
 	Features struct {
 		CCR struct {
-			Available bool `json:"available"`
+			Enabled bool `json:"enabled"`
 		} `json:"CCR"`
 	} `json:"features"`
 }

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -462,8 +462,8 @@ var (
 	// Global cache for license information. Assumption is that license information changes infrequently.
 	licenseCache = &_licenseCache{}
 
-	// LicenseEnableCaching controls whether license caching is enabled or not. Intended for test use.
-	LicenseEnableCaching = true
+	// LicenseCacheEnabled controls whether license caching is enabled or not. Intended for test use.
+	LicenseCacheEnabled = true
 )
 
 type _licenseCache struct {
@@ -486,7 +486,7 @@ func (c *_licenseCache) get() *License {
 }
 
 func (c *_licenseCache) set(license *License, ttl time.Duration) {
-	if !LicenseEnableCaching {
+	if !LicenseCacheEnabled {
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -363,6 +363,27 @@ func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	return stackUsage, err
 }
 
+type XPack struct {
+	Features struct {
+		CCR struct {
+			Available bool `json:"available"`
+		} `json:"CCR"`
+	} `json:"features"`
+}
+
+// GetXPack returns information about xpack features.
+func GetXPack(http *helper.HTTP, resetURI string) (XPack, error) {
+	content, err := fetchPath(http, resetURI, "_xpack", "")
+
+	if err != nil {
+		return XPack{}, err
+	}
+
+	var xpack XPack
+	err = json.Unmarshal(content, &xpack)
+	return xpack, err
+}
+
 // IsMLockAllEnabled returns if the given Elasticsearch node has mlockall enabled
 func IsMLockAllEnabled(http *helper.HTTP, resetURI, nodeID string) (bool, error) {
 	content, err := fetchPath(http, resetURI, "_nodes/"+nodeID, "filter_path=nodes.*.process.mlockall")


### PR DESCRIPTION
## What does this PR do?

Improves the check for CCR availability by not just checking the license level but also checking if the CCR feature is actually available in Elasticsearch.

## Why is it important?

In some environments, like Elastic Cloud, the CCR feature is not available in Elasticsearch despite the license level being high enough. In such environments we currently throw errors in the log. This change will fix the error logging behavior.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. Spin up a deployment on [Elastic Cloud](https://cloud.elastic.co/).
2. Grab the Elasticsearch Endpoint URL.
3. Grab the password for the `elastic` user.
4. Build Metricbeat with this PR.

   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

5. Enable the `elasticsearch-xpack` Metricbeat module.

   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```

6. Edit `modules.d/elasticsearch-xpack.yml`.
    - Set `hosts` to the Elasticsearch Endpoint URL from step 2. 
    - Set `username` to `elastic`.
    - Set `password` to the password from step 3.
7. For ease of testing,  edit `metricbeat.yml` and set `output.elasticsearch.enabled: false`,  `output.file.path: /tmp`, and `output.file.filename: metricbeat`.
8. Start Metricbeat and watch the logs being output to the console.

   ```
   metricbeat -e
   ```

9. Assert that the following message **does not** appear:

   ```
   Error fetching data for metricset elasticsearch.ccr: HTTP error 405 in : 405 Method Not Allowed
   ```

10. Stop Metricbeat.
11. Restart Metricbeat with debug logging for the Elasticsearch CCR metricset and watch the logs being output to the console.

    ```
    metricbeat -d 'elasticsearch.ccr' -e
    ```

12. Assert that the following message **does** appear:

    ```
    DEBUG   [elasticsearch.ccr]     ccr/ccr.go:86   the CCR feature is not enabled on your Elasticsearch cluster.
    ```

## Related issues

- Fixes #16511.
