### PR TITLE
Fix compose up retries in python tests

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -160,10 +160,10 @@ class TestCase(unittest.TestCase, ComposeMixin):
             try:
                 self.compose_up()
                 return
-            except e:
+            except Exception as e:
                 if i + 1 >= retries:
                     raise e
-                print("Compose up failed, retrying: " + e)
+                print("Compose up failed, retrying: {}".format(e))
                 self.compose_down()
 
     def run_beat(self,


### PR DESCRIPTION
Exception is being incorrectly handled, so retries don't work, and provoke misleading errors like:
```
name 'e' is not defined
```

Fixes code introduced in #16921 