### PR TITLE
Cherry-pick #17429 to 7.x: Add data directories to kubernetes manifests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -238,6 +238,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Auditbeat*
 
+- Reference kubernetes manifests mount data directory from the host, so data persist between executions in the same node. {pull}17429[17429]
 - Log to stderr when running using reference kubernetes manifests. {pull}17443[174443]
 
 *Filebeat*
@@ -374,6 +375,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add PubSub metricset to Google Cloud Platform module {pull}15536[15536]
 - Add final tests and move label to GA for the azure module in metricbeat. {pull}17319[17319]
 - Added documentation for running Metricbeat in Cloud Foundry. {pull}17275[17275]
+- Reference kubernetes manifests mount data directory from the host when running metricbeat as daemonset, so data persist between executions in the same node. {pull}17429[17429]
 
 *Packetbeat*
 

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -108,6 +108,8 @@ spec:
         - name: modules
           mountPath: /usr/share/auditbeat/modules.d
           readOnly: true
+        - name: data
+          mountPath: /usr/share/auditbeat/data
         - name: bin
           mountPath: /hostfs/bin
           readOnly: true

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -55,6 +55,8 @@ spec:
         - name: modules
           mountPath: /usr/share/auditbeat/modules.d
           readOnly: true
+        - name: data
+          mountPath: /usr/share/auditbeat/data
         - name: bin
           mountPath: /hostfs/bin
           readOnly: true

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -149,6 +149,8 @@ spec:
           mountPath: /etc/metricbeat.yml
           readOnly: true
           subPath: metricbeat.yml
+        - name: data
+          mountPath: /usr/share/metricbeat/data
         - name: modules
           mountPath: /usr/share/metricbeat/modules.d
           readOnly: true

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -57,6 +57,8 @@ spec:
           mountPath: /etc/metricbeat.yml
           readOnly: true
           subPath: metricbeat.yml
+        - name: data
+          mountPath: /usr/share/metricbeat/data
         - name: modules
           mountPath: /usr/share/metricbeat/modules.d
           readOnly: true


### PR DESCRIPTION
Cherry-pick of PR #17429 to 7.x branch. Original message: 

Mount data directories in Metricbeat and Auditbeat pods too. They were
defined in some places but not mounted.

For Auditbeat this is important so it doesn't have to rebuild its file
integrity database on each run. For Metricbeat I don't think it is so
important, but adding it just in case for consistency with the other
reference manifests. Filebeat is already mounting its data directory.