### PR TITLE
Cherry-pick #17374 to 7.6: Fix mbean parsing for mbeans with multiple quoted properties

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -62,6 +62,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Convert increments of 100 nanoseconds/ticks to milliseconds for WriteTime and ReadTime in diskio metricset (Windows) for consistency. {issue}14233[14233]
 - Fix diskio issue for windows 32 bit on disk_performance struct alignment. {issue}16680[16680]
 - Reduce memory usage in `elasticsearch/index` metricset. {issue}16503[16503] {pull}16538[16538]
+- Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 
 *Packetbeat*
 

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -117,7 +117,14 @@ type MBeanName struct {
 	Properties map[string]string
 }
 
-var mbeanRegexp = regexp.MustCompile("([^,=:*?]+)=([^,=:\"]+|\".*\")")
+// Parse strings with properties with the format key=value, being:
+// - Key a nonempty string of characters which may not contain any of the characters,
+//   comma (,), equals (=), colon, asterisk, or question mark.
+// - Value a string that can be quoted or unquoted, if unquoted it cannot be empty and
+//   cannot contain any of the characters comma, equals, colon, or quote.
+//   If quoted, it can contain any character, including newlines, but quote needs to be
+//   escaped with a backslash.
+var mbeanRegexp = regexp.MustCompile(`([^,=:*?]+)=([^,=:"]+|"([^\\"]|\\.)*?")`)
 
 // This replacer is responsible for adding a "!" before special characters in GET request URIs
 // For more information refer: https://jolokia.org/reference/html/protocol.html
@@ -158,7 +165,6 @@ func (m *MBeanName) Canonicalize(escape bool) string {
 // The Mbean string has to abide by the rules which are imposed by Java.
 // For more info: https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html#getCanonicalName--
 func ParseMBeanName(mBeanName string) (*MBeanName, error) {
-
 	// Split mbean string in two parts: the bean domain and the properties
 	parts := strings.SplitN(mBeanName, ":", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -168,15 +174,6 @@ func ParseMBeanName(mBeanName string) (*MBeanName, error) {
 	// Create a new MBean object
 	mybean := &MBeanName{
 		Domain: parts[0],
-	}
-
-	// First of all verify that all bean properties are
-	// in the form key=value
-	tmpProps := propertyRegexp.FindAllString(parts[1], -1)
-	propertyList := strings.Join(tmpProps, ",")
-	if len(propertyList) != len(parts[1]) {
-		// Some property didn't match
-		return nil, fmt.Errorf("mbean properties must be in the form key=value: %s", mBeanName)
 	}
 
 	// Using this regexp we will split the properties in a 2 dimensional array
@@ -195,7 +192,6 @@ func ParseMBeanName(mBeanName string) (*MBeanName, error) {
 	// }
 	properties := mbeanRegexp.FindAllStringSubmatch(parts[1], -1)
 
-	// If we could not parse MBean properties
 	if properties == nil {
 		return nil, fmt.Errorf("mbean properties must be in the form key=value: %s", mBeanName)
 	}
@@ -203,6 +199,8 @@ func ParseMBeanName(mBeanName string) (*MBeanName, error) {
 	// Initialise properties map
 	mybean.Properties = make(map[string]string)
 
+	// Get the parsed string to check that everything has been parsed
+	var parsed []string
 	for _, prop := range properties {
 
 		// If every row does not have 3 columns, then
@@ -212,7 +210,14 @@ func ParseMBeanName(mBeanName string) (*MBeanName, error) {
 			return nil, fmt.Errorf("mbean properties must be in the form key=value: %s", mBeanName)
 		}
 
+		parsed = append(parsed, prop[0])
+
 		mybean.Properties[prop[1]] = prop[2]
+	}
+
+	// Not all the properties definition has been parsed
+	if parsed := strings.Join(parsed, ","); len(parts[1]) != len(parsed) {
+		return nil, fmt.Errorf("not all properties could be parsed: %s, parsed: %s", mBeanName, parsed)
 	}
 
 	return mybean, nil
@@ -417,13 +422,6 @@ func (pc *JolokiaHTTPPostFetcher) BuildRequestsAndMappings(configMappings []JMXM
 
 	return httpRequests, mapping, nil
 }
-
-// Parse strings with properties with the format key=value, being:
-// - key a nonempty string of characters which may not contain any of the characters,
-//   comma (,), equals (=), colon, asterisk, or question mark.
-// - value a string that can be quoted or unquoted, if unquoted it cannot be empty and
-//   cannot contain any of the characters comma, equals, colon, or quote.
-var propertyRegexp = regexp.MustCompile("[^,=:*?]+=([^,=:\"]+|\".*\")")
 
 func (pc *JolokiaHTTPPostFetcher) buildRequestBodyAndMapping(mappings []JMXMapping) ([]byte, AttributeMapping, error) {
 	responseMapping := make(AttributeMapping)


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17374 to 7.6 branch. Original message: 

## What does this PR do?

Fix mbean parsing when multiple properties are quoted.

## Why is it important?

There are mbeans that can contain multiple quoted properties, and we are failing to correctly parse them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Fix case of quoted property containing escaped quote, what in principle should work according to the definition in https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html#getCanonicalName

## Related issues

- Fixes #17375.