### PR TITLE
Cherry-pick #17456 to 7.x: [Filebeat] Add access_key_id, secret_access_key and session_token into aws module config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -298,6 +298,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings in mongodb module. {issue}16170[16170] {pull}17371[17371]
 - Improve ECS categorization field mappings for mssql module. {issue}16171[16171] {pull}17376[17376]
 - Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
+- Added access_key_id, secret_access_key and session_token into aws module config. {pull}17456[17456]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[filebeat-module-aws]]
 [role="xpack"]
 
+:libbeat-xpack-dir: ../../../x-pack/libbeat
+
 :modulename: aws
 :has-dashboards: true
 
@@ -23,6 +25,11 @@ from network interfaces in AWS VPC. ELB access logs captures detailed informatio
 about requests sent to the load balancer. CloudTrail logs contain events
 that represent actions taken by a user, role or AWS service.
 
+The `aws` module requires AWS credentials configuration in order to make AWS API calls.
+Users can either use `access_key_id`, `secret_access_key` and/or
+`session_token`, or use shared AWS credentials file.
+Please see <<aws-credentials-options,AWS credentials options>> for more details.
+
 include::../include/gs-link.asciidoc[]
 
 [float]
@@ -38,6 +45,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -47,6 +57,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -56,6 +69,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -65,6 +81,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -74,6 +93,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -83,23 +105,17 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
-
 ----
 
 *`var.queue_url`*::
 
-AWS SQS queue url.
-
-*`var.shared_credential_file`*::
-
-Filename of AWS credential file.
-
-*`var.credential_profile_name`*::
-
-AWS credential profile name.
+(Required) AWS SQS queue url.
 
 *`var.visibility_timeout`*::
 
@@ -113,6 +129,23 @@ Maximum duration before AWS API request will be interrupted. Default to be 120 s
 *`var.endpoint`*::
 
 Custom endpoint used to access AWS APIs.
+
+*`var.shared_credential_file`*::
+
+Filename of AWS credential file.
+
+*`var.credential_profile_name`*::
+
+AWS credential profile name.
+
+*`var.access_key_id`*::
+First part of access key.
+
+*`var.access_key_id`*::
+Second part of access key.
+
+*`var.access_key_id`*::
+Required when using temporary security credentials.
 
 [float]
 === cloudtrail fileset
@@ -187,6 +220,9 @@ This fileset comes with a predefined dashboard:
 
 [role="screenshot"]
 image::./images/filebeat-aws-vpcflow-overview.png[]
+
+[id="aws-credentials-options"]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 
 
 [float]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -111,6 +111,11 @@ filebeat.modules:
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -136,6 +141,42 @@ filebeat.modules:
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
+    # The duration that the received messages are hidden from ReceiveMessage request
+    # Default to be 300s
+    #var.visibility_timeout: 300s
+
+    # Maximum duration before AWS API request will be interrupted
+    # Default to be 120s
+    #var.api_timeout: 120s
+
+    # Custom endpoint used to access AWS APIs
+    #var.endpoint: amazonaws.com
+
+  ec2:
+    enabled: false
+
+    # AWS SQS queue url
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
+
+    # Filename of AWS credential file
+    # If not set "$HOME/.aws/credentials" is used on Linux/Mac
+    # "%UserProfile%\.aws\credentials" is used on Windows
+    #var.shared_credential_file: /etc/filebeat/aws_credentials
+
+    # Profile name for aws credential
+    # If not set the default profile is used
+    #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
@@ -163,6 +204,11 @@ filebeat.modules:
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -189,6 +235,11 @@ filebeat.modules:
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -214,6 +265,11 @@ filebeat.modules:
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s

--- a/x-pack/filebeat/module/aws/_meta/config.yml
+++ b/x-pack/filebeat/module/aws/_meta/config.yml
@@ -14,6 +14,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -39,6 +44,42 @@
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
+    # The duration that the received messages are hidden from ReceiveMessage request
+    # Default to be 300s
+    #var.visibility_timeout: 300s
+
+    # Maximum duration before AWS API request will be interrupted
+    # Default to be 120s
+    #var.api_timeout: 120s
+
+    # Custom endpoint used to access AWS APIs
+    #var.endpoint: amazonaws.com
+
+  ec2:
+    enabled: false
+
+    # AWS SQS queue url
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
+
+    # Filename of AWS credential file
+    # If not set "$HOME/.aws/credentials" is used on Linux/Mac
+    # "%UserProfile%\.aws\credentials" is used on Windows
+    #var.shared_credential_file: /etc/filebeat/aws_credentials
+
+    # Profile name for aws credential
+    # If not set the default profile is used
+    #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
@@ -66,6 +107,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -92,6 +138,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -117,6 +168,11 @@
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 [role="xpack"]
 
+:libbeat-xpack-dir: ../../../x-pack/libbeat
+
 :modulename: aws
 :has-dashboards: true
 
@@ -18,6 +20,11 @@ from network interfaces in AWS VPC. ELB access logs captures detailed informatio
 about requests sent to the load balancer. CloudTrail logs contain events
 that represent actions taken by a user, role or AWS service.
 
+The `aws` module requires AWS credentials configuration in order to make AWS API calls.
+Users can either use `access_key_id`, `secret_access_key` and/or
+`session_token`, or use shared AWS credentials file.
+Please see <<aws-credentials-options,AWS credentials options>> for more details.
+
 include::../include/gs-link.asciidoc[]
 
 [float]
