### PR TITLE
Remove dataType field of query metricset

### DIFF
--- a/metricbeat/module/prometheus/query/_meta/data.json
+++ b/metricbeat/module/prometheus/query/_meta/data.json
@@ -12,12 +12,12 @@
     "prometheus": {
         "labels": {
             "__name__": "go_threads",
+            "dataType": "vector",
             "instance": "localhost:9090",
             "job": "prometheus"
         },
         "query": {
-            "dataType": "vector",
-            "go_threads": 26
+            "go_threads": 18
         }
     },
     "service": {

--- a/metricbeat/module/prometheus/query/_meta/data.json
+++ b/metricbeat/module/prometheus/query/_meta/data.json
@@ -12,7 +12,6 @@
     "prometheus": {
         "labels": {
             "__name__": "go_threads",
-            "dataType": "vector",
             "instance": "localhost:9090",
             "job": "prometheus"
         },
@@ -21,7 +20,7 @@
         }
     },
     "service": {
-        "address": "localhost:32768",
+        "address": "localhost:32769",
         "type": "prometheus"
     }
 }

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -63,7 +63,6 @@ type InstantVectorResponse struct {
 	Data   instantVectorData `json:"data"`
 }
 type instantVectorData struct {
-	ResultType string                `json:"resultType"`
 	Results    []instantVectorResult `json:"result"`
 }
 type instantVectorResult struct {
@@ -85,7 +84,6 @@ type RangeVectorResponse struct {
 	Data   rangeVectorData `json:"data"`
 }
 type rangeVectorData struct {
-	ResultType string              `json:"resultType"`
 	Results    []rangeVectorResult `json:"result"`
 }
 type rangeVectorResult struct {

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -129,7 +129,6 @@ func parseResponse(body []byte, pathConfig QueryConfig) ([]mb.Event, error) {
 
 func getEventsFromMatrix(body []byte, queryName string) ([]mb.Event, error) {
 	events := []mb.Event{}
-	resultType := "matrix"
 	convertedMap, err := convertJSONToRangeVectorResponse(body)
 	if err != nil {
 		return events, err
@@ -149,7 +148,6 @@ func getEventsFromMatrix(body []byte, queryName string) ([]mb.Event, error) {
 				if math.IsNaN(val) || math.IsInf(val, 0) {
 					continue
 				}
-				result.Metric["dataType"] = resultType
 				events = append(events, mb.Event{
 					Timestamp:    getTimestamp(timestamp),
 					ModuleFields: common.MapStr{"labels": result.Metric},
@@ -167,7 +165,6 @@ func getEventsFromMatrix(body []byte, queryName string) ([]mb.Event, error) {
 
 func getEventsFromVector(body []byte, queryName string) ([]mb.Event, error) {
 	events := []mb.Event{}
-	resultType := "vector"
 	convertedMap, err := convertJSONToInstantVectorResponse(body)
 	if err != nil {
 		return events, err
@@ -186,7 +183,6 @@ func getEventsFromVector(body []byte, queryName string) ([]mb.Event, error) {
 			if math.IsNaN(val) || math.IsInf(val, 0) {
 				continue
 			}
-			result.Metric["dataType"] = resultType
 			events = append(events, mb.Event{
 				Timestamp:    getTimestamp(timestamp),
 				ModuleFields: common.MapStr{"labels": result.Metric},
@@ -221,11 +217,6 @@ func getEventFromScalarOrString(body []byte, resultType string, queryName string
 			}
 			return mb.Event{
 				Timestamp: getTimestamp(timestamp),
-				ModuleFields: common.MapStr{
-					"labels": common.MapStr{
-						"dataType": resultType,
-					},
-				},
 				MetricSetFields: common.MapStr{
 					queryName: val,
 				},
@@ -240,8 +231,7 @@ func getEventFromScalarOrString(body []byte, resultType string, queryName string
 				Timestamp: getTimestamp(timestamp),
 				ModuleFields: common.MapStr{
 					"labels": common.MapStr{
-						queryName:  value,
-						"dataType": resultType,
+						queryName: value,
 					},
 				},
 				MetricSetFields: common.MapStr{

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -149,12 +149,12 @@ func getEventsFromMatrix(body []byte, queryName string) ([]mb.Event, error) {
 				if math.IsNaN(val) || math.IsInf(val, 0) {
 					continue
 				}
+				result.Metric["dataType"] = resultType
 				events = append(events, mb.Event{
 					Timestamp:    getTimestamp(timestamp),
 					ModuleFields: common.MapStr{"labels": result.Metric},
 					MetricSetFields: common.MapStr{
-						"dataType": resultType,
-						queryName:  val,
+						queryName: val,
 					},
 				})
 			} else {
@@ -186,12 +186,12 @@ func getEventsFromVector(body []byte, queryName string) ([]mb.Event, error) {
 			if math.IsNaN(val) || math.IsInf(val, 0) {
 				continue
 			}
+			result.Metric["dataType"] = resultType
 			events = append(events, mb.Event{
 				Timestamp:    getTimestamp(timestamp),
 				ModuleFields: common.MapStr{"labels": result.Metric},
 				MetricSetFields: common.MapStr{
-					"dataType": resultType,
-					queryName:  val,
+					queryName: val,
 				},
 			})
 		} else {
@@ -221,9 +221,13 @@ func getEventFromScalarOrString(body []byte, resultType string, queryName string
 			}
 			return mb.Event{
 				Timestamp: getTimestamp(timestamp),
+				ModuleFields: common.MapStr{
+					"labels": common.MapStr{
+						"dataType": resultType,
+					},
+				},
 				MetricSetFields: common.MapStr{
-					"dataType": resultType,
-					queryName:  val,
+					queryName: val,
 				},
 			}, nil
 		} else if resultType == "string" {
@@ -233,11 +237,15 @@ func getEventFromScalarOrString(body []byte, resultType string, queryName string
 				return mb.Event{}, errors.New(msg)
 			}
 			return mb.Event{
-				Timestamp:    getTimestamp(timestamp),
-				ModuleFields: common.MapStr{"labels": common.MapStr{queryName: value}},
+				Timestamp: getTimestamp(timestamp),
+				ModuleFields: common.MapStr{
+					"labels": common.MapStr{
+						queryName:  value,
+						"dataType": resultType,
+					},
+				},
 				MetricSetFields: common.MapStr{
-					"dataType": resultType,
-					queryName:  1,
+					queryName: 1,
 				},
 			}, nil
 		}

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -45,7 +45,7 @@ type ArrayResponse struct {
 	Data   arrayData `json:"data"`
 }
 type arrayData struct {
-	Results    []interface{} `json:"result"`
+	Results []interface{} `json:"result"`
 }
 
 // InstantVectorResponse is for "vector" type from Prometheus Query API Request
@@ -62,7 +62,7 @@ type InstantVectorResponse struct {
 	Data   instantVectorData `json:"data"`
 }
 type instantVectorData struct {
-	Results    []instantVectorResult `json:"result"`
+	Results []instantVectorResult `json:"result"`
 }
 type instantVectorResult struct {
 	Metric map[string]string `json:"metric"`
@@ -83,7 +83,7 @@ type RangeVectorResponse struct {
 	Data   rangeVectorData `json:"data"`
 }
 type rangeVectorData struct {
-	Results    []rangeVectorResult `json:"result"`
+	Results []rangeVectorResult `json:"result"`
 }
 type rangeVectorResult struct {
 	Metric  map[string]string `json:"metric"`

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -45,7 +45,6 @@ type ArrayResponse struct {
 	Data   arrayData `json:"data"`
 }
 type arrayData struct {
-	ResultType string        `json:"resultType"`
 	Results    []interface{} `json:"result"`
 }
 


### PR DESCRIPTION
## What does this PR do?
This PRs moves `prometheus.query.dataType` field to `prometheus.labels.dataType`.


## Why is it important?
`prometheus.query.dataType` is of type string however the mapping of `prometheus.query.*` is for float values (and actually is used to store metrics). This makes it unable to index events in Elasticsearch. Hence, `prometheus.query.dataType` should be moved under labels which are mapped as strings.

closes https://github.com/elastic/beats/issues/17401