### PR TITLE
Cherry-pick #17112 to 7.x: [Agent] Support for config constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.1
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/date v0.2.0
+	github.com/Masterminds/semver v1.4.2
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Shopify/sarama v0.0.0-00010101000000-000000000000
 	github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6

--- a/x-pack/agent/CHANGELOG.asciidoc
+++ b/x-pack/agent/CHANGELOG.asciidoc
@@ -20,3 +20,4 @@
 - Generate index name in a format type-dataset-namespace {pull}16903[16903]
 - OS agnostic default configuration {pull}17016[17016]
 - Display the stability of the agent at enroll and start.  {pull}17336[17336]
+- Support for config constraints {pull}17112[17112]

--- a/x-pack/agent/pkg/agent/application/filters/constraints_filter.go
+++ b/x-pack/agent/pkg/agent/application/filters/constraints_filter.go
@@ -1,0 +1,274 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package filters
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/transpiler"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/boolexp"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/release"
+	"github.com/elastic/go-sysinfo"
+)
+
+const (
+	datasourcesKey          = "datasources"
+	constraintsKey          = "constraints"
+	validateVersionFuncName = "validate_version"
+)
+
+// List of variables available to be used in constraint definitions.
+const (
+	// `agent.id` is a generated (in standalone) or assigned (in fleet) agent identifier.
+	agentIDKey = "agent.id"
+	// `agent.version` specifies current version of an agent.
+	agentVersionKey = "agent.version"
+	// `host.architecture` defines architecture of a host (e.g. x86_64, arm, ppc, mips).
+	hostArchKey = "host.architecture"
+	// `os.family` defines a family of underlying operating system (e.g. redhat, debian, freebsd, windows).
+	osFamilyKey = "os.family"
+	// `os.kernel` specifies current version of a kernel in a semver format.
+	osKernelKey = "os.kernel"
+	// `os.platform` specifies platform agent is running on (e.g. centos, ubuntu, windows).
+	osPlatformKey = "os.platform"
+	// `os.version` specifies version of underlying operating system (e.g. 10.12.6).
+	osVersionKey = "os.version"
+)
+
+var (
+	boolexpVarStore    *constraintVarStore
+	boolexpMethodsRegs *boolexp.MethodsReg
+)
+
+// ConstraintFilter filters ast based on included constraints.
+func ConstraintFilter(log *logger.Logger, ast *transpiler.AST) error {
+	// get datasources
+	dsNode, found := transpiler.Lookup(ast, datasourcesKey)
+	if !found {
+		return nil
+	}
+
+	dsListNode, ok := dsNode.Value().(*transpiler.List)
+	if !ok {
+		return nil
+	}
+
+	dsList, ok := dsListNode.Value().([]transpiler.Node)
+	if !ok {
+		return nil
+	}
+
+	// for each datasource
+	i := 0
+	originalLen := len(dsList)
+	for i < len(dsList) {
+		constraintMatch, err := evaluateConstraints(log, dsList[i])
+		if err != nil {
+			return err
+		}
+
+		if constraintMatch {
+			i++
+			continue
+		}
+		dsList = append(dsList[:i], dsList[i+1:]...)
+	}
+
+	if len(dsList) == originalLen {
+		return nil
+	}
+
+	// Replace datasources with limited set
+	if err := transpiler.RemoveKey(datasourcesKey).Apply(ast); err != nil {
+		return err
+	}
+
+	newList := transpiler.NewList(dsList)
+	return transpiler.Insert(ast, newList, datasourcesKey)
+}
+
+func evaluateConstraints(log *logger.Logger, datasourceNode transpiler.Node) (bool, error) {
+	constraintsNode, found := datasourceNode.Find(constraintsKey)
+	if !found {
+		return true, nil
+	}
+
+	constraintsListNode, ok := constraintsNode.Value().(*transpiler.List)
+	if !ok {
+		return false, errors.New("constraints not a list", errors.TypeConfig)
+	}
+
+	constraintsList, ok := constraintsListNode.Value().([]transpiler.Node)
+	if !ok {
+		return false, errors.New("constraints not a list", errors.TypeConfig)
+	}
+
+	for _, c := range constraintsList {
+		strval, ok := c.(*transpiler.StrVal)
+		if !ok {
+			return false, errors.New("constraints is not a string")
+		}
+
+		constraint := strval.String()
+		if isOK, err := evaluateConstraint(constraint); !isOK || err != nil {
+			if err == nil {
+				// log only constraint not matching
+				log.Infof("constraint '%s' not matching for datasource '%s'", constraint, datasourceIdentifier(datasourceNode))
+			}
+
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func datasourceIdentifier(datasourceNode transpiler.Node) string {
+	namespace := "default"
+	output := "default"
+
+	if nsNode, found := datasourceNode.Find("namespace"); found {
+		nsKey, ok := nsNode.(*transpiler.Key)
+		if ok {
+			if valNode, ok := nsKey.Value().(transpiler.Node); ok {
+				namespace = valNode.String()
+			}
+		}
+	}
+
+	if outNode, found := datasourceNode.Find("use_output"); found {
+		nsKey, ok := outNode.(*transpiler.Key)
+		if ok {
+			if valNode, ok := nsKey.Value().(transpiler.Node); ok {
+				output = valNode.String()
+			}
+		}
+	}
+
+	ID := "unknown"
+	if idNode, found := datasourceNode.Find("id"); found {
+		nsKey, ok := idNode.(*transpiler.Key)
+		if ok {
+			if valNode, ok := nsKey.Value().(transpiler.Node); ok {
+				ID = valNode.String()
+			}
+		}
+	}
+
+	return fmt.Sprintf("namespace:%s, output:%s, id:%s", namespace, output, ID)
+}
+
+func evaluateConstraint(constraint string) (bool, error) {
+	store, regs, err := boolexpMachinery()
+	if err != nil {
+		return false, err
+	}
+
+	return boolexp.Eval(constraint, regs, store)
+}
+
+func boolexpMachinery() (*constraintVarStore, *boolexp.MethodsReg, error) {
+	if boolexpMethodsRegs != nil && boolexpVarStore != nil {
+		return boolexpVarStore, boolexpMethodsRegs, nil
+	}
+
+	regs := boolexp.NewMethodsReg()
+	if err := regs.Register(validateVersionFuncName, regValidateVersion); err != nil {
+		return nil, nil, err
+	}
+
+	store, err := newVarStore()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := initVarStore(store); err != nil {
+		return nil, nil, err
+	}
+
+	boolexpMethodsRegs = regs
+	boolexpVarStore = store
+
+	return boolexpVarStore, boolexpMethodsRegs, nil
+}
+
+func regValidateVersion(args []interface{}) (interface{}, error) {
+	if len(args) != 2 {
+		return false, errors.New("validate_version: invalid number of arguments, expecting 2")
+	}
+
+	version, isString := args[0].(string)
+	if !isString {
+		return false, errors.New("version should be a string")
+	}
+
+	constraint, isString := args[1].(string)
+	if !isString {
+		return false, errors.New("version constraint should be a string")
+	}
+
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("constraint '%s' is invalid", constraint))
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("version '%s' is invalid", version))
+	}
+
+	isOK, _ := c.Validate(v)
+	return isOK, nil
+}
+
+type constraintVarStore struct {
+	vars map[string]interface{}
+}
+
+func (s *constraintVarStore) Lookup(v string) (interface{}, bool) {
+	val, ok := s.vars[v]
+	return val, ok
+}
+
+func newVarStore() (*constraintVarStore, error) {
+	return &constraintVarStore{
+		vars: make(map[string]interface{}),
+	}, nil
+}
+
+func initVarStore(store *constraintVarStore) error {
+	sysInfo, err := sysinfo.Host()
+	if err != nil {
+		return err
+	}
+
+	agentInfo, err := info.NewAgentInfo()
+	if err != nil {
+		return err
+	}
+
+	info := sysInfo.Info()
+
+	// 	Agent
+	store.vars[agentIDKey] = agentInfo.AgentID()
+	store.vars[agentVersionKey] = release.Version()
+
+	// Host
+	store.vars[hostArchKey] = info.Architecture
+
+	// Operating system
+	store.vars[osFamilyKey] = runtime.GOOS
+	store.vars[osKernelKey] = info.KernelVersion
+	store.vars[osPlatformKey] = info.OS.Family
+	store.vars[osVersionKey] = info.OS.Version
+
+	return nil
+}

