### PR TITLE
Cherry-pick #17431 to 7.x: Add auditd example with Auditbeat in kubernetes manifests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -240,6 +240,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Auditbeat*
 
+- Reference kubernetes manifests include configuration for auditd and enrichment with kubernetes metadata. {pull}17431[17431]
 - Reference kubernetes manifests mount data directory from the host, so data persist between executions in the same node. {pull}17429[17429]
 - Log to stderr when running using reference kubernetes manifests. {pull}17443[174443]
 - Fix syscall kprobe arguments for 32-bit systems in socket module. {pull}17500[17500]

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -16,6 +16,17 @@ data:
 
     processors:
       - add_cloud_metadata:
+      - add_process_metadata:
+          match_pids: ['process.pid']
+          include_fields: ['container.id']
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          default_indexers.enabled: false
+          default_matchers.enabled: false
+          indexers:
+            - container:
+          matchers:
+            - fields.lookup_fields: ['container.id']
 
     cloud.id: ${ELASTIC_CLOUD_ID}
     cloud.auth: ${ELASTIC_CLOUD_AUTH}
@@ -50,6 +61,14 @@ data:
       max_file_size: 100 MiB
       hash_types: [sha1]
       recursive: true
+    - module: auditd
+      audit_rules: |
+        # Executions
+        -a always,exit -F arch=b64 -S execve,execveat -k exec
+
+        # Unauthorized access attempts
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 ---
 # Deploy a auditbeat instance per node for node metrics retrieval
 apiVersion: apps/v1
@@ -71,6 +90,7 @@ spec:
       serviceAccountName: auditbeat
       terminationGracePeriodSeconds: 30
       hostNetwork: true
+      hostPID: true  # Required by auditd module
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
@@ -94,6 +114,12 @@ spec:
           value:
         securityContext:
           runAsUser: 0
+          capabilities:
+            add:
+              # Capabilities needed for auditd module
+              - 'AUDIT_READ'
+              - 'AUDIT_WRITE'
+              - 'AUDIT_CONTROL'
         resources:
           limits:
             memory: 200Mi

--- a/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
@@ -16,6 +16,17 @@ data:
 
     processors:
       - add_cloud_metadata:
+      - add_process_metadata:
+          match_pids: ['process.pid']
+          include_fields: ['container.id']
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          default_indexers.enabled: false
+          default_matchers.enabled: false
+          indexers:
+            - container:
+          matchers:
+            - fields.lookup_fields: ['container.id']
 
     cloud.id: ${ELASTIC_CLOUD_ID}
     cloud.auth: ${ELASTIC_CLOUD_AUTH}
@@ -50,3 +61,11 @@ data:
       max_file_size: 100 MiB
       hash_types: [sha1]
       recursive: true
+    - module: auditd
+      audit_rules: |
+        # Executions
+        -a always,exit -F arch=b64 -S execve,execveat -k exec
+
+        # Unauthorized access attempts
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -18,6 +18,7 @@ spec:
       serviceAccountName: auditbeat
       terminationGracePeriodSeconds: 30
       hostNetwork: true
+      hostPID: true  # Required by auditd module
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
@@ -41,6 +42,12 @@ spec:
           value:
         securityContext:
           runAsUser: 0
+          capabilities:
+            add:
+              # Capabilities needed for auditd module
+              - 'AUDIT_READ'
+              - 'AUDIT_WRITE'
+              - 'AUDIT_CONTROL'
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
Cherry-pick of PR #17431 to 7.x branch. Original message: 

Add an example configuration of the auditd module in the Auditbeat
reference manifest, including the processors needed for enrichement of
events.

For enrichement it makes use of #15947, included in 7.7.

### How to test?

* Run Auditbeat in kubernetes with the reference configuration.
* Exec a command inside a container, check that an event about this is collected.
* Try to access or write to a file without permissions in a container, check that an event about this is collected.
* Check that events collected about containers include the kubernetes metadata.