### PR TITLE
Use Go 1.13.1 runtime on GCP for cloud functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,11 @@ jobs:
       env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
       go: $TRAVIS_GO_VERSION
       stage: test
+    - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/functionbeat libbeat || travis_terminate 0
+      env: TARGETS="-C x-pack/functionbeat test-gcp-functions"
+      go: 1.13.1
+      stage: test
 
     # Docker Log Driver
     - os: linux

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -432,6 +432,9 @@ pipeline {
             stage('Functionbeat x-pack'){
               steps {
                 mageTarget("Functionbeat x-pack Linux", "x-pack/functionbeat", "update build test")
+                withEnv(["GO_VERSION=1.13.1"]){
+                  makeTarget("Functionbeat x-pack Linux", "-C x-pack/functionbeat test-gcp-functions")
+                }
               }
             }
             stage('Functionbeat Mac OS X x-pack'){

--- a/x-pack/functionbeat/Makefile
+++ b/x-pack/functionbeat/Makefile
@@ -9,3 +9,6 @@ ES_BEATS?=../../
 #
 include $(ES_BEATS)/dev-tools/make/xpack.mk
 
+.PHONY:
+test-gcp-functions:
+	mage testGCPFunctions

--- a/x-pack/functionbeat/Makefile
+++ b/x-pack/functionbeat/Makefile
@@ -9,6 +9,6 @@ ES_BEATS?=../../
 #
 include $(ES_BEATS)/dev-tools/make/xpack.mk
 
-.PHONY:
-test-gcp-functions:
+.PHONY: test-gcp-functions
+test-gcp-functions: mage
 	mage testGCPFunctions

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -185,7 +185,7 @@ func BuildPkgForFunctions() error {
 	return nil
 }
 
-// TestGCPFunctions are used by Travis to test if the GCP functions can be built with
+// TestGCPFunctions are used by the CI to test if the GCP functions can be built with
 // the selected Go version.
 // The version is 1.13.1 (Ref: https://cloud.google.com/functions/docs/concepts/go-runtime)
 func TestGCPFunctions() error {

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -185,6 +185,29 @@ func BuildPkgForFunctions() error {
 	return nil
 }
 
+// TestGCPFunctions are used by Travis to test if the GCP functions can be built with
+// the selected Go version.
+// The version is 1.13.1 (Ref: https://cloud.google.com/functions/docs/concepts/go-runtime)
+func TestGCPFunctions() error {
+	for _, f := range []string{"pubsub", "storage"} {
+		params := devtools.DefaultBuildArgs()
+		inputFiles := filepath.Join("provider", "gcp", f, f+".go")
+		params.InputFiles = []string{inputFiles}
+		params.Name = f
+		params.CGO = false
+		params.Env = map[string]string{
+			"GOOS":   "linux",
+			"GOARCH": "amd64",
+		}
+
+		err := devtools.Build(params)
+		if err != nil {
+			return fmt.Errorf("error while building %s for GCP: %+v", f, err)
+		}
+	}
+	return nil
+}
+
 // BuildSystemTestBinary build a binary for testing that is instrumented for
 // testing and measuring code coverage. The binary is only instrumented for
 // coverage when TEST_COVERAGE=true (default is false).

--- a/x-pack/functionbeat/manager/gcp/template_builder.go
+++ b/x-pack/functionbeat/manager/gcp/template_builder.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	runtime          = "go111"                            // Golang 1.11
+	runtime          = "go113"                            // Golang 1.11
 	archiveURL       = "gs://%s/%s"                       // path to the function archive
 	locationTemplate = "projects/%s/locations/%s"         // full name of the location
 	functionName     = locationTemplate + "/functions/%s" // full name of the functions

--- a/x-pack/functionbeat/manager/gcp/template_builder.go
+++ b/x-pack/functionbeat/manager/gcp/template_builder.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	runtime          = "go113"                            // Golang 1.11
+	runtime          = "go113"                            // Golang 1.13
 	archiveURL       = "gs://%s/%s"                       // path to the function archive
 	locationTemplate = "projects/%s/locations/%s"         // full name of the location
 	functionName     = locationTemplate + "/functions/%s" // full name of the functions


### PR DESCRIPTION
## What does this PR do?

This PR changes the runtime of Google Cloud Functions provided by Functionbeat to 1.13.1. Furthermore, a test is added to Travis CI to check if the cloud functions can be built using Go 1.13.1.

~~One of the limitations of this PR is that no check is added to Jenkins yet.~~

## Why is it important?

Previously, we had no check to catch if we had broken something in the GCP functions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~


## Related issues

- Closes #16827
