### PR TITLE
Cherry-pick #17291 to 7.x: Set accept header for prometheus client scraping

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,6 +175,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Check if CCR feature is available on Elasticsearch cluster before attempting to call CCR APIs from `elasticsearch/ccr` metricset. {issue}16511[16511] {pull}17073[17073]
 - Use max in k8s overview dashboard aggregations. {pull}17015[17015]
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
+- Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
 
 *Packetbeat*
 

--- a/metricbeat/helper/http.go
+++ b/metricbeat/helper/http.go
@@ -39,7 +39,7 @@ import (
 type HTTP struct {
 	hostData mb.HostData
 	client   *http.Client // HTTP client that is reused across requests.
-	headers  map[string]string
+	headers  http.Header
 	name     string
 	uri      string
 	method   string
@@ -58,8 +58,12 @@ func NewHTTP(base mb.BaseMetricSet) (*HTTP, error) {
 
 // newHTTPWithConfig creates a new http helper from some configuration
 func newHTTPFromConfig(config Config, name string, hostData mb.HostData) (*HTTP, error) {
+	headers := http.Header{}
 	if config.Headers == nil {
 		config.Headers = map[string]string{}
+	}
+	for k, v := range config.Headers {
+		headers.Set(k, v)
 	}
 
 	if config.BearerTokenFile != "" {
@@ -67,7 +71,7 @@ func newHTTPFromConfig(config Config, name string, hostData mb.HostData) (*HTTP,
 		if err != nil {
 			return nil, err
 		}
-		config.Headers["Authorization"] = header
+		headers.Set("Authorization", header)
 	}
 
 	tlsConfig, err := tlscommon.LoadTLSConfig(config.TLS)
@@ -103,7 +107,7 @@ func newHTTPFromConfig(config Config, name string, hostData mb.HostData) (*HTTP,
 			},
 			Timeout: config.Timeout,
 		},
-		headers: config.Headers,
+		headers: headers,
 		method:  "GET",
 		uri:     hostData.SanitizedURI,
 		body:    nil,
@@ -124,12 +128,9 @@ func (h *HTTP) FetchResponse() (*http.Response, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create HTTP request")
 	}
+	req.Header = h.headers
 	if h.hostData.User != "" || h.hostData.Password != "" {
 		req.SetBasicAuth(h.hostData.User, h.hostData.Password)
-	}
-
-	for k, v := range h.headers {
-		req.Header.Set(k, v)
 	}
 
 	resp, err := h.client.Do(req)
@@ -142,7 +143,17 @@ func (h *HTTP) FetchResponse() (*http.Response, error) {
 
 // SetHeader sets HTTP headers to use in requests
 func (h *HTTP) SetHeader(key, value string) {
-	h.headers[key] = value
+	h.headers.Set(key, value)
+}
+
+// SetHeaderDefault sets HTTP header as default
+//
+// Note: This will only set the header when the header is not already set.
+func (h *HTTP) SetHeaderDefault(key, value string) {
+	c := h.headers.Get(key)
+	if c == "" {
+		h.headers.Set(key, value)
+	}
 }
 
 // SetMethod sets HTTP method to use in requests

--- a/metricbeat/helper/http_test.go
+++ b/metricbeat/helper/http_test.go
@@ -162,6 +162,34 @@ func TestAuthentication(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "response status code")
 }
 
+func TestSetHeader(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Headers = map[string]string{
+		"Override": "default",
+	}
+
+	h, err := newHTTPFromConfig(cfg, "test", mb.HostData{})
+	require.NoError(t, err)
+
+	h.SetHeader("Override", "overridden")
+	v := h.headers.Get("override")
+	assert.Equal(t, "overridden", v)
+}
+
+func TestSetHeaderDefault(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Headers = map[string]string{
+		"Override": "default",
+	}
+
+	h, err := newHTTPFromConfig(cfg, "test", mb.HostData{})
+	require.NoError(t, err)
+
+	h.SetHeaderDefault("Override", "overridden")
+	v := h.headers.Get("override")
+	assert.Equal(t, "default", v)
+}
+
 func TestOverUnixSocket(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("unix domain socket aren't supported under Windows")

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -33,6 +33,8 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
+const acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+
 // Prometheus helper retrieves prometheus formatted metrics
 type Prometheus interface {
 	// GetFamilies requests metric families from prometheus endpoint and returns them
@@ -55,10 +57,11 @@ type httpfetcher interface {
 // NewPrometheusClient creates new prometheus helper
 func NewPrometheusClient(base mb.BaseMetricSet) (Prometheus, error) {
 	http, err := helper.NewHTTP(base)
-
 	if err != nil {
 		return nil, err
 	}
+
+	http.SetHeaderDefault("Accept", acceptHeader)
 	return &prometheus{http, base.Logger()}, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #17291 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Sets the default `Accept` header for the prometheus scraper to match the same accept header used by [upstream prometheus](https://github.com/prometheus/prometheus/blob/c453def8c5c7529a727508c07c872912e1a27920/scrape/scrape.go#L532).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Some servers that expose prometheus metrics can fail to respond unless this Accept header is present and correct.

Example being the referenced but that returns HTTP error code 406.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] `Accept` header is sent on request.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Closes elastic/beats#16870

