### PR TITLE
Cherry-pick #17488 to 7.x: Log updates on autodiscovered pods at the debug level

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -142,7 +142,7 @@ func (p *pod) OnUpdate(obj interface{}) {
 		return
 	}
 
-	p.logger.Infof("Watcher Pod update: %+v", obj)
+	p.logger.Debugf("Watcher Pod update: %+v", obj)
 	p.emit(pod, "stop")
 	p.emit(pod, "start")
 }


### PR DESCRIPTION
Cherry-pick of PR #17488 to 7.x branch. Original message: 

Kubernetes autodiscover is logging whole pod objects at the info level
on updates, what floods logs. Log these objects at the debug level.

Not adding changelog because it only affects un-released 7.7 branch.