### PR TITLE
Fix Unix socket path in memcached

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,7 +141,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
-- Fix Unix socket path in memcached.
+- Fix Unix socket path in memcached. {pull}17512[17512]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,6 +141,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
+- Fix Unix socket path in memcached.
 
 *Packetbeat*
 

--- a/metricbeat/module/memcached/stats/stats.go
+++ b/metricbeat/module/memcached/stats/stats.go
@@ -52,7 +52,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	network, address, err := m.getNetworkAndAddress()
+	network, address, err := getNetworkAndAddress(m.HostData())
 	if err != nil {
 		return errors.Wrap(err, "error in fetch")
 	}
@@ -92,14 +92,18 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	return nil
 }
 
-func (m *MetricSet) getNetworkAndAddress() (network string, address string, err error) {
-	hostData := m.HostData()
+func getNetworkAndAddress(hostData mb.HostData) (network string, address string, err error) {
 	u, err := url.Parse(hostData.URI)
 	if err != nil {
 		err = errors.Wrap(err, "invalid URL")
 		return
 	}
+
 	network = u.Scheme
-	address = u.Host
+	if network == "unix" {
+		address = u.Path
+	} else {
+		address = u.Host
+	}
 	return
 }

--- a/metricbeat/module/memcached/stats/stats_test.go
+++ b/metricbeat/module/memcached/stats/stats_test.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/metricbeat/mb"
+)
+
+func TestGetNetworkAddress_URL(t *testing.T) {
+	hostData := mb.HostData{
+		Host: "127.0.0.1:11211",
+		URI: "tcp://127.0.0.1:11211",
+	}
+	network, address, err := getNetworkAndAddress(hostData)
+	require.NoError(t, err)
+	require.Equal(t, "tcp", network)
+	require.Equal(t, "127.0.0.1:11211", address)
+}
+
+func TestGetNetworkAddress_Unix(t *testing.T) {
+	hostData := mb.HostData{
+		Host: "/tmp/d.sock",
+		URI: "unix:///tmp/d.sock",
+	}
+	network, address, err := getNetworkAndAddress(hostData)
+	require.NoError(t, err)
+	require.Equal(t, "unix", network)
+	require.Equal(t, "/tmp/d.sock", address)
+}

--- a/metricbeat/module/memcached/stats/stats_test.go
+++ b/metricbeat/module/memcached/stats/stats_test.go
@@ -28,7 +28,7 @@ import (
 func TestGetNetworkAddress_URL(t *testing.T) {
 	hostData := mb.HostData{
 		Host: "127.0.0.1:11211",
-		URI: "tcp://127.0.0.1:11211",
+		URI:  "tcp://127.0.0.1:11211",
 	}
 	network, address, err := getNetworkAndAddress(hostData)
 	require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestGetNetworkAddress_URL(t *testing.T) {
 func TestGetNetworkAddress_Unix(t *testing.T) {
 	hostData := mb.HostData{
 		Host: "/tmp/d.sock",
-		URI: "unix:///tmp/d.sock",
+		URI:  "unix:///tmp/d.sock",
 	}
 	network, address, err := getNetworkAndAddress(hostData)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes the Unix socket path in Memcached Metricset module.