### PR TITLE
Cherry-pick #17105 to 7.x: Copy missing go version to the generated Beats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,15 +154,14 @@ jobs:
       stage: test
 
     # Generators
-    # https://github.com/elastic/beats/issues/16951
-    #- os: linux
-    #  env: TARGETS="-C generator/_templates/metricbeat test test-package"
-    #  go: $TRAVIS_GO_VERSION
-    #  stage: test
-    #- os: linux
-    #  env: TARGETS="-C generator/_templates/beat test test-package"
-    #  go: $TRAVIS_GO_VERSION
-    #  stage: test
+    - os: linux
+      env: TARGETS="-C generator/_templates/metricbeat test test-package"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C generator/_templates/beat test test-package"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
     - os: osx
       env: TARGETS="-C generator/_templates/metricbeat test"

--- a/generator/_templates/beat/{beat}/tools/tools.go
+++ b/generator/_templates/beat/{beat}/tools/tools.go
@@ -6,6 +6,7 @@ package tools
 
 import (
 	_ "github.com/pierrre/gotestcover"
+	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
 
 	_ "github.com/mitchellh/gox"

--- a/generator/_templates/metricbeat/{beat}/tools/tools.go
+++ b/generator/_templates/metricbeat/{beat}/tools/tools.go
@@ -6,6 +6,7 @@ package tools
 
 import (
 	_ "github.com/pierrre/gotestcover"
+	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
 
 	_ "github.com/mitchellh/gox"


### PR DESCRIPTION
Cherry-pick of PR #17105 to 7.x branch. Original message: 

## What does this PR do?

This PR makes beat generator copy `.go-version` to the vendored beats folder as it is not copied automatically.

## Why is it important?

If the file `.go-version` is missing, the beat cannot be generated and package properly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

```
$ make -C generator/_templates/beat test test-package
```

## Related issues

- Closes elastic/beats#16951 