### PR TITLE
Restore patched version of gopacket

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3030,6 +3030,9 @@ Apache License 2.0
 Dependency: github.com/google/gopacket
 Version: v1.1.18
 Revision: 0ad7f2610e34
+Overwrite: github.com/adriansr/gopacket
+Overwrite-Version: v1.1.18
+Overwrite-Revision: dd62abfa8a41
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/google/gopacket/LICENSE:
 --------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -178,6 +178,7 @@ replace (
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
+	github.com/google/gopacket => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41
 	github.com/insomniacslk/dhcp => github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 // indirect
 	github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 )

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6 h1:2Gl9Tray0NEjP
 github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d h1:g0M6kedfjDpyAAuxqBvJzMNjFzlrQ7Av6LCDFqWierk=
 github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d/go.mod h1:VykaKG/ofkKje+MSvqjrDsz1wfyHIvEVFljhq2EOZ4g=
+github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41 h1:9OmEpkkO4vm8Wz+JKWHDLZdzYrqXr4dovxIJDkTltKE=
+github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/aerospike/aerospike-client-go v1.27.1-0.20170612174108-0f3b54da6bdc h1:9iW/Fbn/R/nyUOiqo6AgwBe8uirqUIoTGF3vKG8qjoc=
 github.com/aerospike/aerospike-client-go v1.27.1-0.20170612174108-0f3b54da6bdc/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
@@ -351,8 +353,6 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34 h1:/wV+gZsAEt7vP+fJkT1AltOejfLS3uonB4RTOdXWjVk=
-github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/vendor/github.com/google/gopacket/.travis.yml
+++ b/vendor/github.com/google/gopacket/.travis.yml
@@ -39,10 +39,11 @@ jobs:
       install: ./.travis.install.sh
     - os: osx
       go: 1.x
-    - os: windows
-      go: 1.x
-      # winpcap does not work on travis ci - so install npcap (package is unlisted -> version)
-      before_install: choco install npcap --version 0.86
+# windows doesn't work on travis (package installation just hangs and then errors out)
+#    - os: windows
+#      go: 1.x
+#      # We don't need nmap - but that's the only way to get npcap:
+#      before_install: choco install npcap --version 0.86 -y
     - stage: style
       name: "fmt/vet/lint"
       go: 1.x

--- a/vendor/github.com/google/gopacket/afpacket/afpacket.go
+++ b/vendor/github.com/google/gopacket/afpacket/afpacket.go
@@ -337,20 +337,18 @@ func (h *TPacket) Stats() (Stats, error) {
 func (h *TPacket) InitSocketStats() error {
 	if h.tpVersion == TPacketVersion3 {
 		socklen := unsafe.Sizeof(h.socketStatsV3)
-		slt := C.socklen_t(socklen)
 		var ssv3 SocketStatsV3
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), &socklen)
 		if err != nil {
 			return err
 		}
 		h.socketStatsV3 = SocketStatsV3{}
 	} else {
 		socklen := unsafe.Sizeof(h.socketStats)
-		slt := C.socklen_t(socklen)
 		var ss SocketStats
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), &socklen)
 		if err != nil {
 			return err
 		}
@@ -366,10 +364,9 @@ func (h *TPacket) SocketStats() (SocketStats, SocketStatsV3, error) {
 	// We need to save the counters since asking for the stats will clear them
 	if h.tpVersion == TPacketVersion3 {
 		socklen := unsafe.Sizeof(h.socketStatsV3)
-		slt := C.socklen_t(socklen)
 		var ssv3 SocketStatsV3
 
-		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), uintptr(unsafe.Pointer(&slt)))
+		err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ssv3), &socklen)
 		if err != nil {
 			return SocketStats{}, SocketStatsV3{}, err
 		}
