### PR TITLE
Cherry-pick #17473 to 7.7: Jenkinsfile: Fix auditbeat check and add comments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -810,54 +810,82 @@ def isChangedXPackCode(patterns) {
 }
 
 def loadConfigEnvVars(){
-  env.BUILD_AUDITBEAT = isChanged([
+  // Libbeat is the core framework of Beats. It has no additional dependencies
+  // on other projects in the Beats repository.
+  env.BUILD_LIBBEAT = isChangedOSSCode([])
+  env.BUILD_LIBBEAT_XPACK = env.BUILD_LIBBEAT || isChangedXPackCode([])
+
+  // Auditbeat depends on metricbeat as framework, but does not include any of
+  // the modules from Metricbeat.
+  // The Auditbeat x-pack build contains all functionality from OSS Auditbeat.
+  env.BUILD_AUDITBEAT = isChangedOSSCode([
     "^metricbeat/.*",
     "^auditbeat/.*",
   ])
-  env.BUILD_AUDITBEAT_XPACK = isChangedXPackCode([
-    "^metricbeat/.*",
-    "^auditbeat/.*",
+  env.BUILD_AUDITBEAT_XPACK = env.BUILD_AUDITBEAT || isChangedXPackCode([
     "^x-pack/auditbeat/.*",
   ])
+
+  // Dockerlogbeat is a standalone Beat that only relies on libbeat.
   env.BUILD_DOCKERLOGBEAT_XPACK = isChangedXPackCode([
     "^x-pack/dockerlogbeat/.*",
   ])
+
+  // Filebeat depends on libbeat only.
+  // The Filebeat x-pack build contains all functionality from OSS Filebeat.
   env.BUILD_FILEBEAT = isChangedOSSCode(["^filebeat/.*"])
-  env.BUILD_FILEBEAT_XPACK = isChangedXPackCode([
-    "^filebeat/.*",
+  env.BUILD_FILEBEAT_XPACK = env.BUILD_FILEBEAT || isChangedXPackCode([
     "^x-pack/filebeat/.*",
   ])
+
+  // Metricbeat depends on libbeat only.
+  // The Metricbeat x-pack build contains all functionality from OSS Metricbeat.
+  env.BUILD_METRICBEAT = isChangedOSSCode(["^metricbeat/.*"])
+  env.BUILD_METRICBEAT_XPACK = env.BUILD_METRICBEAT || isChangedXPackCode([
+    "^x-pack/metricbeat/.*",
+  ])
+
+  // Functionbeat is a standalone beat that depends on libbeat only.
+  // Functionbeat is available as x-pack build only.
   env.BUILD_FUNCTIONBEAT_XPACK = isChangedXPackCode([
     "^x-pack/functionbeat/.*",
   ])
-  env.BUILD_GENERATOR = isChangedOSSCode(["^generator/.*"])
+
+  // Heartbeat depends on libbeat only.
+  // The Heartbeat x-pack build contains all functionality from OSS Heartbeat.
   env.BUILD_HEARTBEAT = isChangedOSSCode(["^heartbeat/.*"])
-  env.BUILD_HEARTBEAT_XPACK = isChangedXPackCode([
-    "^heartbeat/.*",
+  env.BUILD_HEARTBEAT_XPACK = env.BUILD_HEARTBEAT || isChangedXPackCode([
     "^x-pack/heartbeat/.*",
   ])
+
+
+  // Journalbeat depends on libbeat only.
+  // The Journalbeat x-pack build contains all functionality from OSS Journalbeat.
   env.BUILD_JOURNALBEAT = isChangedOSSCode(["^journalbeat/.*"])
-  env.BUILD_JOURNALBEAT_XPACK = isChangedXPackCode([
-    "^journalbeat/.*",
+  env.BUILD_JOURNALBEAT_XPACK = env.BUILD_JOURNALBEAT || isChangedXPackCode([
     "^x-pack/journalbeat/.*",
   ])
-  env.BUILD_KUBERNETES = isChanged(["^deploy/kubernetes/*"])
-  env.BUILD_LIBBEAT = isChangedOSSCode([])
-  env.BUILD_LIBBEAT_XPACK = isChangedXPackCode([])
-  env.BUILD_METRICBEAT = isChangedOSSCode(["^metricbeat/.*"])
-  env.BUILD_METRICBEAT_XPACK = isChangedXPackCode([
-    "^metricbeat/.*",
-    "^x-pack/metricbeat/.*",
-  ])
+
+  // Packetbeat depends on libbeat only.
+  // The Packetbeat x-pack build contains all functionality from OSS Packetbeat.
   env.BUILD_PACKETBEAT = isChangedOSSCode(["^packetbeat/.*"])
-  env.BUILD_PACKETBEAT_XPACK = isChangedXPackCode([
-    "^packetbeat/.*",
+  env.BUILD_PACKETBEAT_XPACK = env.BUILD_PACKETBEAT || isChangedXPackCode([
     "^x-pack/packetbeat/.*",
   ])
+
+  // Winlogbeat depends on libbeat only.
+  // The Winlogbeat x-pack build contains all functionality from OSS Winlogbeat.
   env.BUILD_WINLOGBEAT = isChangedOSSCode(["^winlogbeat/.*"])
-  env.BUILD_WINLOGBEAT_XPACK = isChangedXPackCode([
-    "^winlogbeat/.*",
+  env.BUILD_WINLOGBEAT_XPACK = env.BUILD_WINLOGBEAT || isChangedXPackCode([
     "^x-pack/winlogbeat/.*",
   ])
+
+  // The Kubernetes test use Filebeat and Metricbeat, but only need to be run
+  // if the deployment scripts have been updated. No Beats specific testing is
+  // involved.
+  env.BUILD_KUBERNETES = isChanged(["^deploy/kubernetes/*"])
+
+  env.BUILD_GENERATOR = isChangedOSSCode(["^generator/.*"])
+
   env.GO_VERSION = readFile(".go-version").trim()
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17473 to 7.7 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug
- Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

1. Add isCheckedOSSCode to auditbeat build check.
1. For x-pack builds with dependency on OSS build use `env.BUILD_X_XPACK = env.BUILD_X || isChangedXPackDode`
1. Add comment to each check about dependencies and what the tests are supposed to run

## Why is it important?

1. we've been missing auditbeat CI runs on PRs. This ensures auditbeat tests are running when required
1. points out dependencies of X-Pack code on OSS-code directly
1. Not all contributors have experience with all Beats and test suite. Having comments on the checks documents the Beats authors intend, sharing the why with contributors not familiar with Beats.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
