### PR TITLE
[7.6] docs: change how-to heading (#17092)

### DIFF
--- a/auditbeat/docs/howto/howto.asciidoc
+++ b/auditbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/heartbeat/docs/howto/howto.asciidoc
+++ b/heartbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/journalbeat/docs/howto/howto.asciidoc
+++ b/journalbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/metricbeat/docs/howto/howto.asciidoc
+++ b/metricbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/packetbeat/docs/howto/howto.asciidoc
+++ b/packetbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/winlogbeat/docs/howto/howto.asciidoc
+++ b/winlogbeat/docs/howto/howto.asciidoc
@@ -1,5 +1,5 @@
 [[howto-guides]]
-= How to
+= How to guides
 
 [partintro]
 --

--- a/x-pack/functionbeat/docs/howto/howto.asciidoc
+++ b/x-pack/functionbeat/docs/howto/howto.asciidoc
@@ -1,6 +1,6 @@
 [[howto-guides]]
 [role="xpack"]
-= How to
+= How to guides
 
 [partintro]
 --


### PR DESCRIPTION
Backports #17092 to 7.6 branch.