### PR TITLE
[Heartbeat] Fix concurrency errors with multiple ports

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,7 +40,7 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 
 *Heartbeat*
-
+- Fix crashes when multiple TCP ports are specified. {pull}17262[17262]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -51,8 +51,8 @@ type BuilderSettings struct {
 // Endpoint configures a host with all port numbers to be monitored by a dialer
 // based job.
 type Endpoint struct {
-	Host  string
-	Ports []uint16
+	Host string
+	Port uint16
 }
 
 // NewBuilder creates a new Builder for constructing dialers.
@@ -137,23 +137,30 @@ func MakeDialerJobs(
 ) ([]monitors.Job, error) {
 	var jobs []monitors.Job
 	for _, endpoint := range endpoints {
-		endpointJobs, err := makeEndpointJobs(b, typ, scheme, endpoint, mode, fn)
+		/*
+			endpointJobs, err := makeEndpointJobs(b, typ, scheme, endpoint, mode, fn)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, endpointJobs...)
+		*/
+		endpointJob, err := makeEndpointJob(b, typ, scheme, endpoint, mode, fn)
 		if err != nil {
 			return nil, err
 		}
-		jobs = append(jobs, endpointJobs...)
+		jobs = append(jobs, endpointJob)
 	}
 
 	return jobs, nil
 }
 
-func makeEndpointJobs(
+func makeEndpointJob(
 	b *Builder,
 	typ, scheme string,
 	endpoint Endpoint,
 	mode monitors.IPSettings,
 	fn func(*beat.Event, transport.Dialer, string) error,
-) ([]monitors.Job, error) {
+) (monitors.Job, error) {
 
 	fields := common.MapStr{
 		"monitor": common.MapStr{
@@ -166,25 +173,22 @@ func makeEndpointJobs(
 	// in resolving the actual IP.
 	// Create one job for every port number configured.
 	if b.resolveViaSocks5 {
-		jobs := make([]monitors.Job, len(endpoint.Ports))
-		for i, port := range endpoint.Ports {
-			address := net.JoinHostPort(endpoint.Host, strconv.Itoa(int(port)))
-			jobs[i] = monitors.MakeSimpleJob(func(event *beat.Event) error {
-				return b.Run(event, address, func(event *beat.Event, dialer transport.Dialer) error {
-					return fn(event, dialer, address)
-				})
+		address := net.JoinHostPort(endpoint.Host, strconv.Itoa(int(endpoint.Port)))
+		job := monitors.MakeSimpleJob(func(event *beat.Event) error {
+			return b.Run(event, address, func(event *beat.Event, dialer transport.Dialer) error {
+				return fn(event, dialer, address)
 			})
-		}
-		return jobs, nil
+		})
+		return job, nil
 	}
 
 	// Create job that first resolves one or multiple IP (depending on
 	// config.Mode) in order to create one continuation Task per IP.
-	jobID := jobID(typ, scheme, endpoint.Host, endpoint.Ports)
+	jobID := jobID(typ, scheme, endpoint.Host, []uint16{endpoint.Port})
 	settings := monitors.MakeHostJobSettings(jobID, endpoint.Host, mode)
 
 	job, err := monitors.MakeByHostJob(settings,
-		monitors.MakePingAllIPPortFactory(endpoint.Ports,
+		monitors.MakePingAllIPPortFactory([]uint16{endpoint.Port},
 			func(event *beat.Event, ip *net.IPAddr, port uint16) error {
 				// use address from resolved IP
 				portStr := strconv.Itoa(int(port))
@@ -199,7 +203,7 @@ func makeEndpointJobs(
 	if err != nil {
 		return nil, err
 	}
-	return []monitors.Job{monitors.WithJobId(jobID, monitors.WithFields(fields, job))}, nil
+	return monitors.WithJobId(jobID, monitors.WithFields(fields, job)), nil
 }
 
 func jobID(typ, jobType, host string, ports []uint16) string {

--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -137,13 +137,6 @@ func MakeDialerJobs(
 ) ([]monitors.Job, error) {
 	var jobs []monitors.Job
 	for _, endpoint := range endpoints {
-		/*
-			endpointJobs, err := makeEndpointJobs(b, typ, scheme, endpoint, mode, fn)
-			if err != nil {
-				return nil, err
-			}
-			jobs = append(jobs, endpointJobs...)
-		*/
 		endpointJob, err := makeEndpointJob(b, typ, scheme, endpoint, mode, fn)
 		if err != nil {
 			return nil, err

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -131,22 +131,25 @@ func collectHosts(config *Config, defaultScheme string) (map[string][]dialchain.
 
 		pair := strings.SplitN(host, ":", 2)
 		ports := config.Ports
-		if len(pair) == 2 {
-			port, err := strconv.ParseUint(pair[1], 10, 16)
-			if err != nil {
-				return nil, fmt.Errorf("'%v' is no valid port number in '%v'", pair[1], h)
+		for _, port := range ports {
+			if len(pair) == 2 {
+				port64, err := strconv.ParseUint(pair[1], 10, 16)
+				port = uint16(port64)
+				if err != nil {
+					return nil, fmt.Errorf("'%v' is no valid port number in '%v'", pair[1], h)
+				}
+
+				host = pair[0]
+			} else if len(config.Ports) == 0 {
+				return nil, fmt.Errorf("host '%v' missing port number", h)
 			}
 
-			ports = []uint16{uint16(port)}
-			host = pair[0]
-		} else if len(config.Ports) == 0 {
-			return nil, fmt.Errorf("host '%v' missing port number", h)
+			endpoints[scheme] = append(endpoints[scheme], dialchain.Endpoint{
+				Host: host,
+				Port: port,
+			})
 		}
 
-		endpoints[scheme] = append(endpoints[scheme], dialchain.Endpoint{
-			Host:  host,
-			Ports: ports,
-		})
 	}
 	return endpoints, nil
 }

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -104,6 +104,7 @@ func create(
 	}
 
 	errWrappedJobs := monitors.WrapAll(jobs, monitors.WithErrAsField)
+
 	return errWrappedJobs, numHosts, nil
 }
 
@@ -130,26 +131,28 @@ func collectHosts(config *Config, defaultScheme string) (map[string][]dialchain.
 		}
 
 		pair := strings.SplitN(host, ":", 2)
-		ports := config.Ports
-		for _, port := range ports {
-			if len(pair) == 2 {
-				port64, err := strconv.ParseUint(pair[1], 10, 16)
-				port = uint16(port64)
-				if err != nil {
-					return nil, fmt.Errorf("'%v' is no valid port number in '%v'", pair[1], h)
-				}
-
-				host = pair[0]
-			} else if len(config.Ports) == 0 {
-				return nil, fmt.Errorf("host '%v' missing port number", h)
+		if len(pair) == 2 {
+			port64, err := strconv.ParseUint(pair[1], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("'%v' is no valid port number in '%v'", pair[1], h)
 			}
 
+			host = pair[0]
+			endpoints[scheme] = append(endpoints[scheme], dialchain.Endpoint{
+				Host: host,
+				Port: uint16(port64),
+			})
+		} else if len(config.Ports) == 0 {
+			// If there's no port in the URL or in the Ports config field bail.
+			return nil, fmt.Errorf("host '%v' missing port number", h)
+		}
+
+		for _, port := range config.Ports {
 			endpoints[scheme] = append(endpoints[scheme], dialchain.Endpoint{
 				Host: host,
 				Port: port,
 			})
 		}
-
 	}
 	return endpoints, nil
 }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/beats/issues/16917 , where in heartbeat 6.x multiple TCP ports cause a crash with [configs like this one](https://github.com/elastic/uptime-contrib/blob/master/testing/configs/tcp_multiport.yml).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

