### PR TITLE
chore: hide mage install output

### DIFF
--- a/dev-tools/make/mage.mk
+++ b/dev-tools/make/mage.mk
@@ -7,7 +7,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION) from vendor dir.
-	go install -mod=vendor -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}/...
+	@go install -mod=vendor -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}/...
 	@-mage -clean
 endif
 	@true


### PR DESCRIPTION

## What does this PR do?

It hides the output when we install mage.

## Why is it important?

This was unintended change pushed with another PR.
