### PR TITLE
Cherry-pick #17095 to 7.x: Fix cisco-ftd test case for new behavior of lowercase processor

### DIFF
--- a/x-pack/filebeat/module/cisco/ftd/test/security-connection.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/security-connection.log-expected.json
@@ -421,8 +421,8 @@
         "log.level": "alert",
         "log.offset": 3037,
         "network.application": [
-            "Advanced Packaging Tool",
-            "Ubuntu"
+            "advanced packaging tool",
+            "ubuntu"
         ],
         "network.iana_number": 6,
         "network.protocol": "http",


### PR DESCRIPTION
**Warn:** Do not merge until the problem appears in 7.x branch.
See _Logs_ below for the problem this fixes.

----

Cherry-pick of PR #17095 to 7.x branch. Original message: 

## What does this PR do?

Updates the golden files for Filebeat's cisco/ftd fileset to adapt to the new behavior of ingest node's lowercase processor after elastic/elasticsearch#53343

## Why is it important?

So that integration tests pass when run against an Elasticsearch that contains the changes linked above.

## Logs

Error fixed by this:

**test_xpack_modules.XPackTest.test_fileset_file_065_cisco**
```
AssertionError: The following expected object doesn't match:
 Diff:
{'iterable_item_added': {"root['network.application'][0]": 'advanced packaging tool', "root['network.application'][1]": 'ubuntu'}, 'iterable_item_removed': {"root['network.application'][1]": 'Ubuntu', "root['network.application'][0]": 'Advanced Packaging Tool'}}, full object:
[...]
```
