### PR TITLE
[metricbeat] fix system/service filtering issues

### DIFF
--- a/metricbeat/module/system/service/service_test.go
+++ b/metricbeat/module/system/service/service_test.go
@@ -72,3 +72,28 @@ func TestFormProps(t *testing.T) {
 	assert.Equal(t, event.MetricSetFields["state_since"], testEvent["state_since"])
 	assert.NotEmpty(t, event.RootFields)
 }
+
+func TestFilter(t *testing.T) {
+	unitsIn := []dbus.UnitStatus{
+		dbus.UnitStatus{
+			Name: "sshd.service",
+		},
+		dbus.UnitStatus{
+			Name: "metricbeat.service",
+		},
+	}
+
+	filtersMatch := []string{
+		"ssh*",
+	}
+	filtersBad := []string{
+		"asdf",
+	}
+
+	shouldMatch, err := matchUnitPatterns(filtersMatch, unitsIn)
+	assert.NoError(t, err)
+	assert.Len(t, shouldMatch, 1)
+	shouldNotMatch, err := matchUnitPatterns(filtersBad, unitsIn)
+	assert.NoError(t, err)
+	assert.Empty(t, shouldNotMatch)
+}


### PR DESCRIPTION

## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/17414
The native implementation of name filtering in dbus will "short circuit" to the first match, but that doesn't work when we want to filter everything by `*.service`, so lets filter that later.


## Why is it important?

This is a bug.

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Pull down and build on a linux box, add a `pattern_filter` to the config.

