### PR TITLE
Fix issues with output reloading

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bug with `monitoring.cluster_uuid` setting not always being exposed via GET /state Beats API. {issue}16732[16732] {pull}17420[17420]
 - Fix building on FreeBSD by removing build flags from `add_cloudfoundry_metadata` processor. {pull}17486[17486]
 - Do not rotate log files on startup when interval is configured and rotateonstartup is disabled. {pull}17613[17613]
+- Fix goroutine leak and Elasticsearch output file descriptor leak when output reloading is in use. {issue}10491[10491] {pull}17381[17381]
 
 *Auditbeat*
 

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -407,6 +407,9 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 		req.Host = host
 	}
 
+	// TODO: workaround for output reloading leaking FDs until context.WithCancel is used on transport dialer instead
+	req.Header.Set("Connection", "close")
+
 	resp, err := conn.HTTP.Do(req)
 	if err != nil {
 		return 0, nil, err

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -280,6 +280,7 @@ func (conn *Connection) Ping() (string, error) {
 
 // Close closes a connection.
 func (conn *Connection) Close() error {
+	conn.HTTP.CloseIdleConnections()
 	return nil
 }
 

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -63,11 +63,15 @@ type ConnectionSettings struct {
 	Parameters       map[string]string
 	CompressionLevel int
 	EscapeHTML       bool
-	Timeout          time.Duration
+
+	Timeout         time.Duration
+	IdleConnTimeout time.Duration
 }
 
 // NewConnection returns a new Elasticsearch client
 func NewConnection(s ConnectionSettings) (*Connection, error) {
+	s = settingsWithDefaults(s)
+
 	u, err := url.Parse(s.URL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse elasticsearch URL: %v", err)
@@ -124,12 +128,22 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 				DialTLS:         tlsDialer.Dial,
 				TLSClientConfig: s.TLS.ToConfig(),
 				Proxy:           proxy,
+				IdleConnTimeout: s.IdleConnTimeout,
 			},
 			Timeout: s.Timeout,
 		},
 		Encoder: encoder,
 		log:     logp.NewLogger("esclientleg"),
 	}, nil
+}
+
+func settingsWithDefaults(s ConnectionSettings) ConnectionSettings {
+	settings := s
+	if settings.IdleConnTimeout == 0 {
+		settings.IdleConnTimeout = 1 * time.Minute
+	}
+
+	return settings
 }
 
 // NewClients returns a list of Elasticsearch clients based on the given
@@ -406,9 +420,6 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	if host := req.Header.Get("Host"); host != "" {
 		req.Host = host
 	}
