### PR TITLE
Disable remote_write and query metricsets from Prom default config

### DIFF
--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -47,21 +47,21 @@ metricbeat.modules:
 
 
 # Metrics sent by a Prometheus server using remote_write option
-- module: prometheus
-  metricsets: ["remote_write"]
-  host: "localhost"
-  port: "9201"
+#- module: prometheus
+  #metricsets: ["remote_write"]
+  #host: "localhost"
+  #port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
   #ssl.key: "/etc/pki/server/cert.key"
 
 # Metrics that will be collected using a PromQL
-- module: prometheus
-  period: 10s
-  hosts: ["localhost:9090"]
-  metricsets: ["query"]
-  queries:
+#- module: prometheus
+  #metricsets: ["query"]
+  #hosts: ["localhost:9090"]
+  #period: 10s
+  #queries:
   #- name: "instant_vector"
   #  path: "/api/v1/query"
   #  params:

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -48,9 +48,9 @@ metricbeat.modules:
 
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
-  #metricsets: ["remote_write"]
-  #host: "localhost"
-  #port: "9201"
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
@@ -58,29 +58,29 @@ metricbeat.modules:
 
 # Metrics that will be collected using a PromQL
 #- module: prometheus
-  #metricsets: ["query"]
-  #hosts: ["localhost:9090"]
-  #period: 10s
-  #queries:
-  #- name: "instant_vector"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "sum(rate(prometheus_http_requests_total[1m]))"
-  #- name: "range_vector"
-  #  path: "/api/v1/query_range"
-  #  params:
-  #    query: "up"
-  #    start: "2019-12-20T00:00:00.000Z"
-  #    end:  "2019-12-21T00:00:00.000Z"
-  #    step: 1h
-  #- name: "scalar"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "100"
-  #- name: "string"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "some_value"
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -719,21 +719,21 @@ metricbeat.modules:
 
 
 # Metrics sent by a Prometheus server using remote_write option
-- module: prometheus
-  metricsets: ["remote_write"]
-  host: "localhost"
-  port: "9201"
+#- module: prometheus
+  #metricsets: ["remote_write"]
+  #host: "localhost"
+  #port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
   #ssl.key: "/etc/pki/server/cert.key"
 
 # Metrics that will be collected using a PromQL
-- module: prometheus
-  period: 10s
-  hosts: ["localhost:9090"]
-  metricsets: ["query"]
-  queries:
+#- module: prometheus
+  #metricsets: ["query"]
+  #hosts: ["localhost:9090"]
+  #period: 10s
+  #queries:
   #- name: "instant_vector"
   #  path: "/api/v1/query"
   #  params:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -720,9 +720,9 @@ metricbeat.modules:
 
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
-  #metricsets: ["remote_write"]
-  #host: "localhost"
-  #port: "9201"
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
@@ -730,29 +730,29 @@ metricbeat.modules:
 
 # Metrics that will be collected using a PromQL
 #- module: prometheus
-  #metricsets: ["query"]
-  #hosts: ["localhost:9090"]
-  #period: 10s
-  #queries:
-  #- name: "instant_vector"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "sum(rate(prometheus_http_requests_total[1m]))"
-  #- name: "range_vector"
-  #  path: "/api/v1/query_range"
-  #  params:
-  #    query: "up"
-  #    start: "2019-12-20T00:00:00.000Z"
-  #    end:  "2019-12-21T00:00:00.000Z"
-  #    step: 1h
-  #- name: "scalar"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "100"
-  #- name: "string"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "some_value"
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"
 
 #------------------------------- RabbitMQ Module -------------------------------
 - module: rabbitmq

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -18,9 +18,9 @@
 
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
-  #metricsets: ["remote_write"]
-  #host: "localhost"
-  #port: "9201"
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
@@ -28,26 +28,26 @@
 
 # Metrics that will be collected using a PromQL
 #- module: prometheus
-  #metricsets: ["query"]
-  #hosts: ["localhost:9090"]
-  #period: 10s
-  #queries:
-  #- name: "instant_vector"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "sum(rate(prometheus_http_requests_total[1m]))"
-  #- name: "range_vector"
-  #  path: "/api/v1/query_range"
-  #  params:
-  #    query: "up"
-  #    start: "2019-12-20T00:00:00.000Z"
-  #    end:  "2019-12-21T00:00:00.000Z"
-  #    step: 1h
-  #- name: "scalar"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "100"
-  #- name: "string"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "some_value"
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -17,21 +17,21 @@
 
 
 # Metrics sent by a Prometheus server using remote_write option
