### PR TITLE
Small correction to googlecloud/firewall docs

### DIFF
--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -82,8 +82,8 @@ Example config:
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id
-    var.topic: googlecloud-vpc-flowlogs
-    var.subscription_name: filebeat-googlecloud-vpc-flowlogs-sub
+    var.topic: googlecloud-vpc-firewall
+    var.subscription_name: filebeat-googlecloud-vpc-firewall-sub
     var.credentials_file: ${path.config}/gcp-service-account-xyz.json
     var.keep_original_message: false
 ----

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -77,8 +77,8 @@ Example config:
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id
-    var.topic: googlecloud-vpc-flowlogs
-    var.subscription_name: filebeat-googlecloud-vpc-flowlogs-sub
+    var.topic: googlecloud-vpc-firewall
+    var.subscription_name: filebeat-googlecloud-vpc-firewall-sub
     var.credentials_file: ${path.config}/gcp-service-account-xyz.json
     var.keep_original_message: false
 ----


### PR DESCRIPTION
## What does this PR do?

Fixes misleading config example in the docs for Filebeat's googlecloud/firewall fileset.

## Why is it important?

Well it's not that important.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
