### PR TITLE
[Metricbeat] Fix HAProxy "Connections per server" and "Downtime seconds" visualization

### DIFF
--- a/metricbeat/module/haproxy/_meta/kibana/7/dashboard/Metricbeat-haproxy-visualizations.json
+++ b/metricbeat/module/haproxy/_meta/kibana/7/dashboard/Metricbeat-haproxy-visualizations.json
@@ -259,7 +259,7 @@
                                     {
                                         "field": "haproxy.stat.connection.total", 
                                         "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
+                                        "type": "max"
                                     }, 
                                     {
                                         "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
@@ -326,7 +326,7 @@
                                     {
                                         "field": "haproxy.stat.downtime", 
                                         "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
-                                        "type": "avg"
+                                        "type": "max"
                                     }, 
                                     {
                                         "field": "61ca57f2-469d-11e7-af02-69e470af7417", 


### PR DESCRIPTION
Fixes: https://github.com/elastic/beats/issues/16623

- Connections per server [Metricbeat HAProxy] ECS: The number of connections can't be negative so we can consider a monotonically increasing number, the aggregation has been also changed from `avg` to `max`.
- Downtime seconds [Metricbeat HAProxy] ECS: Seconds accumulated of downtime can't be negative, it's zero or more so the aggregation has been also changed from `avg` to `max`.

@sorantis can you review this, please? :slightly_smiling_face: 