### PR TITLE
Filebeat: Fix fields indentation

### DIFF
--- a/x-pack/filebeat/module/coredns/_meta/fields.yml
+++ b/x-pack/filebeat/module/coredns/_meta/fields.yml
@@ -3,55 +3,55 @@
   description: >
     Module for handling logs produced by coredns
   fields:
-  - name: coredns
-    type: group
-    description: >
-      coredns fields after normalization
-    fields:
-    - name: id
-      type: keyword
+    - name: coredns
+      type: group
       description: >
-        id of the DNS transaction
+        coredns fields after normalization
+      fields:
+      - name: id
+        type: keyword
+        description: >
+          id of the DNS transaction
 
-    - name: query.size
-      type: integer
-      format: bytes
-      description: >
-        size of the DNS query
+      - name: query.size
+        type: integer
+        format: bytes
+        description: >
+          size of the DNS query
 
-    - name: query.class
-      type: keyword
-      description: >
-        DNS query class
+      - name: query.class
+        type: keyword
+        description: >
+          DNS query class
 
-    - name: query.name
-      type: keyword
-      description: >
-        DNS query name
+      - name: query.name
+        type: keyword
+        description: >
+          DNS query name
 
-    - name: query.type
-      type: keyword
-      description: >
-        DNS query type
+      - name: query.type
+        type: keyword
+        description: >
+          DNS query type
 
-    - name: response.code
-      type: keyword
-      description: >
-        DNS response code
+      - name: response.code
+        type: keyword
+        description: >
+          DNS response code
 
-    - name: response.flags
-      type: keyword
-      description: >
-        DNS response flags
+      - name: response.flags
+        type: keyword
+        description: >
+          DNS response flags
 
-    - name: response.size
-      type: integer
-      format: bytes
-      description: >
-        size of the DNS response
-    
-    - name: dnssec_ok
-      type: boolean
-      description: >
-        dnssec flag
-        
+      - name: response.size
+        type: integer
+        format: bytes
+        description: >
+          size of the DNS response
+
+      - name: dnssec_ok
+        type: boolean
+        description: >
+          dnssec flag
+

--- a/x-pack/filebeat/module/envoyproxy/_meta/fields.yml
+++ b/x-pack/filebeat/module/envoyproxy/_meta/fields.yml
@@ -3,43 +3,43 @@
   description: >
     Module for handling logs produced by envoy
   fields:
-  - name: envoyproxy
-    type: group
-    description: >
-      Fields from envoy proxy logs after normalization
-    fields:
-    - name: log_type
-      type: keyword
+    - name: envoyproxy
+      type: group
       description: >
-        Envoy log type, normally ACCESS
+        Fields from envoy proxy logs after normalization
+      fields:
+      - name: log_type
+        type: keyword
+        description: >
+          Envoy log type, normally ACCESS
 
-    - name: response_flags
-      type: keyword
-      description: >
-        Response flags
+      - name: response_flags
+        type: keyword
+        description: >
+          Response flags
 
-    - name: upstream_service_time
-      type: long
-      format: duration
-      input_format: nanoseconds
-      description: >
-        Upstream service time in nanoseconds
+      - name: upstream_service_time
+        type: long
+        format: duration
+        input_format: nanoseconds
+        description: >
+          Upstream service time in nanoseconds
 
-    - name: request_id
-      type: keyword
-      description: >
-        ID of the request
+      - name: request_id
+        type: keyword
+        description: >
+          ID of the request
 
-    - name: authority
-      type: keyword
-      description: >
-        Envoy proxy authority field
+      - name: authority
+        type: keyword
+        description: >
+          Envoy proxy authority field
 
-    - name: proxy_type
-      type: keyword
-      description: >
-        Envoy proxy type, tcp or http
+      - name: proxy_type
+        type: keyword
+        description: >
+          Envoy proxy type, tcp or http
 
 
 
-        
+


### PR DESCRIPTION
This PR fixes the indentation in the `fields.yml` file for coredns and envoyproxy modules.

Spotted while trying to unmarshall both files. Failed with: 
```
2020/04/02 16:43:07 creating from logs source failed: unmarshalling fields failed: yaml: unmarshal errors:
  line 1: cannot unmarshal !!map into []main.mapStr
```