### PR TITLE
Adding unit tests for publisher output

### DIFF
--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -67,6 +67,13 @@ func (w *clientWorker) Close() error {
 func (w *clientWorker) run() {
 	for !w.closed.Load() {
 		for batch := range w.qu {
+			if w.closed.Load() {
+				if batch != nil {
+					batch.Cancelled()
+				}
+				return
+			}
+
 			w.observer.outBatchSend(len(batch.events))
 
 			if err := w.client.Publish(batch); err != nil {

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -39,7 +39,7 @@ var (
 	SeedFlag = flag.Int64("seed", 0, "Randomization seed")
 )
 
-func TestPublish(t *testing.T) {
+func TestMakeClientWorker(t *testing.T) {
 	tests := map[string]func(uint) publishCountable{
 		"client":         newMockClient,
 		"network_client": newMockNetworkClient,
@@ -79,7 +79,7 @@ func TestPublish(t *testing.T) {
 	}
 }
 
-func TestPublishWithClose(t *testing.T) {
+func TestMakeClientWorkerAndClose(t *testing.T) {
 	tests := map[string]func(uint) publishCountable{
 		"client":         newMockClient,
 		"network_client": newMockNetworkClient,

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -169,7 +169,7 @@ func (c *mockClient) Publish(batch publisher.Batch) error {
 
 	// Block publishing
 	if c.publishLimit > 0 && c.published >= c.publishLimit {
-		time.Sleep(10 * time.Second)
+		time.Sleep(30 * time.Second)
 		return nil
 	}
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -18,6 +18,7 @@
 package pipeline
 
 import (
+	"flag"
 	"math/rand"
 	"sync"
 	"testing"
@@ -31,6 +32,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+)
+
+var (
+	SeedFlag = flag.Int64("seed", 0, "Randomization seed")
 )
 
 func TestPublish(t *testing.T) {
@@ -47,7 +52,7 @@ func TestPublish(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			rand.Seed(time.Now().UnixNano())
+			seedPRNG(t)
 
 			wqu := makeWorkQueue()
 			makeClientWorker(nilObserver, wqu, test.client)
@@ -78,7 +83,7 @@ func TestPublish(t *testing.T) {
 }
 
 func TestPublishWithClose(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	seedPRNG(t)
 
 	wqu := makeWorkQueue()
 	client := &mockNetworkClient{}
@@ -178,4 +183,14 @@ func randomBatch(min, max int, wqu workQueue) *Batch {
 // randIntBetween returns a random integer in [min, max)
 func randIntBetween(min, max int) int {
 	return rand.Intn(max-min) + min
+}
+
+func seedPRNG(t *testing.T) {
+	seed := *SeedFlag
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+
+	t.Logf("seeding PRNG with %v", seed)
+	rand.Seed(seed)
 }

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -108,7 +108,7 @@ func TestPublishWithClose(t *testing.T) {
 						wqu <- batch
 
 						// To ensure worker doesn't have time to publish all batches
-						time.Sleep(750 * time.Microsecond)
+						time.Sleep(1 * time.Millisecond)
 					}()
 				}
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -19,6 +19,7 @@ package pipeline
 
 import (
 	"flag"
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -107,7 +108,7 @@ func TestPublishWithClose(t *testing.T) {
 					}()
 				}
 
-				client := ctor(numEvents.Load() / 2) // Stop short of publishing all events
+				client := ctor(uint(math.Floor(float64(numEvents.Load()) * 0.8))) // Stop short of publishing all events
 				worker := makeClientWorker(nilObserver, wqu, client)
 
 				// Close worker before all batches have had time to be published

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -140,7 +140,7 @@ func TestPublishWithClose(t *testing.T) {
 	}
 }
 
-const publishLatency = 1 * time.Microsecond
+const publishLatency = 5 * time.Microsecond
 
 func newMockClient() outputs.Client { return &mockClient{} }
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -64,7 +64,7 @@ func TestPublish(t *testing.T) {
 				}
 
 				// Give some time for events to be published
-				timeout := time.Duration(numEvents.Load()*3) * time.Microsecond
+				timeout := 20 * time.Second
 
 				// Make sure that all events have eventually been published
 				c := client.(interface{ Published() int })
@@ -125,7 +125,7 @@ func TestPublishWithClose(t *testing.T) {
 				wg.Wait()
 
 				// Give some time for events to be published
-				timeout := time.Duration(remaining*3) * time.Microsecond
+				timeout := 20 * time.Second
 
 				// Make sure that all events have eventually been published
 				return waitUntilTrue(timeout, func() bool {

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -98,16 +98,15 @@ func TestPublishWithClose(t *testing.T) {
 				numEvents := atomic.MakeUint(0)
 
 				var wg sync.WaitGroup
-				for batchIdx := uint(0); batchIdx <= numBatches; batchIdx++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for batchIdx := uint(0); batchIdx <= numBatches; batchIdx++ {
 						batch := randomBatch(minEventsInBatch, 150, wqu)
 						numEvents.Add(uint(len(batch.Events())))
 						wqu <- batch
-					}()
-				}
+					}
+				}()
 
 				// Publish at least 1 batch worth of events but no more than 20% events
 				publishLimit := uint(math.Min(minEventsInBatch, float64(numEvents.Load())*0.2))

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -122,9 +122,7 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 				blockingPublishFn := func(batch publisher.Batch) error {
 					// Emulate blocking
 					if publishedFirst.Load() >= publishLimit {
-						batch.Retry()
 						<-blockCtrl
-						return nil
 					}
 
 					publishedFirst.Add(uint(len(batch.Events())))

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -50,7 +50,7 @@ func TestPublish(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 100 + (i % 200) // between 100 and 299
+				numBatches := 3000 + (i % 1000) // between 3000 and 3999
 
 				client := ctor()
 				wqu := makeWorkQueue()
@@ -91,7 +91,7 @@ func TestPublishWithClose(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 2000 + (i % 1000) // between 2000 and 2999
+				numBatches := 3000 + (i % 1000) // between 3000 and 3999
 
 				wqu := makeWorkQueue()
 				numEvents := atomic.MakeInt(0)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -140,7 +140,7 @@ func TestPublishWithClose(t *testing.T) {
 					total := published + client.Published()
 					return numEvents.Load() == total
 				})
-			}, nil)
+			}, &quick.Config{MaxCount: 50})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -163,7 +163,7 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return numEvents.Load() == publishedFirst.Load()+publishedLater.Load()
 				})
-			}, &quick.Config{MaxCount: 50})
+			}, &quick.Config{MaxCount: 25})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -108,7 +108,8 @@ func TestPublishWithClose(t *testing.T) {
 					}()
 				}
 
-				client := ctor(uint(math.Floor(float64(numEvents.Load()) * 0.8))) // Stop short of publishing all events
+				publishLimit := math.Floor(float64(numEvents.Load()) * 0.2) // Only publish first 20% of events
+				client := ctor(uint(publishLimit))
 				worker := makeClientWorker(nilObserver, wqu, client)
 
 				// Close worker before all batches have had time to be published

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -50,7 +50,7 @@ func TestPublish(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 3000 + (i % 1000) // between 3000 and 3999
+				numBatches := 300 + (i % 100) // between 300 and 399
 
 				wqu := makeWorkQueue()
 				client := ctor(0)
@@ -90,7 +90,7 @@ func TestPublishWithClose(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 3000 + (i % 1000) // between 3000 and 3999
+				numBatches := 300 + (i % 100) // between 300 and 399
 
 				wqu := makeWorkQueue()
 				numEvents := atomic.MakeUint(0)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -1,0 +1,143 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/atomic"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+)
+
+func TestPublish(t *testing.T) {
+	tests := map[string]struct {
+		client outputs.Client
+	}{
+		"client": {
+			&mockClient{},
+		},
+		"network_client": {
+			&mockNetworkClient{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			rand.Seed(time.Now().UnixNano())
+
+			wqu := makeWorkQueue()
+			makeClientWorker(nilObserver, wqu, test.client)
+
+			numEvents := atomic.MakeInt(0)
+			var wg sync.WaitGroup
+			for batchIdx := 0; batchIdx <= randIntBetween(25, 200); batchIdx++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					batch := randomBatch(50, 150, wqu)
+
+					numEvents.Add(len(batch.Events()))
+
+					wqu <- batch
+				}()
+			}
+			wg.Wait()
+
+			// Give some time for events to be published
+			time.Sleep(time.Duration(numEvents.Load()*2) * time.Microsecond)
+
+			c := test.client.(interface{ Published() int })
+			assert.Equal(t, numEvents.Load(), c.Published())
+		})
+	}
+}
+
+type mockClient struct{ published int }
+
+func (c *mockClient) Published() int { return c.published }
+
+func (c *mockClient) String() string { return "mock_client" }
+func (c *mockClient) Close() error   { return nil }
+func (c *mockClient) Publish(batch publisher.Batch) error {
+	c.published += len(batch.Events())
+	return nil
+}
+
+type mockNetworkClient struct{ published int }
+
+func (c *mockNetworkClient) Published() int { return c.published }
+
+func (c *mockNetworkClient) String() string { return "mock_network_client" }
+func (c *mockNetworkClient) Close() error   { return nil }
+func (c *mockNetworkClient) Publish(batch publisher.Batch) error {
+	c.published += len(batch.Events())
+	return nil
+}
+func (c *mockNetworkClient) Connect() error { return nil }
+
+type mockQueue struct{}
+
+func (q mockQueue) Close() error                                     { return nil }
+func (q mockQueue) BufferConfig() queue.BufferConfig                 { return queue.BufferConfig{} }
+func (q mockQueue) Producer(cfg queue.ProducerConfig) queue.Producer { return mockProducer{} }
+func (q mockQueue) Consumer() queue.Consumer                         { return mockConsumer{} }
+
+type mockProducer struct{}
+
+func (p mockProducer) Publish(event publisher.Event) bool    { return true }
+func (p mockProducer) TryPublish(event publisher.Event) bool { return true }
+func (p mockProducer) Cancel() int                           { return 0 }
+
+type mockConsumer struct{}
+
+func (c mockConsumer) Get(eventCount int) (queue.Batch, error) { return &Batch{}, nil }
+func (c mockConsumer) Close() error                            { return nil }
+
+func randomBatch(min, max int, wqu workQueue) *Batch {
+	numEvents := randIntBetween(min, max)
+	events := make([]publisher.Event, numEvents)
+
+	consumer := newEventConsumer(logp.L(), mockQueue{}, &batchContext{})
+	retryer := newRetryer(logp.L(), nilObserver, wqu, consumer)
+
+	batch := Batch{
+		events: events,
+		ctx: &batchContext{
+			observer: nilObserver,
+			retryer:  retryer,
+		},
+	}
+
+	return &batch
+}
+
+// randIntBetween returns a random integer in [min, max)
+func randIntBetween(min, max int) int {
+	return rand.Intn(max-min) + min
+}

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -140,8 +140,6 @@ func TestPublishWithClose(t *testing.T) {
 	}
 }
 
-const publishLatency = 50 * time.Microsecond
-
 func newMockClient() outputs.Client { return &mockClient{} }
 
 type mockClient struct {
@@ -162,7 +160,6 @@ func (c *mockClient) Publish(batch publisher.Batch) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	time.Sleep(publishLatency)
 	c.published += len(batch.Events())
 	return nil
 }
@@ -187,7 +184,6 @@ func (c *mockNetworkClient) Publish(batch publisher.Batch) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	time.Sleep(publishLatency)
 	c.published += len(batch.Events())
 	return nil
 }

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -140,7 +140,7 @@ func TestPublishWithClose(t *testing.T) {
 	}
 }
 
-const publishLatency = 5 * time.Microsecond
+const publishLatency = 50 * time.Microsecond
 
 func newMockClient() outputs.Client { return &mockClient{} }
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -58,19 +58,11 @@ func TestPublish(t *testing.T) {
 			makeClientWorker(nilObserver, wqu, test.client)
 
 			numEvents := atomic.MakeInt(0)
-			var wg sync.WaitGroup
 			for batchIdx := 0; batchIdx <= randIntBetween(25, 200); batchIdx++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					batch := randomBatch(50, 150, wqu)
-
-					numEvents.Add(len(batch.Events()))
-
-					wqu <- batch
-				}()
+				batch := randomBatch(50, 150, wqu)
+				numEvents.Add(len(batch.Events()))
+				wqu <- batch
 			}
-			wg.Wait()
 
 			// Give some time for events to be published
 			timeout := time.Duration(numEvents.Load()*3) * time.Microsecond

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -78,6 +78,12 @@ func TestPublish(t *testing.T) {
 	}
 }
 
