### PR TITLE
add_process_metadata: container id: Do not cache whole cgroup file for each process

### DIFF
--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -107,7 +107,7 @@ func (p gosigarCidProvider) getCid(cgroups map[string]string) string {
 	for _, path := range cgroups {
 		for _, prefix := range p.cgroupPrefixes {
 			if strings.HasPrefix(path, prefix) {
-				return filepath.Base(strings.TrimSuffix(path, "/kube-proxy"))
+				return filepath.Base(path)
 			}
 		}
 	}

--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -37,10 +37,21 @@ type gosigarCidProvider struct {
 	hostPath           string
 	cgroupPrefixes     []string
 	processCgroupPaths func(string, int) (map[string]string, error)
-	cgroupsCache       *common.Cache
+	pidCidCache        *common.Cache
 }
 
 func (p gosigarCidProvider) GetCid(pid int) (result string, err error) {
+
+	var cid string
+	var ok bool
+
+	// check from cache
+	if p.pidCidCache != nil {
+		if cid, ok = p.pidCidCache.Get(pid).(string); ok {
+			p.log.Debugf("Using cached container id for pid=%v", pid)
+			return cid, nil
+		}
+	}
 
 	cgroups, err := p.getProcessCgroups(pid)
 
@@ -48,18 +59,22 @@ func (p gosigarCidProvider) GetCid(pid int) (result string, err error) {
 		p.log.Debugf("failed to get cgroups for pid=%v: %v", pid, err)
 	}
 
-	cid := p.getCid(cgroups)
+	cid = p.getCid(cgroups)
 
+	// add pid and cid to cache
+	if p.pidCidCache != nil {
+		p.pidCidCache.Put(pid, cid)
+	}
 	return cid, nil
 }
 
-func newCidProvider(hostPath string, cgroupPrefixes []string, processCgroupPaths func(string, int) (map[string]string, error), cgroupsCache *common.Cache) gosigarCidProvider {
+func newCidProvider(hostPath string, cgroupPrefixes []string, processCgroupPaths func(string, int) (map[string]string, error), pidCidCache *common.Cache) gosigarCidProvider {
 	return gosigarCidProvider{
 		log:                logp.NewLogger(providerName),
 		hostPath:           hostPath,
 		cgroupPrefixes:     cgroupPrefixes,
 		processCgroupPaths: processCgroupPaths,
-		cgroupsCache:       cgroupsCache,
+		pidCidCache:        pidCidCache,
 	}
 }
 
@@ -68,14 +83,6 @@ func newCidProvider(hostPath string, cgroupPrefixes []string, processCgroupPaths
 func (p gosigarCidProvider) getProcessCgroups(pid int) (map[string]string, error) {
 
 	var cgroup map[string]string
-	var ok bool
-
-	if p.cgroupsCache != nil {
-		if cgroup, ok = p.cgroupsCache.Get(pid).(map[string]string); ok {
-			p.log.Debugf("Using cached cgroups for pid=%v", pid)
-			return cgroup, nil
-		}
-	}
 
 	cgroup, err := p.processCgroupPaths(p.hostPath, pid)
 	switch err.(type) {
@@ -85,10 +92,6 @@ func (p gosigarCidProvider) getProcessCgroups(pid int) (map[string]string, error
 	default:
 		// should never happen
 		return cgroup, errors.Wrapf(err, "failed to read cgroups for pid=%v", pid)
-	}
-
-	if p.cgroupsCache != nil {
-		p.cgroupsCache.Put(pid, cgroup)
 	}
 
 	return cgroup, nil
@@ -104,7 +107,7 @@ func (p gosigarCidProvider) getCid(cgroups map[string]string) string {
 	for _, path := range cgroups {
 		for _, prefix := range p.cgroupPrefixes {
 			if strings.HasPrefix(path, prefix) {
-				return filepath.Base(path)
+				return filepath.Base(strings.TrimSuffix(path, "/kube-proxy"))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Current solution caches whole content of cgroup file for each process. Let's cache only found container ids. 

Also, current solution skips kube-proxy container processes, because cgroup path has suffix /kube-proxy. 
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Caching such a pile of useless data has performance impact.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 
Relates #15947
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
