### PR TITLE
Cherry-pick #17393 to 7.x: Add metricbeat as dependency for auditbeat to Pipeline check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -810,8 +810,12 @@ def isChangedXPackCode(patterns) {
 }
 
 def loadConfigEnvVars(){
-  env.BUILD_AUDITBEAT = isChanged(["^auditbeat/.*"])
+  env.BUILD_AUDITBEAT = isChanged([
+    "^metricbeat/.*",
+    "^auditbeat/.*",
+  ])
   env.BUILD_AUDITBEAT_XPACK = isChangedXPackCode([
+    "^metricbeat/.*",
     "^auditbeat/.*",
     "^x-pack/auditbeat/.*",
   ])


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17393 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- bug

## What does this PR do?

Run auditbeat tests if metricbeat has been modified.

## Why is it important?

Auditbeat reuses the metricbeat framework. Changes in the code of metricbeat must trigger auditbeat tests as well.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- elastic/beats#16953 