### PR TITLE
Cherry-pick #17147 to 7.x: Add support for MODULE in mage goIntegTest for metricbeat

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -68,4 +68,5 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Compare event by event in `testadata` framework to avoid sorting problems {pull}13747[13747]
 - Added a `default_field` option to fields in fields.yml to offer a way to exclude fields from the default_field list. {issue}14262[14262] {pull}14341[14341]
 - `supported-versions.yml` can be used in metricbeat python system tests to obtain the build args for docker compose builds. {pull}14520[14520]
+- Add support for MODULE environment variable in `mage goIntegTest` in metricbeat to run integration tests for a single module. {pull}17147[17147]
 - Add support for a `TEST_TAGS` environment variable to add tags for tests selection following go build tags semantics, this environment variable is used by mage test targets to add build tags. Python tests can also be tagged with a decorator (`@beat.tag('sometag')`). {pull}16937[16937] {pull}17075[17075]

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -135,8 +135,15 @@ func DefaultTestBinaryArgs() TestBinaryArgs {
 // This method executes integration tests for a single module at a time.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
+// Use MODULE=module to run only tests for `module`.
 func GoTestIntegrationForModule(ctx context.Context) error {
 	return RunIntegTest("goIntegTest", func() error {
+		module := EnvOr("MODULE", "")
+		if module != "" {
+			err := GoTest(ctx, GoTestIntegrationArgsForModule(module))
+			return errors.Wrapf(err, "integration tests failed for module %s", module)
+		}
+
 		modulesFileInfo, err := ioutil.ReadDir("./module")
 		if err != nil {
 			return err

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -149,6 +149,7 @@ func RunIntegTest(mageTarget string, test func() error, passThroughEnvVars ...st
 		"RACE_DETECTOR",
 		"TEST_TAGS",
 		"PYTHON_EXE",
+		"MODULE",
 	}
 	env = append(env, passThroughEnvVars...)
 	return runInIntegTestEnv(mageTarget, test, env...)

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -176,6 +176,7 @@ func CollectDocs() error {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 // Use TEST_TAGS=tag1,tag2 to add additional build tags.
+// Use MODULE=module to run only tests for `module`.
 func GoIntegTest(ctx context.Context) error {
 	mg.Deps(Fields)
 	return devtools.GoTestIntegrationForModule(ctx)

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -140,6 +140,7 @@ func IntegTest() {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 // Use TEST_TAGS=tag1,tag2 to add additional build tags.
+// Use MODULE=module to run only tests for `module`.
 func GoIntegTest(ctx context.Context) error {
 	return devtools.GoTestIntegrationForModule(ctx)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17147 to 7.x branch. Original message: 

## What does this PR do?

Add support for `MODULE` environment variable in `mage goIntegTest` for Metricbeat to run integration tests for an specific module. For example, to run integration tests for sql module only:
```
MODULE=sql mage goIntegTest
```

## Why is it important?

Metricbeat integration tests are slow, running them as they are run in CI requires to run all tests, but when running them locally you are usually interested in running a single module.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Use `MODULE` environment variable to run integration tests of a single module, for example:
```
MODULE=sql mage goIntegTest
```