### PR TITLE
Use ascending order of supported versions of redis

### DIFF
--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -26,7 +26,7 @@ output.redis:
 
 ==== Compatibility
 
-This output is expected to work with all Redis versions between 5.0.8 and 3.2.4. Other versions might work as well,
+This output is expected to work with all Redis versions between 3.2.4 and 5.0.8. Other versions might work as well,
 but are not supported.
 
 ==== Configuration options


### PR DESCRIPTION
(docs update)

This PR adjusts the order of supported versions for Redis.