### PR TITLE
Cherry-pick #17223 to 7.x: [BUG] Use Pod.Status.Phase for pod updates in kubernetes autodiscovery

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update replicaset group to apps/v1 {pull}15854[15802]
 - Fix `metricbeat test output` with an ipv6 ES host in the output.hosts. {pull}15368[15368]
 - Fix `convert` processor conversion of string to integer with leading zeros. {issue}15513[15513] {pull}15557[15557]
+- Fix Kubernetes autodiscovery provider to correctly handle pod states and avoid missing event data {pull}17223[17223]
 - Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
 - Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix missing output in dockerlogbeat {pull}15719[15719]

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -72,6 +72,19 @@ type StatefulSet = appsv1.StatefulSet
 // Service data
 type Service = v1.Service
 
+const (
+	// PodPending phase
+	PodPending = v1.PodPending
+	// PodRunning phase
+	PodRunning = v1.PodRunning
+	// PodSucceeded phase
+	PodSucceeded = v1.PodSucceeded
+	// PodFailed phase
+	PodFailed = v1.PodFailed
+	// PodUnknown phase
+	PodUnknown = v1.PodUnknown
+)
+
 // Time extracts time from k8s.Time type
 func Time(t *metav1.Time) time.Time {
 	return t.Time


### PR DESCRIPTION
Cherry-pick of PR #17223 to 7.x branch. Original message: 

## What does this PR do?

This change fixes several issues with beats loosing events when
using kubernetes autodiscovery by incorrectly handling of pod states.

Switch the pod status verification in OnUpdate() from
ObjectMeta.DeletionTimestamp (which is present only for deleted pods)
to Pod.Status.Phase in order to correctly handle pod states.

ObjectMeta.DeletionTimestamp is only present for deleted pods and when a
pod runs to completion (eg. pods generated by conjobs), OnUpdate()
will emit a pod stop event disrespecting the CleanupTimeout and leading to
early termination of running beats.

## Why is it important?

Avoids missing log, audit and metrics data when using kubernetes autodiscovery.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [] I have made corresponding changes to the documentation~~
~~- [] I have made corresponding change to the default configuration files~~
~~- [] I have added tests that prove my fix is effective or that my feature works~~

Fixes #17246