### PR TITLE
Improve prometheus remote_write docs

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -7,16 +7,19 @@ remote_write:
   - url: "http://localhost:9201/write"
 ------------------------------------------------------------------------------
 
-TIP: It is recommended to carefully choose the https://prometheus.io/docs/practices/remote_write/#parameters[parameters]
-of remote_write configuration so as to tune the queue according to each specific case and system's characteristics. More
-specifically, `max_shards` option sets the max number of parallelism with which Prometheus will try to send metrics to
-the remote storage. The default value of this is `1000`, which means that in case of Prometheus falls behind the
-remote storage the number of shards will be increased up to `1000` to increase thoughput. This can happen in cases
-of network delays for instance where the whole queue faces issues to consume metrics and finally send metrics to Elasticsearch.
-However increasing the number of parallelism, means that we increase the number of parallel connections from Prometheus
-to Metricbeat. This can lead to resource saturation if the system on which Metricbeat runs has a limit in `fd` (file descriptors)
-which is lower than `max_shards`. This can be resolved either by setting a higher `fd` limit in the system with `ulimit -n 2048`
-or by setting a lower value for `max_shards`.
+
+TIP: In order to assure the health of the whole queue the following two configuration
+ https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
+
+- `max_shards`: Sets the maximum number of paralelism with which Prometheus will try to send samples to Metricbeat.
+It is recomended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
+Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of paralelism that
+Metricbeat can actually achieve is the optimal queue configuration.
+- `max_samples_per_send`: Sets the number of samples to batch together for each send. Recomended values are
+between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
+storage since Metricbeat groups metrics with the same labels into same event documents.
+However this will increase the memory usage of Metricbeat.
+- `capacity`: 3 to 5 times the `max_samples_per_send`.
 
 
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -8,7 +8,7 @@ remote_write:
 ------------------------------------------------------------------------------
 
 
-TIP: In order to assure the health of the whole queue the following two configuration
+TIP: In order to assure the health of the whole queue, the following two configuration
  https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
 
 - `max_shards`: Sets the maximum number of paralelism with which Prometheus will try to send samples to Metricbeat.
@@ -19,7 +19,7 @@ Metricbeat can actually achieve is the optimal queue configuration.
 between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
 storage since Metricbeat groups metrics with the same labels into same event documents.
 However this will increase the memory usage of Metricbeat.
-- `capacity`: 3 to 5 times the `max_samples_per_send`.
+- `capacity`: 3-5 times the value of `max_samples_per_send`.
 
 
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -20,7 +20,7 @@ between 100 (default) and 1000. Having a bigger batch can lead to improved throu
 storage since Metricbeat groups metrics with the same labels into same event documents.
 However this will increase the memory usage of Metricbeat.
 - `capacity`: It is recommended to set capacity to 3-5 times `max_samples_per_send`.
-Capacity sets the number samples that are queued in memory per shard, and hence capacity should be high enough so as to
+Capacity sets the number of samples that are queued in memory per shard, and hence capacity should be high enough so as to
 be able to cover `max_samples_per_send`.
 
 

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ remote_write:
 TIP: It is recommended to carefully choose the https://prometheus.io/docs/practices/remote_write/#parameters[parameters]
 of remote_write configuration so as to tune the queue according to each specific case and system's characteristics. More
 specifically, `max_shards` option sets the max number of parallelism with which Prometheus will try to send metrics to
-the remote storage. The default value of this is `1000`, which means that in case that Prometheus falls behind the
+the remote storage. The default value of this is `1000`, which means that in case of Prometheus falls behind the
 remote storage the number of shards will be increased up to `1000` to increase thoughput. This can happen in cases
 of network delays for instance where the whole queue faces issues to consume metrics and finally send metrics to Elasticsearch.
 However increasing the number of parallelism, means that we increase the number of parallel connections from Prometheus

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -14,9 +14,9 @@ the remote storage. The default value of this is `1000`, which means that in cas
 remote storage the number of shards will be increased up to `1000` to increase thoughput. This can happen in cases
 of network delays for instance where the whole queue faces issues to consume metrics and finally send metrics to Elasticsearch.
 However increasing the number of parallelism, means that we increase the number of parallel connections from Prometheus
