### PR TITLE
Fix redundant operator in activemq ingest pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed a mapping exception when ingesting Logstash plain logs (7.4+) with pipeline ids containing non alphanumeric chars. {issue}17242[17242] {pull}17243[17243]
 - Fixed MySQL slowlog module causing "regular expression has redundant nested repeat operator" warning in Elasticsearch. {issue}17086[17086] {pull}17156[17156]
 - Fix `elasticsearch.audit` data ingest pipeline to be more forgiving with date formats found in Elasticsearch audit logs. {pull}17406[17406]
+- Fixed activemq module causing "regular expression has redundant nested repeat operator" warning in Elasticsearch. {pull}17428[17428]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/activemq/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/activemq/log/ingest/pipeline.yml
@@ -8,7 +8,7 @@ processors:
         NOPIPEGREEDYDATA: "((?! \\|).)*"
         THREAD_NAME: "((?! \n).)*"
       patterns:
-        - "%{TIMESTAMP_ISO8601:timestamp}%{SPACE}\\|%{SPACE}%{LOGLEVEL:log.level}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:message}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:activemq.caller}%{SPACE}\\|%{SPACE}%{THREAD_NAME:activemq.thread}%{SPACE}?%{GREEDYMULTILINE:activemq.log.stack_trace}"
+        - "%{TIMESTAMP_ISO8601:timestamp}%{SPACE}\\|%{SPACE}%{LOGLEVEL:log.level}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:message}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:activemq.caller}%{SPACE}\\|%{SPACE}%{THREAD_NAME:activemq.thread}%{SPACE}%{GREEDYMULTILINE:activemq.log.stack_trace}"
       ignore_missing: true
   - date:
       if: "ctx.event.timezone == null"


### PR DESCRIPTION
Grok processor has a redundant `*` operator in a regular expression, which causes the following warning to be printed to the Elasticsearch logs every time the pipeline is loaded:

```
regular expression has redundant nested repeat operator * /(?<TIMESTAMP_ISO8601:timestamp>(?:(?>\d\d){1,2})-(?:(?:0?[1-9]|1[0-2]))-(?:(?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9]))[T ](?:(?:2[0123]|[01][0-9])):?(?:(?:[0-5][0-9]))(?::?(?:(?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)))?(?:(?:Z|[+-](?:(?:2[0123]|[01]?[0-9]))(?::?(?:(?:[0-5][0-9])))))?)(?:\s*)\|(?:\s*)(?<LOGLEVEL:log.level>([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?))(?:\s*)\|(?:\s*)(?<NOPIPEGREEDYDATA:message>((?! \|).)*)(?:\s*)\|(?:\s*)(?<NOPIPEGREEDYDATA:activemq.caller>((?! \|).)*)(?:\s*)\|(?:\s*)(?<THREAD_NAME:activemq.thread>((?!
).)*)(?:\s*)?(?<GREEDYMULTILINE:activemq.log.stack_trace>(.|\n|\t)*)/
```

In this case the redundancy is caused by following a `{SPACE}` expression followed by a match-zero-or-one operator: `?`. The `SPACE` pattern expands to `(?:\s*)` which already matches zero or more spaces. Perhaps a better name would have been `SPACES`.

### I'm still seeing this error after upgrading Filebeat

if you're still seeing this error after upgrading Filebeat, note that the error is still printed when an Elasticsearch node is started if pipelines for older versions are installed (`filebeat-X.Y.Z-elasticsearch-gc-pipeline` for `X.Y.Z` < `7.7.0`). A newer version won't remove existing pipelines.

Relates #15900 #17156