### PR TITLE
[Metricbeat]Combine metrics with no dimension into one event

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,6 +134,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use max in k8s overview dashboard aggregations. {pull}17015[17015]
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
+- Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -120,6 +120,7 @@ image::./images/metricbeat-aws-elb-overview.png[]
 [float]
 === `lambda`
 When an invocation completes, Lambda sends a set of metrics to CloudWatch for that invocation.
+Default period in aws module configuration is set to `5m` for lambda metricset.
 The lambda metricset comes with a predefined dashboard:
 
 image::./images/metricbeat-aws-lambda-overview.png[]

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -112,6 +112,7 @@ image::./images/metricbeat-aws-elb-overview.png[]
 [float]
 === `lambda`
 When an invocation completes, Lambda sends a set of metrics to CloudWatch for that invocation.
+Default period in aws module configuration is set to `5m` for lambda metricset.
 The lambda metricset comes with a predefined dashboard:
 
 image::./images/metricbeat-aws-lambda-overview.png[]


### PR DESCRIPTION
## What does this PR do?

When collecting CloudWatch metrics with no dimension, they should be reported in the same metric/event instead of separate metrics/events. For example, lambda namespace reports metrics across all functions: ConcurrentExecutions, Duration, Errors, Invocations, Throttles. For metrics across all functions, they represent aggregate metrics for all functions in the current AWS Region. Instead of separating these metrics into individual events, cloudwatch metricset should report them as one metric.

## Why is it important?

Combining metrics with no dimension into one event will easily show users all the aggregated metrics from CloudWatch in one event.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. make sure there is at least one lambda function and also check cloudwatch to see if there are metrics for that lambda function.
2. enable aws module by `./metricbeat modules enable aws`
3. change aws.yml under modules.d to:
```
- module: aws
  period: 30s
  credential_profile_name: elastic-beats
  metricsets:
    - lambda
```
4. You should see events in Kibana with/without dimensions. There should be only one event without dimension which includes all CloudWatch aggregated metrics. For example:
```
{
  "_index": "metricbeat-8.0.0-2020.03.09-000001",
  "_type": "_doc",
  "_id": "YMxZLXEBCsIwLMtCN8hn",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2020-03-30T21:29:02.851Z",
    "ecs": {
      "version": "1.5.0"
    },
    "host": {
      "os": {
        "family": "darwin",
        "name": "Mac OS X",
        "kernel": "17.7.0",
        "build": "17G10021",
        "platform": "darwin",
        "version": "10.13.6"
      },
    "cloud": {
      "provider": "aws",
      "region": "us-west-1",
      "account": {
        "name": "elastic-beats",
        "id": "428152502467"
      }
    },
    "aws": {
      "lambda": {
        "metrics": {
          "Throttles": {
            "avg": 0
          },
          "Duration": {
            "avg": 3003.1659999999997
          },
          "Errors": {
            "avg": 1
          },
          "ConcurrentExecutions": {
            "avg": 1
          },
          "Invocations": {
            "avg": 1
          }
        }
      },
      "cloudwatch": {
        "namespace": "AWS/Lambda"
      }
    },
    "event": {
      "duration": 9918983165,
      "dataset": "aws.lambda",
      "module": "aws"
    },
    "metricset": {
      "name": "lambda",
      "period": 300000
    },
    "service": {
      "type": "aws"
    }
  },
  "fields": {
    "@timestamp": [
      "2020-03-30T21:29:02.851Z"
    ]
  },
  "sort": [
    1585603742851
  ]
}
```