### PR TITLE
Cherry-pick #17193 to 7.7: dev-tools/mage: fix build date/commit embedding

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -54,13 +54,13 @@ func DefaultBuildArgs() BuildArgs {
 			"-s", // Strip all debug symbols from binary (does not affect Go stack traces).
 		},
 		Vars: map[string]string{
-			"github.com/elastic/beats/libbeat/version.buildTime": "{{ date }}",
-			"github.com/elastic/beats/libbeat/version.commit":    "{{ commit }}",
+			elasticBeatsModulePath + "/libbeat/version.buildTime": "{{ date }}",
+			elasticBeatsModulePath + "/libbeat/version.commit":    "{{ commit }}",
 		},
 		WinMetadata: true,
 	}
 	if versionQualified {
-		args.Vars["github.com/elastic/beats/libbeat/version.qualifier"] = "{{ .Qualifier }}"
+		args.Vars[elasticBeatsModulePath+"/libbeat/version.qualifier"] = "{{ .Qualifier }}"
 	}
 	return args
 }

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -46,6 +46,8 @@ const (
 	BeatsCrossBuildImage = "docker.elastic.co/beats-dev/golang-crossbuild"
 
 	elasticBeatsImportPath = "github.com/elastic/beats"
+
+	elasticBeatsModulePath = "github.com/elastic/beats/v7"
 )
 
 // Common settings with defaults derived from files, CWD, and environment.
@@ -284,7 +286,7 @@ func findElasticBeatsDir() (string, error) {
 	if repo.IsElasticBeats() {
 		return repo.RootDir, nil
 	}
-	return listModuleDir("github.com/elastic/beats/v7")
+	return listModuleDir(elasticBeatsModulePath)
 }
 
 var (


### PR DESCRIPTION
Cherry-pick of PR #17193 to 7.7 branch. Original message: 

## What does this PR do?

Fix the Vars returned by DefaultBuildArgs, so they have the correct import path. The import paths were missing "v7", which was added with the migration to modules.

## Why is it important?

Without this change, the build date/commit are not being correctly recorded.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

`cd filebeat; mage build; ./filebeat version`

Before change:

```
filebeat version 8.0.0 (amd64), libbeat 8.0.0 [unknown built unknown]
```

After change:

```
filebeat version 8.0.0 (amd64), libbeat 8.0.0 [c300624eefc6688a3c3334637244d203cd08f11a built 2020-03-24 07:19:15 +0000 UTC]
```

## Related issues

Closes https://github.com/elastic/apm-server/issues/3532