### PR TITLE
Find correct subdirectory in project repo when outside GOPATH

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -602,13 +602,13 @@ func getProjectRepoInfoWithModules() (*ProjectRepoInfo, error) {
 
 		if isRoot {
 			rootDir = possibleRoot
+			subDir, err = filepath.Rel(rootDir, cwd)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
 			break
 		}
 
-		subDir, err = filepath.Rel(possibleRoot, cwd)
-		if err != nil {
-			errs = append(errs, err.Error())
-		}
 		possibleRoot = filepath.Dir(possibleRoot)
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR selects the correct subdirectory when determining the root of the project when it is outside of the GOPATH.

## Why is it important?

Without this fixes the generated files (e.g. `filebeat/include/list.go`) contain incorrect import paths after running `make check`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

```
$ cd filebeat
$ make check
```

Check if the command runs successfully.