### PR TITLE
Cherry-pick #17198 to 7.x: Update redis dependency as output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -212,6 +212,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `translate_sid` processor on Windows for converting Windows security identifier (SID) values to names. {issue}7451[7451] {pull}16013[16013]
 - Update RPM packages contained in Beat Docker images. {issue}17035[17035]
 - Add Kerberos support to Kafka input and output. {pull}16781[16781]
+- Update supported versions of `redis` output. {pull}17198[17198]
 
 *Auditbeat*
 

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -23,7 +23,8 @@ output.redis:
 
 ==== Compatibility
 
-This output works with Redis 3.2.4.
+This output is expected to work with all Redis versions between 5.0.8 and 3.2.4. Other versions might work as well,
+but are not supported.
 
 ==== Configuration options
 

--- a/testing/environments/docker/redis/Dockerfile
+++ b/testing/environments/docker/redis/Dockerfile
@@ -1,2 +1,2 @@
-FROM redis:3.2.4-alpine
+FROM redis:5.0.8-alpine
 HEALTHCHECK --interval=1s --retries=600 CMD nc -z localhost 6379


### PR DESCRIPTION
Cherry-pick of PR #17198 to 7.x branch. Original message: 

This PR verifies if `redis` dependency can be updated, which means that the `libbeat` output supported versions can be adjusted accordingly.