### PR TITLE
Add support of TEST_TAGS in python tests

### DIFF
--- a/libbeat/tests/system/beat/tags.py
+++ b/libbeat/tests/system/beat/tags.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+
+def tag(tag):
+    """
+    Decorates a test function with a tag following go build tags semantics,
+    if the tag is not included in TEST_TAGS environment variable, the test is
+    skipped.
+    TEST_TAGS can be a comma-separated list of tags, e.g: TEST_TAGS=oracle,mssql.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            set_tags = [
+                tag.strip() for tag in os.environ.get("TEST_TAGS", "").split(",")
+                if tag.strip() != ""
+            ]
+            if not tag in set_tags:
+                raise unittest.SkipTest("tag '{}' is not included in TEST_TAGS".format(tag))
+            return func(*args, **kwargs)
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = func.__doc__
+        return wrapper
+
+    return decorator

--- a/libbeat/tests/system/beat/tags.py
+++ b/libbeat/tests/system/beat/tags.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+
 def tag(tag):
     """
     Decorates a test function with a tag following go build tags semantics,

--- a/metricbeat/module/redis/test_redis.py
+++ b/metricbeat/module/redis/test_redis.py
@@ -29,7 +29,6 @@ class Test(metricbeat.BaseTest):
     COMPOSE_SERVICES = ['redis']
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    @metricbeat.tag('redis')
     @attr('integration')
     def test_info(self):
         """

--- a/metricbeat/module/redis/test_redis.py
+++ b/metricbeat/module/redis/test_redis.py
@@ -29,6 +29,7 @@ class Test(metricbeat.BaseTest):
     COMPOSE_SERVICES = ['redis']
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @metricbeat.tag('redis')
     @attr('integration')
     def test_info(self):
         """

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,12 +1,12 @@
 import os
 import re
 import sys
-import unittest
 import yaml
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
 
 from beat.beat import TestCase
+from beat.tags import tag
 from parameterized import parameterized_class
 
 COMMON_FIELDS = ["@timestamp", "agent", "metricset.name", "metricset.host",
@@ -140,26 +140,3 @@ def parameterized_with_supported_versions(base_class):
     variants = supported_versions(versions_path)
     decorator = parameterized_class(['COMPOSE_ENV'], variants)
     decorator(base_class)
-
-
-def tag(tag):
-    """
-    Decorates a test function with a tag following go build tags semantics,
-    if the tag is not included in TEST_TAGS environment variable, the test is
-    skipped.
-    TEST_TAGS can be a comma-separated list of tags, e.g: TEST_TAGS=oracle,mssql.
-    """
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            set_tags = [
-                tag.strip() for tag in os.environ.get("TEST_TAGS", "").split(",")
-                if tag.strip() != ""
-            ]
-            if not tag in set_tags:
-                raise unittest.SkipTest("tag '{}' is not included in TEST_TAGS".format(tag))
-            return func(*args, **kwargs)
-        wrapper.__name__ = func.__name__
-        wrapper.__doc__ = func.__doc__
-        return wrapper
-
-    return decorator

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,6 +1,7 @@
+import os
 import re
 import sys
-import os
+import unittest
 import yaml
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
@@ -139,3 +140,26 @@ def parameterized_with_supported_versions(base_class):
     variants = supported_versions(versions_path)
     decorator = parameterized_class(['COMPOSE_ENV'], variants)
     decorator(base_class)
+
+
+def tag(tag):
+    """
+    Decorates a test function with a tag following go build tags semantics,
+    if the tag is not included in TEST_TAGS environment variable, the test is
+    skipped.
+    TEST_TAGS can be a comma-separated list of tags, e.g: TEST_TAGS=oracle,mssql.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            set_tags = [
+                tag.strip() for tag in os.environ.get("TEST_TAGS", "").split(",")
+                if tag.strip() != ""
+            ]
+            if not tag in set_tags:
+                raise unittest.SkipTest("tag '{}' is not included in TEST_TAGS".format(tag))
+            return func(*args, **kwargs)
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = func.__doc__
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## What does this PR do?

Add a `tag(tag)` decorator that skips a test if the tag is not included
in the comma-separated list of `TEST_TAGS` environment variable.
This offers an initial support for the similar implementation added for
mage in #16937.

## Why is it important?

#16937 was intended for cloud tests, where we only have go-based
integration tests. But we have found similar needings in some services
like oracle, where we need an image that we cannot distribute. In that
case we need a similar approach to run the test only in our Jenkins
instances, where the image is available.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

* Tag a python test with `@metricbeat.tag('sometag')`.
* Check that the test is skipped if `TEST_TAGS` is not used.
* Check that the test is executed if `TEST_TAGS` environment variable includes `sometag` (e.g: `TEST_TAGS=sometag` or `TEST_TAGS=sometag,foo`.

## Related issues

- Required by #16833 to enable tests only in Jenkins.
- Extends #16937.
- Could be useful in #15891 if we add system tests for cloud features.

## Use cases

- Run certain tests that require some application or credentials to be available only where they are.
