### PR TITLE
Fixing typos in JSON field names

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -68,7 +68,7 @@ type indexStats struct {
 	Merges struct {
 		TotalSizeInBytes int `json:"total_size_in_bytes"`
 	} `json:"merges"`
-	QueryCache   cacheStats `json:"query_stats"`
+	QueryCache   cacheStats `json:"query_cache"`
 	RequestCache cacheStats `json:"request_cache"`
 	Search       struct {
 		QueryTotal        int `json:"query_total"`
@@ -117,7 +117,7 @@ type shardStats struct {
 	UnassignedReplicas  int `json:"unassigned_replicas"`
 
 	Initializing int `json:"initializing"`
-	Relocating   int `json:"relocationg"`
+	Relocating   int `json:"relocating"`
 }
 
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {


### PR DESCRIPTION
## What does this PR do?

Fix typos introduced in #16538.

## Why is it important?

So the correct field names are used when indexing `type: index_stats` data into `.monitoring-es-*` indices.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~