### PR TITLE
Cherry-pick #17220 to 7.6: Fix CEF processor mapping exception

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix s3 input with cloudtrail fileset reading json file. {issue}16374[16374] {pull}16441[16441]
 - Add queue_url definition in manifest file for aws module. {pull}16640{16640}
+- Fixed a mapping exception when ingesting CEF logs that used the spriv or dpriv extensions. {issue}17216[17216] {pull}17220[17220]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cef/log/test/cef.log
+++ b/x-pack/filebeat/module/cef/log/test/cef.log
@@ -1,1 +1,2 @@
 CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Web request|low|eventId=3457 requestMethod=POST slat=38.915 slong=-77.511 proto=TCP sourceServiceName=httpd requestContext=https://www.google.com src=6.7.8.9 spt=33876 dst=192.168.10.1 dpt=443 request=https://www.example.com/cart
+CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|spriv=user dpriv=root

--- a/x-pack/filebeat/module/cef/log/test/cef.log-expected.json
+++ b/x-pack/filebeat/module/cef/log/test/cef.log-expected.json
@@ -50,5 +50,34 @@
             "cef"
         ],
         "url.original": "https://www.example.com/cart"
+    },
+    {
+        "cef.device.event_class_id": "18",
+        "cef.device.product": "Vaporware",
+        "cef.device.vendor": "Elastic",
+        "cef.device.version": "1.0.0-alpha",
+        "cef.extensions.destinationUserPrivileges": "root",
+        "cef.extensions.sourceUserPrivileges": "user",
+        "cef.name": "Authentication",
+        "cef.severity": "low",
+        "cef.version": "0",
+        "destination.user.group.name": "root",
+        "event.code": "18",
+        "event.dataset": "cef.log",
+        "event.module": "cef",
+        "event.original": "CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|spriv=user dpriv=root",
+        "event.severity": 0,
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.offset": 269,
+        "message": "Authentication",
+        "observer.product": "Vaporware",
+        "observer.vendor": "Elastic",
+        "observer.version": "1.0.0-alpha",
+        "service.type": "cef",
+        "source.user.group.name": "user",
+        "tags": [
+            "cef"
+        ]
     }
 ]

--- a/x-pack/filebeat/processors/decode_cef/keys.ecs.go
+++ b/x-pack/filebeat/processors/decode_cef/keys.ecs.go
@@ -45,7 +45,7 @@ var ecsExtensionMapping = map[string]mappedField{
 	"destinationTranslatedPort":    {Target: "destination.nat.port"},
 	"destinationUserId":            {Target: "destination.user.id"},
 	"destinationUserName":          {Target: "destination.user.name"},
-	"destinationUserPrivileges":    {Target: "destination.user.group"},
+	"destinationUserPrivileges":    {Target: "destination.user.group.name"},
 	"deviceAction":                 {Target: "event.action"},
 	"deviceAddress":                {Target: "observer.ip"},
 	"deviceDirection": {
@@ -108,7 +108,7 @@ var ecsExtensionMapping = map[string]mappedField{
 	"sourceTranslatedPort":    {Target: "source.nat.port"},
 	"sourceUserId":            {Target: "source.user.id"},
 	"sourceUserName":          {Target: "source.user.name"},
-	"sourceUserPrivileges":    {Target: "source.user.group"},
+	"sourceUserPrivileges":    {Target: "source.user.group.name"},
 	"startTime":               {Target: "event.start"},
 	"transportProtocol": {
 		Target: "network.transport",


### PR DESCRIPTION
Cherry-pick of PR #17220 to 7.6 branch. Original message: 

Extensions `spriv`/`dpriv` were mapped to `{source|destination}.user.group` instead of `{source|destination}.user.group.name`.

This caused a mapping exception when attempting to ingest CEF logs that used those extensions.

Fixes #17216

## What does this PR do?

Fixes the CEF decoder mapping of `spriv`/`dpriv` extensions to {source|destination}.user.group` instead of `{source|destination}.user.group.name`.

## Why is it important?

This caused a mapping exception when attempting to ingest CEF logs that used those extensions.

## Checklist


- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

Fixes #17216
