### PR TITLE
Cherry-pick #17424 to 7.x: [Metricbeat] Fix cloudwatch metricset missing tags collection

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,6 +182,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
 - Further revise check for bad data in docker/memory. {pull}17400[17400] 
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
+- Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/aws/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs.go
@@ -133,7 +133,7 @@ func getQueueUrls(svc sqsiface.ClientAPI) ([]string, error) {
 	req := svc.ListQueuesRequest(listQueuesInput)
 	output, err := req.Send(context.TODO())
 	if err != nil {
-		err = errors.Wrap(err, "Error DescribeInstances")
+		err = errors.Wrap(err, "Error ListQueues")
 		return nil, err
 	}
 	return output.QueueUrls, nil


### PR DESCRIPTION
Cherry-pick of PR #17424 to 7.x branch. Original message: 

## What does this PR do?

This PR is to fix cloudwatch metricset from missing tags when `tags.resource_type_filter` is given. When user tries to collect daily storage metrics and s3 bucket tags with the cloudwatch metricset, it will fail to collect tags. This is because for CloudWatch metrics from S3 buckets, they always have `StorageType` as dimension. Dimension and S3 bucket name are combined to be the `identifierValue` in cloudwatch metricset code. But when collecting tags, dimension `StorageType` is not collected. That's why there is a mismatch between `identifierValue` and `resourceTagMap`.

## Why is it important?

This PR will fix tags collection for all namespaces that always have a dimension reported in CloudWatch metrics.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Make sure the AWS account you use for testing has S3 buckets with tags.
2. Use config below for aws.yml:
```
- module: aws
  period: 86400s
  metricsets:
    - cloudwatch
  metrics:
    - namespace: AWS/S3
      tags.resource_type_filter: s3
```
3. After starting Metricbeat, you should see tags collected from S3 buckets.

## Related issues

- Closes https://github.com/elastic/beats/issues/17419

