### PR TITLE
Cherry-pick #17194 to 7.x: Add dashboards for the azure container metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -339,6 +339,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release ActiveMQ module as GA. {issue}17047[17047] {pull}17049[17049]
 - Add support for CouchDB v2 {issue}16352[16352] {pull}16455[16455]
 - Release Zookeeper/connection module as GA. {issue}14281[14281] {pull}17043[17043]
+- Add dashboards for the azure container metricsets. {pull}17194[17194]
 - Replace vpc metricset into vpn, transitgateway and natgateway metricsets. {pull}16892[16892]
 - Release Oracle module as GA. {issue}14279[14279] {pull}16833[16833]
 

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-instance-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-instance-overview.json
@@ -1,0 +1,571 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "This dashboard shows metrics for the container instances in Azure.",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 5,
+                            "i": "c3f93abd-4a7c-43fa-bde7-d26925082d2f",
+                            "w": 11,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "panelIndex": "c3f93abd-4a7c-43fa-bde7-d26925082d2f",
+                        "panelRefName": "panel_0",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Instance CPU Utilization"
+                        },
+                        "gridData": {
+                            "h": 16,
+                            "i": "ea4c505b-43fb-4869-a94a-bba028071ecc",
+                            "w": 17,
+                            "x": 11,
+                            "y": 0
+                        },
+                        "panelIndex": "ea4c505b-43fb-4869-a94a-bba028071ecc",
+                        "panelRefName": "panel_1",
+                        "title": "Container Instance CPU Utilization",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Instance Memory Utilization"
+                        },
+                        "gridData": {
+                            "h": 16,
+                            "i": "0899027b-629e-4889-821f-45ee0161bd91",
+                            "w": 20,
+                            "x": 28,
+                            "y": 0
+                        },
+                        "panelIndex": "0899027b-629e-4889-821f-45ee0161bd91",
+                        "panelRefName": "panel_2",
+                        "title": "Container Instance Memory Utilization",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Containers Filters"
+                        },
+                        "gridData": {
+                            "h": 11,
+                            "i": "f72bd066-3696-4e0a-9660-78fb47c92152",
+                            "w": 11,
+                            "x": 0,
+                            "y": 5
+                        },
+                        "panelIndex": "f72bd066-3696-4e0a-9660-78fb47c92152",
+                        "panelRefName": "panel_3",
+                        "title": "Containers Filters",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Instance Netowrk Bytes Received/s"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "7c9016b9-a76e-41f6-9945-ac6880fd9ab0",
+                            "w": 24,
+                            "x": 0,
+                            "y": 16
+                        },
+                        "panelIndex": "7c9016b9-a76e-41f6-9945-ac6880fd9ab0",
+                        "panelRefName": "panel_4",
+                        "title": "Container Instance Netowrk Bytes Received/s",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Instance Network Bytes Transmitted/s"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "0abdf4ee-b569-430b-972a-a60160ef2221",
+                            "w": 24,
+                            "x": 24,
+                            "y": 16
+                        },
+                        "panelIndex": "0abdf4ee-b569-430b-972a-a60160ef2221",
+                        "panelRefName": "panel_5",
+                        "title": "Container Instance Network Bytes Transmitted/s",
+                        "version": "7.6.0"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat Azure] Container Instance Overview",
+                "version": 1
+            },
+            "id": "9c11ac60-6cf6-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "dashboard": "7.3.0"
+            },
+            "references": [
+                {
+                    "id": "5720b830-6aad-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_0",
+                    "type": "visualization"
+                },
+                {
+                    "id": "04f8eec0-6ab1-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_1",
+                    "type": "visualization"
+                },
+                {
+                    "id": "942844b0-6ac5-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_2",
+                    "type": "visualization"
+                },
+                {
+                    "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_3",
+                    "type": "visualization"
+                },
+                {
+                    "id": "bd1c93b0-6cf7-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_4",
+                    "type": "visualization"
+                },
+                {
+                    "id": "74a8e130-6cfa-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_5",
+                    "type": "visualization"
+                }
+            ],
+            "type": "dashboard",
+            "updated_at": "2020-03-24T13:44:34.832Z",
+            "version": "WzY1MzIsN10="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Navigation Container Instance Overview [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "### Azure Containers\n\n[**Instances**](#/dashboard/9c11ac60-6cf6-11ea-8fe8-71add5fd7c38) |\n[Registries](#/dashboard/6f2393f0-6d08-11ea-8fe8-71add5fd7c38) |\n[Services](#/dashboard/dae20ed0-6d0a-11ea-8fe8-71add5fd7c38) ",
+                        "openLinksInNewTab": false
+                    },
+                    "title": "Navigation Container Instance Overview [Metricbeat Azure]",
+                    "type": "markdown"
+                }
+            },
+            "id": "5720b830-6aad-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T19:02:37.594Z",
+            "version": "WzY0NDQsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Instance CPU Utilization [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerInstance/containerGroups\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(164,221,0,1)",
+                                "fill": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Azure Container CPU Utilization",
+                                "line_width": "2",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_instance.cpu_usage.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Instance CPU Utilization [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "04f8eec0-6ab1-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T11:39:04.001Z",
+            "version": "WzU5NjYsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Instance Memory Utilization [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_min": "0",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerInstance/containerGroups\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "filter": {
+                                    "language": "kuery",
+                                    "query": ""
+                                },
+                                "formatter": "bytes",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Instance Memory Utilization",
+                                "line_width": "2",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_instance.memory_usage.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Instance Memory Utilization [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "942844b0-6ac5-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T11:40:55.708Z",
+            "version": "WzU5NzEsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Containers Filters [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "azure.subscription_id",
+                                "id": "1584710440054",
+                                "indexPatternRefName": "control_0_index_pattern",
+                                "label": "Subscription",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "azure.resource.group",
+                                "id": "1584710497045",
+                                "indexPatternRefName": "control_1_index_pattern",
+                                "label": "Resource Group",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "cloud.instance.name",
+                                "id": "1584710535722",
+                                "indexPatternRefName": "control_2_index_pattern",
+                                "label": "Resource",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            }
+                        ],
+                        "pinFilters": false,
+                        "updateFiltersOnChange": true,
+                        "useTimeFilter": false
+                    },
+                    "title": "Containers Filters [Metricbeat Azure]",
+                    "type": "input_control_vis"
+                }
+            },
+            "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_0_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_1_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_2_index_pattern",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:32:43.461Z",
+            "version": "WzY0MDAsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Instance Network Bytes Received/s [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_min": "0",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerInstance/containerGroups\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(251,158,0,1)",
+                                "fill": "0",
+                                "filter": {
+                                    "language": "kuery",
+                                    "query": ""
+                                },
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Instance Network Bytes Received/s",
+                                "line_width": "2",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_instance.network_bytes_received_per_second.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Instance Network Bytes Received/s [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "bd1c93b0-6cf7-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:22:21.233Z",
+            "version": "WzYyODUsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Instance Network Bytes Transmitted/s [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_min": "0",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerInstance/containerGroups\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(128,137,0,1)",
+                                "fill": "0",
+                                "filter": {
+                                    "language": "kuery",
+                                    "query": ""
+                                },
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Instance Network Bytes Transmitted/s",
+                                "line_width": "2",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_instance.network_bytes_transmitted_per_second.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Instance Network Bytes Transmitted/s [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "74a8e130-6cfa-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:23:04.729Z",
+            "version": "WzYyOTMsNV0="
+        }
+    ],
+    "version": "7.6.0"
+}

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-registry-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-registry-overview.json
@@ -1,0 +1,556 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "This dashboard shows metrics for the container registry in Azure.",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 5,
+                            "i": "51fee31f-97e1-4f8e-aeb2-daeca1ccf9be",
+                            "w": 9,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "panelIndex": "51fee31f-97e1-4f8e-aeb2-daeca1ccf9be",
+                        "panelRefName": "panel_0",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Registry Successful Pull Count"
+                        },
+                        "gridData": {
+                            "h": 16,
+                            "i": "dde974c7-6d81-4580-9b7f-c7a999ecc19e",
+                            "w": 18,
+                            "x": 9,
+                            "y": 0
+                        },
+                        "panelIndex": "dde974c7-6d81-4580-9b7f-c7a999ecc19e",
+                        "panelRefName": "panel_1",
+                        "title": "Container Registry Successful Pull Count",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Registry Successful Push Count"
+                        },
+                        "gridData": {
+                            "h": 16,
+                            "i": "25a02616-f735-494a-97f7-4a56531e9e5e",
+                            "w": 21,
+                            "x": 27,
+                            "y": 0
+                        },
+                        "panelIndex": "25a02616-f735-494a-97f7-4a56531e9e5e",
+                        "panelRefName": "panel_2",
+                        "title": "Container Registry Successful Push Count",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Containers Filters"
+                        },
+                        "gridData": {
+                            "h": 11,
+                            "i": "ec183a66-545b-4a67-bfb4-568def660612",
+                            "w": 9,
+                            "x": 0,
+                            "y": 5
+                        },
+                        "panelIndex": "ec183a66-545b-4a67-bfb4-568def660612",
+                        "panelRefName": "panel_3",
+                        "title": "Containers Filters",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Registry Total Pull Count"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "7f508c43-afd7-4874-86ef-c6976700759b",
+                            "w": 24,
+                            "x": 0,
+                            "y": 16
+                        },
+                        "panelIndex": "7f508c43-afd7-4874-86ef-c6976700759b",
+                        "panelRefName": "panel_4",
+                        "title": "Container Registry Total Pull Count",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Registry Total Push Count"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "97a048da-9b56-420b-af8c-1f0d568f0f94",
+                            "w": 24,
+                            "x": 24,
+                            "y": 16
+                        },
+                        "panelIndex": "97a048da-9b56-420b-af8c-1f0d568f0f94",
+                        "panelRefName": "panel_5",
+                        "title": "Container Registry Total Push Count",
+                        "version": "7.6.0"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat Azure] Container Registry Overview",
+                "version": 1
+            },
+            "id": "6f2393f0-6d08-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "dashboard": "7.3.0"
+            },
+            "references": [
+                {
+                    "id": "1e70dc50-6d22-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_0",
+                    "type": "visualization"
+                },
+                {
+                    "id": "7972b260-6d07-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_1",
+                    "type": "visualization"
+                },
+                {
+                    "id": "b88b7f90-6d07-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_2",
+                    "type": "visualization"
+                },
+                {
+                    "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_3",
+                    "type": "visualization"
+                },
+                {
+                    "id": "ff303710-6d07-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_4",
+                    "type": "visualization"
+                },
+                {
+                    "id": "ddea7430-6d07-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_5",
+                    "type": "visualization"
+                }
+            ],
+            "type": "dashboard",
+            "updated_at": "2020-03-24T13:49:52.134Z",
+            "version": "WzY1NDUsN10="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Navigation Container Registry Overview [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "### Azure Containers\n\n[Instances](#/dashboard/9c11ac60-6cf6-11ea-8fe8-71add5fd7c38) |\n[**Registries**](#/dashboard/6f2393f0-6d08-11ea-8fe8-71add5fd7c38) |\n[Services](#/dashboard/dae20ed0-6d0a-11ea-8fe8-71add5fd7c38) ",
+                        "openLinksInNewTab": false
+                    },
+                    "title": "Navigation Container Registry Overview [Metricbeat Azure]",
+                    "type": "markdown"
+                }
+            },
+            "id": "1e70dc50-6d22-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:59:05.580Z",
+            "version": "WzY0MjksNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Registry Successful Pull Count [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerRegistry/registries\" "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(188,74,0,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Registry Successful Pull Count",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_registry.successful_pull_count.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Registry Successful Pull Count [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "7972b260-6d07-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:26:30.797Z",
+            "version": "WzYzMTEsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Registry Successful Push Count [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerRegistry/registries\" "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(128,137,0,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Registry Successful Push Count",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_registry.successful_push_count.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Registry Successful Push Count [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "b88b7f90-6d07-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:27:11.947Z",
+            "version": "WzYzMTgsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Containers Filters [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "azure.subscription_id",
+                                "id": "1584710440054",
+                                "indexPatternRefName": "control_0_index_pattern",
+                                "label": "Subscription",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "azure.resource.group",
+                                "id": "1584710497045",
+                                "indexPatternRefName": "control_1_index_pattern",
+                                "label": "Resource Group",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "cloud.instance.name",
+                                "id": "1584710535722",
+                                "indexPatternRefName": "control_2_index_pattern",
+                                "label": "Resource",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            }
+                        ],
+                        "pinFilters": false,
+                        "updateFiltersOnChange": true,
+                        "useTimeFilter": false
+                    },
+                    "title": "Containers Filters [Metricbeat Azure]",
+                    "type": "input_control_vis"
+                }
+            },
+            "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_0_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_1_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_2_index_pattern",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:32:43.461Z",
+            "version": "WzY0MDAsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Registry Total Pull Count [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerRegistry/registries\" "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(254,146,0,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Registry Total Pull Count",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_registry.total_pull_count.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Registry Total Pull Count [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "ff303710-6d07-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T13:13:17.642Z",
+            "version": "WzYwNDQsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Registry Total Push Count [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerRegistry/registries\" "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(252,196,0,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Registry Total Push Count",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_registry.total_push_count.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Registry Total Push Count [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "ddea7430-6d07-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T13:12:37.912Z",
+            "version": "WzYwMzYsNV0="
+        }
+    ],
+    "version": "7.6.0"
+}

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-service-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-container-service-overview.json
@@ -1,0 +1,822 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "This dashboard shows metrics for the container service in Azure.",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {
+                            "title": ""
+                        },
+                        "gridData": {
+                            "h": 5,
+                            "i": "32b4e6e2-bf3f-4c4a-8fdb-925f21f9d22b",
+                            "w": 9,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "panelIndex": "32b4e6e2-bf3f-4c4a-8fdb-925f21f9d22b",
+                        "panelRefName": "panel_0",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Service Kube Node Status Allocatable Memory"
+                        },
+                        "gridData": {
+                            "h": 17,
+                            "i": "c35d3d89-2f34-43a0-b346-85ba0e7c9e89",
+                            "w": 18,
+                            "x": 9,
+                            "y": 0
+                        },
+                        "panelIndex": "c35d3d89-2f34-43a0-b346-85ba0e7c9e89",
+                        "panelRefName": "panel_1",
+                        "title": "Container Service Kube Node Status Allocatable Memory",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Service Kube Node Status Allocatable CPU Cores"
+                        },
+                        "gridData": {
+                            "h": 17,
+                            "i": "e1952edf-ed31-49ee-8db1-24370998ab89",
+                            "w": 21,
+                            "x": 27,
+                            "y": 0
+                        },
+                        "panelIndex": "e1952edf-ed31-49ee-8db1-24370998ab89",
+                        "panelRefName": "panel_2",
+                        "title": "Container Service Kube Node Status Allocatable CPU Cores",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Filters"
+                        },
+                        "gridData": {
+                            "h": 12,
+                            "i": "ec183a66-545b-4a67-bfb4-568def660612",
+                            "w": 9,
+                            "x": 0,
+                            "y": 5
+                        },
+                        "panelIndex": "ec183a66-545b-4a67-bfb4-568def660612",
+                        "panelRefName": "panel_3",
+                        "title": "Container Filters",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Service Kube Pod Status Phase"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "ada37452-619f-470a-b9cd-bafa20e7d7b1",
+                            "w": 24,
+                            "x": 0,
+                            "y": 17
+                        },
+                        "panelIndex": "ada37452-619f-470a-b9cd-bafa20e7d7b1",
+                        "panelRefName": "panel_4",
+                        "title": "Container Service Kube Pod Status Phase",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Service Kube Pod Status Ready"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "c8d3ed1a-6e72-4115-9a69-db1919a36fc4",
+                            "w": 24,
+                            "x": 24,
+                            "y": 17
+                        },
+                        "panelIndex": "c8d3ed1a-6e72-4115-9a69-db1919a36fc4",
+                        "panelRefName": "panel_5",
+                        "title": "Container Service Kube Pod Status Ready",
+                        "version": "7.6.0"
+                    },
+                    {
+                        "embeddableConfig": {
+                            "title": "Container Service Kube Node Status Condition"
+                        },
+                        "gridData": {
+                            "h": 15,
+                            "i": "707fb714-99af-4484-a56e-bfecdf592c58",
+                            "w": 48,
+                            "x": 0,
+                            "y": 32
+                        },
+                        "panelIndex": "707fb714-99af-4484-a56e-bfecdf592c58",
+                        "panelRefName": "panel_6",
+                        "title": "Container Service Kube Node Status Condition",
+                        "version": "7.6.0"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat Azure] Container Service Overview",
+                "version": 1
+            },
+            "id": "dae20ed0-6d0a-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "dashboard": "7.3.0"
+            },
+            "references": [
+                {
+                    "id": "3630b9a0-6d22-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_0",
+                    "type": "visualization"
+                },
+                {
+                    "id": "eda368d0-6d1d-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_1",
+                    "type": "visualization"
+                },
+                {
+                    "id": "6e2d9930-6d1e-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_2",
+                    "type": "visualization"
+                },
+                {
+                    "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+                    "name": "panel_3",
+                    "type": "visualization"
+                },
+                {
+                    "id": "bda7b580-6d1f-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_4",
+                    "type": "visualization"
+                },
+                {
+                    "id": "c19586f0-6d1e-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_5",
+                    "type": "visualization"
+                },
+                {
+                    "id": "e79211c0-6d37-11ea-8fe8-71add5fd7c38",
+                    "name": "panel_6",
+                    "type": "visualization"
+                }
+            ],
+            "type": "dashboard",
+            "updated_at": "2020-03-24T13:52:52.325Z",
+            "version": "WzY1NTAsN10="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Navigation Container Service Overview [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "### Azure Containers\n\n[Instances](#/dashboard/9c11ac60-6cf6-11ea-8fe8-71add5fd7c38) |\n[Registries](#/dashboard/6f2393f0-6d08-11ea-8fe8-71add5fd7c38) |\n[**Services**](#/dashboard/dae20ed0-6d0a-11ea-8fe8-71add5fd7c38) ",
+                        "openLinksInNewTab": false
+                    },
+                    "title": "Navigation Container Service Overview [Metricbeat Azure]",
+                    "type": "markdown"
+                }
+            },
+            "id": "3630b9a0-6d22-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:35:29.015Z",
+            "version": "WzY0MTEsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Service Kube Node Status Allocatable Memory Bytes [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerService/managedClusters\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(176,188,0,1)",
+                                "fill": "0",
+                                "formatter": "bytes",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Service Kube Node Status Allocatable Memory Bytes",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_service.kube_node_status_allocatable_memory_bytes.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Service Kube Node Status Allocatable Memory Bytes [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "eda368d0-6d1d-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:07:52.221Z",
+            "version": "WzYxOTMsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Service Kube Node Status Allocatable CPU Cores [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerService/managedClusters\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(196,81,0,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Service Kube Node Status Allocatable CPU Cores",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_service.kube_node_status_allocatable_cpu_cores.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.name",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Service Kube Node Status Allocatable CPU Cores [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "6e2d9930-6d1e-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:09:00.844Z",
+            "version": "WzYyMDMsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Containers Filters [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "azure.subscription_id",
+                                "id": "1584710440054",
+                                "indexPatternRefName": "control_0_index_pattern",
+                                "label": "Subscription",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "azure.resource.group",
+                                "id": "1584710497045",
+                                "indexPatternRefName": "control_1_index_pattern",
+                                "label": "Resource Group",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "cloud.instance.name",
+                                "id": "1584710535722",
+                                "indexPatternRefName": "control_2_index_pattern",
+                                "label": "Resource",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": false,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            }
+                        ],
+                        "pinFilters": false,
+                        "updateFiltersOnChange": true,
+                        "useTimeFilter": false
+                    },
+                    "title": "Containers Filters [Metricbeat Azure]",
+                    "type": "input_control_vis"
+                }
+            },
+            "id": "0fa31060-6aae-11ea-af5c-73e8f396b3e9",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_0_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_1_index_pattern",
+                    "type": "index-pattern"
+                },
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_2_index_pattern",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:32:43.461Z",
+            "version": "WzY0MDAsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Service Kube Pod Status Phase [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "0d772fb0-6d1f-11ea-a156-a582cfb250e8"
+                            }
+                        ],
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerService/managedClusters\"  "
+                        },
+                        "gauge_color_rules": [
+                            {
+                                "id": "0ba507c0-6d1f-11ea-a156-a582cfb250e8"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(240,213,175,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Container Service Kube Pod Status Phase",
+                                "line_width": "2",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_service.kube_pod_status_phase.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "00",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "azure.dimensions.pod"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Service Kube Pod Status Phase [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "bda7b580-6d1f-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:06:42.759Z",
+            "version": "WzYxODUsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Container Service Kube Pod Status Ready [Metricbeat Azure]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "default_index_pattern": "filebeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": {
+                            "language": "kuery",
+                            "query": "azure.resource.type : \"Microsoft.ContainerService/managedClusters\"  "
+                        },
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "\u003e=5m",
+                        "isModelInvalid": false,
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(200,205,124,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "",
+                                "line_width": "02",
+                                "metrics": [
+                                    {
+                                        "field": "azure.container_service.kube_pod_status_ready.avg",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "",
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "azure.dimensions.pod",
+                                "type": "timeseries"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Container Service Kube Pod Status Ready [Metricbeat Azure]",
+                    "type": "metrics"
+                }
+            },
+            "id": "c19586f0-6d1e-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2020-03-23T16:05:32.621Z",
+            "version": "WzYxODEsNV0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
+                    }
+                },
+                "title": "Container Service Kube Node Status Condition [Metricbeat Azure]",
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 0.2": "rgb(165,0,38)",
+                            "0.2 - 0.4": "rgb(244,109,67)",
+                            "0.4 - 0.6": "rgb(254,224,139)",
+                            "0.6 - 0.8": "rgb(217,239,139)",
+                            "0.8 - 1": "rgb(102,189,99)"
+                        },
+                        "legendOpen": true
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "field": "azure.container_service.kube_node_status_condition.avg"
+                            },
+                            "schema": "metric",
+                            "type": "avg"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "filters": [
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"Ready\"  and azure.dimensions.status : \"true\" "
+                                        },
+                                        "label": "Ready \"true\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"Ready\"  and azure.dimensions.status : \"false\"  "
+                                        },
+                                        "label": "Ready \"false\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"NetworkUnavailable\"  and azure.dimensions.status : \"true\"    "
+                                        },
+                                        "label": "Network Unavailable \"true\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"NetworkUnavailable\"  and azure.dimensions.status : \"false\"     "
+                                        },
+                                        "label": "NetworkUnavailable  \"false\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"OutOfDisk\"  and azure.dimensions.status : \"false\" "
+                                        },
+                                        "label": "OutOfDisk \"false\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"OutOfDisk\"  and azure.dimensions.status : \"true\"  "
+                                        },
+                                        "label": "OutOfDisk \"true\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"MemoryPressure\"  and azure.dimensions.status : \"true\"  "
+                                        },
+                                        "label": "MemoryPressure \"true\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"MemoryPressure\"  and azure.dimensions.status : \"false\"   "
+                                        },
+                                        "label": "MemoryPressure \"false\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"DiskPressure\"  and azure.dimensions.status : \"false\"   "
+                                        },
+                                        "label": "DiskPressure \"false\""
+                                    },
+                                    {
+                                        "input": {
+                                            "language": "kuery",
+                                            "query": "azure.dimensions.condition : \"DiskPressure\"  and azure.dimensions.status : \"true\"    "
+                                        },
+                                        "label": "DiskPressure \"true\""
+                                    }
+                                ]
+                            },
+                            "schema": "segment",
+                            "type": "filters"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "azure.dimensions.node",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 10
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "colorSchema": "Green to Red",
+                        "colorsNumber": 5,
+                        "colorsRange": [
+                            {
+                                "from": 0,
+                                "to": 10
+                            }
+                        ],
+                        "dimensions": {
+                            "series": [
+                                {
+                                    "accessor": 1,
+                                    "aggType": "terms",
+                                    "format": {
+                                        "id": "terms",
+                                        "params": {
+                                            "id": "string",
+                                            "missingBucketLabel": "Missing",
+                                            "otherBucketLabel": "Other",
+                                            "parsedUrl": {
+                                                "basePath": "",
+                                                "origin": "http://localhost:5601",
+                                                "pathname": "/app/kibana"
+                                            }
+                                        }
+                                    },
+                                    "label": "azure.dimensions.node: Descending",
+                                    "params": {}
+                                }
+                            ],
+                            "x": {
+                                "accessor": 0,
+                                "aggType": "filters",
+                                "format": {},
+                                "label": "filters",
+                                "params": {}
+                            },
+                            "y": [
+                                {
+                                    "accessor": 2,
+                                    "aggType": "avg",
+                                    "format": {
+                                        "id": "number",
+                                        "params": {
+                                            "parsedUrl": {
+                                                "basePath": "",
+                                                "origin": "http://localhost:5601",
+                                                "pathname": "/app/kibana"
+                                            }
+                                        }
+                                    },
+                                    "label": "Average azure.container_service.kube_node_status_condition.avg",
+                                    "params": {}
+                                }
+                            ]
+                        },
+                        "enableHover": false,
+                        "invertColors": true,
+                        "legendPosition": "right",
+                        "percentageMode": false,
+                        "setColorRange": false,
+                        "times": [],
+                        "type": "heatmap",
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1",
+                                "labels": {
+                                    "color": "black",
+                                    "overwriteColor": false,
+                                    "rotate": 0,
+                                    "show": false
+                                },
+                                "scale": {
+                                    "defaultYExtents": false,
+                                    "type": "linear"
+                                },
+                                "show": false,
+                                "type": "value"
+                            }
+                        ]
+                    },
+                    "title": "Container Service Kube Node Status Condition [Metricbeat Azure]",
+                    "type": "heatmap"
+                }
+            },
+            "id": "e79211c0-6d37-11ea-8fe8-71add5fd7c38",
+            "migrationVersion": {
+                "visualization": "7.4.2"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2020-03-23T18:55:46.396Z",
+            "version": "WzY0MjAsNV0="
+        }
+    ],
+    "version": "7.6.0"
+}

