### PR TITLE
Cherry-pick #17200 to 7.x: Add system test for Openmetrics module

### DIFF
--- a/x-pack/metricbeat/module/openmetrics/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/openmetrics/_meta/Dockerfile
@@ -1,0 +1,5 @@
+ARG NODE_EXPORTER_VERSION
+FROM prom/node-exporter:v${NODE_EXPORTER_VERSION}
+EXPOSE 9100
+HEALTHCHECK --interval=1s --retries=90 CMD wget -q http://localhost:9100/metrics -O - | grep "node_cpu_seconds_total"
+

--- a/x-pack/metricbeat/module/openmetrics/docker-compose.yml
+++ b/x-pack/metricbeat/module/openmetrics/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2.3'
+
+services:
+  openmetrics-node_exporter:
+    image: docker.elastic.co/integrations-ci/beats-openmetrics-node-exporter:${NODE_EXPORTER_VERSION:-0.18.1}-1
+    build:
+      context: ./_meta
+      args:
+        NODE_EXPORTER_VERSION: ${NODE_EXPORTER_VERSION:-0.18.1}
+    ports:
+      - 9100

--- a/x-pack/metricbeat/module/openmetrics/test_openmetrics.py
+++ b/x-pack/metricbeat/module/openmetrics/test_openmetrics.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
+from xpack_metricbeat import XPackTest, metricbeat
+
+
+class Test(XPackTest):
+
+    COMPOSE_SERVICES = ['openmetrics-node_exporter']
+
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    def test_openmetrics(self):
+        """
+        openmetrics collector test
+        """
+        self.render_config_template(modules=[{
+            "name": "openmetrics",
+            "metricsets": ["collector"],
+            "hosts": self.get_hosts(),
+            "period": "5s",
+        }])
+        proc = self.start_beat(home=self.beat_path)
+        self.wait_until(lambda: self.output_lines() > 0, 60)
+        proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
+
+        output = self.read_output_json()
+        self.assertGreater(len(output), 0)
+
+        for evt in output:
+            self.assert_fields_are_documented(evt)
+            self.assertIn("openmetrics", evt.keys(), evt)
+            self.assertIn("metrics", evt["openmetrics"].keys(), evt)
+            self.assertGreater(len(evt["openmetrics"]["metrics"].keys()), 0)


### PR DESCRIPTION
Cherry-pick of PR #17200 to 7.x branch. Original message: 

## What does this PR do?
This PR adds system test for Openmetrics module.

## Why is it important?
To ensure the functionality of the module as well as the fields' mapping.

## Related issues

- Relates https://github.com/elastic/beats/issues/14982
