### PR TITLE
Cherry-pick #17196 to 7.7: Recommend `remote_write` instead of federate API

### DIFF
--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -79,6 +79,13 @@ When `use_types` and `rate_counters` are enabled, metrics are stored like this:
 [float]
 === Scraping all metrics from a Prometheus server
 
+[WARNING]
+=======================================
+Depending on your scale this method may not be suitable. We recommend using the
+<<metricbeat-metricset-prometheus-remote_write,remote_write>> metricset for this,
+and make Prometheus push metrics to Metricbeat.
+=======================================
+
 This module can scrape all metrics stored in a Prometheus server, by using the
 https://prometheus.io/docs/prometheus/latest/federation/[federation API]. By pointing this
 config to the Prometheus server:


### PR DESCRIPTION
Cherry-pick of PR #17196 to 7.7 branch. Original message: 

Update docs to recommend using `remote_write` over the federate API to obtain metrics from a Prometheus server. Remote write should be more robust as the federate API is not really intended for this use.