### PR TITLE
Make tests of urldecode processor parallelized

### DIFF
--- a/libbeat/processors/urldecode/urldecode_test.go
+++ b/libbeat/processors/urldecode/urldecode_test.go
@@ -188,7 +188,7 @@ func TestURLDecode(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.description, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 
 			f := &urlDecode{
 				log:    logp.NewLogger("urldecode"),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Make tests of `urldecode` processor parallelized.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#17505 
