### PR TITLE
Ignore trailing spaces in CEF messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix default index pattern in IBM MQ filebeat dashboard. {pull}17146[17146]
 - Fix `elasticsearch.gc` fileset to not collect _all_ logs when Elasticsearch is running in Docker. {issue}13164[13164] {issue}16583[16583] {pull}17164[17164]
 - Fixed a mapping exception when ingesting CEF logs that used the spriv or dpriv extensions. {issue}17216[17216] {pull}17220[17220]
+- CEF: Fixed decoding errors caused by trailing spaces in messages. {pull}17253[17253]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cef/log/test/cef.log
+++ b/x-pack/filebeat/module/cef/log/test/cef.log
@@ -1,3 +1,4 @@
 CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Web request|low|eventId=3457 requestMethod=POST slat=38.915 slong=-77.511 proto=TCP sourceServiceName=httpd requestContext=https://www.google.com src=6.7.8.9 spt=33876 dst=192.168.10.1 dpt=443 request=https://www.example.com/cart
 CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|eventId=123 src=6.7.8.9 spt=33876 dst=1.2.3.4 dpt=443 duser=alice suser=bob destinationTranslatedAddress=10.10.10.10 fileHash=bc8bbe52f041fd17318f08a0f73762ce oldFileHash=a9796280592f86b74b27e370662d41eb
 CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|spriv=user dpriv=root
+CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|message=This event is padded with whitespace dst=192.168.1.2 src=192.168.3.4     

--- a/x-pack/filebeat/module/cef/log/test/cef.log-expected.json
+++ b/x-pack/filebeat/module/cef/log/test/cef.log-expected.json
@@ -150,5 +150,39 @@
         "tags": [
             "cef"
         ]
+    },
+    {
+        "cef.device.event_class_id": "18",
+        "cef.device.product": "Vaporware",
+        "cef.device.vendor": "Elastic",
+        "cef.device.version": "1.0.0-alpha",
+        "cef.extensions.destinationAddress": "192.168.1.2",
+        "cef.extensions.message": "This event is padded with whitespace",
+        "cef.extensions.sourceAddress": "192.168.3.4",
+        "cef.name": "Authentication",
+        "cef.severity": "low",
+        "cef.version": "0",
+        "destination.ip": "192.168.1.2",
+        "event.code": "18",
+        "event.dataset": "cef.log",
+        "event.module": "cef",
+        "event.original": "CEF:0|Elastic|Vaporware|1.0.0-alpha|18|Authentication|low|message=This event is padded with whitespace dst=192.168.1.2 src=192.168.3.4     ",
+        "event.severity": 0,
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.offset": 611,
+        "message": "This event is padded with whitespace",
+        "observer.product": "Vaporware",
+        "observer.vendor": "Elastic",
+        "observer.version": "1.0.0-alpha",
+        "related.ip": [
+            "192.168.1.2",
+            "192.168.3.4"
+        ],
+        "service.type": "cef",
+        "source.ip": "192.168.3.4",
+        "tags": [
+            "cef"
+        ]
     }
 ]