+func TestPublishWithClose(t *testing.T) {
+	// Test that multiple batches are all published, even if
+	// the worker is closed midway
+	// TODO
+}
+
 type mockClient struct{ published int }
 
 func (c *mockClient) Published() int { return c.published }

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -52,8 +52,8 @@ func TestPublish(t *testing.T) {
 			err := quick.Check(func(i uint) bool {
 				numBatches := 3000 + (i % 1000) // between 3000 and 3999
 
-				client := ctor()
 				wqu := makeWorkQueue()
+				client := ctor()
 				makeClientWorker(nilObserver, wqu, client)
 
 				numEvents := atomic.MakeInt(0)
@@ -94,6 +94,7 @@ func TestPublishWithClose(t *testing.T) {
 				numBatches := 3000 + (i % 1000) // between 3000 and 3999
 
 				wqu := makeWorkQueue()
+
 				numEvents := atomic.MakeInt(0)
 
 				var wg sync.WaitGroup
@@ -101,9 +102,13 @@ func TestPublishWithClose(t *testing.T) {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
+
 						batch := randomBatch(50, 150, wqu)
 						numEvents.Add(len(batch.Events()))
 						wqu <- batch
+
+						// To ensure worker doesn't have time to publish all batches
+						time.Sleep(750 * time.Microsecond)
 					}()
 				}
 

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -23,18 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/beats/v7/libbeat/publisher/queue"
-
 	"github.com/elastic/beats/v7/libbeat/logp"
-
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
 func TestPublish(t *testing.T) {

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -90,7 +90,7 @@ func TestPublishWithClose(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 600 + (i % 100) // between 600 and 699
+				numBatches := 1000 + (i % 100) // between 1000 and 1099
 
 				wqu := makeWorkQueue()
 				numEvents := atomic.MakeUint(0)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -19,6 +19,7 @@ package pipeline
 
 import (
 	"flag"
+	"fmt"
 	"math"
 	"math/rand"
 	"sync"
@@ -109,6 +110,7 @@ func TestPublishWithClose(t *testing.T) {
 				}
 
 				publishLimit := math.Floor(float64(numEvents.Load()) * 0.2) // Only publish up to first 20% of events
+				fmt.Printf("[%v] publishLimit = %v\n", name, publishLimit)
 				client := ctor(uint(publishLimit))
 				worker := makeClientWorker(nilObserver, wqu, client)
 
@@ -117,6 +119,7 @@ func TestPublishWithClose(t *testing.T) {
 				require.NoError(t, err)
 
 				published := client.Published()
+				fmt.Printf("[%v] published = %v, total = %v\n", name, published, numEvents.Load())
 				assert.Less(t, published, numEvents.Load())
 
 				// Start new worker to drain work queue

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -90,7 +90,7 @@ func TestPublishWithClose(t *testing.T) {
 			seedPRNG(t)
 
 			err := quick.Check(func(i uint) bool {
-				numBatches := 300 + (i % 100) // between 300 and 399
+				numBatches := 600 + (i % 100) // between 600 and 699
 
 				wqu := makeWorkQueue()
 				numEvents := atomic.MakeUint(0)

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -106,9 +106,6 @@ func TestPublishWithClose(t *testing.T) {
 						batch := randomBatch(50, 150, wqu)
 						numEvents.Add(len(batch.Events()))
 						wqu <- batch
-
-						// To ensure worker doesn't have time to publish all batches
-						time.Sleep(1 * time.Millisecond)
 					}()
 				}
 
@@ -143,6 +140,8 @@ func TestPublishWithClose(t *testing.T) {
 	}
 }
 
+const publishLatency = 1 * time.Microsecond
+
 func newMockClient() outputs.Client { return &mockClient{} }
 
 type mockClient struct {
@@ -163,6 +162,7 @@ func (c *mockClient) Publish(batch publisher.Batch) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	time.Sleep(publishLatency)
 	c.published += len(batch.Events())
 	return nil
 }
@@ -187,6 +187,7 @@ func (c *mockNetworkClient) Publish(batch publisher.Batch) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	time.Sleep(publishLatency)
 	c.published += len(batch.Events())
 	return nil
 }

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -120,7 +120,8 @@ func TestMakeClientWorkerAndClose(t *testing.T) {
 				var publishedFirst atomic.Uint
 				blockCtrl := make(chan struct{})
 				blockingPublishFn := func(batch publisher.Batch) error {
-					// Emulate blocking
+					// Emulate blocking. Upon unblocking the in-flight batch that was
+					// blocked is published.
 					if publishedFirst.Load() >= publishLimit {
 						<-blockCtrl
 					}


### PR DESCRIPTION
## What does this PR do?

Adds unit tests for the publisher output functionality in libbeat.

## Why is it important?

It checks that the publisher output publishes the expected number of events under various scenarios.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related PRs
- In preparation for #17381