### PR TITLE
[Agent] fixed mage package for agent

### DIFF
--- a/dev-tools/mage/dmgbuilder.go
+++ b/dev-tools/mage/dmgbuilder.go
@@ -244,6 +244,7 @@ func (b *dmgBuilder) buildDMG() error {
 		"create",
 		"-volname", b.MustExpand("{{.BeatName | title}} {{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}"),
 		"-srcfolder", b.dmgDir,
+		"-size", "500m", // allowing extra space
 		"-ov",
 		createDir(dmgFile),
 	}


### PR DESCRIPTION
## What does this PR do?
 
`mage package` for `dmg` was failing for agent as `hdiutils create` failed to fit content of package into volume.
Specifying a larger initial size of a volume seems to fix the issue.

## Why is it important?

makes mage package work

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
