### PR TITLE
[7.x] journalbeat: tests for config (#17114)

### DIFF
--- a/journalbeat/cmd/root.go
+++ b/journalbeat/cmd/root.go
@@ -20,7 +20,7 @@ package cmd
 import (
 	"github.com/elastic/beats/v7/journalbeat/beater"
 
-	cmd "github.com/elastic/beats/v7/libbeat/cmd"
+	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 
 	// Import processors.

--- a/journalbeat/config/config_test.go
+++ b/journalbeat/config/config_test.go
@@ -18,3 +18,77 @@
 // +build !integration
 
 package config
+
+import (
+	"testing"
+)
+
+func TestUnpack(t *testing.T) {
+
+	tests := []struct {
+		mode    SeekMode
+		modeStr string
+	}{
+		{
+			mode:    SeekHead,
+			modeStr: seekHeadStr,
+		},
+		{
+			mode:    SeekTail,
+			modeStr: seekTailStr,
+		},
+		{
+			mode:    SeekCursor,
+			modeStr: seekCursorStr,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.modeStr, func(t *testing.T) {
+			t.Parallel()
+
+			m := SeekInvalid
+			err := m.Unpack(tc.modeStr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if m != tc.mode {
+				t.Errorf("wrong mode, expected %v, got %v", tc.mode, m)
+			}
+		})
+	}
+}
+
+func TestUnpackFailure(t *testing.T) {
+
+	tests := []struct {
+		modeStr string
+	}{
+		{
+			modeStr: "invalid",
+		},
+		{
+			modeStr: "",
+		},
+		{
+			modeStr: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.modeStr, func(t *testing.T) {
+			t.Parallel()
+
+			m := SeekInvalid
+			err := m.Unpack(tc.modeStr)
+			if err == nil {
+				t.Errorf("an error was expected, got %v", m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - journalbeat: tests for config  (#17114)