### PR TITLE
Postpone selection of the logger output

### DIFF
--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -38,6 +38,7 @@ type Config struct {
 
 	Files FileConfig `config:"files"`
 
+	environment Environment
 	addCaller   bool // Adds package and line number info to messages.
 	development bool // Controls how DPanic behaves.
 }
@@ -59,41 +60,16 @@ const defaultLevel = InfoLevel
 // DefaultConfig returns the default config options for a given environment the
 // Beat is supposed to be run within.
 func DefaultConfig(environment Environment) Config {
-	switch environment {
-	case SystemdEnvironment, ContainerEnvironment:
-		return defaultToStderrConfig()
-
-	case MacOSServiceEnvironment, WindowsServiceEnvironment:
-		fallthrough
-	default:
-		return defaultToFileConfig()
-	}
-}
-
-func defaultToStderrConfig() Config {
 	return Config{
-		Level:     defaultLevel,
-		ToStderr:  true,
-		Files:     defaultFileConfig(),
-		addCaller: true,
-	}
-}
-
-func defaultToFileConfig() Config {
-	return Config{
-		Level:     defaultLevel,
-		ToFiles:   true,
-		Files:     defaultFileConfig(),
-		addCaller: true,
-	}
-}
-
-func defaultFileConfig() FileConfig {
-	return FileConfig{
-		MaxSize:         10 * 1024 * 1024,
-		MaxBackups:      7,
-		Permissions:     0600,
-		Interval:        0,
-		RotateOnStartup: true,
+		Level: defaultLevel,
+		Files: FileConfig{
+			MaxSize:         10 * 1024 * 1024,
+			MaxBackups:      7,
+			Permissions:     0600,
+			Interval:        0,
+			RotateOnStartup: true,
+		},
+		environment: environment,
+		addCaller:   true,
 	}
 }

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -67,21 +67,10 @@ func Configure(cfg Config) error {
 	)
 
 	// Build a single output (stderr has priority if more than one are enabled).
-	switch {
-	case cfg.toObserver:
+	if cfg.toObserver {
 		sink, observedLogs = observer.New(cfg.Level.zapLevel())
-	case cfg.toIODiscard:
-		sink, err = makeDiscardOutput(cfg)
-	case cfg.ToStderr:
-		sink, err = makeStderrOutput(cfg)
-	case cfg.ToSyslog:
-		sink, err = makeSyslogOutput(cfg)
-	case cfg.ToEventLog:
-		sink, err = makeEventLogOutput(cfg)
-	case cfg.ToFiles:
-		fallthrough
-	default:
-		sink, err = makeFileOutput(cfg)
+	} else {
+		sink, err = createLogOutput(cfg)
 	}
 	if err != nil {
 		return errors.Wrap(err, "failed to build log output")
@@ -123,6 +112,30 @@ func Configure(cfg Config) error {
 		observedLogs: observedLogs,
 	})
 	return nil
+}
+
+func createLogOutput(cfg Config) (zapcore.Core, error) {
+	switch {
+	case cfg.toIODiscard:
+		return makeDiscardOutput(cfg)
+	case cfg.ToStderr:
+		return makeStderrOutput(cfg)
+	case cfg.ToSyslog:
+		return makeSyslogOutput(cfg)
+	case cfg.ToEventLog:
+		return makeEventLogOutput(cfg)
+	case cfg.ToFiles:
+		return makeFileOutput(cfg)
+	}
+
+	switch cfg.environment {
+	case SystemdEnvironment, ContainerEnvironment:
+		return makeStderrOutput(cfg)
+	case MacOSServiceEnvironment, WindowsServiceEnvironment:
+		fallthrough
+	default:
+		return makeFileOutput(cfg)
+	}
 }
 
 // DevelopmentSetup configures the logger in development mode at debug level.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

Postpone the selection of the log output after configuration file has been read and CLI flags have been assigned.

## Why is it important?

Fix regression found during 7.7.0 testing. The configured log output is not respected and can not be overwritten. This change ensures that CLI flags and configuration files are always respected.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
