### PR TITLE
Fix Event ID is no string value message

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -306,7 +306,7 @@ func createEventBulkMeta(
 			if s, ok := tmp.(string); ok {
 				id = s
 			} else {
-				log.Errorf("Event ID '%v' is no string value", id)
+				log.Errorf("Event ID '%v' is no string value", tmp)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

When a value provided for `_id` is not a string, an error is logged.

This log information is missing the correct data (provided value for `m["_id"]`) and always uses an empty `id` value.

## Why is it important?

Missing information in log for debugging.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~