### PR TITLE
Copy missing go version to the generated Beats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,17 +191,16 @@ jobs:
       stage: test
 
     # Generators
-    # https://github.com/elastic/beats/issues/16951
-    #- os: linux
-    #  before_install: .ci/scripts/travis_has_changes.sh generator metricbeat libbeat || travis_terminate 0
-    #  env: TARGETS="-C generator/_templates/metricbeat test test-package"
-    #  go: $TRAVIS_GO_VERSION
-    #  stage: test
-    #- os: linux
-    #  before_install: .ci/scripts/travis_has_changes.sh generator libbeat || travis_terminate 0
-    #  env: TARGETS="-C generator/_templates/beat test test-package"
-    #  go: $TRAVIS_GO_VERSION
-    #  stage: test
+    - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh generator metricbeat libbeat || travis_terminate 0
+      env: TARGETS="-C generator/_templates/metricbeat test test-package"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh generator libbeat || travis_terminate 0
+      env: TARGETS="-C generator/_templates/beat test test-package"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
     - os: osx
       before_install: .ci/scripts/travis_has_changes.sh generator metricbeat libbeat || travis_terminate 0

--- a/dev-tools/mage/gomod.go
+++ b/dev-tools/mage/gomod.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/dev-tools/mage/gotool"
 )
 
@@ -57,35 +59,35 @@ func Vendor() error {
 
 	err := mod.Tidy()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while running go mod tidy")
 	}
 
 	err = mod.Vendor()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while running go mod vendor")
 	}
 
 	err = mod.Verify()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while running go mod verify")
 	}
 
 	repo, err := GetProjectRepoInfo()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while getting repository information")
 	}
 
 	vendorFolder := filepath.Join(repo.RootDir, "vendor")
 	err = CopyFilesToVendor(vendorFolder, copyAll)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error copying required files")
 	}
 
 	for _, p := range filesToRemove {
 		p = filepath.Join(vendorFolder, p)
 		err = os.RemoveAll(p)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error while removing file: %s", p)
 		}
 	}
 	return nil
@@ -96,16 +98,16 @@ func CopyFilesToVendor(vendorFolder string, modulesToCopy []CopyModule) error {
 	for _, p := range modulesToCopy {
 		path, err := gotool.ListModuleCacheDir(p.Name)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error while looking up cached dir of module: %s", p.Name)
 		}
 
 		for _, f := range p.FilesToCopy {
 			from := filepath.Join(path, f)
 			to := filepath.Join(vendorFolder, p.Name, f)
-			copyTask := &CopyTask{Source: from, Dest: to, Mode: 0640, DirMode: os.ModeDir | 0750}
+			copyTask := &CopyTask{Source: from, Dest: to, Mode: 0600, DirMode: os.ModeDir | 0750}
 			err = copyTask.Execute()
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "error while copying file from %s to %s", from, to)
 			}
 		}
 	}

--- a/dev-tools/mage/gomod.go
+++ b/dev-tools/mage/gomod.go
@@ -102,7 +102,7 @@ func CopyFilesToVendor(vendorFolder string, modulesToCopy []CopyModule) error {
 		for _, f := range p.FilesToCopy {
 			from := filepath.Join(path, f)
 			to := filepath.Join(vendorFolder, p.Name, f)
-			copyTask := &CopyTask{Source: from, Dest: to, DirMode: os.ModeDir | 0750}
+			copyTask := &CopyTask{Source: from, Dest: to, Mode: 0640, DirMode: os.ModeDir | 0750}
 			err = copyTask.Execute()
 			if err != nil {
 				return err

--- a/generator/_templates/beat/{beat}/tools/tools.go
+++ b/generator/_templates/beat/{beat}/tools/tools.go
@@ -6,6 +6,7 @@ package tools
 
 import (
 	_ "github.com/pierrre/gotestcover"
+	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
 
 	_ "github.com/mitchellh/gox"

--- a/generator/_templates/metricbeat/{beat}/tools/tools.go
+++ b/generator/_templates/metricbeat/{beat}/tools/tools.go
@@ -6,6 +6,7 @@ package tools
 
 import (
 	_ "github.com/pierrre/gotestcover"
+	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
 
 	_ "github.com/mitchellh/gox"

--- a/generator/common/beatgen/setup/setup.go
+++ b/generator/common/beatgen/setup/setup.go
@@ -29,17 +29,6 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/gotool"
 )
 
-var (
-	makefileDeps = []string{
-		"dev-tools",
-		"libbeat",
-		"licenses",
-		"metricbeat",
-		"script",
-		".go-version",
-	}
-)
-
 func InitModule() error {
 	err := gotool.Mod.Init()
 	if err != nil {
@@ -113,21 +102,32 @@ func CopyVendor() error {
 		return err
 	}
 
-	path, err := gotool.ListModuleCacheDir("github.com/elastic/beats/v7")
+	err = devtools.CopyFilesToVendor(
+		"./vendor",
+		[]devtools.CopyModule{
+			devtools.CopyModule{
+				Name: "github.com/elastic/beats/v7",
+				FilesToCopy: []string{
+					"dev-tools",
+					"libbeat",
+					"licenses",
+					"metricbeat",
+					"script",
+					".go-version",
+				},
+			},
+			devtools.CopyModule{
+				Name: "github.com/tsg/go-daemon",
+				FilesToCopy: []string{
+					"src",
+				},
+			},
+		},
+	)
 	if err != nil {
 		return err
 	}
 
-	vendorPath := "./vendor/github.com/elastic/beats/v7"
-	for _, d := range makefileDeps {
-		from := filepath.Join(path, d)
-		to := filepath.Join(vendorPath, d)
-		copyTask := &devtools.CopyTask{Source: from, Dest: to, Mode: 0640, DirMode: os.ModeDir | 0750}
-		err = copyTask.Execute()
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/generator/common/beatgen/setup/setup.go
+++ b/generator/common/beatgen/setup/setup.go
@@ -36,6 +36,7 @@ var (
 		"licenses",
 		"metricbeat",
 		"script",
+		".go-version",
 	}
 )
 

--- a/generator/common/beatgen/setup/setup.go
+++ b/generator/common/beatgen/setup/setup.go
@@ -99,7 +99,7 @@ func copyReplacedModules() error {
 func CopyVendor() error {
 	err := gotool.Mod.Vendor()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error while running go mod vendor")
 	}
 
 	err = devtools.CopyFilesToVendor(
@@ -125,7 +125,7 @@ func CopyVendor() error {
 		},
 	)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error while copying required files to vendor")
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR do?

This PR makes beat generator copy `.go-version` to the vendored beats folder as it is not copied automatically.

## Why is it important?

If the file `.go-version` is missing, the beat cannot be generated and package properly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

```
$ make -C generator/_templates/beat test test-package
```

## Related issues

- Closes elastic/beats#16951 