@@ -33,6 +40,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -42,6 +52,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -51,6 +64,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -60,6 +76,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -69,6 +88,9 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
@@ -78,23 +100,17 @@ Example config:
     #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
     #var.shared_credential_file: /etc/filebeat/aws_credentials
     #var.credential_profile_name: fb-aws
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
-
 ----
 
 *`var.queue_url`*::
 
-AWS SQS queue url.
-
-*`var.shared_credential_file`*::
-
-Filename of AWS credential file.
-
-*`var.credential_profile_name`*::
-
-AWS credential profile name.
+(Required) AWS SQS queue url.
 
 *`var.visibility_timeout`*::
 
@@ -108,6 +124,23 @@ Maximum duration before AWS API request will be interrupted. Default to be 120 s
 *`var.endpoint`*::
 
 Custom endpoint used to access AWS APIs.
+
+*`var.shared_credential_file`*::
+
+Filename of AWS credential file.
+
+*`var.credential_profile_name`*::
+
+AWS credential profile name.
+
+*`var.access_key_id`*::
+First part of access key.
+
+*`var.access_key_id`*::
+Second part of access key.
+
+*`var.access_key_id`*::
+Required when using temporary security credentials.
 
 [float]
 === cloudtrail fileset
@@ -182,3 +215,6 @@ This fileset comes with a predefined dashboard:
 
 [role="screenshot"]
 image::./images/filebeat-aws-vpcflow-overview.png[]
+
+[id="aws-credentials-options"]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]

--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -21,3 +21,15 @@ api_timeout: {{ .api_timeout }}
 {{ if .endpoint }}
 endpoint: {{ .endpoint }}
 {{ end }}
+
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
@@ -20,3 +20,15 @@ api_timeout: {{ .api_timeout }}
 {{ if .endpoint }}
 endpoint: {{ .endpoint }}
 {{ end }}
+
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/ec2/config/s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/s3.yml
@@ -20,3 +20,15 @@ api_timeout: {{ .api_timeout }}
 {{ if .endpoint }}
 endpoint: {{ .endpoint }}
 {{ end }}
+
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/ec2/manifest.yml
+++ b/x-pack/filebeat/module/aws/ec2/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/elb/config/s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/s3.yml
@@ -20,3 +20,15 @@ api_timeout: {{ .api_timeout }}
 {{ if .endpoint }}
 endpoint: {{ .endpoint }}
 {{ end }}
+
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/s3access/config/s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/s3.yml
@@ -20,3 +20,15 @@ api_timeout: {{ .api_timeout }}
 {{ if .endpoint }}
 endpoint: {{ .endpoint }}
 {{ end }}
+
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -23,6 +23,18 @@ api_timeout: {{ .api_timeout }}
 endpoint: {{ .endpoint }}
 {{ end }}
 
+{{ if .access_key_id }}
+access_key_id: {{ .access_key_id }}
+{{ end }}
+
+{{ if .secret_access_key }}
+secret_access_key: {{ .secret_access_key }}
+{{ end }}
+
+{{ if .session_token }}
+session_token: {{ .session_token }}
+{{ end }}
+
 {{ else if eq .input "file" }}
 
 type: log

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -9,6 +9,9 @@ var:
   - name: visibility_timeout
   - name: api_timeout
   - name: endpoint
+  - name: access_key_id
+  - name: secret_access_key
+  - name: session_token
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -17,6 +17,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -42,6 +47,42 @@
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
+    # The duration that the received messages are hidden from ReceiveMessage request
+    # Default to be 300s
+    #var.visibility_timeout: 300s
+
+    # Maximum duration before AWS API request will be interrupted
+    # Default to be 120s
+    #var.api_timeout: 120s
+
+    # Custom endpoint used to access AWS APIs
+    #var.endpoint: amazonaws.com
+
+  ec2:
+    enabled: false
+
+    # AWS SQS queue url
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
+
+    # Filename of AWS credential file
+    # If not set "$HOME/.aws/credentials" is used on Linux/Mac
+    # "%UserProfile%\.aws\credentials" is used on Windows
+    #var.shared_credential_file: /etc/filebeat/aws_credentials
+
+    # Profile name for aws credential
+    # If not set the default profile is used
+    #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
@@ -69,6 +110,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -95,6 +141,11 @@
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
 
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
+
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s
     #var.visibility_timeout: 300s
@@ -120,6 +171,11 @@
     # Profile name for aws credential
     # If not set the default profile is used
     #var.credential_profile_name: fb-aws
+
+    # Use access_key_id, secret_access_key and/or session_token instead of shared credential file
+    #var.access_key_id: access_key_id
+    #var.secret_access_key: secret_access_key
+    #var.session_token: session_token
 
     # The duration that the received messages are hidden from ReceiveMessage request
     # Default to be 300s


### PR DESCRIPTION
Cherry-pick of PR #17456 to 7.x branch. Original message: 

## What does this PR do?
This PR is to add missing configuration parameters into filesets under aws module.

## Why is it important?

With this PR, users will be able to use `access_key_id`, `secret_access_key` and `session_token` directly in Filebeat aws module. 

This PR also adds the missing config for `ec2` fileset into default `aws.yml.disabled` config with `enabled: false`.
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.