### PR TITLE
Cherry-pick #17430 to 7.7: Add autodiscover example for Auditbeat

### DIFF
--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -73,3 +73,12 @@ $ kubectl --namespace=kube-system get ds/{beatname_lc}
 NAME       DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE-SELECTOR   AGE
 {beatname_lc}   32        32        0         32           0           <none>          1m
 ------------------------------------------------
+
+[WARNING]
+=======================================
+{beatname_uc} is able to monitor the file integrity of files in pods,
+to do that, the directories with the container root file systems have to be
+mounted as volumes in the {beatname_uc} container. For example, containers
+executed with containerd have their root file systems under `/run/containerd`.
+The https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/{beatname_lc}-kubernetes.yaml[reference manifest] contains an example of this.
+=======================================

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -14,6 +14,21 @@ data:
       # Reload module configs as they change:
       reload.enabled: false
 
+    # When using containerd as runtime, a configuration like the following one
+    # can be used to monitor files in containers using autodiscover.
+    #auditbeat.autodiscover:
+    #  providers:
+    #  - type: kubernetes
+    #    host: ${NODE_NAME}
+    #    templates:
+    #      - config:
+    #        - module: 'file_integrity'
+    #          paths:
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/bin'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/etc'
+    #          scan_at_start: false
+    #          recursive: true
+
     processors:
       - add_cloud_metadata:
 
@@ -92,6 +107,10 @@ spec:
           value:
         - name: ELASTIC_CLOUD_AUTH
           value:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
         resources:
@@ -125,6 +144,12 @@ spec:
         - name: etc
           mountPath: /hostfs/etc
           readOnly: true
+        # Directory with root filesystems of containers executed with containerd, this can be
+        # different with other runtimes. This volume is needed to monitor the file integrity
+        # of files in containers.
+        - name: run-containerd
+          mountPath: /run/containerd
+          readOnly: true
       volumes:
       - name: bin
         hostPath:
@@ -152,6 +177,10 @@ spec:
       - name: data
         hostPath:
           path: /var/lib/auditbeat-data
+          type: DirectoryOrCreate
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd
           type: DirectoryOrCreate
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
@@ -14,6 +14,21 @@ data:
       # Reload module configs as they change:
       reload.enabled: false
 
+    # When using containerd as runtime, a configuration like the following one
+    # can be used to monitor files in containers using autodiscover.
+    #auditbeat.autodiscover:
+    #  providers:
+    #  - type: kubernetes
+    #    host: ${NODE_NAME}
+    #    templates:
+    #      - config:
+    #        - module: 'file_integrity'
+    #          paths:
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/bin'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/etc'
+    #          scan_at_start: false
+    #          recursive: true
+
     processors:
       - add_cloud_metadata:
 

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -39,6 +39,10 @@ spec:
           value:
         - name: ELASTIC_CLOUD_AUTH
           value:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
         resources:
@@ -72,6 +76,12 @@ spec:
         - name: etc
           mountPath: /hostfs/etc
           readOnly: true
+        # Directory with root filesystems of containers executed with containerd, this can be
+        # different with other runtimes. This volume is needed to monitor the file integrity
+        # of files in containers.
+        - name: run-containerd
+          mountPath: /run/containerd
+          readOnly: true
       volumes:
       - name: bin
         hostPath:
@@ -99,4 +109,8 @@ spec:
       - name: data
         hostPath:
           path: /var/lib/auditbeat-data
+          type: DirectoryOrCreate
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd
           type: DirectoryOrCreate


### PR DESCRIPTION
Cherry-pick of PR #17430 to 7.7 branch. Original message: 

Add autodiscover example to monitor the file integrity of files in containers.

Add `NODE_NAME` environment variable, that is needed for the example
and is commonly used in kubernetes config snippets.
