### PR TITLE
Cherry-pick #17031 to 7.x: Improve remote_write handler

### DIFF
--- a/metricbeat/module/prometheus/remote_write/remote_write.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write.go
@@ -50,7 +50,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	m := &MetricSet{
 		BaseMetricSet: base,
 		events:        make(chan mb.Event),
@@ -71,7 +70,6 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 		select {
 		case <-reporter.Done():
 			m.server.Stop()
-			close(m.events)
 			return
 		case e := <-m.events:
 			reporter.Event(e)
@@ -100,12 +98,16 @@ func (m *MetricSet) handleFunc(writer http.ResponseWriter, req *http.Request) {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}
-	// refactor, optimize
+
 	samples := protoToSamples(&protoReq)
 	events := samplesToEvents(samples)
 
 	for _, e := range events {
-		m.events <- e
+		select {
+		case <-req.Context().Done():
+			return
+		case m.events <- e:
+		}
 	}
 	writer.WriteHeader(http.StatusAccepted)
 }


### PR DESCRIPTION
Cherry-pick of PR #17031 to 7.x branch. Original message: 

## What does this PR do?

This PR improves `remote_write` handlers by:

~~- adding `defer req.Body.Close()`~~
~~- setting timeouts on httpServer~~
- Gracefully handling channel on Metricbeat stop, by avoid closing events channel and have the writers to be notified by the server that they should stop writing.
~~- remove metrics processing from handlerFunc to avoid having blocking connections~~

## Why is it important?

To void having panics on Metricbeat stopping:
```
2020-03-16T16:04:17.503+0200	DEBUG	[module]	module/wrapper.go:214	Stopped metricSetWrapper[module=prometheus, name=remote_write, host=]
2020-03-16T16:04:17.503+0200	DEBUG	[module]	module/wrapper.go:155	Stopped Wrapper[name=prometheus, len(metricSetWrappers)=1]
2020/03/16 16:04:17 http: panic serving 127.0.0.1:59319: send on closed channel
goroutine 2337 [running]:
net/http.(*conn).serve.func1(0xc002927e00)
	/usr/local/opt/go/libexec/src/net/http/server.go:1767 +0x139
panic(0x5ee0200, 0x67cbfe0)
	/usr/local/opt/go/libexec/src/runtime/panic.go:679 +0x1b2
github.com/elastic/beats/v7/metricbeat/module/prometheus/remote_write.(*MetricSet).handleFunc(0xc0002f0f00, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/Users/chrismark/go/src/github.com/elastic/beats/metricbeat/module/prometheus/remote_write/remote_write.go:108 +0x44e
net/http.HandlerFunc.ServeHTTP(0xc0003dba40, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/usr/local/opt/go/libexec/src/net/http/server.go:2007 +0x44
net/http.serverHandler.ServeHTTP(0xc000272000, 0x68884c0, 0xc002c23500, 0xc004f8e200)
	/usr/local/opt/go/libexec/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc002927e00, 0x6890dc0, 0xc00011b4c0)
	/usr/local/opt/go/libexec/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/opt/go/libexec/src/net/http/server.go:2927 +0x38e
2020/03/16 16:04:17 http: panic serving 127.0.0.1:59172: send on closed channel
```

~~To avoid reaching out of resources with the following error: `write accept: too many open files; retrying in 1s`~~
