### PR TITLE
Cherry-pick #17415 to 7.7: [metricbeat] fix system/service filtering issues

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,6 +182,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
+- Fix how we filter services by name in system/service {pull}17400[17400]
 - Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
 

--- a/metricbeat/module/system/service/service_test.go
+++ b/metricbeat/module/system/service/service_test.go
@@ -29,6 +29,18 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
+var exampleUnits = []dbus.UnitStatus{
+	dbus.UnitStatus{
+		Name: "sshd.service",
+	},
+	dbus.UnitStatus{
+		Name: "metricbeat.service",
+	},
+	dbus.UnitStatus{
+		Name: "filebeat.service",
+	},
+}
+
 func TestFormProps(t *testing.T) {
 	testUnit := dbus.UnitStatus{
 		Name:        "test.service",
@@ -71,4 +83,24 @@ func TestFormProps(t *testing.T) {
 	assert.NotEmpty(t, event.MetricSetFields["resources"])
 	assert.Equal(t, event.MetricSetFields["state_since"], testEvent["state_since"])
 	assert.NotEmpty(t, event.RootFields)
+}
+
+func TestFilterEmpty(t *testing.T) {
+
+	filtersBad := []string{
+		"asdf",
+	}
+	shouldNotMatch, err := matchUnitPatterns(filtersBad, exampleUnits)
+	assert.NoError(t, err)
+	assert.Empty(t, shouldNotMatch)
+}
+
+func TestFilterMatches(t *testing.T) {
+	filtersMatch := []string{
+		"ssh*",
+	}
+
+	shouldMatch, err := matchUnitPatterns(filtersMatch, exampleUnits)
+	assert.NoError(t, err)
+	assert.Len(t, shouldMatch, 1)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17415 to 7.7 branch. Original message: 


## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/17414
The native implementation of name filtering in dbus will "short circuit" to the first match, but that doesn't work when we want to filter everything by `*.service`, so lets filter that later.


## Why is it important?

This is a bug.

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Pull down and build on a linux box, add a `pattern_filter` to the config.

