### PR TITLE
Cherry-pick #17313 to 7.7: Move azure-eventhub input to GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -284,6 +284,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new module `o365` for ingesting Office 365 management activity API events. {issue}16196[16196] {pull}16386[16386]
 - Add Filebeat Okta module. {pull}16362[16362]
 - Improve AWS cloudtrail field mappings {issue}16086[16086] {issue}16110[16110] {pull}17155[17155]
+- Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
+- Move azure-eventhub input to GA. {issue}15671[15671] {pull}17313[17313]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -284,7 +284,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new module `o365` for ingesting Office 365 management activity API events. {issue}16196[16196] {pull}16386[16386]
 - Add Filebeat Okta module. {pull}16362[16362]
 - Improve AWS cloudtrail field mappings {issue}16086[16086] {issue}16110[16110] {pull}17155[17155]
-- Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
 - Move azure-eventhub input to GA. {issue}15671[15671] {pull}17313[17313]
 
 *Heartbeat*

--- a/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
@@ -9,8 +9,6 @@
 <titleabbrev>Azure eventhub</titleabbrev>
 ++++
 
-beta[]
-
 Users can make use of the `azure-eventhub` input in order to read messages from an azure eventhub.
 The azure-eventhub input implementation is based on the the event processor host (EPH is intended to be run across multiple processes and machines while load balancing message consumers more on this here https://github.com/Azure/azure-event-hubs-go#event-processor-host, https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-event-processor-host).
 State such as leases on partitions and checkpoints in the event stream are shared between receivers using an Azure Storage container. For this reason, as a prerequisite to using this input, users will have to create or use an existing storage account.

--- a/x-pack/filebeat/input/azureeventhub/input.go
+++ b/x-pack/filebeat/input/azureeventhub/input.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
@@ -62,7 +60,6 @@ func NewInput(
 	connector channel.Connector,
 	inputContext input.Context,
 ) (input.Input, error) {
-	cfgwarn.Beta("The %s input is beta", inputName)
 	var config azureInputConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, errors.Wrapf(err, "reading %s input config", inputName)


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17313 to 7.7 branch. Original message:

## What does this PR do?

Removes the beta labels in the azure-eventhub input

## Why is it important?

To move the input to GA

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Run the azure-eventhub input and check for the beta warnings in the logs, should be none

## Related issues

- Closes elastic/beats#15671