--- a/x-pack/metricbeat/module/azure/container_service/manifest.yml
+++ b/x-pack/metricbeat/module/azure/container_service/manifest.yml
@@ -12,19 +12,39 @@ input:
         namespace: "Microsoft.ContainerService/managedClusters"
         timegrain: "PT5M"
         dimensions:
+        - name: "node"
+          value: "*"
         - name: "status"
           value: "*"
-      - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes", "kube_pod_status_ready", "kube_pod_status_phase"]
+        - name: "condition"
+          value: "*"
+      - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes"]
         namespace: "Microsoft.ContainerService/managedClusters"
         timegrain: "PT5M"
+      - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+        namespace: "Microsoft.ContainerService/managedClusters"
+        timegrain: "PT5M"
+        dimensions:
+        - name: "pod"
+          value: "*"
     - resource_id: ""
       metrics:
       - name: ["kube_node_status_condition"]
         namespace: "Microsoft.ContainerService/managedClusters"
         timegrain: "PT5M"
         dimensions:
+        - name: "node"
+          value: "*"
         - name: "status"
           value: "*"
-      - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes", "kube_pod_status_ready", "kube_pod_status_phase"]
+        - name: "condition"
+          value: "*"
+      - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes"]
         namespace: "Microsoft.ContainerService/managedClusters"
         timegrain: "PT5M"
+      - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+        namespace: "Microsoft.ContainerService/managedClusters"
+        timegrain: "PT5M"
+        dimensions:
+        - name: "pod"
+          value: "*"


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17194 to 7.x branch. Original message:

Adding dashboards for the container_service, container_instance and container_registry azure metricsets:

![image](https://user-images.githubusercontent.com/1900090/77404385-f0835800-6db1-11ea-94fa-7bf0b1e3efd7.png)

![image](https://user-images.githubusercontent.com/1900090/77404530-27f20480-6db2-11ea-9b0c-84d82b4cebb0.png)

![image](https://user-images.githubusercontent.com/1900090/77404584-41934c00-6db2-11ea-95bc-ed3f940959f1.png)