--- a/x-pack/agent/pkg/agent/application/filters/constraints_filter_test.go
+++ b/x-pack/agent/pkg/agent/application/filters/constraints_filter_test.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package filters
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/release"
+)
+
+func TestEvaluation(t *testing.T) {
+	type testCase struct {
+		name      string
+		condition string
+		result    bool
+	}
+
+	testCases := []testCase{
+		testCase{"simple version", "validate_version(%{[agent.version]}, '" + release.Version() + "')", true},
+		testCase{"~ version release", "validate_version(%{[agent.version]}, '~" + release.Version() + "')", true},
+		testCase{"^ version release", "validate_version(%{[agent.version]}, '^" + release.Version() + "')", true},
+		testCase{"range to release", "validate_version(%{[agent.version]}, '1.0.0 - " + release.Version() + "')", true},
+		testCase{"range lower", "validate_version(%{[agent.version]}, '1.0.0 - 5.0.0')", false},
+		testCase{"range include", "validate_version(%{[agent.version]}, '1.0.0 - 100.0.0')", true},
+		testCase{"family should equal", "%{[os.family]} == '" + runtime.GOOS + "'", true},
+		testCase{"family should not equal", "%{[os.family]} != '" + runtime.GOOS + "'", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := evaluateConstraint(tc.condition)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.result, r)
+
+			// cleanup
+			os.Remove("fleet.yml")
+			os.Remove("fleet.yml.old")
+		})
+	}
+}

--- a/x-pack/agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/agent/pkg/agent/application/info/agent_id.go
@@ -80,6 +80,10 @@ func getInfoFromStore(s ioStore) (*persistentAgentInfo, error) {
 			errors.M(errors.MetaKeyPath, AgentConfigFile))
 	}
 
