### PR TITLE
Cherry-pick #16922 to 7.x: [Agent] Fixed test to pass on windows

### DIFF
--- a/x-pack/agent/pkg/agent/operation/common_test.go
+++ b/x-pack/agent/pkg/agent/operation/common_test.go
@@ -1,0 +1,103 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package operation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	operatorCfg "github.com/elastic/beats/v7/x-pack/agent/pkg/agent/operation/config"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/stateresolver"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact/download"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact/install"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/app"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/app/monitoring"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/process"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/retry"
+)
+
+var installPath = "tests/scripts"
+
+func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.Config) {
+	operatorConfig := &operatorCfg.Config{
+		RetryConfig: &retry.Config{
+			Enabled:      true,
+			RetriesCount: 2,
+			Delay:        3 * time.Second,
+			MaxDelay:     10 * time.Second,
+		},
+		ProcessConfig: &process.Config{},
+		DownloadConfig: &artifact.Config{
+			InstallPath: installPath,
+		},
+		MonitoringConfig: &monitoring.Config{
+			MonitorMetrics: false,
+		},
+	}
+
+	cfg, err := config.NewConfigFrom(operatorConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l := getLogger()
+
+	fetcher := &DummyDownloader{}
+	installer := &DummyInstaller{}
+
+	stateResolver, err := stateresolver.NewStateResolver(l)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, installer, stateResolver, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	operator.config.DownloadConfig.OperatingSystem = "darwin"
+	operator.config.DownloadConfig.Architecture = "32"
+
+	return operator, operatorConfig
+}
+
+func getLogger() *logger.Logger {
+	l, _ := logger.New()
+	return l
+}
+
+func getProgram(binary, version string) *app.Descriptor {
+	downloadCfg := &artifact.Config{
+		InstallPath:     installPath,
+		OperatingSystem: "darwin",
+	}
+	return app.NewDescriptor(binary, version, downloadCfg, nil)
+}
+
+type TestConfig struct {
+	TestFile string
+}
+
+type DummyDownloader struct {
+}
+
+func (*DummyDownloader) Download(_ context.Context, p, v string) (string, error) {
+	return "", nil
+}
+
+var _ download.Downloader = &DummyDownloader{}
+
+type DummyInstaller struct {
+}
+
+func (*DummyInstaller) Install(p, v, _ string) error {
+	return nil
+}
+
+var _ install.Installer = &DummyInstaller{}

--- a/x-pack/agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/agent/pkg/agent/operation/monitoring_test.go
@@ -2,8 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build linux darwin
-
 package operation
 
 import (

--- a/x-pack/agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/agent/pkg/agent/operation/operator_test.go
@@ -7,7 +7,6 @@
 package operation
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -15,22 +14,11 @@ import (
 	"testing"
 	"time"
 
-	operatorCfg "github.com/elastic/beats/v7/x-pack/agent/pkg/agent/operation/config"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/program"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/stateresolver"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact/download"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/artifact/install"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/config"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/app"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/app/monitoring"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/process"
-	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/retry"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/plugin/state"
 )
-
-var installPath = "tests/scripts"
 
 func TestMain(m *testing.M) {
 	// init supported with test cases
@@ -374,81 +362,3 @@ func TestConfigurableByFileRun(t *testing.T) {
 		t.Fatal("Process found")
 	}
 }
-
-func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.Config) {
-	operatorConfig := &operatorCfg.Config{
-		RetryConfig: &retry.Config{
-			Enabled:      true,
-			RetriesCount: 2,
-			Delay:        3 * time.Second,
-			MaxDelay:     10 * time.Second,
-		},
-		ProcessConfig: &process.Config{},
-		DownloadConfig: &artifact.Config{
-			InstallPath: installPath,
-		},
-		MonitoringConfig: &monitoring.Config{
-			MonitorMetrics: false,
-		},
-	}
-
-	cfg, err := config.NewConfigFrom(operatorConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	l := getLogger()
-
-	fetcher := &DummyDownloader{}
-	installer := &DummyInstaller{}
-
-	stateResolver, err := stateresolver.NewStateResolver(l)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, installer, stateResolver, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	operator.config.DownloadConfig.OperatingSystem = "darwin"
-	operator.config.DownloadConfig.Architecture = "32"
-
-	return operator, operatorConfig
-}
-
-func getLogger() *logger.Logger {
-	l, _ := logger.New()
-	return l
-}
-
-func getProgram(binary, version string) *app.Descriptor {
-	downloadCfg := &artifact.Config{
-		InstallPath:     installPath,
-		OperatingSystem: "darwin",
-	}
-	return app.NewDescriptor(binary, version, downloadCfg, nil)
-}
-
-type TestConfig struct {
-	TestFile string
-}
-
-type DummyDownloader struct {
-}
-
-func (*DummyDownloader) Download(_ context.Context, p, v string) (string, error) {
-	return "", nil
-}
-
-var _ download.Downloader = &DummyDownloader{}
-
-type DummyInstaller struct {
-}
-
-func (*DummyInstaller) Install(p, v, _ string) error {
-	return nil
-}
-
-var _ install.Installer = &DummyInstaller{}

--- a/x-pack/agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -150,7 +150,10 @@ func (b *Monitor) monitoringDrop() string {
 func monitoringDrop(path string) (drop string) {
 	defer func() {
 		if drop != "" {
-			drop = filepath.Dir(drop)
+			// Dir call changes separator to the one used in OS
+			// '/var/lib' -> '\var\lib\' on windows
+			baseLen := len(filepath.Dir(drop))
+			drop = drop[:baseLen]
 		}
 	}()
 

--- a/x-pack/agent/pkg/core/plugin/app/monitoring/beats/drop_test.go
+++ b/x-pack/agent/pkg/core/plugin/app/monitoring/beats/drop_test.go
@@ -5,42 +5,36 @@
 package beats
 
 import (
-	"runtime"
 	"testing"
 )
 
 type testCase struct {
-	Endpoint    string
-	Drop        string
-	SkipWindows bool
+	Endpoint string
+	Drop     string
 }
 
 func TestMonitoringDrops(t *testing.T) {
 	cases := []testCase{
-		testCase{`/var/lib/drop/abc.sock`, "/var/lib/drop", true},
-		testCase{`npipe://drop`, "", false},
-		testCase{`http+npipe://drop`, "", false},
-		testCase{`\\.\pipe\drop`, "", false},
-		testCase{`unix:///var/lib/drop/abc.sock`, "/var/lib/drop", true},
-		testCase{`http+unix:///var/lib/drop/abc.sock`, "/var/lib/drop", true},
-		testCase{`file:///var/lib/drop/abc.sock`, "/var/lib/drop", true},
-		testCase{`http://localhost/stats`, "", false},
-		testCase{`localhost/stats`, "", false},
-		testCase{`http://localhost:8080/stats`, "", false},
-		testCase{`localhost:8080/stats`, "", false},
-		testCase{`http://1.2.3.4/stats`, "", false},
-		testCase{`http://1.2.3.4:5678/stats`, "", false},
-		testCase{`1.2.3.4:5678/stats`, "", false},
-		testCase{`http://hithere.com:5678/stats`, "", false},
-		testCase{`hithere.com:5678/stats`, "", false},
+		testCase{`/var/lib/drop/abc.sock`, "/var/lib/drop"},
+		testCase{`npipe://drop`, ""},
+		testCase{`http+npipe://drop`, ""},
+		testCase{`\\.\pipe\drop`, ""},
+		testCase{`unix:///var/lib/drop/abc.sock`, "/var/lib/drop"},
+		testCase{`http+unix:///var/lib/drop/abc.sock`, "/var/lib/drop"},
+		testCase{`file:///var/lib/drop/abc.sock`, "/var/lib/drop"},
+		testCase{`http://localhost/stats`, ""},
+		testCase{`localhost/stats`, ""},
+		testCase{`http://localhost:8080/stats`, ""},
+		testCase{`localhost:8080/stats`, ""},
+		testCase{`http://1.2.3.4/stats`, ""},
+		testCase{`http://1.2.3.4:5678/stats`, ""},
+		testCase{`1.2.3.4:5678/stats`, ""},
+		testCase{`http://hithere.com:5678/stats`, ""},
+		testCase{`hithere.com:5678/stats`, ""},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Endpoint, func(t *testing.T) {
-			if runtime.GOOS == "windows" && c.SkipWindows {
-				t.Skip("Skipped under windows")
-			}
-
 			drop := monitoringDrop(c.Endpoint)
 			if drop != c.Drop {
 				t.Errorf("Case[%s]: Expected '%s', got '%s'", c.Endpoint, c.Drop, drop)


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#16922 to 7.x branch. Original message: 

Funny behavior of `filepath.Dir` caused drop test to fail.
Monitoring tests failed due to mixup in build tags.

Fixes: elastic/beats#16854