### PR TITLE
Add prometheus metricsets configs in x-pack version

### DIFF
--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1027,7 +1027,6 @@ metricbeat.modules:
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
 
-
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
 #  metricsets: ["remote_write"]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1026,6 +1026,44 @@ metricbeat.modules:
 
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
+
+
+# Metrics sent by a Prometheus server using remote_write option
+#- module: prometheus
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
+
+  # Secure settings for the server using TLS/SSL:
+  #ssl.certificate: "/etc/pki/server/cert.pem"
+  #ssl.key: "/etc/pki/server/cert.key"
+
+# Metrics that will be collected using a PromQL
+#- module: prometheus
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"
+
 #------------------------------ Prometheus Module ------------------------------
 # Metrics collected from a Prometheus endpoint
 - module: prometheus

--- a/x-pack/metricbeat/module/prometheus/_meta/config.yml
+++ b/x-pack/metricbeat/module/prometheus/_meta/config.yml
@@ -19,3 +19,40 @@
 
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
+
+
+# Metrics sent by a Prometheus server using remote_write option
+#- module: prometheus
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
+
+  # Secure settings for the server using TLS/SSL:
+  #ssl.certificate: "/etc/pki/server/cert.pem"
+  #ssl.key: "/etc/pki/server/cert.key"
+
+# Metrics that will be collected using a PromQL
+#- module: prometheus
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"

--- a/x-pack/metricbeat/module/prometheus/_meta/config.yml
+++ b/x-pack/metricbeat/module/prometheus/_meta/config.yml
@@ -20,7 +20,6 @@
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
 
-
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
 #  metricsets: ["remote_write"]

--- a/x-pack/metricbeat/modules.d/prometheus.yml.disabled
+++ b/x-pack/metricbeat/modules.d/prometheus.yml.disabled
@@ -22,3 +22,40 @@
 
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
+
+
+# Metrics sent by a Prometheus server using remote_write option
+#- module: prometheus
+#  metricsets: ["remote_write"]
+#  host: "localhost"
+#  port: "9201"
+
+  # Secure settings for the server using TLS/SSL:
+  #ssl.certificate: "/etc/pki/server/cert.pem"
+  #ssl.key: "/etc/pki/server/cert.key"
+
+# Metrics that will be collected using a PromQL
+#- module: prometheus
+#  metricsets: ["query"]
+#  hosts: ["localhost:9090"]
+#  period: 10s
+#  queries:
+#  - name: "instant_vector"
+#    path: "/api/v1/query"
+#    params:
+#      query: "sum(rate(prometheus_http_requests_total[1m]))"
+#  - name: "range_vector"
+#    path: "/api/v1/query_range"
+#    params:
+#      query: "up"
+#      start: "2019-12-20T00:00:00.000Z"
+#      end:  "2019-12-21T00:00:00.000Z"
+#      step: 1h
+#  - name: "scalar"
+#    path: "/api/v1/query"
+#    params:
+#      query: "100"
+#  - name: "string"
+#    path: "/api/v1/query"
+#    params:
+#      query: "some_value"

--- a/x-pack/metricbeat/modules.d/prometheus.yml.disabled
+++ b/x-pack/metricbeat/modules.d/prometheus.yml.disabled
@@ -23,7 +23,6 @@
   # Store counter rates instead of original cumulative counters (experimental, default: false)
   #rate_counters: true
 
-
 # Metrics sent by a Prometheus server using remote_write option
 #- module: prometheus
 #  metricsets: ["remote_write"]


### PR DESCRIPTION
## What does this PR do?
Adds configuration for remaining metricsets of Prometheus when x-pack is used.

## Why is it important?
So as to have default configurations for `query` and `remote_write` metricsets when using x-pack version.