### PR TITLE
Recommend `remote_write` instead of federate API

### DIFF
--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -27,6 +27,13 @@ to retrieve the metrics from (`/metrics` by default) can be configured with `met
 [float]
 === Scraping all metrics from a Prometheus server
 
+[WARNING]
+=======================================
+Depending on your scale this method may not be suitable. We recommend using the
+<<metricbeat-metricset-prometheus-remote_write,remote_write>> metricset for this,
+and make Prometheus push metrics to Metricbeat.
+=======================================
+
 This module can scrape all metrics stored in a Prometheus server, by using the
 https://prometheus.io/docs/prometheus/latest/federation/[federation API]. By pointing this
 config to the Prometheus server:


### PR DESCRIPTION
Update docs to recommend using `remote_write` over the federate API to obtain metrics from a Prometheus server. Remote write should be more robust as the federate API is not really intended for this use.