-
-	// TODO: workaround for output reloading leaking FDs until context.WithCancel is used on transport dialer instead
-	req.Header.Set("Connection", "close")
 
 	resp, err := conn.HTTP.Do(req)
 	if err != nil {

--- a/libbeat/publisher/pipeline/batch.go
+++ b/libbeat/publisher/pipeline/batch.go
@@ -24,7 +24,13 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
-type Batch struct {
+type Batch interface {
+	publisher.Batch
+
+	reduceTTL() bool
+}
+
+type batch struct {
 	original queue.Batch
 	ctx      *batchContext
 	ttl      int
@@ -38,17 +44,17 @@ type batchContext struct {
 
 var batchPool = sync.Pool{
 	New: func() interface{} {
-		return &Batch{}
+		return &batch{}
 	},
 }
 
-func newBatch(ctx *batchContext, original queue.Batch, ttl int) *Batch {
+func newBatch(ctx *batchContext, original queue.Batch, ttl int) *batch {
 	if original == nil {
 		panic("empty batch")
 	}
 
-	b := batchPool.Get().(*Batch)
-	*b = Batch{
+	b := batchPool.Get().(*batch)
+	*b = batch{
 		original: original,
 		ctx:      ctx,
 		ttl:      ttl,
@@ -57,45 +63,47 @@ func newBatch(ctx *batchContext, original queue.Batch, ttl int) *Batch {
 	return b
 }
 
-func releaseBatch(b *Batch) {
-	*b = Batch{} // clear batch
+func releaseBatch(b *batch) {
+	*b = batch{} // clear batch
 	batchPool.Put(b)
 }
 
-func (b *Batch) Events() []publisher.Event {
+func (b *batch) Events() []publisher.Event {
 	return b.events
 }
 
-func (b *Batch) ACK() {
-	b.ctx.observer.outBatchACKed(len(b.events))
+func (b *batch) ACK() {
+	if b.ctx != nil {
+		b.ctx.observer.outBatchACKed(len(b.events))
+	}
 	b.original.ACK()
 	releaseBatch(b)
 }
 
-func (b *Batch) Drop() {
+func (b *batch) Drop() {
 	b.original.ACK()
 	releaseBatch(b)
 }
 
-func (b *Batch) Retry() {
+func (b *batch) Retry() {
 	b.ctx.retryer.retry(b)
 }
 
-func (b *Batch) Cancelled() {
+func (b *batch) Cancelled() {
 	b.ctx.retryer.cancelled(b)
 }
 
-func (b *Batch) RetryEvents(events []publisher.Event) {
+func (b *batch) RetryEvents(events []publisher.Event) {
 	b.updEvents(events)
 	b.Retry()
 }
 
-func (b *Batch) CancelledEvents(events []publisher.Event) {
+func (b *batch) CancelledEvents(events []publisher.Event) {
 	b.updEvents(events)
 	b.Cancelled()
 }
 
-func (b *Batch) updEvents(events []publisher.Event) {
+func (b *batch) updEvents(events []publisher.Event) {
 	l1 := len(b.events)
 	l2 := len(events)
 	if l1 > l2 {
@@ -104,4 +112,34 @@ func (b *Batch) updEvents(events []publisher.Event) {
 	}
 
 	b.events = events
+}
+
+// reduceTTL reduces the time to live for all events that have no 'guaranteed'
+// sending requirements.  reduceTTL returns true if the batch is still alive.
+func (b *batch) reduceTTL() bool {
+	if b.ttl <= 0 {
+		return true
+	}
+
+	b.ttl--
+	if b.ttl > 0 {
+		return true
+	}
+
+	// filter for evens with guaranteed send flags
+	events := b.events[:0]
+	for _, event := range b.events {
+		if event.Guaranteed() {
+			events = append(events, event)
+		}
+	}
+	b.events = events
+
+	if len(b.events) > 0 {
+		b.ttl = -1 // we need infinite retry for all events left in this batch
+		return true
+	}
+
+	// all events have been dropped:
+	return false
 }

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -129,6 +129,8 @@ func (c *eventConsumer) updOutput(grp *outputGroup) {
 		tag:      sigConsumerUpdateInput,
 		consumer: c.consumer,
 	}
+
+	//lf("consumer: updated output group to id = %v", grp.id)
 }
 
 func (c *eventConsumer) loop(consumer queue.Consumer) {
@@ -157,7 +159,7 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 		}
 
 		paused = c.paused()
-		if !paused && c.out != nil && batch != nil {
+		if c.out != nil && batch != nil {
 			out = c.out.workQueue
 		} else {
 			out = nil
@@ -170,19 +172,19 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 			//lf("consuming from queue...")
 			queueBatch, err := consumer.Get(c.out.batchSize)
 			if err != nil {
-				lf("error consuming from queue")
+				//lf("error consuming from queue")
 				out = nil
 				consumer = nil
 				continue
 			}
 			if queueBatch != nil {
-				lf("consumed batch of %v events from queue", len(queueBatch.Events()))
+				//lf("consumed batch of %v events from queue", len(queueBatch.Events()))
 				batch = newBatch(c.ctx, queueBatch, c.out.timeToLive)
 			}
 
 			paused = c.paused()
 			if paused || batch == nil {
-				lf("paused: %v, batch == nil? = %v; setting out to nil", paused, batch == nil)
+				//lf("paused: %v, batch == nil? = %v; setting out to nil", paused, batch == nil)
 				out = nil
 			}
 			//} else {
@@ -197,26 +199,26 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 		default:
 		}
 
-		if out == nil && batch != nil {
-			lf("out == nil and batch != nil")
-		}
+		//if out == nil && batch != nil {
+		//	lf("out == nil but have batch with %v events", len(batch.Events()))
+		//}
 
 		select {
 		case <-c.done:
-			lf("consumer done")
+			//lf("consumer done")
 			log.Debug("stop pipeline event consumer")
 			return
 		case sig := <-c.sig:
 			if out == nil && batch != nil {
-				lf("in second select; handled sig %v", sig.tag)
+				//lf("in second select; handled sig %v", sig.tag)
 			}
 			handleSignal(sig)
 		case out <- batch:
-			numEvents := 0
-			if batch != nil {
-				numEvents = len(batch.Events())
-			}
-			lf("in consumer: sent batch of %v events to workqueue", numEvents)
+			//numEvents := 0
+			//if batch != nil {
+			//	numEvents = len(batch.Events())
+			//}
+			//lf("in consumer: sent batch of %v events to workqueue", numEvents)
 			batch = nil
 		}
 	}

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -129,8 +129,6 @@ func (c *eventConsumer) updOutput(grp *outputGroup) {
 		tag:      sigConsumerUpdateInput,
 		consumer: c.consumer,
 	}
-
-	//lf("consumer: updated output group to id = %v", grp.id)
 }
 
 func (c *eventConsumer) loop(consumer queue.Consumer) {
@@ -149,9 +147,6 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 		case sigConsumerCheck:
 
 		case sigConsumerUpdateOutput:
-			//if out == nil && batch != nil {
-			//	lf("handling sigConsumerUpdateOutput")
-			//}
 			c.out = sig.out
 
 		case sigConsumerUpdateInput:
@@ -169,27 +164,20 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 	for {
 		if !paused && c.out != nil && consumer != nil && batch == nil {
 			out = c.out.workQueue
-			//lf("consuming from queue...")
 			queueBatch, err := consumer.Get(c.out.batchSize)
 			if err != nil {
-				//lf("error consuming from queue")
 				out = nil
 				consumer = nil
 				continue
 			}
 			if queueBatch != nil {
-				//lf("consumed batch of %v events from queue", len(queueBatch.Events()))
 				batch = newBatch(c.ctx, queueBatch, c.out.timeToLive)
 			}
 
 			paused = c.paused()
 			if paused || batch == nil {
-				//lf("paused: %v, batch == nil? = %v; setting out to nil", paused, batch == nil)
 				out = nil
 			}
-			//} else {
-			//	lf("paused = %v, c.out == nil = %v, consumer == nil = %v, batch == nil? = %v",
-			//		paused, c.out == nil, consumer == nil, batch == nil)
 		}
 
 		select {
@@ -199,26 +187,13 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 		default:
 		}
 
-		//if out == nil && batch != nil {
-		//	lf("out == nil but have batch with %v events", len(batch.Events()))
-		//}
-
 		select {
 		case <-c.done:
-			//lf("consumer done")
 			log.Debug("stop pipeline event consumer")
 			return
 		case sig := <-c.sig:
-			if out == nil && batch != nil {
-				//lf("in second select; handled sig %v", sig.tag)
-			}
 			handleSignal(sig)
 		case out <- batch:
-			//numEvents := 0
-			//if batch != nil {
-			//	numEvents = len(batch.Events())
-			//}
-			//lf("in consumer: sent batch of %v events to workqueue", numEvents)
 			batch = nil
 		}
 	}

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -138,7 +138,7 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 
 	var (
 		out    workQueue
-		batch  *Batch
+		batch  Batch
 		paused = true
 	)
 

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -195,6 +195,9 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 			handleSignal(sig)
 		case out <- batch:
 			batch = nil
+			if paused {
+				out = nil
+			}
 		}
 	}
 }

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
@@ -51,7 +52,7 @@ type outputGroup struct {
 	timeToLive int // event lifetime
 }
 
-type workQueue chan *Batch
+type workQueue chan publisher.Batch
 
 // outputWorker instances pass events from the shared workQueue to the outputs.Client
 // instances.
@@ -143,7 +144,7 @@ func (c *outputController) Set(outGrp outputs.Group) {
 }
 
 func makeWorkQueue() workQueue {
-	return workQueue(make(chan *Batch, 0))
+	return workQueue(make(chan publisher.Batch, 0))
 }
 
 // Reload the output

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -103,7 +103,8 @@ func (c *outputController) Set(outGrp outputs.Group) {
 	// Pause consumer
 	c.consumer.sigPause()
 
-	// close old group, so events are send to new workQueue via retryer
+	// close old output group's workers and "remove" them from the retryer
+	// so it temporarily stops processing the retry queue
 	if c.out != nil {
 		for _, w := range c.out.outputs {
 			w.Close()
@@ -111,7 +112,7 @@ func (c *outputController) Set(outGrp outputs.Group) {
 		}
 	}
 
-	// create new outputGroup with shared work queue
+	// create new output group with the shared work queue
 	clients := outGrp.Clients
 	worker := make([]outputWorker, len(clients))
 	for i, client := range clients {

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -20,10 +20,13 @@ package pipeline
 import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
+
+var _grpID atomic.Uint
 
 // outputController manages the pipelines output capabilities, like:
 // - start
@@ -44,6 +47,7 @@ type outputController struct {
 
 // outputGroup configures a group of load balanced outputs with shared work queue.
 type outputGroup struct {
+	id        uint
 	workQueue workQueue
 	outputs   []outputWorker
 
@@ -118,6 +122,7 @@ func (c *outputController) Set(outGrp outputs.Group) {
 		worker[i] = makeClientWorker(c.observer, c.workQueue, client)
 	}
 	grp := &outputGroup{
+		id:         _workerID.Inc(),
 		workQueue:  c.workQueue,
 		outputs:    worker,
 		timeToLive: outGrp.Retry + 1,

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -64,18 +64,18 @@ func newOutputController(
 	beat beat.Info,
 	monitors Monitors,
 	observer outputObserver,
-	b queue.Queue,
+	queue queue.Queue,
 ) *outputController {
 	c := &outputController{
 		beat:      beat,
 		monitors:  monitors,
 		observer:  observer,
-		queue:     b,
+		queue:     queue,
 		workQueue: makeWorkQueue(),
 	}
 
 	ctx := &batchContext{}
-	c.consumer = newEventConsumer(monitors.Logger, b, ctx)
+	c.consumer = newEventConsumer(monitors.Logger, queue, ctx)
 	c.retryer = newRetryer(monitors.Logger, observer, c.workQueue, c.consumer)
 	ctx.observer = observer
 	ctx.retryer = c.retryer

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -121,7 +121,6 @@ func (c *outputController) Set(outGrp outputs.Group) {
 			c.retryer.sigOutputRemoved()
 		}
 	}
-	c.retryer.updOutput(c.workQueue)
 	for range clients {
 		c.retryer.sigOutputAdded()
 	}

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -137,7 +137,6 @@ func (c *outputController) Set(outGrp outputs.Group) {
 
 	// restart consumer (potentially blocked by retryer)
 	c.consumer.sigContinue()
-	c.consumer.sigUnWait()
 
 	c.observer.updateOutputGroup()
 }

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestOutputReload(t *testing.T) {
 	tests := map[string]func(mockPublishFn) outputs.Client{
-		//"client":         newMockClient,
+		"client":         newMockClient,
 		"network_client": newMockNetworkClient,
 	}
 
@@ -49,11 +49,11 @@ func TestOutputReload(t *testing.T) {
 			defer goroutines.Check(t)
 
 			err := quick.Check(func(q uint) bool {
-				lf("*** Starting new test ***")
-				//numEventsToPublish := 15000 + (q % 500) // 15000 to 19999
-				//numOutputReloads := 350 + (q % 150)     // 350 to 499
-				numEventsToPublish := uint(19999)
-				numOutputReloads := uint(499)
+				//lf("*** Starting new test ***")
+				numEventsToPublish := 15000 + (q % 500) // 15000 to 19999
+				numOutputReloads := 350 + (q % 150)     // 350 to 499
+				//numEventsToPublish := uint(19999)
+				//numOutputReloads := uint(499)
 
 				queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
 					return memqueue.NewQueue(
@@ -67,7 +67,7 @@ func TestOutputReload(t *testing.T) {
 				var publishedCount atomic.Uint
 				countingPublishFn := func(batch publisher.Batch) error {
 					publishedCount.Add(uint(len(batch.Events())))
-					lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
+					//lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
 					return nil
 				}
 
@@ -105,18 +105,18 @@ func TestOutputReload(t *testing.T) {
 
 				wg.Wait()
 
-				timeout := 5 * time.Second
+				timeout := 20 * time.Second
 				success := waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
 				if !success {
 					lf(
-						"in test: result: numOutputReloads = %v, numEventsToPublish = %v, publishedCounted = %v",
+						"*** test result: numOutputReloads = %v, numEventsToPublish = %v, publishedCounted = %v ***",
 						numOutputReloads, numEventsToPublish, publishedCount.Load(),
 					)
 				}
 				return success
-			}, &quick.Config{MaxCount: 250})
+			}, &quick.Config{MaxCount: 25})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -104,7 +104,7 @@ func TestOutputReload(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
-			}, &quick.Config{MaxCount: 15})
+			}, &quick.Config{MaxCount: 10})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -49,11 +49,8 @@ func TestOutputReload(t *testing.T) {
 			defer goroutines.Check(t)
 
 			err := quick.Check(func(q uint) bool {
-				//lf("*** Starting new test ***")
 				numEventsToPublish := 15000 + (q % 500) // 15000 to 19999
 				numOutputReloads := 350 + (q % 150)     // 350 to 499
-				//numEventsToPublish := uint(19999)
-				//numOutputReloads := uint(499)
 
 				queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
 					return memqueue.NewQueue(
@@ -67,7 +64,6 @@ func TestOutputReload(t *testing.T) {
 				var publishedCount atomic.Uint
 				countingPublishFn := func(batch publisher.Batch) error {
 					publishedCount.Add(uint(len(batch.Events())))
-					//lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
 					return nil
 				}
 
@@ -99,23 +95,15 @@ func TestOutputReload(t *testing.T) {
 					out := outputs.Group{
 						Clients: []outputs.Client{outputClient},
 					}
-					//lf("in test: reloading output...")
 					pipeline.output.Set(out)
 				}
 
 				wg.Wait()
 
 				timeout := 20 * time.Second
-				success := waitUntilTrue(timeout, func() bool {
+				return waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
-				if !success {
-					lf(
-						"*** test result: numOutputReloads = %v, numEventsToPublish = %v, publishedCounted = %v ***",
-						numOutputReloads, numEventsToPublish, publishedCount.Load(),
-					)
-				}
-				return success
 			}, &quick.Config{MaxCount: 25})
 
 			if err != nil {

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -1,0 +1,115 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+
+	"github.com/elastic/beats/v7/libbeat/outputs"
+
+	"github.com/elastic/beats/v7/libbeat/publisher"
+
+	"github.com/elastic/beats/v7/libbeat/common/atomic"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
+
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+)
+
+func TestOutputReload(t *testing.T) {
+	tests := map[string]func(mockPublishFn) outputs.Client{
+		"client":         newMockClient,
+		"network_client": newMockNetworkClient,
+	}
+
+	for name, ctor := range tests {
+		t.Run(name, func(t *testing.T) {
+			seedPRNG(t)
+
+			goroutines := resources.NewGoroutinesChecker()
+			defer goroutines.Check(t)
+
+			err := quick.Check(func(q uint) bool {
+				numEventsToPublish := 500 + (q % 1000) // 500 to 1499
+				numOutputReloads := 5 + (q % 10)       // 5 to 14
+
+				queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
+					return memqueue.NewQueue(
+						logp.L(),
+						memqueue.Settings{
+							ACKListener: ackListener,
+							Events:      int(numEventsToPublish),
+						}), nil
+				}
+
+				var publishedCount atomic.Uint
+				countingPublishFn := func(batch publisher.Batch) error {
+					publishedCount.Add(uint(len(batch.Events())))
+					return nil
+				}
+
+				pipeline, err := New(
+					beat.Info{},
+					Monitors{},
+					queueFactory,
+					outputs.Group{},
+					Settings{},
+				)
+				require.NoError(t, err)
+				defer pipeline.Close()
+
+				pipelineClient, err := pipeline.Connect()
+				require.NoError(t, err)
+				defer pipelineClient.Close()
+
+				go func() {
+					for i := uint(0); i < numEventsToPublish; i++ {
+						pipelineClient.Publish(beat.Event{})
+					}
+				}()
+
+				for i := uint(0); i < numOutputReloads; i++ {
+					outputClient := ctor(countingPublishFn)
+					out := outputs.Group{
+						Clients: []outputs.Client{outputClient},
+					}
+					pipeline.output.Set(out)
+				}
+
+				timeout := 20 * time.Second
+				return waitUntilTrue(timeout, func() bool {
+					return uint(numEventsToPublish) == publishedCount.Load()
+				})
+			}, &quick.Config{MaxCount: 25})
+
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -38,8 +38,8 @@ import (
 
 func TestOutputReload(t *testing.T) {
 	tests := map[string]func(mockPublishFn) outputs.Client{
-		"client":         newMockClient,
-		"network_client": newMockNetworkClient,
+		"client": newMockClient,
+		//"network_client": newMockNetworkClient,
 	}
 
 	for name, ctor := range tests {
@@ -65,7 +65,7 @@ func TestOutputReload(t *testing.T) {
 				var publishedCount atomic.Uint
 				countingPublishFn := func(batch publisher.Batch) error {
 					publishedCount.Add(uint(len(batch.Events())))
-					lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
+					//lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
 					return nil
 				}
 
@@ -97,7 +97,7 @@ func TestOutputReload(t *testing.T) {
 					out := outputs.Group{
 						Clients: []outputs.Client{outputClient},
 					}
-					lf("in test: reloading output...")
+					//lf("in test: reloading output...")
 					pipeline.output.Set(out)
 				}
 
@@ -121,9 +121,4 @@ func TestOutputReload(t *testing.T) {
 			}
 		})
 	}
-}
-
-func lf(msg string, v ...interface{}) {
-	now := time.Now().Format("15:04:05.00000")
-	fmt.Printf(now+" "+msg+"\n", v...)
 }

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -104,7 +104,7 @@ func TestOutputReload(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
-			}, &quick.Config{MaxCount: 10})
+			}, &quick.Config{MaxCount: 1})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -104,7 +104,7 @@ func TestOutputReload(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
-			}, &quick.Config{MaxCount: 25})
+			}, &quick.Config{MaxCount: 15})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -104,7 +104,7 @@ func TestOutputReload(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return uint(numEventsToPublish) == publishedCount.Load()
 				})
-			}, &quick.Config{MaxCount: 1})
+			}, &quick.Config{MaxCount: 25})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -154,7 +154,7 @@ func (w *netClientWorker) run() {
 
 		case batch, ok := <-w.qu:
 			if !ok {
-				w.lf("workqueue closed")
+				//w.lf("workqueue closed")
 			}
 			if batch == nil {
 				continue
@@ -185,7 +185,7 @@ func (w *netClientWorker) run() {
 				continue
 			}
 
-			w.lf("about to publish %v events", len(batch.Events()))
+			//w.lf("about to publish %v events", len(batch.Events()))
 			w.inFlight = make(chan struct{})
 			if err := w.client.Publish(batch); err != nil {
 				close(w.inFlight)

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -51,16 +51,21 @@ func makeClientWorker(observer outputObserver, qu workQueue, client outputs.Clie
 		qu:       qu,
 	}
 
+	var c interface {
+		outputWorker
+		run()
+	}
+
 	if nc, ok := client.(outputs.NetworkClient); ok {
-		c := &netClientWorker{
+		c = &netClientWorker{
 			worker: w,
 			client: nc,
 			logger: logp.NewLogger("publisher_pipeline_output"),
 		}
-		go c.run()
-		return c
+	} else {
+		c = &clientWorker{worker: w, client: client}
 	}
-	c := &clientWorker{worker: w, client: client}
+
 	go c.run()
 	return c
 }

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -19,10 +19,16 @@ package pipeline
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 )
+
+func lf(msg string, v ...interface{}) {
+	now := time.Now().Format("15:04:05.00000")
+	fmt.Printf(now+" "+msg+"\n", v...)
+}
 
 type worker struct {
 	observer outputObserver
@@ -88,10 +94,10 @@ func (w *worker) close() {
 	for {
 		select {
 		case batch := <-w.qu:
-			//fmt.Println("Canceling in-flight batch before closing...")
+			//lf("Canceling in-flight batch before closing...")
 			batch.Cancelled()
 		default:
-			fmt.Println("no inflight batches")
+			//lf("no inflight batches")
 			return
 		}
 	}

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -70,8 +70,17 @@ func makeClientWorker(observer outputObserver, qu workQueue, client outputs.Clie
 	return c
 }
 
+func (w *worker) close() {
+	close(w.done)
+
+	// Cancel in-flight batches so they may be retried
+	for batch := range w.qu {
+		batch.Cancelled()
+	}
+}
+
 func (w *clientWorker) Close() error {
-	close(w.worker.done)
+	w.worker.close()
 	return w.client.Close()
 }
 
@@ -95,7 +104,7 @@ func (w *clientWorker) run() {
 }
 
 func (w *netClientWorker) Close() error {
-	close(w.worker.done)
+	w.worker.close()
 	return w.client.Close()
 }
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -20,7 +20,6 @@ package pipeline
 import (
 	"flag"
 	"math"
-	"math/rand"
 	"sync"
 	"testing"
 	"testing/quick"
@@ -29,10 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
-	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
 var (
@@ -170,92 +167,4 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 			}
 		})
 	}
-}
-
-type mockPublishFn func(publisher.Batch) error
-
-func newMockClient(publishFn mockPublishFn) outputs.Client {
-	return &mockClient{publishFn: publishFn}
-}
-
-type mockClient struct {
-	publishFn mockPublishFn
-}
-
-func (c *mockClient) String() string { return "mock_client" }
-func (c *mockClient) Close() error   { return nil }
-func (c *mockClient) Publish(batch publisher.Batch) error {
-	return c.publishFn(batch)
-}
-
-func newMockNetworkClient(publishFn mockPublishFn) outputs.Client {
-	return &mockNetworkClient{newMockClient(publishFn)}
-}
-
-type mockNetworkClient struct {
-	outputs.Client
-}
-
-func (c *mockNetworkClient) Connect() error { return nil }
-
-type mockQueue struct{}
-
-func (q mockQueue) Close() error                                     { return nil }
-func (q mockQueue) BufferConfig() queue.BufferConfig                 { return queue.BufferConfig{} }
-func (q mockQueue) Producer(cfg queue.ProducerConfig) queue.Producer { return mockProducer{} }
-func (q mockQueue) Consumer() queue.Consumer                         { return mockConsumer{} }
-
-type mockProducer struct{}
-
-func (p mockProducer) Publish(event publisher.Event) bool    { return true }
-func (p mockProducer) TryPublish(event publisher.Event) bool { return true }
-func (p mockProducer) Cancel() int                           { return 0 }
-
-type mockConsumer struct{}
-
-func (c mockConsumer) Get(eventCount int) (queue.Batch, error) { return &Batch{}, nil }
-func (c mockConsumer) Close() error                            { return nil }
-
-func randomBatch(min, max int, wqu workQueue) *Batch {
-	numEvents := randIntBetween(min, max)
-	events := make([]publisher.Event, numEvents)
-
-	consumer := newEventConsumer(logp.L(), mockQueue{}, &batchContext{})
-	retryer := newRetryer(logp.L(), nilObserver, wqu, consumer)
-
-	batch := Batch{
-		events: events,
-		ctx: &batchContext{
-			observer: nilObserver,
-			retryer:  retryer,
-		},
-	}
-
-	return &batch
-}
-
-// randIntBetween returns a random integer in [min, max)
-func randIntBetween(min, max int) int {
-	return rand.Intn(max-min) + min
-}
-
-func seedPRNG(t *testing.T) {
-	seed := *SeedFlag
-	if seed == 0 {
-		seed = time.Now().UnixNano()
-	}
-
-	t.Logf("reproduce test with `go test ... -seed %v`", seed)
-	rand.Seed(seed)
-}
-
-func waitUntilTrue(duration time.Duration, fn func() bool) bool {
-	end := time.Now().Add(duration)
-	for time.Now().Before(end) {
-		if fn() {
-			return true
-		}
-		time.Sleep(1 * time.Millisecond)
-	}
-	return false
 }

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -18,6 +18,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 )
@@ -43,22 +45,38 @@ func TestMakeClientWorker(t *testing.T) {
 
 			err := quick.Check(func(i uint) bool {
 				numBatches := 300 + (i % 100) // between 300 and 399
+				numEvents := atomic.MakeUint(0)
+
+				wqu := makeWorkQueue()
+				retryer := newRetryer(logp.NewLogger("test"), nilObserver, wqu, nil)
+				defer retryer.close()
 
 				var published atomic.Uint
+				var batchCount int
 				publishFn := func(batch publisher.Batch) error {
+					batchCount++
 					published.Add(uint(len(batch.Events())))
+					fmt.Printf("received batch %p of size: %d -> events: %d/%d, batches: %d/%d\n",
+						batch, len(batch.Events()),
+						published.Load(), numEvents.Load(),
+						batchCount, numBatches,
+					)
 					return nil
 				}
 
-				wqu := makeWorkQueue()
 				client := ctor(publishFn)
-				makeClientWorker(nilObserver, wqu, client)
 
-				numEvents := atomic.MakeUint(0)
-				for batchIdx := uint(0); batchIdx <= numBatches; batchIdx++ {
-					batch := randomBatch(50, 150, wqu)
+				worker := makeClientWorker(nilObserver, wqu, client)
+				defer func() {
+					fmt.Println("shut down client worker")
+					worker.Close()
+				}()
+
+				for i := uint(0); i < numBatches; i++ {
+					batch := randomBatch(50, 150).withRetryer(retryer)
 					numEvents.Add(uint(len(batch.Events())))
 					wqu <- batch
+					fmt.Printf("send batch %p of size: %d\n", batch, len(batch.Events()))
 				}
 
 				// Give some time for events to be published
@@ -77,48 +95,78 @@ func TestMakeClientWorker(t *testing.T) {
 	}
 }
 
-func TestMakeClientWorkerAndClose(t *testing.T) {
+func TestReplaceClientWorker(t *testing.T) {
 	tests := map[string]func(mockPublishFn) outputs.Client{
 		"client":         newMockClient,
 		"network_client": newMockNetworkClient,
 	}
 
 	const minEventsInBatch = 50
+	const maxEventsInBatch = 150
 
 	for name, ctor := range tests {
 		t.Run(name, func(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 1000 + (i % 100) // between 1000 and 1099
+				numBatches := 10000 + (i % 100) // between 1000 and 1099
+
+				fmt.Printf("Starting test with numBatch: %d\n", numBatches)
+				defer fmt.Printf("Finished test with numBatch: %d\n", numBatches)
 
 				wqu := makeWorkQueue()
-				numEvents := atomic.MakeUint(0)
+				retryer := newRetryer(logp.NewLogger("test"), nilObserver, wqu, nil)
+				defer retryer.close()
+
+				var batches []publisher.Batch
+				var numEvents int
+				for i := uint(0); i < numBatches; i++ {
+					batch := randomBatch(minEventsInBatch, maxEventsInBatch).withRetryer(retryer)
+					numEvents += batch.Len()
+					batches = append(batches, batch)
+				}
 
 				var wg sync.WaitGroup
 				wg.Add(1)
 				go func() {
+					fmt.Println("start forwarding batches")
+					defer fmt.Println("stopped forwarding batches")
+
 					defer wg.Done()
-					for batchIdx := uint(0); batchIdx <= numBatches; batchIdx++ {
-						batch := randomBatch(minEventsInBatch, 150, wqu)
-						numEvents.Add(uint(len(batch.Events())))
+					for _, batch := range batches {
 						wqu <- batch
+						// fmt.Printf("send batch %p of size: %d\n", batch, len(batch.Events()))
 					}
 				}()
 
 				// Publish at least 1 batch worth of events but no more than 20% events
-				publishLimit := uint(math.Max(minEventsInBatch, float64(numEvents.Load())*0.2))
+				publishLimit := uint(math.Max(minEventsInBatch, float64(numEvents)*0.2))
 
 				var publishedFirst atomic.Uint
 				blockCtrl := make(chan struct{})
+				var batchCount int
 				blockingPublishFn := func(batch publisher.Batch) error {
+					batchCount++
+					// fmt.Printf("(blocking) received batch %p of size: %d -> events: %d/%d, batches: %d/%d\n",
+					// 	batch, len(batch.Events()),
+					// 	publishedFirst.Load(), numEvents,
+					// 	batchCount, numBatches,
+					// )
+
 					// Emulate blocking. Upon unblocking the in-flight batch that was
 					// blocked is published.
 					if publishedFirst.Load() >= publishLimit {
+						// fmt.Printf("(blocking) blocking processing waiting for signal. count=%v, limit=%v\n",
+						// 	publishedFirst.Load(),
+						// 	publishLimit,
+						// )
 						<-blockCtrl
 					}
 
 					publishedFirst.Add(uint(len(batch.Events())))
+					// if publishedFirst.Load() >= publishLimit {
+					// 	time.Sleep(500 * time.Millisecond)
+					// }
 					return nil
 				}
 
@@ -128,15 +176,24 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 				// Allow the worker to make *some* progress before we close it
 				timeout := 10 * time.Second
 				progress := waitUntilTrue(timeout, func() bool {
+					// fmt.Printf("waiting progress: count=%d, limit=%d\n",
+					// 	publishedFirst.Load(),
+					// 	publishLimit,
+					// )
 					return publishedFirst.Load() >= publishLimit
 				})
 				if !progress {
 					return false
 				}
+				fmt.Println("progress detected")
 
 				// Close worker before all batches have had time to be published
+				fmt.Println("closing worker")
 				err := worker.Close()
 				require.NoError(t, err)
+				fmt.Println("worker closed")
+
+				fmt.Println("unblock output")
 				close(blockCtrl)
 
 				// Start new worker to drain work queue
@@ -153,7 +210,7 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 				// Make sure that all events have eventually been published
 				timeout = 20 * time.Second
 				return waitUntilTrue(timeout, func() bool {
-					return numEvents.Load() == publishedFirst.Load()+publishedLater.Load()
+					return numEvents == int(publishedFirst.Load()+publishedLater.Load())
 				})
 			}, &quick.Config{MaxCount: 25})
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -18,7 +18,6 @@
 package pipeline
 
 import (
-	"flag"
 	"math"
 	"sync"
 	"testing"
@@ -30,10 +29,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
-)
-
-var (
-	SeedFlag = flag.Int64("seed", 0, "Randomization seed")
 )
 
 func TestMakeClientWorker(t *testing.T) {

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -51,9 +51,7 @@ func TestMakeClientWorker(t *testing.T) {
 				defer retryer.close()
 
 				var published atomic.Uint
-				var batchCount int
 				publishFn := func(batch publisher.Batch) error {
-					batchCount++
 					published.Add(uint(len(batch.Events())))
 					return nil
 				}
@@ -127,9 +125,7 @@ func TestReplaceClientWorker(t *testing.T) {
 
 				var publishedFirst atomic.Uint
 				blockCtrl := make(chan struct{})
-				var batchCount int
 				blockingPublishFn := func(batch publisher.Batch) error {
-					batchCount++
 					// Emulate blocking. Upon unblocking the in-flight batch that was
 					// blocked is published.
 					if publishedFirst.Load() >= publishLimit {

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -97,7 +97,7 @@ func TestReplaceClientWorker(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 10000 + (i % 100) // between 1000 and 1099
+				numBatches := 1000 + (i % 100) // between 1000 and 1099
 
 				wqu := makeWorkQueue()
 				retryer := newRetryer(logp.NewLogger("test"), nilObserver, wqu, nil)

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -49,6 +49,7 @@ type retryQueue chan batchEvent
 type retryerSignal struct {
 	tag     retryerEventTag
 	channel workQueue
+	done    chan struct{}
 }
 
 type batchEvent struct {

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -112,13 +112,6 @@ func (r *retryer) sigOutputRemoved() {
 	r.sig <- retryerSignal{tag: sigRetryerOutputRemoved}
 }
 
-func (r *retryer) updOutput(ch workQueue) {
-	r.sig <- retryerSignal{
-		tag:     sigRetryerUpdateOutput,
-		channel: ch,
-	}
-}
-
 func (r *retryer) retry(b Batch) {
 	r.in <- batchEvent{tag: retryBatch, batch: b}
 }
@@ -212,8 +205,6 @@ func (r *retryer) loop() {
 
 		case sig := <-r.sig:
 			switch sig.tag {
-			case sigRetryerUpdateOutput:
-				r.out = sig.channel
 			case sigRetryerOutputAdded:
 				numOutputs++
 			case sigRetryerOutputRemoved:

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -54,7 +54,6 @@ type retryQueue chan batchEvent
 type retryerSignal struct {
 	tag     retryerEventTag
 	channel workQueue
-	done    chan struct{}
 }
 
 type batchEvent struct {

--- a/libbeat/publisher/pipeline/testing.go
+++ b/libbeat/publisher/pipeline/testing.go
@@ -1,0 +1,117 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+)
+
+type mockPublishFn func(publisher.Batch) error
+
+func newMockClient(publishFn mockPublishFn) outputs.Client {
+	return &mockClient{publishFn: publishFn}
+}
+
+type mockClient struct {
+	publishFn mockPublishFn
+}
+
+func (c *mockClient) String() string { return "mock_client" }
+func (c *mockClient) Close() error   { return nil }
+func (c *mockClient) Publish(batch publisher.Batch) error {
+	return c.publishFn(batch)
+}
+
+func newMockNetworkClient(publishFn mockPublishFn) outputs.Client {
+	return &mockNetworkClient{newMockClient(publishFn)}
+}
+
+type mockNetworkClient struct {
+	outputs.Client
+}
+
+func (c *mockNetworkClient) Connect() error { return nil }
+
+type mockQueue struct{}
+
+func (q mockQueue) Close() error                                     { return nil }
+func (q mockQueue) BufferConfig() queue.BufferConfig                 { return queue.BufferConfig{} }
+func (q mockQueue) Producer(cfg queue.ProducerConfig) queue.Producer { return mockProducer{} }
+func (q mockQueue) Consumer() queue.Consumer                         { return mockConsumer{} }
+
+type mockProducer struct{}
+
+func (p mockProducer) Publish(event publisher.Event) bool    { return true }
+func (p mockProducer) TryPublish(event publisher.Event) bool { return true }
+func (p mockProducer) Cancel() int                           { return 0 }
+
+type mockConsumer struct{}
+
+func (c mockConsumer) Get(eventCount int) (queue.Batch, error) { return &Batch{}, nil }
+func (c mockConsumer) Close() error                            { return nil }
+
+func randomBatch(min, max int, wqu workQueue) *Batch {
+	numEvents := randIntBetween(min, max)
+	events := make([]publisher.Event, numEvents)
+
+	consumer := newEventConsumer(logp.L(), mockQueue{}, &batchContext{})
+	retryer := newRetryer(logp.L(), nilObserver, wqu, consumer)
+
+	batch := Batch{
+		events: events,
+		ctx: &batchContext{
+			observer: nilObserver,
+			retryer:  retryer,
+		},
+	}
+
+	return &batch
+}
+
+// randIntBetween returns a random integer in [min, max)
+func randIntBetween(min, max int) int {
+	return rand.Intn(max-min) + min
+}
+
+func seedPRNG(t *testing.T) {
+	seed := *SeedFlag
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+
+	t.Logf("reproduce test with `go test ... -seed %v`", seed)
+	rand.Seed(seed)
+}
+
+func waitUntilTrue(duration time.Duration, fn func() bool) bool {
+	end := time.Now().Add(duration)
+	for time.Now().Before(end) {
+		if fn() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}

--- a/libbeat/publisher/pipeline/testing.go
+++ b/libbeat/publisher/pipeline/testing.go
@@ -18,6 +18,7 @@
 package pipeline
 
 import (
+	"flag"
 	"math/rand"
 	"testing"
 	"time"
@@ -26,6 +27,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+)
+
+var (
+	SeedFlag = flag.Int64("seed", 0, "Randomization seed")
 )
 
 type mockPublishFn func(publisher.Batch) error

--- a/libbeat/publisher/pipeline/testing.go
+++ b/libbeat/publisher/pipeline/testing.go
@@ -149,26 +149,6 @@ func randomBatch(min, max int) *mockBatch {
 	}
 }
 
-/*
-func randomBatch(min, max int, wqu workQueue) *Batch {
-	numEvents := randIntBetween(min, max)
-	events := make([]publisher.Event, numEvents)
-
-	consumer := newEventConsumer(logp.L(), mockQueue{}, &batchContext{})
-	retryer := newRetryer(logp.L(), nilObserver, wqu, consumer)
-
-	batch := Batch{
-		events: events,
-		ctx: &batchContext{
-			observer: nilObserver,
-			retryer:  retryer,
-		},
-	}
-
-	return &batch
-}
-*/
-
 // randIntBetween returns a random integer in [min, max)
 func randIntBetween(min, max int) int {
 	return rand.Intn(max-min) + min

--- a/libbeat/publisher/pipeline/testing.go
+++ b/libbeat/publisher/pipeline/testing.go
@@ -127,11 +127,14 @@ func (b *mockBatch) Len() int {
 }
 
 func (b *mockBatch) withRetryer(r *retryer) *mockBatch {
-	tmp := &mockBatch{}
-	*tmp = *b
-	tmp.onRetry = func() { r.retry(b) }
-	tmp.onCancelled = func() { r.cancelled(b) }
-	return tmp
+	return &mockBatch{
+		events:      b.events,
+		onACK:       b.onACK,
+		onDrop:      b.onDrop,
+		onRetry:     func() { r.retry(b) },
+		onCancelled: func() { r.cancelled(b) },
+		onReduceTTL: b.onReduceTTL,
+	}
 }
 
 func signalFn(fn func()) {

--- a/libbeat/publisher/queue/memqueue/consume.go
+++ b/libbeat/publisher/queue/memqueue/consume.go
@@ -77,7 +77,7 @@ func (c *consumer) Get(sz int) (queue.Batch, error) {
 
 	// if request has been send, we do have to wait for a response
 	resp := <-c.resp
-	lf("in memqueue Get(): about to return batch of %v events", len(resp.buf))
+	//lf("in memqueue Get(): about to return batch of %v events", len(resp.buf))
 	return &batch{
 		consumer: c,
 		events:   resp.buf,

--- a/libbeat/publisher/queue/memqueue/consume.go
+++ b/libbeat/publisher/queue/memqueue/consume.go
@@ -19,12 +19,19 @@ package memqueue
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
+
+func lf(msg string, v ...interface{}) {
+	now := time.Now().Format("15:04:05.00000")
+	fmt.Printf(now+" "+msg+"\n", v...)
+}
 
 type consumer struct {
 	broker *broker
@@ -70,6 +77,7 @@ func (c *consumer) Get(sz int) (queue.Batch, error) {
 
 	// if request has been send, we do have to wait for a response
 	resp := <-c.resp
+	lf("in memqueue Get(): about to return batch of %v events", len(resp.buf))
 	return &batch{
 		consumer: c,
 		events:   resp.buf,

--- a/libbeat/publisher/queue/memqueue/consume.go
+++ b/libbeat/publisher/queue/memqueue/consume.go
@@ -19,19 +19,12 @@ package memqueue
 
 import (
 	"errors"
-	"fmt"
 	"io"
-	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
-
-func lf(msg string, v ...interface{}) {
-	now := time.Now().Format("15:04:05.00000")
-	fmt.Printf(now+" "+msg+"\n", v...)
-}
 
 type consumer struct {
 	broker *broker
@@ -77,7 +70,6 @@ func (c *consumer) Get(sz int) (queue.Batch, error) {
 
 	// if request has been send, we do have to wait for a response
 	resp := <-c.resp
-	//lf("in memqueue Get(): about to return batch of %v events", len(resp.buf))
 	return &batch{
 		consumer: c,
 		events:   resp.buf,


### PR DESCRIPTION
## What does this PR do?

Beats Central Management (today) and Agent (in the future) will need to reload outputs on the fly, whenever users change the Beat's configuration while the Beat is running. The current output reloading implementation has three bugs:

1. When outputs are reloaded several times, and very quickly at that, all events don't always getting eventually published,

1. Whenever an output is reloaded, a goroutine is leaked from the publisher pipeline's output handling code, and

2. If the output being reloaded is the Elasticsearch output, old TCP connections to Elasticsearch are hanging around.

This PR addresses all three issues.

## Why is it important?

- To ensure that all events will eventually be published, even if outputs are rapidly reloaded multiple times.
- To prevent leakage of memory (goroutines consume memory).
- To prevent exhaustion of file descriptors over time.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Start up Elasticsearch and Kibana and setup [Beats Central Management](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-central-management.html).
   1. Enroll Filebeat. This will backup your original `filebeat.yml` file and create a new one suitable for Beats Central Management.
   1. Create a configuration tag in the Beats Central Management UI in Kibana with input paths containing `/tmp/logs/*.log` and the Elasticsearch output pointing to localhost:9200 (or wherever your local ES is listening). Make sure to assign this tag to your enrolled Filebeat instance in the UI.
3. Edit the new `filebeat.yml` file and set `management.period: 2s` to speed up output reloading.
4. Start up Filebeat with the `-httpprof localhost:5050` flag. This will let us see if Filebeat is leaking goroutines.
5. In a new window, check TCP connections used by your Filebeat process. This will let us see if Filebeat is leaking file descriptors.
   ```
   watch -n 2 lsof -a -cfilebeat -i4 -i6 -itcp
   ```
6. In another new window, make sure some data is constantly being ingested by Filebeat from the input path.
   ```
   rm -rf /tmp/logs
   mkdir -p /tmp/logs
   while true; do echo "foo bar $RANDOM" >> /tmp/logs/test.log; sleep 1; done
   ```
7. In the Central Management UI, change the configuration for your tag slightly (maybe add an input path then later remove it and so on) to trigger output reloading in Filebeat. 
8. Check the Filebeat log for messages like `New configurations retrieved` to confirm that your changes in Kibana are being picked up by Filebeat.
8. Check the output of the `lsof` window and make sure the list of file descriptors isn't growing over time.
9. Visit (or refresh) http://localhost:5050/debug/pprof/goroutine?debug=1 in a browser window and make sure the number of goroutines isn't growing over time.
10. Wait a few seconds, then repeat steps 6 onwards a few times.

## Related issues

- Fixes elastic/beats#10491

