### PR TITLE
Cherry-pick #16915 to 7.x: Add missing logger init in New() functions

### DIFF
--- a/libbeat/reader/readjson/json_test.go
+++ b/libbeat/reader/readjson/json_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -185,6 +187,7 @@ func TestDecodeJSON(t *testing.T) {
 
 		var p JSONReader
 		p.cfg = &test.Config
+		p.logger = logp.NewLogger("json_test")
 		text, M := p.decode([]byte(test.Text))
 		assert.Equal(t, test.ExpectedText, string(text))
 		assert.Equal(t, test.ExpectedMap, M)


### PR DESCRIPTION
Cherry-pick of PR #16915 to 7.x branch. Original message: 

This PR fixes https://github.com/elastic/beats/pull/16886 by adding init loggers in New() functions.

Note:
This is to fix the partial manual cherrypick I did in https://github.com/elastic/beats/pull/16912. 