--- a/x-pack/filebeat/processors/decode_cef/cef/cef.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/cef.go
@@ -14,7 +14,10 @@ import (
 // Parser is generated from a ragel state machine using the following command:
 //go:generate ragel -Z -G1 cef.rl -o parser.go
 //go:generate goimports -l -w parser.go
-
+//
+// Run go vet and remove any unreachable code in the generated parser.go.
+// The go generator outputs duplicated goto statements sometimes.
+//
 // An SVG rendering of the state machine can be viewed by opening cef.svg in
 // Chrome / Firefox.
 //go:generate ragel -V -p cef.rl -o cef.dot

--- a/x-pack/filebeat/processors/decode_cef/cef/cef.rl
+++ b/x-pack/filebeat/processors/decode_cef/cef/cef.rl
@@ -124,13 +124,13 @@ func (e *Event) unpack(data string) error {
         extension_key_start_chars = alnum | '_';
         extension_key_chars = extension_key_start_chars | '.' | ',' | '[' | ']';
         extension_key_pattern = extension_key_start_chars extension_key_chars*;
-        extension_value_chars = backslash | escape_equal | (any -- equal -- escape);
+        extension_value_chars_nospace = backslash | escape_equal | (any -- equal -- escape -- space);
 
         # Extension fields.
         extension_key = extension_key_pattern >mark %extension_key;
-        extension_value = (extension_value_chars @extension_value_mark)* >extension_value_start $err(extension_err);
-        extension = extension_key equal extension_value %/extension_eof;
-        extensions = " "* extension (" " extension)*;
+        extension_value = (space* extension_value_chars_nospace @extension_value_mark)* >extension_value_start $err(extension_err);
+        extension = extension_key equal extension_value;
+        extensions = " "* extension (space* " " extension)* space* %/extension_eof;
 
         # gobble_extension attempts recovery from a malformed value by trying to
         # advance to the next extension key and re-entering the main state machine.

--- a/x-pack/filebeat/processors/decode_cef/cef/parser.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/parser.go
@@ -874,8 +874,6 @@ func (e *Event) unpack(data string) error {
 		(p)--
 		cs = 28
 		goto _again
-
-		goto _again
 	f17:
 //line cef.rl:87
 
@@ -883,8 +881,6 @@ func (e *Event) unpack(data string) error {
 		// Resume processing at p, the start of the next extension key.
 		p = mark
 		cs = 24
-		goto _again
-
 		goto _again
 	f2:
 //line cef.rl:37

--- a/x-pack/filebeat/processors/decode_cef/cef/parser.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/parser.go
@@ -329,145 +329,177 @@ func (e *Event) unpack(data string) error {
 		case 32:
 			switch data[(p)] {
 			case 32:
-				goto tr54
+				goto tr55
 			case 61:
 				goto tr46
 			case 92:
-				goto tr55
+				goto tr56
+			}
+			if 9 <= data[(p)] && data[(p)] <= 13 {
+				goto tr54
 			}
 			goto tr53
 		case 33:
 			switch data[(p)] {
 			case 32:
-				goto tr56
+				goto tr58
 			case 61:
 				goto tr46
 			case 92:
+				goto tr59
+			}
+			if 9 <= data[(p)] && data[(p)] <= 13 {
 				goto tr57
 			}
 			goto tr48
 		case 34:
 			switch data[(p)] {
 			case 32:
-				goto tr56
+				goto tr58
 			case 61:
 				goto tr46
 			case 92:
-				goto tr57
+				goto tr59
 			case 95:
-				goto tr58
+				goto tr60
 			}
 			switch {
-			case data[(p)] < 65:
-				if 48 <= data[(p)] && data[(p)] <= 57 {
-					goto tr58
+			case data[(p)] < 48:
+				if 9 <= data[(p)] && data[(p)] <= 13 {
+					goto tr57
 				}
-			case data[(p)] > 90:
-				if 97 <= data[(p)] && data[(p)] <= 122 {
-					goto tr58
+			case data[(p)] > 57:
+				switch {
+				case data[(p)] > 90:
+					if 97 <= data[(p)] && data[(p)] <= 122 {
+						goto tr60
+					}
+				case data[(p)] >= 65:
+					goto tr60
 				}
 			default:
-				goto tr58
+				goto tr60
 			}
 			goto tr48
 		case 35:
 			switch data[(p)] {
 			case 32:
-				goto tr56
+				goto tr58
 			case 44:
-				goto tr59
+				goto tr61
 			case 46:
-				goto tr59
+				goto tr61
 			case 61:
-				goto tr60
+				goto tr62
 			case 92:
-				goto tr57
-			case 95:
 				goto tr59
+			case 95:
+				goto tr61
 			}
 			switch {
-			case data[(p)] < 65:
-				if 48 <= data[(p)] && data[(p)] <= 57 {
-					goto tr59
+			case data[(p)] < 48:
+				if 9 <= data[(p)] && data[(p)] <= 13 {
+					goto tr57
 				}
-			case data[(p)] > 93:
-				if 97 <= data[(p)] && data[(p)] <= 122 {
-					goto tr59
+			case data[(p)] > 57:
+				switch {
+				case data[(p)] > 93:
+					if 97 <= data[(p)] && data[(p)] <= 122 {
+						goto tr61
+					}
+				case data[(p)] >= 65:
+					goto tr61
 				}
 			default:
-				goto tr59
+				goto tr61
 			}
 			goto tr48
 		case 36:
 			switch data[(p)] {
 			case 32:
-				goto tr62
+				goto tr65
 			case 61:
 				goto tr46
 			case 92:
-				goto tr63
+				goto tr66
 			}
-			goto tr61
+			if 9 <= data[(p)] && data[(p)] <= 13 {
+				goto tr64
+			}
+			goto tr63
 		case 37:
 			switch data[(p)] {
 			case 32:
-				goto tr64
+				goto tr68
 			case 61:
 				goto tr46
 			case 92:
-				goto tr65
+				goto tr69
+			}
+			if 9 <= data[(p)] && data[(p)] <= 13 {
+				goto tr67
 			}
 			goto tr47
 		case 38:
 			switch data[(p)] {
 			case 32:
-				goto tr64
+				goto tr68
 			case 61:
 				goto tr46
 			case 92:
-				goto tr65
+				goto tr69
 			case 95:
-				goto tr66
+				goto tr70
 			}
 			switch {
-			case data[(p)] < 65:
-				if 48 <= data[(p)] && data[(p)] <= 57 {
-					goto tr66
+			case data[(p)] < 48:
+				if 9 <= data[(p)] && data[(p)] <= 13 {
+					goto tr67
 				}
-			case data[(p)] > 90:
-				if 97 <= data[(p)] && data[(p)] <= 122 {
-					goto tr66
+			case data[(p)] > 57:
+				switch {
+				case data[(p)] > 90:
+					if 97 <= data[(p)] && data[(p)] <= 122 {
+						goto tr70
+					}
+				case data[(p)] >= 65:
+					goto tr70
 				}
 			default:
-				goto tr66
+				goto tr70
 			}
 			goto tr47
 		case 39:
 			switch data[(p)] {
 			case 32:
-				goto tr64
+				goto tr68
 			case 44:
-				goto tr67
+				goto tr71
 			case 46:
-				goto tr67
+				goto tr71
 			case 61:
-				goto tr60
+				goto tr62
 			case 92:
-				goto tr65
+				goto tr69
 			case 95:
-				goto tr67
+				goto tr71
 			}
 			switch {
-			case data[(p)] < 65:
-				if 48 <= data[(p)] && data[(p)] <= 57 {
+			case data[(p)] < 48:
+				if 9 <= data[(p)] && data[(p)] <= 13 {
 					goto tr67
 				}
-			case data[(p)] > 93:
-				if 97 <= data[(p)] && data[(p)] <= 122 {
-					goto tr67
+			case data[(p)] > 57:
+				switch {
+				case data[(p)] > 93:
+					if 97 <= data[(p)] && data[(p)] <= 122 {
+						goto tr71
+					}
+				case data[(p)] >= 65:
+					goto tr71
 				}
 			default:
-				goto tr67
+				goto tr71
 			}
 			goto tr47
 		case 26:
@@ -678,16 +710,16 @@ func (e *Event) unpack(data string) error {
 	tr43:
 		cs = 25
 		goto f0
-	tr65:
+	tr69:
 		cs = 26
 		goto _again
-	tr63:
+	tr66:
 		cs = 26
 		goto f20
-	tr57:
+	tr59:
 		cs = 27
 		goto _again
-	tr55:
+	tr56:
 		cs = 27
 		goto f20
 	tr49:
@@ -708,43 +740,55 @@ func (e *Event) unpack(data string) error {
 	tr45:
 		cs = 32
 		goto f14
+	tr57:
+		cs = 33
+		goto _again
 	tr48:
 		cs = 33
 		goto f16
 	tr53:
 		cs = 33
 		goto f19
-	tr56:
-		cs = 34
-		goto f16
 	tr54:
+		cs = 33
+		goto f20
+	tr58:
 		cs = 34
-		goto f19
-	tr59:
+		goto _again
+	tr55:
+		cs = 34
+		goto f20
+	tr61:
 		cs = 35
 		goto f16
-	tr58:
+	tr60:
 		cs = 35
 		goto f22
-	tr60:
+	tr62:
 		cs = 36
 		goto f14
+	tr67:
+		cs = 37
+		goto _again
 	tr47:
 		cs = 37
 		goto f16
-	tr61:
+	tr63:
 		cs = 37
 		goto f19
 	tr64:
+		cs = 37
+		goto f20
+	tr68:
 		cs = 38
-		goto f16
-	tr62:
+		goto _again
+	tr65:
 		cs = 38
-		goto f19
-	tr67:
+		goto f20
+	tr71:
 		cs = 39
 		goto f16
-	tr66:
+	tr70:
 		cs = 39
 		goto f23
 	tr52:
@@ -830,6 +874,8 @@ func (e *Event) unpack(data string) error {
 		(p)--
 		cs = 28
 		goto _again
+
+		goto _again
 	f17:
 //line cef.rl:87
 
@@ -837,6 +883,8 @@ func (e *Event) unpack(data string) error {
 		// Resume processing at p, the start of the next extension key.
 		p = mark
 		cs = 24
+		goto _again
+
 		goto _again
 	f2:
 //line cef.rl:37
@@ -973,7 +1021,7 @@ func (e *Event) unpack(data string) error {
 					extKey, extValueStart, extValueEnd = "", 0, 0
 				}
 
-//line parser.go:847
+//line parser.go:883
 			}
 		}
 


### PR DESCRIPTION
## What does this PR do?

This patch updates the Ragel state machine to skip trailing space at the end of CEF messages.

Some CEF exporters, Check Point for example, have been observed to add a trailing space to CEF messages:

> "CEF:0:| [...] src=127.0.0.1 "

Currently, this space character is interpreted as part of the last field's value, which can cause decoding errors if the value is an integer or an IP address:

```json
"error": {
    "message": "sourceAddress: value is not a valid IP address"
  }
```

For maximizing compatibility, we also want to ignore other kinds of white-space characters (newline, carriage return, tab). For example we can get a trailing newline when processing CEF messages from UDP input instead of syslog, which removes newlines.

Trailing space in other extensions' values is preserved, as the CEF standard permits (but discourages) it's use in non-final extensions.

## Why is it important?

We've observed users experiencing this problem, trying to fix it (unsuccessfully) with a processor:

```yaml
- dissect:
      when:
        equals:
          event.module: "cef"
      tokenizer: "%{sourceAddress} "
      field: "cef.extensions.sourceAddress"
      target_prefix: "cef.extensions"
```

## Why a draft?

While the current solution is complete, I'm not satisfied of the changes that introduces to the Ragel SM definition.

Originally I wanted to get something more elegant like this to work:
```go
extensions = (extension " ")* final_extension space*
```

So that we can keep the `extension` machine as-is, and add a specialized `final_extension` machine that will disallow trailing space. However, I didn't manage to get this kind of pattern to work. It requires rewriting a lot of the capture actions to allow for the necessary backtracking, and I wasn't confident enough to get that right without introducing more problems than I was solving, or dedicating too many hours to this fix, due to my limited experience with ragel.

The current solution works by accident. I decided to try a different approach starting by disallowing trailing space in all extensions, and found out that it works as I wanted and captures white-space as value in all extensions but the last. This is a side effect of how an extension value is captured differently in `extension_key` vs `extension_eof`. The former captures the previous value up to `mark-1`, that is the start of the current key minus the space separator. The later captures up to `extValueEnd`, which is not incremented for trailing space.

The current machine definition is an ugly mix of `" "` and `space` usage, because we want to have the space character as the only separator, but trim al trailing space:  `[\t\v\f\n\r ]`

