### PR TITLE
Cherry-pick #15890 to 7.x: [Auditbeat] Reduce system/socket logging noise

### DIFF
--- a/x-pack/auditbeat/module/system/socket/arch_amd64.go
+++ b/x-pack/auditbeat/module/system/socket/arch_amd64.go
@@ -17,13 +17,14 @@ var archVariables = common.MapStr{
 	"P5": "%r8",
 	"P6": "%r9",
 
-	// System call parameters
-	"SYS_P1": "%di",
-	"SYS_P2": "%si",
-	"SYS_P3": "%dx",
-	"SYS_P4": "%cx", // This already translated from r10 by syscall handler
-	"SYS_P5": "%r8",
-	"SYS_P6": "%r9",
+	// System call parameters. These are temporary, the definitive SYS_Px args
+	// will be determined by guess/syscallargs.go.
+	"_SYS_P1": "%di",
+	"_SYS_P2": "%si",
+	"_SYS_P3": "%dx",
+	"_SYS_P4": "%cx", // This already translated from r10 by syscall handler
+	"_SYS_P5": "%r8",
+	"_SYS_P6": "%r9",
 
 	"RET": "%ax",
 }

--- a/x-pack/auditbeat/module/system/socket/guess/deref.go
+++ b/x-pack/auditbeat/module/system/socket/guess/deref.go
@@ -73,6 +73,7 @@ func (g *guessDeref) Provides() []string {
 func (g *guessDeref) Requires() []string {
 	return []string{
 		"SYS_UNAME",
+		"SYS_P1",
 	}
 }
 
@@ -85,7 +86,7 @@ func (g *guessDeref) Probes() ([]helper.ProbeDef, error) {
 				Type:      tracing.TypeKProbe,
 				Name:      "guess_null_ptr_deref",
 				Address:   "{{.SYS_UNAME}}",
-				Fetchargs: helper.MakeMemoryDump("{{.P1}}", 0, credDumpBytes),
+				Fetchargs: helper.MakeMemoryDump("{{.SYS_P1}}", 0, credDumpBytes),
 			},
 			Decoder: tracing.NewDumpDecoder,
 		},

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -541,13 +541,26 @@ func (s *state) getProcess(pid uint32) *process {
 	return s.processes[pid]
 }
 
+type threadEnterError struct {
+	tid      uint32
+	existing event
+}
+
+// Error is the error message string.
+func (t threadEnterError) Error() string {
+	return fmt.Sprintf("thread already had an event. tid=%d existing=%v", t.tid, t.existing)
+}
+
 func (s *state) ThreadEnter(tid uint32, ev event) error {
 	s.Lock()
 	prev, hasPrev := s.threads[tid]
 	s.threads[tid] = ev
 	s.Unlock()
 	if hasPrev {
-		return fmt.Errorf("thread already had an event. tid=%d existing=%v", tid, prev)
+		return threadEnterError{
+			tid:      tid,
+			existing: prev,
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry-pick of PR #15890 to 7.x branch. Original message: 

## What does this PR do?

This PR updates the logging of system/socket dataset to be less noisy, especially when `-d '*'` is used. Also updates some code that could introduce a difficult to spot bug in the future.

- Make ThreadEnter errors less noisy

    The socket dataset uses ThreadEnter(event) / ThreadLeave(event) as a
    single-event per-thread state tracking, useful for correlating function
    calls and their return values.

    However, in some cases functions are stacked, like sys_execve() calling
    itself recursively or inet6_create() calling inet_create(). This results
    in an existing stored event to be evicted, which is not a problem but
    currently is causing a warning to be printed to the logs.

    This patch makes two changes to this situation:
    - Only print warnings from the state machine when socketdetailed selector
      is enabled. The state machine currently only generates warnings for
      ThreadEnter/ThreadExit issues.

    - Change ThreadEnter errors to be constructed on demand by their Error()
      method, so that the somewhat expensive fmt.Sprintf() / event.String()
      is only invoked if the error is going to be printed to the log.

    This is a huge CPU saving in systems where this benign eviction is
    happening frequently.

- socketdetailed selector has to be enabled explicitly

    This selector is extremely noisy. This change excludes it from being
    enabled when debug is enabled with `-d '*'` and requires it to be
    explicitly defined: `-d '*,socketdetailed'`.

- Print template variables when socket debug is enabled

    It makes no sense to print guesses' progress in regular debug (socket)
    and the resulting template variables only when socketdetailed is set.

- Fix syscall arguments usage in guesses

    The syscall parameter templates (`SYS_Pn`) were not valid until
    guess_syscall_args runs. As the variables `SYS_Pn` already existed,
    another guess using them could use the wrong values because the
    dependency mechanism only checks if the variable exists.

    The fix for this is to have temporary variables (`_SYS_Pn`) and have
    guess_syscall_args create the definitive ones.

    This didn't cause any bug as the only guess that used syscall
    args is the new guess_deref which is enabled on demand via an
    environment variable for diagnostic purposes.

## Why is it important?

Two reasons: 
- In some cases this dataset would generate noisy and misleading messages in the logs at INFO level. This causes unnecessary concern and increased CPU usage.
- The `socketdetailed` selector being activated by default when `-d '*'` is specified caused the logs to be full of kprobe events at rates of 10.000 per second or more. Log files would rotate every few minutes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

- [x] I haven't added a changelog entry because I don't think these changes have entity to deserve it.
