### PR TITLE
Cherry-pick #17566 to 7.x: Ceph: describe exposed ports

### DIFF
--- a/metricbeat/docs/modules/ceph.asciidoc
+++ b/metricbeat/docs/modules/ceph.asciidoc
@@ -6,7 +6,10 @@ This file is generated! See scripts/mage/docs_collector.go
 == Ceph module
 
 The Ceph module collects metrics by submitting HTTP GET requests to
-the http://docs.ceph.com/docs/master/man/8/ceph-rest-api/[ceph-rest-api]. The default metricsets are `cluster_disk`, `cluster_health`, `monitor_health`, `pool_disk`, `osd_tree`.
+the https://docs.ceph.com/docs/jewel/man/8/ceph-rest-api/[ceph-rest-api]. The default metricsets are `cluster_disk`, `cluster_health`, `monitor_health`, `pool_disk`, `osd_tree`.
+
+Metricsets connecting to the Ceph REST API uses by default the service exposed on port 5000.
+Metricsets using the Ceph Manager Daemon communicate with the API exposed by default on port 8003 (SSL encryption).
 
 [float]
 === Compatibility
@@ -33,11 +36,25 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 [source,yaml]
 ----
 metricbeat.modules:
+# Metricsets depending on the Ceph REST API (default port: 5000)
 - module: ceph
   metricsets: ["cluster_disk", "cluster_health", "monitor_health", "pool_disk", "osd_tree"]
   period: 10s
   hosts: ["localhost:5000"]
   enabled: true
+
+# Metricsets depending on the Ceph Manager Daemon (default port: 8003)
+- module: ceph
+  metricsets:
+    - mgr_cluster_disk
+    - mgr_osd_perf
+    - mgr_pool_disk
+    - mgr_osd_pool_stats
+    - mgr_osd_tree
+  period: 1m
+  hosts: [ "https://localhost:8003" ]
+  #username: "user"
+  #password: "secret"
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -177,11 +177,25 @@ metricbeat.modules:
   #xpack.enabled: false
 
 #--------------------------------- Ceph Module ---------------------------------
+# Metricsets depending on the Ceph REST API (default port: 5000)
 - module: ceph
   metricsets: ["cluster_disk", "cluster_health", "monitor_health", "pool_disk", "osd_tree"]
   period: 10s
   hosts: ["localhost:5000"]
   enabled: true
+
+# Metricsets depending on the Ceph Manager Daemon (default port: 8003)
+- module: ceph
+  metricsets:
+    - mgr_cluster_disk
+    - mgr_osd_perf
+    - mgr_pool_disk
+    - mgr_osd_pool_stats
+    - mgr_osd_tree
+  period: 1m
+  hosts: [ "https://localhost:8003" ]
+  #username: "user"
+  #password: "secret"
 
 #-------------------------------- Consul Module --------------------------------
 - module: consul

--- a/metricbeat/module/ceph/_meta/config.reference.yml
+++ b/metricbeat/module/ceph/_meta/config.reference.yml
@@ -1,5 +1,19 @@
+# Metricsets depending on the Ceph REST API (default port: 5000)
 - module: ceph
   metricsets: ["cluster_disk", "cluster_health", "monitor_health", "pool_disk", "osd_tree"]
   period: 10s
   hosts: ["localhost:5000"]
   enabled: true
+
+# Metricsets depending on the Ceph Manager Daemon (default port: 8003)
+- module: ceph
+  metricsets:
+    - mgr_cluster_disk
+    - mgr_osd_perf
+    - mgr_pool_disk
+    - mgr_osd_pool_stats
+    - mgr_osd_tree
+  period: 1m
+  hosts: [ "https://localhost:8003" ]
+  #username: "user"
+  #password: "secret"

--- a/metricbeat/module/ceph/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/_meta/docs.asciidoc
@@ -1,5 +1,8 @@
 The Ceph module collects metrics by submitting HTTP GET requests to
-the http://docs.ceph.com/docs/master/man/8/ceph-rest-api/[ceph-rest-api]. The default metricsets are `cluster_disk`, `cluster_health`, `monitor_health`, `pool_disk`, `osd_tree`.
+the https://docs.ceph.com/docs/jewel/man/8/ceph-rest-api/[ceph-rest-api]. The default metricsets are `cluster_disk`, `cluster_health`, `monitor_health`, `pool_disk`, `osd_tree`.
+
+Metricsets connecting to the Ceph REST API uses by default the service exposed on port 5000.
+Metricsets using the Ceph Manager Daemon communicate with the API exposed by default on port 8003 (SSL encryption).
 
 [float]
 === Compatibility

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -338,11 +338,25 @@ metricbeat.modules:
   #xpack.enabled: false
 
 #--------------------------------- Ceph Module ---------------------------------
+# Metricsets depending on the Ceph REST API (default port: 5000)
 - module: ceph
   metricsets: ["cluster_disk", "cluster_health", "monitor_health", "pool_disk", "osd_tree"]
   period: 10s
   hosts: ["localhost:5000"]
   enabled: true
+
+# Metricsets depending on the Ceph Manager Daemon (default port: 8003)
+- module: ceph
+  metricsets:
+    - mgr_cluster_disk
+    - mgr_osd_perf
+    - mgr_pool_disk
+    - mgr_osd_pool_stats
+    - mgr_osd_tree
+  period: 1m
+  hosts: [ "https://localhost:8003" ]
+  #username: "user"
+  #password: "secret"
 
 #----------------------------- Cloudfoundry Module -----------------------------
 - module: cloudfoundry


### PR DESCRIPTION
Cherry-pick of PR #17566 to 7.x branch. Original message: 

This PR adjusts Ceph docs to contain information about different exposed ports.