### PR TITLE
Add process.command_line to Sysmon module

### DIFF
--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -307,6 +307,7 @@ var sysmon = (function () {
             return;
         }
         evt.Put(field, winlogbeat.splitCommandLine(commandLine));
+        evt.Put("process.command_line", commandLine);
     };
 
     var splitProcessArgs = function(evt) {
@@ -468,6 +469,7 @@ var sysmon = (function () {
                 {from: "winlog.event_data.ProcessGuid", to: "process.entity_id"},
                 {from: "winlog.event_data.ProcessId", to: "process.pid", type: "long"},
                 {from: "winlog.event_data.Image", to: "process.executable"},
+                {from: "winlog.event_data.CommandLine", to: "process.command_line"},
                 {from: "winlog.event_data.CommandLine", to: "process.args"},
                 {from: "winlog.event_data.CurrentDirectory", to: "process.working_directory"},
                 {from: "winlog.event_data.ParentProcessGuid", to: "process.parent.entity_id"},


### PR DESCRIPTION
Adds the process.command_line field to Sysmon module that does not split the field into multiple values.

-Enhancement

## What does this PR do?


Added process.command_line field to sysmon module.


## Why is it important?

Previously the only field for the Sysmon module was `process.args`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes elastic/beats#16072