### PR TITLE
Cherry-pick #17500 to 7.7: [Auditbeat] Memory leak and syscall fix

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,8 +182,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use max in k8s overview dashboard aggregations. {pull}17015[17015]
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
-- Further revise check for bad data in docker/memory. {pull}17400[17400]
-- Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 - Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,6 +182,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use max in k8s overview dashboard aggregations. {pull}17015[17015]
 - Fix Disk Used and Disk Usage visualizations in the Metricbeat System dashboards. {issue}12435[12435] {pull}17272[17272]
 - Fix missing Accept header for Prometheus and OpenMetrics module. {issue}16870[16870] {pull}17291[17291]
+- Further revise check for bad data in docker/memory. {pull}17400[17400]
+- Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
 - Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
@@ -238,6 +240,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Log to stderr when running using reference kubernetes manifests. {pull}17443[174443]
+- Fix syscall kprobe arguments for 32-bit systems in socket module. {pull}17500[17500]
+- Fix memory leak on when we miss socket close kprobe events. {pull}17500[17500]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -127,6 +127,12 @@ Determines how long to wait after a socket has been closed for out of order
 packets. With TCP, some packets can be received shortly after a socket is
 closed. If set too low, additional flows will be generated for those packets.
 
+- `socket.socket_inactive_timeout` (default: 1m)
+
+How long a socket can be inactive to be evicted from the internal cache.
+A lower value reduces memory usage at the expense of some flows being
+reported as multiple partial flows.
+
 - `socket.perf_queue_size` (default: 4096)
 
 The number of tracing samples that can be queued for processing. A larger value

--- a/x-pack/auditbeat/module/system/socket/arch_386.go
+++ b/x-pack/auditbeat/module/system/socket/arch_386.go
@@ -21,10 +21,10 @@ var archVariables = common.MapStr{
 	"RET": "%ax",
 
 	// System call parameters
-	"SYS_P1": "$stack1",
-	"SYS_P2": "$stack2",
-	"SYS_P3": "$stack3",
-	"SYS_P4": "$stack4",
-	"SYS_P5": "$stack5",
-	"SYS_P6": "$stack6",
+	"_SYS_P1": "$stack1",
+	"_SYS_P2": "$stack2",
+	"_SYS_P3": "$stack3",
+	"_SYS_P4": "$stack4",
+	"_SYS_P5": "$stack5",
+	"_SYS_P6": "$stack6",
 }

--- a/x-pack/auditbeat/module/system/socket/config.go
+++ b/x-pack/auditbeat/module/system/socket/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	// considered closed.
 	FlowInactiveTimeout time.Duration `config:"socket.flow_inactive_timeout"`
 
+	// SocketInactiveTimeout determines how long a socket has to be inactive to be
+	// considered terminated or closed.
+	SocketInactiveTimeout time.Duration `config:"socket.socket_inactive_timeout"`
+
 	// FlowTerminationTimeout determines how long to wait after a flow has been
 	// closed for out of order packets. With TCP, some packets can be received
 	// shortly after a socket is closed. If set too low, additional flows will
@@ -71,6 +75,7 @@ var defaultConfig = Config{
 	ErrQueueSize:           1,
 	RingSizeExp:            7,
 	FlowInactiveTimeout:    30 * time.Second,
+	SocketInactiveTimeout:  60 * time.Second,
 	FlowTerminationTimeout: 5 * time.Second,
 	ClockMaxDrift:          100 * time.Millisecond,
 	ClockSyncPeriod:        10 * time.Second,

--- a/x-pack/auditbeat/module/system/socket/socket_linux.go
+++ b/x-pack/auditbeat/module/system/socket/socket_linux.go
@@ -123,6 +123,7 @@ func (m *MetricSet) Run(r mb.PushReporterV2) {
 	st := NewState(r,
 		m.log,
 		m.config.FlowInactiveTimeout,
+		m.config.SocketInactiveTimeout,
 		m.config.FlowTerminationTimeout,
 		m.config.ClockMaxDrift)
 


### PR DESCRIPTION
Cherry-pick of PR #17500 to 7.7 branch. Original message: 

## What does this PR do?

This fixes some syscall  issues and a memory leak in auditbeat's socket module.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #16877
- Relates #16879

#16879 can rebase off of these fixes once they go in so we can backport this without introducing the refactor