### PR TITLE
Cherry-pick #17511 to 7.x: Release Google Cloud module as GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,6 +315,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
 - Added access_key_id, secret_access_key and session_token into aws module config. {pull}17456[17456]
 - Improve ECS categorization field mappings for mysql module. {issue}16172[16172] {pull}17491[17491]
+- Release Google Cloud module as GA. {pull}17511[17511]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -10,7 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == Google Cloud module
 
-beta[]
 
 This is a module for Google Cloud logs. It supports reading VPC flow
 and firewall logs that have been exported from Stackdriver to a

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -5,7 +5,6 @@
 
 == Google Cloud module
 
-beta[]
 
 This is a module for Google Cloud logs. It supports reading VPC flow
 and firewall logs that have been exported from Stackdriver to a


### PR DESCRIPTION
Cherry-pick of PR #17511 to 7.x branch. Original message: 

This updates the  `googlecloud` module docs to remove the Beta tag, making it officially GA.