### PR TITLE
Cherry-pick #16365 to 7.x: Refactor keystore interface into 3 different interfaces

### DIFF
--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -130,10 +130,15 @@ func createKeystore(settings instance.Settings, force bool) error {
 		return err
 	}
 
+	writableKeystore, err := keystore.AsWritableKeystore(store)
+	if err != nil {
+		return fmt.Errorf("error creating the keystore: %s", err)
+	}
+
 	if store.IsPersisted() == true && force == false {
 		response := terminal.PromptYesNo("A keystore already exists, Overwrite?", false)
 		if response == true {
-			err := store.Create(true)
+			err := writableKeystore.Create(true)
 			if err != nil {
 				return fmt.Errorf("error creating the keystore: %s", err)
 			}
@@ -142,7 +147,7 @@ func createKeystore(settings instance.Settings, force bool) error {
 			return nil
 		}
 	} else {
-		err := store.Create(true)
+		err := writableKeystore.Create(true)
 		if err != nil {
 			return fmt.Errorf("Error creating the keystore: %s", err)
 		}
@@ -160,6 +165,11 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 		return fmt.Errorf("could not create secret for: %s, you can only provide one key per invocation", keys)
 	}
 
+	writableKeystore, err := keystore.AsWritableKeystore(store)
+	if err != nil {
+		return fmt.Errorf("error creating the keystore: %s", err)
+	}
+
 	if store.IsPersisted() == false {
 		if force == false {
 			answer := terminal.PromptYesNo("The keystore does not exist. Do you want to create it?", false)
@@ -167,7 +177,7 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 				return errors.New("exiting without creating keystore")
 			}
 		}
-		err := store.Create(true)
+		err := writableKeystore.Create(true)
 		if err != nil {
 			return fmt.Errorf("could not create keystore, error: %s", err)
 		}
@@ -202,10 +212,10 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 			return fmt.Errorf("could not read value from the input, error: %s", err)
 		}
 	}
