### PR TITLE
Cherry-pick #17569 to 7.7: [Auditbeat][System] Fix error handling around go-sysinfo.Host

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - system/socket: Fixed compatibility issue with kernel 5.x. {pull}15771[15771]
 - system/package: Fix parsing of Installed-Size field of DEB packages. {issue}16661[16661] {pull}17188[17188]
+- system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/system.go
+++ b/x-pack/auditbeat/module/system/system.go
@@ -55,19 +55,20 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	log := logp.NewLogger(moduleName)
 
 	var hostID string
-	hostInfo, err := sysinfo.Host()
-	if hostInfo != nil {
+	if hostInfo, err := sysinfo.Host(); err != nil {
+		log.Errorf("Could not get host info. err=%+v", err)
+	} else {
 		hostID = hostInfo.Info().UniqueID
 	}
 
 	if hostID == "" {
-		log.Warnf("Could not get host ID, will not fill entity_id fields. Error: %+v", err)
+		log.Warnf("Could not get host ID, will not fill entity_id fields.")
 	}
 
 	return &SystemModule{
 		BaseModule: base,
 		config:     config,
-		hostID:     hostInfo.Info().UniqueID,
+		hostID:     hostID,
 	}, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #17569 to 7.7 branch. Original message: 

Before a system dataset is loaded, host information is loaded to populate `entity_id` fields.

Error handling around it was incorrect and resulted in a panic when fetching host info failed, which afaik it's limited to errors accessing `/proc/stat` file.