### PR TITLE
Add test tag with Oracle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -574,6 +574,7 @@ def withBeatsEnv(Closure body){
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
     "PYTHON_ENV=${WORKSPACE}/python-env",
+    "TEST_TAGS"="aws,azure,oracle",
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -574,7 +574,7 @@ def withBeatsEnv(Closure body){
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
     "PYTHON_ENV=${WORKSPACE}/python-env",
-    "TEST_TAGS"="aws,azure,oracle",
+    "TEST_TAGS"="oracle",
   ]){
     deleteDir()
     unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -574,7 +574,7 @@ def withBeatsEnv(Closure body){
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
     "PYTHON_ENV=${WORKSPACE}/python-env",
-    "TEST_TAGS"="oracle",
+    "TEST_TAGS=oracle",
   ]){
     deleteDir()
     unstash 'source'


### PR DESCRIPTION
Adds the TEST_TAGS environment variable to Jenkins CI set to `aws,azure,oracle`

Continues / Related to: https://github.com/elastic/beats/pull/16937
Related to: https://github.com/elastic/beats/pull/17075

Pinging @jsoriano and @kuisathaverat 