### PR TITLE
[7.x] Improve performance of metrics hashing in statsd module (#17309)

### DIFF
--- a/metricbeat/helper/labelhash/hash.go
+++ b/metricbeat/helper/labelhash/hash.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package prometheus
+package labelhash
 
 import (
 	"bytes"

--- a/metricbeat/helper/labelhash/hash_benchmark_test.go
+++ b/metricbeat/helper/labelhash/hash_benchmark_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package prometheus
+package labelhash
 
 import (
 	"testing"

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
+	"github.com/elastic/beats/v7/metricbeat/helper/labelhash"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 
 	dto "github.com/prometheus/client_model/go"
@@ -36,7 +36,7 @@ type PromEvent struct {
 
 // LabelsHash returns a repeatable string that is unique for the set of labels in this event
 func (p *PromEvent) LabelsHash() string {
-	return prometheus.LabelHash(p.Labels)
+	return labelhash.LabelHash(p.Labels)
 }
 
 // DefaultPromEventsGeneratorFactory returns the default prometheus events generator

--- a/x-pack/metricbeat/module/statsd/server/data_test.go
+++ b/x-pack/metricbeat/module/statsd/server/data_test.go
@@ -448,3 +448,38 @@ func TestChangeType(t *testing.T) {
 		"metric01": map[string]interface{}{"count": int64(2)},
 	}, events[0].MetricSetFields)
 }
+
+func BenchmarkIngest(b *testing.B) {
+	tests := []string{
+		"metric01:1.0|g|#k1:v1,k2:v2",
+		"metric02:2|c|#k1:v1,k2:v2",
+		"metric03:3|c|@0.1|#k1:v1,k2:v2",
+		"metric04:4|ms|#k1:v1,k2:v2",
+		"metric05:5|h|#k1:v1,k2:v2",
+		"metric06:6|h|#k1:v1,k2:v2",
+		"metric07:7|ms|#k1:v1,k2:v2",
+		"metric08:seven|s|#k1:v1,k2:v2",
+		"metric09,k1=v1,k2=v2:8|h",
+		"metric10.with.dots,k1=v1,k2=v2:9|h",
+	}
+
+	events := make([]*testUDPEvent, len(tests))
+	for i, d := range tests {
+		events[i] = &testUDPEvent{
+			event: common.MapStr{
+				server.EventDataKey: []byte(d),
+			},
+			meta: server.Meta{
+				"client_ip": "127.0.0.1",
+			},
+		}
+	}
+	ms := mbtest.NewMetricSet(b, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := ms.processor.Process(events[i%len(events)])
+		assert.NoError(b, err)
+	}
+
+}

--- a/x-pack/metricbeat/module/statsd/server/registry.go
+++ b/x-pack/metricbeat/module/statsd/server/registry.go
@@ -5,13 +5,13 @@
 package server
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/metricbeat/helper/labelhash"
 )
 
 var logger = logp.NewLogger("statd")
@@ -374,9 +374,9 @@ func (r *registry) GetOrNewSet(name string, tags map[string]string) *setMetric {
 }
 
 func (r *registry) metricHash(tags map[string]string) string {
-	b, err := json.Marshal(tags)
-	if err != nil { // shouldn't happen on a map[string]string
-		panic(err)
+	mapstrTags := common.MapStr{}
+	for k, v := range tags {
+		mapstrTags[k] = v
 	}
-	return string(b)
+	return labelhash.LabelHash(mapstrTags)
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Improve performance of metrics hashing in statsd module  (#17309)