-to Metricbeat. This can lead to resource saturation if the system where Metricbeat runs has limit in `fd` (file descriptors)
-which is lower than `max_shards`. This can be resolved either by setting a higher `fd` limit in the system with `ulimit -n 2048
-` or by setting a lower value for `max_shards`.
+to Metricbeat. This can lead to resource saturation if the system on which Metricbeat runs has a limit in `fd` (file descriptors)
+which is lower than `max_shards`. This can be resolved either by setting a higher `fd` limit in the system with `ulimit -n 2048`
+or by setting a lower value for `max_shards`.
 
 
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -19,7 +19,9 @@ Metricbeat can actually achieve is the optimal queue configuration.
 between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
 storage since Metricbeat groups metrics with the same labels into same event documents.
 However this will increase the memory usage of Metricbeat.
-- `capacity`: 3-5 times the value of `max_samples_per_send`.
+- `capacity`: It is recommended to set capacity to 3-5 times `max_samples_per_send`.
+Capacity sets the number samples that are queued in memory per shard, and hence capacity should be high enough so as to
+be able to cover `max_samples_per_send`.
 
 
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -8,7 +8,15 @@ remote_write:
 ------------------------------------------------------------------------------
 
 TIP: It is recommended to carefully choose the https://prometheus.io/docs/practices/remote_write/#parameters[parameters]
-of remote_write configuration so as to tune the queue according to each specific case and system's characteristics.
+of remote_write configuration so as to tune the queue according to each specific case and system's characteristics. More
+specifically, `max_shards` option sets the max number of parallelism with which Prometheus will try to send metrics to
+the remote storage. The default value of this is `1000`, which means that in case that Prometheus falls behind the
+remote storage the number of shards will be increased up to `1000` to increase thoughput. This can happen in cases
+of network delays for instance where the whole queue faces issues to consume metrics and finally send metrics to Elasticsearch.
+However increasing the number of parallelism, means that we increase the number of parallel connections from Prometheus
+to Metricbeat. This can lead to resource saturation if the system where Metricbeat runs has limit in `fd` (file descriptors)
+which is lower than `max_shards`. This can be resolved either by setting a higher `fd` limit in the system with `ulimit -n 2048
+` or by setting a lower value for `max_shards`.
 
 
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -7,6 +7,10 @@ remote_write:
   - url: "http://localhost:9201/write"
 ------------------------------------------------------------------------------
 
+TIP: It is recommended to carefully choose the https://prometheus.io/docs/practices/remote_write/#parameters[parameters]
+of remote_write configuration so as to tune the queue according to each specific case and system's characteristics.
+
+
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.
 A basic configuration would look like:
 

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -12,10 +12,10 @@ TIP: In order to assure the health of the whole queue the following two configur
  https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
 
 - `max_shards`: Sets the maximum number of paralelism with which Prometheus will try to send samples to Metricbeat.
-It is recomended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
-Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of paralelism that
+It is recommended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
+Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
 Metricbeat can actually achieve is the optimal queue configuration.
-- `max_samples_per_send`: Sets the number of samples to batch together for each send. Recomended values are
+- `max_samples_per_send`: Sets the number of samples to batch together for each send. Recommended values are
 between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
 storage since Metricbeat groups metrics with the same labels into same event documents.
 However this will increase the memory usage of Metricbeat.


### PR DESCRIPTION
## What does this PR do?
This PR adds a section in the docs of Prometheus remote_write metricset which points to Prometheus remote_write configuration parameters so as to efficiently tune the queue according to each case and system.


## Why is it important?
To make sure how one can solve issues like this one -> https://github.com/elastic/beats/issues/17079#issuecomment-604994432