### PR TITLE
Cherry-pick #17121 to 7.x: [Filebeat] return error when expand_event_list_from_field is missing

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -64,6 +64,8 @@ are in JSON format and events are found under the JSON object "Records".
 Note: When `expand_event_list_from_field` parameter is given in the config, s3
 input will assume the logs are in JSON format and decode them as JSON. Content
 type will not be checked.
+If a file has "application/json" content-type, `expand_event_list_from_field`
+becomes required to read the json file.
 
 [float]
 ==== `api_timeout`


### PR DESCRIPTION
Cherry-pick of PR #17121 to 7.x branch. Original message: 

## What does this PR do?

This PR is to improve s3 input error when `expand_event_list_from_field` for `application/json` content-type files, such as cloudtrail logs.

## Why is it important?

This problem only happens if user is trying to collect `application/json` content-type files such as cloudtrail logs, but not using cloudtrail fileset. It's good to add the error message there for user to see why log is not being processed by Filebeat. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Collect cloudtrail logs first. Instead of using cloudtrail fileset, use s3 input directly with filebeat.yml config like:
```
filebeat.inputs:
- type: s3
  queue_url:   https://sqs.us-east-1.amazonaws.com/428152502467/test-fb-ks
  credential_profile_name: elastic-beats
```

This should return error when trying to read cloudtrail log:
```
2020-03-19T10:57:08.897-0600    ERROR   [s3]    s3/input.go:434 expand_event_list_from_field parameter is missing in config for application/json content-type file
2020-03-19T10:57:08.897-0600    ERROR   [s3]    s3/input.go:387 createEventsFromS3Info failed for AWSLogs/428152502467/CloudTrail/us-east-2/2019/12/19/428152502467_CloudTrail_us-east-2_20191219T1655Z_WXCas1PVnOaTpABD.json.gz: expand_event_list_from_field parameter is missing in config for application/json content-type file
```

## Related issues

- Closes https://github.com/elastic/beats/issues/16374