### PR TITLE
Cherry-pick #17387 to 7.x: Add .ci to the list of directories that trigger all travis builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -793,6 +793,7 @@ def isChangedOSSCode(patterns) {
     "^libbeat/*",
     "^testing/*",
     "^dev-tools/*",
+    "^\\.ci/*",
   ]
   return isChanged(always + patterns)
 }
@@ -805,6 +806,7 @@ def isChangedXPackCode(patterns) {
     "^dev-tools/*",
     "^testing/*",
     "^x-pack/libbeat/.*",
+    "^\\.ci/*",
   ]
   return isChanged(always + patterns)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17387 to 7.x branch. Original message: 

## What does this PR do?

Add .ci directory to the list of files that trigger all travis builds.

## Why is it important?

Changes in .ci can affect all builds.

## Related issues

Change suggested in #16985.