### PR TITLE
Cherry-pick #17510 to 7.x: Add ingress_controller docs

### DIFF
--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -12,6 +12,10 @@ This file is generated! See scripts/docs_collector.py
 The +{modulename}+ module parses access and error logs created by the
 http://nginx.org/[Nginx] HTTP server.
 
+`ingress_controller` fileset parses access logs created by https://github.com/kubernetes/ingress-nginx[ingress-nginx] controller.
+Log patterns could be found on the controllers'
+https://github.com/kubernetes/ingress-nginx/blob/nginx-0.28.0/docs/user-guide/nginx-configuration/log-format.md[docs].
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
@@ -23,6 +27,8 @@ The Nginx module was tested with logs from version 1.10.
 
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
+
+`ingress_controller` fileset was tested with version 0.28.0 of `nginx-ingress-controller`.
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -48,8 +54,17 @@ To specify the same settings at the command line, you use:
 -M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
 -----
 
+The following example shows how to configure `ingress_controller` fileset which can be used in Kubernetes environments
+to parse ingress-nginx logs:
 
- 
+["source","yaml",subs="attributes"]
+-----
+- module: nginx
+  ingress_controller:
+    enabled: true
+    var.paths: ["/path/to/log/nginx/ingress.log"]
+-----
+
 
 //set the fileset name used in the included example
 :fileset_ex: access
@@ -63,6 +78,11 @@ include::../include/var-paths.asciidoc[]
 
 [float]
 ==== `error` log fileset
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `ingress_controller` log fileset
 
 include::../include/var-paths.asciidoc[]
 

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -7,6 +7,10 @@
 The +{modulename}+ module parses access and error logs created by the
 http://nginx.org/[Nginx] HTTP server.
 
+`ingress_controller` fileset parses access logs created by https://github.com/kubernetes/ingress-nginx[ingress-nginx] controller.
+Log patterns could be found on the controllers'
+https://github.com/kubernetes/ingress-nginx/blob/nginx-0.28.0/docs/user-guide/nginx-configuration/log-format.md[docs].
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
@@ -18,6 +22,8 @@ The Nginx module was tested with logs from version 1.10.
 
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
+
+`ingress_controller` fileset was tested with version 0.28.0 of `nginx-ingress-controller`.
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -43,8 +49,17 @@ To specify the same settings at the command line, you use:
 -M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
 -----
 
+The following example shows how to configure `ingress_controller` fileset which can be used in Kubernetes environments
+to parse ingress-nginx logs:
 
- 
+["source","yaml",subs="attributes"]
+-----
+- module: nginx
+  ingress_controller:
+    enabled: true
+    var.paths: ["/path/to/log/nginx/ingress.log"]
+-----
+
 
 //set the fileset name used in the included example
 :fileset_ex: access
@@ -58,6 +73,11 @@ include::../include/var-paths.asciidoc[]
 
 [float]
 ==== `error` log fileset
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `ingress_controller` log fileset
 
 include::../include/var-paths.asciidoc[]
 


### PR DESCRIPTION
Cherry-pick of PR #17510 to 7.x branch. Original message: 

## What does this PR do?
This PR adds docs for `ingress_controller` fileset of `nginx` module.


- Closes https://github.com/elastic/beats/issues/17479
- Related to https://github.com/elastic/beats/pull/16197







