### PR TITLE
Cherry-pick #17469 to 7.7: Replace HOSTNAME with NODE_NAME when accessing Kubelet API

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -76,7 +76,7 @@ data:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["https://${HOSTNAME}:10250"]
+      hosts: ["https://${NODE_NAME}:10250"]
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       ssl.verification_mode: "none"
       # If using Red Hat OpenShift remove ssl.verification_mode entry and

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -76,7 +76,7 @@ data:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["https://${HOSTNAME}:10250"]
+      hosts: ["https://${NODE_NAME}:10250"]
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       ssl.verification_mode: "none"
       # If using Red Hat OpenShift remove ssl.verification_mode entry and

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -140,7 +140,7 @@ metricbeat.modules:
     - volume
   period: 10s
   enabled: true
-  hosts: ["https://${HOSTNAME}:10250"]
+  hosts: ["https://${NODE_NAME}:10250"]
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ssl.verification_mode: "none"
   #ssl.certificate_authorities:

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -85,7 +85,7 @@ specify the following settings under `kubernetes.yml` in the `data` section:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["https://${HOSTNAME}:10250"]
+      hosts: ["https://${NODE_NAME}:10250"]
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       ssl.certificate_authorities:
         - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
@@ -119,7 +119,7 @@ oc patch namespace kube-system -p \
 ----
 +
 This command sets the node selector for the project to an empty string. If you
-don't run this command, the default node selector will skip master nodes.  
+don't run this command, the default node selector will skip master nodes.
 
 [float]
 ==== Deploy

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -456,7 +456,7 @@ metricbeat.modules:
     - volume
   period: 10s
   enabled: true
-  hosts: ["https://${HOSTNAME}:10250"]
+  hosts: ["https://${NODE_NAME}:10250"]
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ssl.verification_mode: "none"
   #ssl.certificate_authorities:

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -8,7 +8,7 @@
     - volume
   period: 10s
   enabled: true
-  hosts: ["https://${HOSTNAME}:10250"]
+  hosts: ["https://${NODE_NAME}:10250"]
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ssl.verification_mode: "none"
   #ssl.certificate_authorities:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -727,7 +727,7 @@ metricbeat.modules:
     - volume
   period: 10s
   enabled: true
-  hosts: ["https://${HOSTNAME}:10250"]
+  hosts: ["https://${NODE_NAME}:10250"]
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ssl.verification_mode: "none"
   #ssl.certificate_authorities:


### PR DESCRIPTION
Cherry-pick of PR #17469 to 7.7 branch. Original message: 

Follow up of https://github.com/elastic/beats/pull/16063.

More info on https://github.com/elastic/helm-charts/pull/471#issuecomment-608419141.

When [`hostNetwork: true`](https://github.com/elastic/beats/blob/257f0ccf27962920e064588fcdecf4cd04698f2f/deploy/kubernetes/metricbeat-kubernetes.yaml#L112) these 2 variables are identical:
```
[root@gke-cluster-1-default-pool-d5378bbe-9kxv metricbeat]# env | grep NODE_NAME
NODE_NAME=gke-cluster-1-default-pool-d5378bbe-9kxv
[root@gke-cluster-1-default-pool-d5378bbe-9kxv metricbeat]# env | grep HOSTNAME
HOSTNAME=gke-cluster-1-default-pool-d5378bbe-9kxv
```

When not `hostNetwork: true` these 2 variables are like:
```
[root@metricbeat-q2dgr metricbeat]# env | grep NODE
NODE_NAME=gke-cluster-1-default-pool-d5378bbe-rvgw
[root@metricbeat-q2dgr metricbeat]# env | grep HOST
HOSTNAME=metricbeat-q2dgr
```