### PR TITLE
Cherry-pick #17443 to 7.x: Log to stderr in auditbeat reference doc for kubernetes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -238,6 +238,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Auditbeat*
 
+- Log to stderr when running using reference kubernetes manifests. {pull}17443[174443]
 
 *Filebeat*
 

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -77,6 +77,7 @@ spec:
         image: docker.elastic.co/beats/auditbeat:7.8.0
         args: [
           "-c", "/etc/auditbeat.yml"
+          "-e",
         ]
         env:
         - name: ELASTICSEARCH_HOST

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         image: docker.elastic.co/beats/auditbeat:%VERSION%
         args: [
           "-c", "/etc/auditbeat.yml"
+          "-e",
         ]
         env:
         - name: ELASTICSEARCH_HOST


### PR DESCRIPTION
Cherry-pick of PR #17443 to 7.x branch. Original message: 

Add flag `-e` so auditbeat logs to stderr instead of logging to files
inside the pod. This is consistent with recommendations for
Kubernetes and with what we do with other beats.