### PR TITLE
Cherry-pick #17332 to 7.7: Populate default settings for logging.file.*

### DIFF
--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -54,6 +54,8 @@ type FileConfig struct {
 	RedirectStderr  bool          `config:"redirect_stderr"`
 }
 
+const defaultLevel = InfoLevel
+
 // DefaultConfig returns the default config options for a given environment the
 // Beat is supposed to be run within.
 func DefaultConfig(environment Environment) Config {
@@ -70,23 +72,28 @@ func DefaultConfig(environment Environment) Config {
 
 func defaultToStderrConfig() Config {
 	return Config{
-		Level:     InfoLevel,
+		Level:     defaultLevel,
 		ToStderr:  true,
+		Files:     defaultFileConfig(),
 		addCaller: true,
 	}
 }
 
 func defaultToFileConfig() Config {
 	return Config{
-		Level:   InfoLevel,
-		ToFiles: true,
-		Files: FileConfig{
-			MaxSize:         10 * 1024 * 1024,
-			MaxBackups:      7,
-			Permissions:     0600,
-			Interval:        0,
-			RotateOnStartup: true,
-		},
+		Level:     defaultLevel,
+		ToFiles:   true,
+		Files:     defaultFileConfig(),
 		addCaller: true,
+	}
+}
+
+func defaultFileConfig() FileConfig {
+	return FileConfig{
+		MaxSize:         10 * 1024 * 1024,
+		MaxBackups:      7,
+		Permissions:     0600,
+		Interval:        0,
+		RotateOnStartup: true,
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #17332 to 7.7 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

If the configured environment default to stderr logging, then the
logging.file.* settings are not populated anymore, which requires users
to configure all settings if they don't want to default to stderr. The change sets the
default settings for logging.file.* always.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Fix bug introduced with #15422 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run Beat with `-environment container`, but configure `logging.to_file: true` in the Beats configuration file. The Beat should start logging to the file, instead of failing to start.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #17307 
- Closes #17302 
- Related #15422 (introduced bug)