### PR TITLE
Cherry-pick #17400 to 7.x: [Metricbeat] Further revise check for bad data in docker/memory

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -178,6 +178,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use max in k8s overview dashboard aggregations. {pull}17015[17015]
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
+- Further revise check for bad data in docker/memory. {pull}17400[17400] 
+- Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -179,7 +179,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
 - Further revise check for bad data in docker/memory. {pull}17400[17400] 
-- Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 
 *Packetbeat*

--- a/metricbeat/module/docker/memory/helper.go
+++ b/metricbeat/module/docker/memory/helper.go
@@ -51,7 +51,7 @@ func (s *MemoryService) getMemoryStatsList(containers []docker.Stat, dedot bool)
 		//during this time, there doesn't appear to be any meaningful data,
 		// and Limit will never be 0 unless the container is not running
 		//and there's no cgroup data, and CPU usage should be greater than 0 for any running container.
-		if containerStats.Stats.MemoryStats.Limit == 0 && containerStats.Stats.PreCPUStats.CPUUsage.TotalUsage == 0 {
+		if containerStats.Stats.MemoryStats.Limit == 0 || containerStats.Stats.PreCPUStats.CPUUsage.TotalUsage == 0 {
 			continue
 		}
 		formattedStats = append(formattedStats, s.getMemoryStats(containerStats, dedot))

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -20,6 +20,8 @@
 package memory
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 
@@ -70,6 +72,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	memoryStats := m.memoryService.getMemoryStatsList(stats, m.dedot)
+	if len(memoryStats) == 0 {
+		return fmt.Errorf("No memory stats data available")
+	}
 	eventsMapping(r, memoryStats)
 
 	return nil

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -109,6 +109,22 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 	assert.Equal(t, expectedFields, event.MetricSetFields)
 }
 
+func TestMemoryServiceBadData(t *testing.T) {
+
+	badMemStats := types.StatsJSON{
+		Stats: types.Stats{
+			Read:        time.Now(),
+			MemoryStats: types.MemoryStats{}, //Test for cases where this is empty
+		},
+	}
+
+	memoryService := &MemoryService{}
+	memoryRawStats := []docker.Stat{docker.Stat{Stats: badMemStats}}
+	rawStats := memoryService.getMemoryStatsList(memoryRawStats, false)
+	assert.Len(t, rawStats, 0)
+
+}
+
 func getMemoryStats(read time.Time, number uint64) types.StatsJSON {
 
 	myMemoryStats := types.StatsJSON{


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17400 to 7.x branch. Original message: 


## What does this PR do?

Apparently, as I discovered in discuss, there are platforms where there's _no_ cgroup memory data, and thus no memory stats for docker to send us. In this case, we were still sending `NaN`s to the output because of the `&&` check.  

## Why is it important?

We don't want to send data with NaNs to the output.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

There's an added test. People have been reporting this bug against CentOS, but I haven't been able to reproduce it myself, as it appears to be a cgroup quirk. 

