### PR TITLE
Cherry-pick #17205 to 7.x: [Filebeat] Get AWS credentials again when token expired

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -130,6 +130,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Elasticsearch `_id` field set by S3 and Google Pub/Sub inputs. {pull}17026[17026]
 - Fixed various Cisco FTD parsing issues. {issue}16863[16863] {pull}16889[16889]
 - Fix default index pattern in IBM MQ filebeat dashboard. {pull}17146[17146]
+- Re-obtain AWS credentials if they expired in s3 input. {pull}17205[17205]
 - Fix `elasticsearch.gc` fileset to not collect _all_ logs when Elasticsearch is running in Docker. {issue}13164[13164] {issue}16583[16583] {pull}17164[17164]
 - Fixed a mapping exception when ingesting CEF logs that used the spriv or dpriv extensions. {issue}17216[17216] {pull}17220[17220]
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17205 to 7.x branch. Original message: 

## What does this PR do?

This PR is to add `GetAWSCredentials` function to get credentials again when previous AWS credentials are expired or invalid.

## Why is it important?

This will avoid users have to manually stop and restart Filebeat in order to obtain the new AWS credentials.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Use `~/.aws/credentials` to store AWS credentials and then in Filebeat, change filebeat.yml to use s3 input:
```
filebeat.inputs:
- type: s3
  queue_url:   https://sqs.us-east-1.amazonaws.com/428152502467/test-fb-ks
  credential_profile_name: elastic-beats
```

Before starting Filebeat, when generating temporary credentials, set `DurationSeconds` to be 900 seconds. Wait after 900 seconds(15min) and then start filebeat with `./filebeat -e`. You should see error message immediately:
```
2020-03-24T11:51:37.872-0600    WARN    [s3]    s3/input.go:206 credentials are invalid, acquiring AWS credentials again from config: ExpiredToken: The security token included in the request is expired
        status code: 403, request id: 702080a4-8d34-5d5a-b212-d650c7ddfa53
```
Then generate a new set of temporary credentials and update credentials in the file `~/.aws/credentials`. This error message should disappear right away.

## Related issues

- Closes https://github.com/elastic/beats/issues/17189
