### PR TITLE
Fix: use 'filebeat' default index pattern

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue where autodiscover hints default configuration was not being copied. {pull}16987[16987]
 - Fix Elasticsearch `_id` field set by S3 and Google Pub/Sub inputs. {pull}17026[17026]
 - Fixed various Cisco FTD parsing issues. {issue}16863[16863] {pull}16889[16889]
+- Fix default index pattern in IBM MQ filebeat dashboard. {pull}17146[17146]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/ibmmq/_meta/kibana/7/dashboard/Filebeat-IBMMQ-Overview.json
+++ b/x-pack/filebeat/module/ibmmq/_meta/kibana/7/dashboard/Filebeat-IBMMQ-Overview.json
@@ -205,7 +205,7 @@
             "axis_formatter": "number",
             "axis_position": "left",
             "axis_scale": "normal",
-            "default_index_pattern": "qbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
             "filter": "event.module:ibmmq",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",


### PR DESCRIPTION
This PR adjusts Kibana dashboard for IBM MQ filebeat module to use correct default index pattern. 

Spotted once working on migrating dashboards to EPR.