-- module: prometheus
-  metricsets: ["remote_write"]
-  host: "localhost"
-  port: "9201"
+#- module: prometheus
+  #metricsets: ["remote_write"]
+  #host: "localhost"
+  #port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
   #ssl.key: "/etc/pki/server/cert.key"
 
 # Metrics that will be collected using a PromQL
-- module: prometheus
-  period: 10s
-  hosts: ["localhost:9090"]
-  metricsets: ["query"]
-  queries:
+#- module: prometheus
+  #metricsets: ["query"]
+  #hosts: ["localhost:9090"]
+  #period: 10s
+  #queries:
   #- name: "instant_vector"
   #  path: "/api/v1/query"
   #  params:

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -21,9 +21,9 @@
 
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
-  #metricsets: ["remote_write"]
-  #host: "localhost"
-  #port: "9201"
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
@@ -31,26 +31,26 @@
 
 # Metrics that will be collected using a PromQL
 #- module: prometheus
-  #metricsets: ["query"]
-  #hosts: ["localhost:9090"]
-  #period: 10s
-  #queries:
-  #- name: "instant_vector"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "sum(rate(prometheus_http_requests_total[1m]))"
-  #- name: "range_vector"
-  #  path: "/api/v1/query_range"
-  #  params:
-  #    query: "up"
-  #    start: "2019-12-20T00:00:00.000Z"
-  #    end:  "2019-12-21T00:00:00.000Z"
-  #    step: 1h
-  #- name: "scalar"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "100"
-  #- name: "string"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "some_value"
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -20,21 +20,21 @@
 
 
 # Metrics sent by a Prometheus server using remote_write option
-- module: prometheus
-  metricsets: ["remote_write"]
-  host: "localhost"
-  port: "9201"
+#- module: prometheus
+  #metricsets: ["remote_write"]
+  #host: "localhost"
+  #port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
   #ssl.key: "/etc/pki/server/cert.key"
 
 # Metrics that will be collected using a PromQL
-- module: prometheus
-  period: 10s
-  hosts: ["localhost:9090"]
-  metricsets: ["query"]
-  queries:
+#- module: prometheus
+  #metricsets: ["query"]
+  #hosts: ["localhost:9090"]
+  #period: 10s
+  #queries:
   #- name: "instant_vector"
   #  path: "/api/v1/query"
   #  params:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1046,21 +1046,21 @@ metricbeat.modules:
 
 
 # Metrics sent by a Prometheus server using remote_write option
-- module: prometheus
-  metricsets: ["remote_write"]
-  host: "localhost"
-  port: "9201"
+#- module: prometheus
+  #metricsets: ["remote_write"]
+  #host: "localhost"
+  #port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
   #ssl.key: "/etc/pki/server/cert.key"
 
 # Metrics that will be collected using a PromQL
-- module: prometheus
-  period: 10s
-  hosts: ["localhost:9090"]
-  metricsets: ["query"]
-  queries:
+#- module: prometheus
+  #metricsets: ["query"]
+  #hosts: ["localhost:9090"]
+  #period: 10s
+  #queries:
   #- name: "instant_vector"
   #  path: "/api/v1/query"
   #  params:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1047,9 +1047,9 @@ metricbeat.modules:
 
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
-  #metricsets: ["remote_write"]
-  #host: "localhost"
-  #port: "9201"
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
 
   # Secure settings for the server using TLS/SSL:
   #ssl.certificate: "/etc/pki/server/cert.pem"
@@ -1057,29 +1057,29 @@ metricbeat.modules:
 
 # Metrics that will be collected using a PromQL
 #- module: prometheus
-  #metricsets: ["query"]
-  #hosts: ["localhost:9090"]
-  #period: 10s
-  #queries:
-  #- name: "instant_vector"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "sum(rate(prometheus_http_requests_total[1m]))"
-  #- name: "range_vector"
-  #  path: "/api/v1/query_range"
-  #  params:
-  #    query: "up"
-  #    start: "2019-12-20T00:00:00.000Z"
-  #    end:  "2019-12-21T00:00:00.000Z"
-  #    step: 1h
-  #- name: "scalar"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "100"
-  #- name: "string"
-  #  path: "/api/v1/query"
-  #  params:
-  #    query: "some_value"
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"
 
 #------------------------------- RabbitMQ Module -------------------------------
 - module: rabbitmq


### PR DESCRIPTION
## What does this PR do?
This PR disables the `remote_write` and `query` metricsets from the default configuration. Users should manually enable them.

## Why is it important?
We don't want them to be enabled by default since these are special ones.

cc: @exekias 