### PR TITLE
Enable aarch64 (arm64) packaging by default

### DIFF
--- a/dev-tools/mage/platforms.go
+++ b/dev-tools/mage/platforms.go
@@ -44,7 +44,7 @@ var BuildPlatforms = BuildPlatformList{
 	{"linux/armv5", CGOSupported | CrossBuildSupported},
 	{"linux/armv6", CGOSupported | CrossBuildSupported},
 	{"linux/armv7", CGOSupported | CrossBuildSupported},
-	{"linux/arm64", CGOSupported | CrossBuildSupported},
+	{"linux/arm64", CGOSupported | CrossBuildSupported | Default},
 	{"linux/mips", CGOSupported | CrossBuildSupported},
 	{"linux/mips64", CGOSupported | CrossBuildSupported},
 	{"linux/mips64le", CGOSupported | CrossBuildSupported},

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -41,8 +41,8 @@ const (
 	hubID             = "elastic"
 	logDriverName     = "elastic-logging-plugin"
 	dockerPluginName  = hubID + "/" + logDriverName
-	packageStagingDir = "build/package"
-	packageEndDir     = "build/distributions"
+	packageStagingDir = "build/package/"
+	packageEndDir     = "build/distributions/"
 	rootImageName     = "rootfsimage"
 )
 

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -14,14 +14,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-
-	"github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/pkg/errors"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
-	"github.com/pkg/errors"
 
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/common"
@@ -31,31 +35,31 @@ import (
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
-
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/archive"
 )
 
-var hubID = "elastic"
-var logDriverName = "elastic-logging-plugin"
-var dockerPluginName = filepath.Join(hubID, logDriverName)
-var packageStagingDir = "build/package/"
-var packageEndDir = "build/distributions/"
-var buildDir = filepath.Join(packageStagingDir, logDriverName)
-var dockerExportPath = filepath.Join(packageStagingDir, "temproot.tar")
-var rootImageName = "rootfsimage"
+const (
+	hubID             = "elastic"
+	logDriverName     = "elastic-logging-plugin"
+	dockerPluginName  = hubID + "/" + logDriverName
+	packageStagingDir = "build/package"
+	packageEndDir     = "build/distributions"
+	rootImageName     = "rootfsimage"
+)
+
+var (
+	buildDir         = filepath.Join(packageStagingDir, logDriverName)
+	dockerExportPath = filepath.Join(packageStagingDir, "temproot.tar")
+)
 
 func init() {
 	devtools.BeatLicense = "Elastic License"
 	devtools.BeatDescription = "The Docker Logging Driver is a docker plugin for the Elastic Stack."
+	devtools.Platforms = devtools.Platforms.Filter("linux/amd64")
 }
 
-// getPluginName returns the fully qualified name:version string
+// getPluginName returns the fully qualified name:version string.
 func getPluginName() (string, error) {
-	version, err := mage.BeatQualifiedVersion()
+	version, err := devtools.BeatQualifiedVersion()
 	if err != nil {
 		return "", errors.Wrap(err, "error getting beats version")
 	}
@@ -126,8 +130,8 @@ func BuildContainer(ctx context.Context) error {
 		return errors.Wrap(err, "error creating docker client")
 	}
 
-	mage.CreateDir(packageStagingDir)
-	mage.CreateDir(packageEndDir)
+	devtools.CreateDir(packageStagingDir)
+	devtools.CreateDir(packageEndDir)
 	err = os.MkdirAll(filepath.Join(buildDir, "rootfs"), 0755)
 	if err != nil {
 		return errors.Wrap(err, "error creating build dir")
@@ -174,7 +178,7 @@ func BuildContainer(ctx context.Context) error {
 
 	//misc prepare operations
 
-	err = mage.Copy("config.json", filepath.Join(buildDir, "config.json"))
+	err = devtools.Copy("config.json", filepath.Join(buildDir, "config.json"))
 	if err != nil {
 		return errors.Wrap(err, "error copying config.json")
 	}
@@ -280,12 +284,12 @@ func Install(ctx context.Context) error {
 
 // Export exports a "ready" root filesystem and config.json into a tarball
 func Export() error {
-	version, err := mage.BeatQualifiedVersion()
+	version, err := devtools.BeatQualifiedVersion()
 	if err != nil {
 		return errors.Wrap(err, "error getting beats version")
 	}
 
-	if mage.Snapshot {
+	if devtools.Snapshot {
 		version = version + "-SNAPSHOT"
 	}
 
@@ -310,7 +314,7 @@ func Export() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return devtools.CrossBuild(devtools.ForPlatforms("linux/amd64"))
+	return devtools.CrossBuild()
 }
 
 // Build builds the base container used by the docker plugin
@@ -321,7 +325,6 @@ func Build() {
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
-
 	buildArgs := devtools.DefaultBuildArgs()
 	buildArgs.CGO = false
 	buildArgs.Static = true
@@ -331,6 +334,14 @@ func GolangCrossBuild() error {
 
 // Package builds a "release" tarball that can be used later with `docker plugin create`
 func Package() {
+	start := time.Now()
+	defer func() { fmt.Println("package ran for", time.Since(start)) }()
+
+	if _, enabled := devtools.Platforms.Get("linux/amd64"); !enabled {
+		fmt.Println(">> package: skipping because linux/amd64 is not enabled")
+		return
+	}
+
 	mg.SerialDeps(Build, Export)
 }
 
@@ -341,7 +352,7 @@ func BuildAndInstall() {
 
 // Update is currently a dummy test for the `testsuite` target
 func Update() {
-	fmt.Printf("There is no Update for The Elastic Log Plugin\n")
+	fmt.Println(">> update: There is no Update for The Elastic Log Plugin")
 }
 
 func newDockerClient(ctx context.Context) (*client.Client, error) {


### PR DESCRIPTION
## What does this PR do?

This adds the aarch64 (arm64) architecture to the default list of Linux package targets.

This will add three new artifacts to each beat project. For example:

- filebeat-$version-arm64.deb
- filebeat-$version-aarch64.rpm
- filebeat-$version-linux-arm64.tar.gz

I had to modify dockerlogbeat to honor the PLATFORMS selector. It was always trying
to build its linux/amd64 docker image even if that platform was not selected.

## Why is it important?

The arm64 architecture is becoming more popular and beats should be available from our package repos.

## Checklist

- [x] Run the CI packaging job on this PR