-	if err = store.Store(key, keyValue); err != nil {
+	if err = writableKeystore.Store(key, keyValue); err != nil {
 		return fmt.Errorf("could not add the key in the keystore, error: %s", err)
 	}
-	if err = store.Save(); err != nil {
+	if err = writableKeystore.Save(); err != nil {
 		return fmt.Errorf("fail to save the keystore: %s", err)
 	} else {
 		fmt.Println("Successfully updated the keystore")
@@ -216,6 +226,11 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 func removeKey(store keystore.Keystore, keys []string) error {
 	if len(keys) == 0 {
 		return errors.New("you must supply at least one key to remove")
+	}
+
+	writableKeystore, err := keystore.AsWritableKeystore(store)
+	if err != nil {
+		return fmt.Errorf("error deleting the keystore: %s", err)
 	}
 
 	if store.IsPersisted() == false {
@@ -229,8 +244,8 @@ func removeKey(store keystore.Keystore, keys []string) error {
 			return fmt.Errorf("could not find key '%v' in the keystore", key)
 		}
 
-		store.Delete(key)
-		err = store.Save()
+		writableKeystore.Delete(key)
+		err = writableKeystore.Save()
 		if err != nil {
 			return fmt.Errorf("could not update the keystore with the changes, key: %s, error: %v", key, err)
 		}
@@ -240,7 +255,11 @@ func removeKey(store keystore.Keystore, keys []string) error {
 }
 
 func list(store keystore.Keystore) error {
-	keys, err := store.List()
+	listingKeystore, err := keystore.AsListingKeystore(store)
+	if err != nil {
+		return fmt.Errorf("error listing the keystore: %s", err)
+	}
+	keys, err := listingKeystore.List()
 	if err != nil {
 		return fmt.Errorf("could not read values from the keystore, error: %s", err)
 	}

--- a/libbeat/keystore/file_keystore.go
+++ b/libbeat/keystore/file_keystore.go
@@ -51,6 +51,12 @@ const (
 // Version of the keystore format, will be added at the beginning of the file.
 var version = []byte("v1")
 
+// Packager defines a keystore that we can read the raw bytes and be packaged in an artifact.
+type Packager interface {
+	Package() ([]byte, error)
+	ConfiguredPath() string
+}
+
 // FileKeystore Allows to store key / secrets pair securely into an encrypted local file.
 type FileKeystore struct {
 	sync.RWMutex
@@ -64,6 +70,27 @@ type FileKeystore struct {
 type serializableSecureString struct {
 	*SecureString
 	Value []byte `json:"value"`
+}
+
+// Factory Create the right keystore with the configured options.
+func Factory(cfg *common.Config, defaultPath string) (Keystore, error) {
+	config := defaultConfig
+
+	if cfg == nil {
+		cfg = common.NewConfig()
+	}
+	err := cfg.Unpack(&config)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not read keystore configuration, err: %v", err)
+	}
+
+	if config.Path == "" {
+		config.Path = defaultPath
+	}
+
+	keystore, err := NewFileKeystore(config.Path)
+	return keystore, err
 }
 
 // NewFileKeystore returns an new File based keystore or an error, currently users cannot set their

--- a/libbeat/keystore/file_keystore_test.go
+++ b/libbeat/keystore/file_keystore_test.go
@@ -37,10 +37,14 @@ func TestCanCreateAKeyStore(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore, err := NewFileKeystore(path)
+	keyStore, err := NewFileKeystore(path)
 	assert.NoError(t, err)
-	assert.Nil(t, keystore.Store(keyValue, secretValue))
-	assert.Nil(t, keystore.Save())
+
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
+
+	assert.Nil(t, writableKeystore.Store(keyValue, secretValue))
+	assert.Nil(t, writableKeystore.Save())
 }
 
 func TestCanReadAnExistingKeyStoreWithEmptyString(t *testing.T) {
@@ -66,15 +70,18 @@ func TestCanDeleteAKeyFromTheStoreAndPersistChanges(t *testing.T) {
 
 	CreateAnExistingKeystore(path)
 
-	keystore, _ := NewFileKeystore(path)
-	_, err := keystore.Retrieve(keyValue)
+	keyStore, _ := NewFileKeystore(path)
+	_, err := keyStore.Retrieve(keyValue)
 	assert.NoError(t, err)
 
-	keystore.Delete(keyValue)
-	_, err = keystore.Retrieve(keyValue)
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
+
+	writableKeystore.Delete(keyValue)
+	_, err = keyStore.Retrieve(keyValue)
 	assert.Error(t, err)
 
-	_ = keystore.Save()
+	_ = writableKeystore.Save()
 	newKeystore, err := NewFileKeystore(path)
 	_, err = newKeystore.Retrieve(keyValue)
 	assert.Error(t, err)
@@ -113,10 +120,14 @@ func TestFilePermissionOnUpdate(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore := CreateAnExistingKeystore(path)
-	err := keystore.Store("newkey", []byte("newsecret"))
+	keyStore := CreateAnExistingKeystore(path)
+
+	writableKeystore, err := AsWritableKeystore(keyStore)
 	assert.NoError(t, err)
-	err = keystore.Save()
+
+	err = writableKeystore.Store("newkey", []byte("newsecret"))
+	assert.NoError(t, err)
+	err = writableKeystore.Save()
 	assert.NoError(t, err)
 	stats, err := os.Stat(path)
 	assert.NoError(t, err)
@@ -152,9 +163,12 @@ func TestReturnsUsedKeysInTheStore(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore := CreateAnExistingKeystore(path)
+	keyStore := CreateAnExistingKeystore(path)
 
-	keys, err := keystore.List()
+	listingKeystore, err := AsListingKeystore(keyStore)
+	assert.NoError(t, err)
+
+	keys, err := listingKeystore.List()
 
 	assert.NoError(t, err)
 	assert.Equal(t, len(keys), 1)
@@ -165,9 +179,13 @@ func TestCannotDecryptKeyStoreWithWrongPassword(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString([]byte("password")))
-	keystore.Store("hello", []byte("world"))
-	keystore.Save()
+	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString([]byte("password")))
+
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
+
+	writableKeystore.Store("hello", []byte("world"))
+	writableKeystore.Save()
 
 	_, err = NewFileKeystoreWithPassword(path, NewSecureString([]byte("wrongpassword")))
 	if assert.Error(t, err, "should fail to decrypt the keystore") {
@@ -199,13 +217,16 @@ func TestGetConfig(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore := CreateAnExistingKeystore(path)
+	keyStore := CreateAnExistingKeystore(path)
+
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
 
 	// Add a bit more data of different type
-	keystore.Store("super.nested", []byte("hello"))
-	keystore.Save()
+	writableKeystore.Store("super.nested", []byte("hello"))
+	writableKeystore.Save()
 
-	cfg, err := keystore.GetConfig()
+	cfg, err := keyStore.GetConfig()
 	assert.NotNil(t, cfg)
 	assert.NoError(t, err)
 
@@ -258,11 +279,14 @@ func createAndReadKeystoreSecret(t *testing.T, password []byte, key string, valu
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
 	assert.Nil(t, err)
 
-	keystore.Store(key, value)
-	keystore.Save()
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
+
+	writableKeystore.Store(key, value)
+	writableKeystore.Save()
 
 	newStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
 	s, _ := newStore.Retrieve(key)
@@ -274,11 +298,14 @@ func createAndReadKeystoreWithPassword(t *testing.T, password []byte) {
 	path := GetTemporaryKeystoreFile()
 	defer os.Remove(path)
 
-	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
 	assert.NoError(t, err)
 
-	keystore.Store("hello", []byte("world"))
-	keystore.Save()
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	assert.NoError(t, err)
+
+	writableKeystore.Store("hello", []byte("world"))
+	writableKeystore.Save()
 
 	newStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
 	s, _ := newStore.Retrieve("hello")
@@ -290,14 +317,20 @@ func createAndReadKeystoreWithPassword(t *testing.T, password []byte) {
 // CreateAnExistingKeystore creates a keystore with an existing key
 /// `output.elasticsearch.password` with the value `secret`.
 func CreateAnExistingKeystore(path string) Keystore {
-	keystore, err := NewFileKeystore(path)
+	keyStore, err := NewFileKeystore(path)
 	// Fail fast in the test suite
 	if err != nil {
 		panic(err)
 	}
-	keystore.Store(keyValue, secretValue)
-	keystore.Save()
-	return keystore
+
+	writableKeystore, err := AsWritableKeystore(keyStore)
+	if err != nil {
+		panic(err)
+	}
+
+	writableKeystore.Store(keyValue, secretValue)
+	writableKeystore.Save()
+	return keyStore
 }
 
 // GetTemporaryKeystoreFile create a temporary file on disk to save the keystore.

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/common/file"
+	"github.com/elastic/beats/v7/libbeat/keystore"
 	"github.com/elastic/beats/v7/libbeat/kibana"
 	"github.com/elastic/beats/v7/x-pack/libbeat/management/api"
 )
@@ -87,16 +88,22 @@ func Enroll(
 }
 
 func storeAccessToken(beat *instance.Beat, accessToken string) error {
-	keystore := beat.Keystore()
-	if !keystore.IsPersisted() {
-		if err := keystore.Create(false); err != nil {
+	keyStore := beat.Keystore()
+
+	wKeystore, err := keystore.AsWritableKeystore(keyStore)
+	if err != nil {
+		return err
+	}
+
+	if !keyStore.IsPersisted() {
+
+		if err := wKeystore.Create(false); err != nil {
 			return errors.Wrap(err, "error creating keystore")
 		}
 	}
-
-	if err := keystore.Store(accessTokenKey, []byte(accessToken)); err != nil {
+	if err := wKeystore.Store(accessTokenKey, []byte(accessToken)); err != nil {
 		return errors.Wrap(err, "error storing the access token")
 	}
 
-	return keystore.Save()
+	return wKeystore.Save()
 }


### PR DESCRIPTION
Cherry-pick of PR #16365 to 7.x branch. Original message: 

## What does this PR do?
This PR refactor keystore interface into 3 different interfaces.

~~This PR introduces a  new `Keystore` backend which is `ReadOnly` and retrieves passwords from k8s secrets through k8s API. In order to implement this, the basic `Keystore` interface is split into 3 different interfaces, `Keystore` (readonly), `WritableKeystore` (Keystore + store/write/delete), `ListingKeystore` (WritableKeystore + list) as proposed on https://github.com/elastic/beats/issues/5832.~~

~~The new Keystore that retrieves data from k8s secrets is of `Keystore` (readonly) type.~~

~~#### Autodiscover adoption
In order to support this k8s Keystore in Autodiscover, a keystore object is attached on every event. The keystore object is either created or retrieved if it already exists. We create only one keystore per namespace and we reuse it for events of the same namespace.~~

## Why is it important?
This is important in order to support different keystore backends, like k8s keystore.

~~This is important in order to support autodiscover hints being able to refer to k8s secrets for password retrieval.~~



## How to test this PR locally
Try all the set of available commands:
1. `./metricbeat keystore create`
2. `./metricbeat keystore add ES_PWD`
3. `./metricbeat keystore add ES_PWD --force`
4. `echo "passpass" | ./metricbeat keystore add ES_PWD --stdin --for`
5. `./metricbeat keystore list`
6. `./metricbeat keystore remove ES_PWD`

Create a key and consume it (Elastic Cloud auth or any other ES setting can be used as an example):
1. `./metricbeat keystore add ES_PWD`
2. `./metricbeat -e -d "*" -E "cloud.id=testkeys:xxxx" -E "cloud.auth=\${ES_PWD}"`

or 

1. `./metricbeat keystore add ES_HOST `
2. `./metricbeat -e -d "*" -E output.elasticsearch.hosts=["\${ES_HOST}"]`

## Related issues

- Relates https://github.com/elastic/beats/issues/5832, https://github.com/elastic/beats/issues/8847

