### PR TITLE
Cherry-pick #17470 to 7.7: Enable GSSAPI authentication when Kerberos is configured

### DIFF
--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -182,6 +182,9 @@ func newSaramaConfig(config kafkaInputConfig) (*sarama.Config, error) {
 
 	if config.Kerberos != nil {
 		cfgwarn.Beta("Kerberos authentication for Kafka is beta.")
+
+		k.Net.SASL.Enable = true
+		k.Net.SASL.Mechanism = sarama.SASLTypeGSSAPI
 		k.Net.SASL.GSSAPI = sarama.GSSAPIConfig{
 			AuthType:           int(config.Kerberos.AuthType),
 			KeyTabPath:         config.Kerberos.KeyTabPath,

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -176,6 +176,9 @@ func newSaramaConfig(log *logp.Logger, config *kafkaConfig) (*sarama.Config, err
 
 	if config.Kerberos != nil {
 		cfgwarn.Beta("Kerberos authentication for Kafka is beta.")
+
+		k.Net.SASL.Enable = true
+		k.Net.SASL.Mechanism = sarama.SASLTypeGSSAPI
 		k.Net.SASL.GSSAPI = sarama.GSSAPIConfig{
 			AuthType:           int(config.Kerberos.AuthType),
 			KeyTabPath:         config.Kerberos.KeyTabPath,


### PR DESCRIPTION
Cherry-pick of PR #17470 to 7.7 branch. Original message: 

None