### PR TITLE
Fix trivial conatiner typo in 6.8

### DIFF
--- a/journalbeat/docs/config-options.asciidoc
+++ b/journalbeat/docs/config-options.asciidoc
@@ -210,7 +210,7 @@ https://docs.docker.com/config/containers/logging/journald/[Docker] are also
 available: 
 
 [horizontal]
-`CONTAINER_ID`::              `conatiner.id_truncated`
+`CONTAINER_ID`::              `container.id_truncated`
 `CONTAINER_ID_FULL`::         `container.id`
 `CONTAINER_NAME`::            `container.name`
 `CONTAINER_PARTIAL_MESSAGE`:: `container.partial`

--- a/journalbeat/reader/fields.go
+++ b/journalbeat/reader/fields.go
@@ -80,7 +80,7 @@ var (
 		sdjournal.SD_JOURNAL_FIELD_UID:               fieldConversion{"process.uid", true, false},
 
 		// docker journald fields from: https://docs.docker.com/config/containers/logging/journald/
-		"CONTAINER_ID":              fieldConversion{"conatiner.id_truncated", false, false},
+		"CONTAINER_ID":              fieldConversion{"container.id_truncated", false, false},
 		"CONTAINER_ID_FULL":         fieldConversion{"container.id", false, false},
 		"CONTAINER_NAME":            fieldConversion{"container.name", false, false},
 		"CONTAINER_TAG":             fieldConversion{"container.image.tag", false, false},


### PR DESCRIPTION
Found this when run journalbeat 6.8.8.

Well, probably 7.x and master have the same issue at least in config-options.asciidoc 