### PR TITLE
Cherry-pick #17418 to 7.x: [Metricbeat AWS] check if cpuOptions is nil in DescribeInstances output 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -180,6 +180,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
 - Further revise check for bad data in docker/memory. {pull}17400[17400] 
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
+- check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -209,7 +209,11 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 
 				events[instanceID].RootFields.Put("cloud.instance.id", instanceID)
 				events[instanceID].RootFields.Put("cloud.machine.type", machineType)
-				events[instanceID].RootFields.Put("cloud.availability_zone", *instanceOutput[instanceID].Placement.AvailabilityZone)
+
+				placement := instanceOutput[instanceID].Placement
+				if placement != nil {
+					events[instanceID].RootFields.Put("cloud.availability_zone", *placement.AvailabilityZone)
+				}
 
 				if len(output.Values) > timestampIdx {
 					metricSetFieldResults[instanceID][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx])
@@ -227,23 +231,28 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 
 				monitoringStates[instanceID] = monitoringState
 
-				events[instanceID].MetricSetFields.Put("instance.image.id", *instanceOutput[instanceID].ImageId)
-				events[instanceID].MetricSetFields.Put("instance.state.name", instanceStateName)
-				events[instanceID].MetricSetFields.Put("instance.state.code", *instanceOutput[instanceID].State.Code)
-				events[instanceID].MetricSetFields.Put("instance.monitoring.state", monitoringState)
-				events[instanceID].MetricSetFields.Put("instance.core.count", *instanceOutput[instanceID].CpuOptions.CoreCount)
-				events[instanceID].MetricSetFields.Put("instance.threads_per_core", *instanceOutput[instanceID].CpuOptions.ThreadsPerCore)
+				cpuOptions := instanceOutput[instanceID].CpuOptions
+				if cpuOptions != nil {
+					events[instanceID].MetricSetFields.Put("instance.core.count", *cpuOptions.CoreCount)
+					events[instanceID].MetricSetFields.Put("instance.threads_per_core", *cpuOptions.ThreadsPerCore)
+				}
+
 				publicIP := instanceOutput[instanceID].PublicIpAddress
 				if publicIP != nil {
 					events[instanceID].MetricSetFields.Put("instance.public.ip", *publicIP)
 				}
 
-				events[instanceID].MetricSetFields.Put("instance.public.dns_name", *instanceOutput[instanceID].PublicDnsName)
-				events[instanceID].MetricSetFields.Put("instance.private.dns_name", *instanceOutput[instanceID].PrivateDnsName)
 				privateIP := instanceOutput[instanceID].PrivateIpAddress
 				if privateIP != nil {
 					events[instanceID].MetricSetFields.Put("instance.private.ip", *privateIP)
 				}
+
+				events[instanceID].MetricSetFields.Put("instance.image.id", *instanceOutput[instanceID].ImageId)
+				events[instanceID].MetricSetFields.Put("instance.state.name", instanceStateName)
+				events[instanceID].MetricSetFields.Put("instance.state.code", *instanceOutput[instanceID].State.Code)
+				events[instanceID].MetricSetFields.Put("instance.monitoring.state", monitoringState)
+				events[instanceID].MetricSetFields.Put("instance.public.dns_name", *instanceOutput[instanceID].PublicDnsName)
+				events[instanceID].MetricSetFields.Put("instance.private.dns_name", *instanceOutput[instanceID].PrivateDnsName)
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #17418 to 7.x branch. Original message: 

I cannot reproduce this error with my AWS account. But based on the error message in the bug report https://github.com/elastic/beats/issues/17392, I believe it is caused by response body of `DescribeInstances` API has empty cpuOptions:
```
2020-04-01T12:57:03.827+0200	ERROR	runtime/panic.go:199	recovered from panic while
fetching 'aws/ec2' for host ''. Recovering, but please report this.	{"panic": "runtime error: 
invalid memory address or nil pointer dereference", "stack": 
"github.com/elastic/beats/libbeat/logp.Recover\n\t/go/src/github.com/elastic/beats/libbeat/logp/
global.go:105\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:679\nruntime.panicmem\n
\t/usr/local/go/src/runtime/panic.go:199\nruntime.sigpanic\n\t/usr/local/go/src/runtime/signal_un
ix.go:394\ngithub.com/elastic/beats/x-pack/metricbeat/module/aws/ec2.
(*MetricSet).createCloudWatchEvents\n\t/go/src/github.com/elastic/beats/x-
pack/metricbeat/module/aws/ec2/ec2.go:238\ngithub.com/elastic/beats/x-
pack/metricbeat/module/aws/ec2.(*MetricSet).Fetch\n\t/go/src/github.com/elastic/beats/x-
pack/metricbeat/module/aws/ec2/ec2.go:133\ngithub.com/elastic/beats/metricbeat/mb/module.
(*metricSetWrapper).fetch\n\t/go/src/github.com/elastic/beats/metricbeat/mb/module/wrapper.
go:249\ngithub.com/elastic/beats/metricbeat/mb/module.
(*metricSetWrapper).startPeriodicFetching\n\t/go/src/github.com/elastic/beats/metricbeat/mb/
module/wrapper.go:217\ngithub.com/elastic/beats/metricbeat/mb/module.
(*metricSetWrapper).run\n\t/go/src/github.com/elastic/beats/metricbeat/mb/module/wrapper.go
:201\ngithub.com/elastic/beats/metricbeat/mb/module.
(*Wrapper).Start.func1\n\t/go/src/github.com/elastic/beats/metricbeat/mb/module/wrapper.go:1
40"}
```
This PR is to fix the error by checking if `cpuOptions` is nil first before evaluating `cpuOptions`.  Similarly, I also added the check for `Placement` field.