### PR TITLE
Fix command which installs mage

### DIFF
--- a/dev-tools/make/mage.mk
+++ b/dev-tools/make/mage.mk
@@ -7,7 +7,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION) from vendor dir.
-	go install -mod=vendor -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}
+	go install -mod=vendor -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}/...
 	@-mage -clean
 endif
 	@true


### PR DESCRIPTION
##  What does this PR do?

This PR fixes the install command of `mage`. With the adoption of go modules adding `/...` has become necessary in order to install the pacakge.

## Why is it important?

This issue prevents beats from installing `mage` if it is not present. One of the symptoms of this problem is the failure to generate new Beats if `mage` is not available.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~