### PR TITLE
Cherry-pick #17555 to 7.x: Fix vsphere VM dashboard show VM host aggregation works

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -189,6 +189,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
 - check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
 - Fix Unix socket path in memcached. {pull}17512[17512]
+- Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
 
 *Packetbeat*
 

--- a/metricbeat/module/vsphere/_meta/kibana/7/dashboard/metricbeat-vsphere-vm.json
+++ b/metricbeat/module/vsphere/_meta/kibana/7/dashboard/metricbeat-vsphere-vm.json
@@ -573,7 +573,7 @@
               "id": "2",
               "params": {
                 "customLabel": "VM ESXi Host",
-                "field": "vsphere.virtualmachine.host",
+                "field": "vsphere.virtualmachine.host.hostname",
                 "missingBucket": false,
                 "missingBucketLabel": "Missing",
                 "order": "desc",
@@ -699,7 +699,7 @@
               "id": "3",
               "params": {
                 "customLabel": "ESXi Host",
-                "field": "vsphere.virtualmachine.host",
+                "field": "vsphere.virtualmachine.host.hostname",
                 "missingBucket": false,
                 "missingBucketLabel": "Missing",
                 "order": "desc",


### PR DESCRIPTION
Cherry-pick of PR #17555 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where 2 of the visualizations in the "VMs overview ECS" dashboard where not using the correct field, preventing the visualization to work.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Fixes issue so vsphere dashboard works correctly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Closes elastic/beats#17490