+	if err := reader.Close(); err != nil {
+		return nil, err
+	}
+
 	configMap, err := cfg.ToMapStr()
 	if err != nil {
 		return nil, errors.New(err,
@@ -116,6 +120,10 @@ func updateAgentInfo(s ioStore, agentInfo *persistentAgentInfo) error {
 		return errors.New(err, fmt.Sprintf("fail to read configuration %s for the agent", AgentConfigFile),
 			errors.TypeFilesystem,
 			errors.M(errors.MetaKeyPath, AgentConfigFile))
+	}
+
+	if err := reader.Close(); err != nil {
+		return err
 	}
 
 	configMap := make(map[string]interface{})

--- a/x-pack/agent/pkg/agent/application/local_mode.go
+++ b/x-pack/agent/pkg/agent/application/local_mode.go
@@ -7,6 +7,7 @@ package application
 import (
 	"context"
 
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/application/filters"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/configrequest"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/errors"
@@ -85,7 +86,7 @@ func newLocal(
 	}
 
 	discover := discoverer(pathConfigFile, c.Management.Path)
-	emit := emitter(log, router, injectMonitoring)
+	emit := emitter(log, router, &configModifiers{Decorators: []decoratorFunc{injectMonitoring}, Filters: []filterFunc{filters.ConstraintFilter}})
 
 	var cfgSource source
 	if !c.Management.Reload.Enabled {

--- a/x-pack/agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/agent/pkg/agent/application/managed_mode.go
@@ -13,6 +13,7 @@ import (
 
 	"time"
 
+	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/application/filters"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/agent/pkg/agent/storage"
@@ -123,7 +124,7 @@ func newManaged(
 		return nil, errors.New(err, "fail to initialize pipeline router")
 	}
 
-	emit := emitter(log, router)
+	emit := emitter(log, router, &configModifiers{Decorators: []decoratorFunc{injectMonitoring}, Filters: []filterFunc{filters.ConstraintFilter}})
 	acker, err := newActionAcker(log, agentInfo, client)
 	if err != nil {
 		return nil, err

--- a/x-pack/agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
+++ b/x-pack/agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
@@ -1,0 +1,16 @@
+filebeat:
+  inputs:
+  - type: log
+    paths:
+      - /var/log/hello1.log
+      - /var/log/hello2.log
+    index: logs-generic-default
+output:
+  elasticsearch:
+    hosts:
+      - 127.0.0.1:9200
+      - 127.0.0.1:9300
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=

--- a/x-pack/agent/pkg/agent/program/testdata/constraints_config.yml
+++ b/x-pack/agent/pkg/agent/program/testdata/constraints_config.yml
@@ -1,0 +1,44 @@
+name:	Production Website DB Servers
+
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200, 127.0.0.1:9300]
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["monitoring:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+
+datasources:
+  - use_output: default
+    inputs:
+    - type: logs
+      streams:
+      - paths:
+        - /var/log/hello1.log
+        - /var/log/hello2.log
+  - namespace: testing
+    use_output: default
+    constraints:
+      - "validate_version(%{[agent.version]}, '1.0.0 - 7.0.0')"
+    inputs:
+      - type: apache/metrics
+        streams:
+          - enabled: true
+            metricset: info
+
+settings.monitoring:
+  use_output: monitoring
+
+management:
+  host: "localhost"
+  mode: "local"
+
+config:
+  reload: 123

--- a/x-pack/agent/pkg/agent/transpiler/ast.go
+++ b/x-pack/agent/pkg/agent/transpiler/ast.go
@@ -169,6 +169,11 @@ type List struct {
 	value []Node
 }
 
+// NewList creates a new list with provided nodes.
+func NewList(nodes []Node) *List {
+	return &List{nodes}
+}
+
 func (l *List) String() string {
 	var sb strings.Builder
 	for i := 0; i < len(l.value); i++ {

--- a/x-pack/agent/pkg/boolexp/boolexp_test.go
+++ b/x-pack/agent/pkg/boolexp/boolexp_test.go
@@ -36,6 +36,7 @@ func TestBoolexp(t *testing.T) {
 	}{
 		// Variables
 		{expression: "%{[hello.var]} == 'hello'", result: true},
+		{expression: "%{[hello.var]} != 'hello'", result: false},
 		{expression: "contains(%{[hello.var]}, 'hell')", result: true},
 
 		{expression: "true", result: true},


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17112 to 7.x branch. Original message: 

## What does this PR do?

Followup tohttps://github.com/elastic/beats/issues/15690. 
This PR introduces contraints as described in this issue: https://github.com/elastic/beats/issues/16409

This PR enhances emitter not only to use decorators to enrich configuration but filters to modify ast by dropping some nodes. 

It introduces also constraints filter which loads all datasets and for those which contain constraint node parses this nodes and uses existing boolexp implementation to evaluate expressions. 
It also allows user to use some basic variables such as `agent.id`, `agent.version` and such.

Nodes containing constraints section and where constraint is evaluated as FALSE, these nodes are dropped.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

Fixes: elastic/beats#16409