### PR TITLE
Fix typo in args

### DIFF
--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       - name: auditbeat
         image: docker.elastic.co/beats/auditbeat:%VERSION%
         args: [
-          "-c", "/etc/auditbeat.yml"
+          "-c", "/etc/auditbeat.yml",
           "-e",
         ]
         env:


### PR DESCRIPTION
Bug; Typo in Args

## What does this PR do?

This PR adds the missing in comma in the args array.

## Why is it important?

Invalid Args array without it, broken manifest on master

## Checklist

- [/ ] My code follows the style guidelines of this project
- [ /] I have commented my code, particularly in hard-to-understand areas
- [ /] I have made corresponding changes to the documentation
- [ /] I have made corresponding change to the default configuration files
- [ /] I have added tests that prove my fix is effective or that my feature works
- [X ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

`k apply -f ./auditbeat-kubernetes.yaml                                                                          configmap/auditbeat-config configured                                                                             configmap/auditbeat-daemonset-modules unchanged                                                                   error: error parsing ./auditbeat-kubernetes.yaml: error converting YAML to JSON: yaml: line 26: did not find expected ',' or ']' `