@@ -380,10 +377,9 @@ func (h *TPacket) SocketStats() (SocketStats, SocketStatsV3, error) {
 		return h.socketStats, h.socketStatsV3, nil
 	}
 	socklen := unsafe.Sizeof(h.socketStats)
-	slt := C.socklen_t(socklen)
 	var ss SocketStats
 
-	err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), uintptr(unsafe.Pointer(&slt)))
+	err := getsockopt(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS, unsafe.Pointer(&ss), &socklen)
 	if err != nil {
 		return SocketStats{}, SocketStatsV3{}, err
 	}

--- a/vendor/github.com/google/gopacket/afpacket/sockopt_linux.go
+++ b/vendor/github.com/google/gopacket/afpacket/sockopt_linux.go
@@ -9,44 +9,38 @@
 package afpacket
 
 import (
+	"errors"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
+const maxOptSize = 8192
+
+var errSockoptTooBig = errors.New("socket option too big")
+
 // setsockopt provides access to the setsockopt syscall.
 func setsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
-	_, _, errno := unix.Syscall6(
-		unix.SYS_SETSOCKOPT,
-		uintptr(fd),
-		uintptr(level),
-		uintptr(name),
-		uintptr(val),
-		vallen,
-		0,
-	)
-	if errno != 0 {
-		return error(errno)
+	if vallen > maxOptSize {
+		return errSockoptTooBig
 	}
-
-	return nil
+	slice := (*[maxOptSize]byte)(val)[:]
+	return syscall.SetsockoptString(fd, level, name, string(slice[:vallen]))
 }
 
 // getsockopt provides access to the getsockopt syscall.
-func getsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
-	_, _, errno := unix.Syscall6(
-		unix.SYS_GETSOCKOPT,
-		uintptr(fd),
-		uintptr(level),
-		uintptr(name),
-		uintptr(val),
-		vallen,
-		0,
-	)
-	if errno != 0 {
-		return error(errno)
+func getsockopt(fd, level, name int, val unsafe.Pointer, vallen *uintptr) error {
+	s, err := unix.GetsockoptString(fd, level, name)
+	if err != nil {
+		return err
 	}
-
+	rcvLen := uintptr(len(s))
+	if rcvLen > *vallen {
+		return errSockoptTooBig
+	}
+	copy((*[maxOptSize]byte)(val)[:rcvLen], s)
+	*vallen = rcvLen
 	return nil
 }
 

--- a/vendor/github.com/google/gopacket/layers/enums.go
+++ b/vendor/github.com/google/gopacket/layers/enums.go
@@ -8,7 +8,6 @@
 package layers
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 
@@ -24,14 +23,6 @@ type EnumMetadata struct {
 	Name string
 	// LayerType is the layer type implied by the given enum.
 	LayerType gopacket.LayerType
-}
-
-// errorFunc returns a decoder that spits out a specific error message.
-func errorFunc(msg string) gopacket.Decoder {
-	var e = errors.New(msg)
-	return gopacket.DecodeFunc(func([]byte, gopacket.PacketBuilder) error {
-		return e
-	})
 }
 
 // EthernetType is an enumeration of ethernet type values, and acts as a decoder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -555,7 +555,7 @@ github.com/google/go-github/v29/github
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
-# github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34
+# github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34 => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41
 github.com/google/gopacket
 github.com/google/gopacket/afpacket
 github.com/google/gopacket/layers


### PR DESCRIPTION
## What does this PR do?

This replaces github.com/google/gopacket with github.com/adriansr/gopacket which includes a fix to make `af_packet` work on 32bit x86 platforms.

This patched version was already vendored but lost during the migration to Go modules.

This patch is on review at https://github.com/google/gopacket/pull/720 to hopefully get it merged upstream.

## Why is it important?

This is necessary so that Auditbeat's system/socket works in 32bit Linux.

## Checklist

- [x] ~~My code follows the style guidelines of this project~~
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ -> no changelog entry needed as this regression has not been released.

## Related issues

- Relates #14128
