### PR TITLE
Allow auto-configuration of Metricbeat stack modules for stack monitoring

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -324,6 +324,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add test for documented fields check for metricsets without a http input. {issue}17315[17315] {pull}17334[17334]
 - Add final tests and move label to GA for the azure module in metricbeat. {pull}17319[17319]
 - Reference kubernetes manifests mount data directory from the host when running metricbeat as daemonset, so data persist between executions in the same node. {pull}17429[17429]
+- Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -5,18 +5,21 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-beat]]
 == Beat module
 
-There are two modules that collect metrics about any Beat or other software based on libbeat:
-
-* The `beat` module tracks only the high-level metrics. The default metricsets in
-this module are `state` and `stats`.
-* The `beat-xpack` module enables you to monitor more Beat metrics with our
-{stack} {monitor-features}. The metricsets automatically configured by this module
-are `state` and `stats`.
+The `beat` module collects metrics about any Beat or other software based on libbeat.
 
 [float]
 === Compatibility
 
-Both modules work with {ls} 7.3.0 and later.
+The `beat` module work with {beats} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
+metricbeat modules enable beat-xpack`.
+
 
 
 [float]

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -20,8 +20,6 @@ UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `met
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
 metricbeat modules enable beat-xpack`.
 
-
-
 [float]
 === Example configuration
 

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -57,4 +57,3 @@ The following metricsets are available:
 include::beat/state.asciidoc[]
 
 include::beat/stats.asciidoc[]
-

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -5,16 +5,18 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-beat]]
 == Beat module
 
-The Beat module contains a minimal set of metrics to enable monitoring of any Beat or other software based on libbeat across
-multiple versions. To monitor more Beat metrics, use our {stack}
-{monitor-features}.
+There are two modules that collect metrics about any Beat or other software based on libbeat:
 
-The default metricsets are `state` and `stats`.
+* The `beat` module tracks only the high-level metrics. The default metricsets in
+this module are `state` and `stats`.
+* The `beat-xpack` module enables you to monitor more Beat metrics with our
+{stack} {monitor-features}. The metricsets automatically configured by this module
+are `state` and `stats`.
 
 [float]
 === Compatibility
 
-The Beat module works with Beats 7.3.0 and later.
+Both modules work with {ls} 7.3.0 and later.
 
 
 [float]

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -10,7 +10,7 @@ The `beat` module collects metrics about any Beat or other software based on lib
 [float]
 === Compatibility
 
-The `beat` module work with {beats} 7.3.0 and later.
+The `beat` module works with {beats} 7.3.0 and later.
 
 [float]
 === Usage for Stack Monitoring
@@ -19,6 +19,7 @@ The `beat` module can be used to collect metrics shown in our {stack} {monitor-f
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
 `metricbeat modules enable beat-xpack`.
+
 
 [float]
 === Example configuration
@@ -57,3 +58,4 @@ The following metricsets are available:
 include::beat/state.asciidoc[]
 
 include::beat/stats.asciidoc[]
+

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -18,7 +18,7 @@ The `beat` module work with {beats} 7.3.0 and later.
 The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
-metricbeat modules enable beat-xpack`.
+`metricbeat modules enable beat-xpack`.
 
 [float]
 === Example configuration

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,20 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-There are two modules that collect metrics about {es}: 
+There are two modules that collect metrics about {es}:
 
-* The Elasticsearch module contains a minimal set of metrics to enable
+* The `elasticsearch` module contains a minimal set of metrics to enable
 monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
-* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
-`index_summary`, `ml_job`, `node_stats`, and `shard`.
+* The `elasticsearch-xpack` module enables you to monitor more {es}
+metrics with our {stack} {monitor-features}. The metricsets automatically
+configured by this module are `ccr`, `cluster_stats`, `enrich`, ``index`,
+`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility
 
-The Elasticsearch module works with Elasticsearch 6.7.0 and later.
+Both modules work with {es} 6.7.0 and later.
 
 
 [float]

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,20 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-There are two modules that collect metrics about {es}:
-
-* The `elasticsearch` module contains a minimal set of metrics to enable
-monitoring of Elasticsearch across multiple versions. The default metricsets in
-this module are `node` and `node_stats`.
-* The `elasticsearch-xpack` module enables you to monitor more {es}
-metrics with our {stack} {monitor-features}. The metricsets automatically
-configured by this module are `ccr`, `cluster_stats`, `enrich`, ``index`,
-`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
+The `elasticsearch` module collects metrics about {es}.
 
 [float]
 === Compatibility
 
-Both modules work with {es} 6.7.0 and later.
+The `elasticsearch` module works with {es} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,18 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-kibana]]
 == Kibana module
 
-There are two modules that collect metrics about {kib}:
-
-* The `kibana` module tracks only the high-level metrics. The default metricset in
-this module is `status`.
-* The `kibana-xpack` module enables you to monitor more {kib} metrics with our
-{stack} {monitor-features}. The metricset automatically configured by this module is
-`stats`.
+The `kibana` module collects metrics about {kib}.
 
 [float]
 === Compatibility
 
-Both modules work with {kib} 6.7.0 and later.
+The `kibana` module works with {kib} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
+`metricbeat modules enable kibana-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,17 +5,18 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-kibana]]
 == Kibana module
 
-There are two modules that collect metrics about {kib}: 
+There are two modules that collect metrics about {kib}:
 
-* The Kibana module tracks only the high-level metrics. The default metricset in
+* The `kibana` module tracks only the high-level metrics. The default metricset in
 this module is `status`.
-* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{stack} {monitor-features}. The default metricset in this module is `stats`.
+* The `kibana-xpack` module enables you to monitor more {kib} metrics with our
+{stack} {monitor-features}. The metricset automatically configured by this module is
+`stats`.
 
 [float]
 === Compatibility
 
-The Kibana module works with Kibana 6.7.0 and later.
+Both modules work with {kib} 6.7.0 and later.
 
 
 [float]

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -5,18 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-logstash]]
 == Logstash module
 
-There are two modules that collect metrics about {ls}:
-
-* The `logstash` module tracks only the high-level metrics. The default metricsets in
-this module are `node` and `node_stats`.
-* The `logstash-xpack` module enables you to monitor more {ls} metrics with our
-{stack} {monitor-features}. The metricsets automatically configured by this module
-are `node` and `node_stats`.
+The `logstash` module collects metrics about {ls}.
 
 [float]
 === Compatibility
 
-Both modules work with {ls} 7.3.0 and later.
+The `logstash` module works with {ls} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
+`metricbeat modules enable logstash-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -5,14 +5,18 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-logstash]]
 == Logstash module
 
-This is the Logstash module.
+There are two modules that collect metrics about {ls}:
 
-The default metricsets are `node` and `node_stats`.
+* The `logstash` module tracks only the high-level metrics. The default metricsets in
+this module are `node` and `node_stats`.
+* The `logstash-xpack` module enables you to monitor more {ls} metrics with our
+{stack} {monitor-features}. The metricsets automatically configured by this module
+are `node` and `node_stats`.
 
 [float]
 === Compatibility
 
-The Logstash module works with Logstash 7.3.0 and later.
+Both modules work with {ls} 7.3.0 and later.
 
 
 [float]

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -164,7 +164,7 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, logger *log
 		return nil, errors.Wrapf(err, "could not reconfigure module %v", moduleName)
 	}
 
-	logger.Debugf("configuration for module %v modified because xpack.enabled was set to true", moduleName)
+	logger.Debugf("Configuration for module %v modified because xpack.enabled was set to true", moduleName)
 
 	return newModule, nil
 }

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -133,7 +135,7 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 		XPackEnabled bool `config:"xpack.enabled"`
 	}{}
 	if err := base.UnpackConfig(&config); err != nil {
-		return err
+		return errors.Wrapf(err, "could not unpack configuration for module %v", base.Name())
 	}
 
 	// No special configuration is needed if xpack.enabled != true
@@ -143,7 +145,7 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 
 	var raw common.MapStr
 	if err := base.UnpackConfig(&raw); err != nil {
-		return err
+		return errors.Wrapf(err, "could not unpack configuration for module %v", base.Name())
 	}
 
 	// These metricsets are exactly the ones required if xpack.enabled == true
@@ -151,11 +153,11 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 
 	newConfig, err := common.NewConfigFrom(raw)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "could not create new configuration for module %v", base.Name())
 	}
 
 	if err := base.ReConfigure(newConfig, register); err != nil {
-		return err
+		return errors.Wrapf(err, "could not reconfigure module %v", base.Name())
 	}
 
 	return nil

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -130,7 +130,7 @@ func FixTimestampField(m common.MapStr, field string) error {
 	return nil
 }
 
-func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, register *mb.Register, logger *logp.Logger) error {
+func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, logger *logp.Logger) error {
 	moduleName := base.Name()
 
 	config := struct {
@@ -158,7 +158,7 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 		return errors.Wrapf(err, "could not create new configuration for module %v", moduleName)
 	}
 
-	if err := base.Reconfigure(newConfig, register); err != nil {
+	if err := base.Reconfigure(newConfig); err != nil {
 		return errors.Wrapf(err, "could not reconfigure module %v", moduleName)
 	}
 

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -128,10 +128,9 @@ func FixTimestampField(m common.MapStr, field string) error {
 	return nil
 }
 
-func ReConfigureXPackEnabledMetricSets(base mb.Module, metricsets []string, register *mb.Register) error {
+func ConfigureModule(base mb.Module, xpackEnabledMetricsets []string, register *mb.Register) error {
 	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
+		XPackEnabled bool `config:"xpack.enabled"`
 	}{}
 	if err := base.UnpackConfig(&config); err != nil {
 		return err
@@ -148,7 +147,7 @@ func ReConfigureXPackEnabledMetricSets(base mb.Module, metricsets []string, regi
 	}
 
 	// These metricsets are exactly the ones required if xpack.enabled == true
-	raw["metricsets"] = metricsets
+	raw["metricsets"] = xpackEnabledMetricsets
 
 	newConfig, err := common.NewConfigFrom(raw)
 	if err != nil {

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -158,7 +158,7 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 		return errors.Wrapf(err, "could not create new configuration for module %v", moduleName)
 	}
 
-	if err := base.ReConfigure(newConfig, register); err != nil {
+	if err := base.Reconfigure(newConfig, register); err != nil {
 		return errors.Wrapf(err, "could not reconfigure module %v", moduleName)
 	}
 

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -128,7 +128,7 @@ func FixTimestampField(m common.MapStr, field string) error {
 	return nil
 }
 
-func ConfigureModule(base mb.Module, xpackEnabledMetricsets []string, register *mb.Register) error {
+func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, register *mb.Register) error {
 	config := struct {
 		XPackEnabled bool `config:"xpack.enabled"`
 	}{}

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -130,12 +130,14 @@ func FixTimestampField(m common.MapStr, field string) error {
 	return nil
 }
 
-func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, register *mb.Register) error {
+func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, register *mb.Register, logger *logp.Logger) error {
+	moduleName := base.Name()
+
 	config := struct {
 		XPackEnabled bool `config:"xpack.enabled"`
 	}{}
 	if err := base.UnpackConfig(&config); err != nil {
-		return errors.Wrapf(err, "could not unpack configuration for module %v", base.Name())
+		return errors.Wrapf(err, "could not unpack configuration for module %v", moduleName)
 	}
 
 	// No special configuration is needed if xpack.enabled != true
@@ -145,7 +147,7 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 
 	var raw common.MapStr
 	if err := base.UnpackConfig(&raw); err != nil {
-		return errors.Wrapf(err, "could not unpack configuration for module %v", base.Name())
+		return errors.Wrapf(err, "could not unpack configuration for module %v", moduleName)
 	}
 
 	// These metricsets are exactly the ones required if xpack.enabled == true
@@ -153,12 +155,14 @@ func ConfigureModule(base *mb.BaseModule, xpackEnabledMetricsets []string, regis
 
 	newConfig, err := common.NewConfigFrom(raw)
 	if err != nil {
-		return errors.Wrapf(err, "could not create new configuration for module %v", base.Name())
+		return errors.Wrapf(err, "could not create new configuration for module %v", moduleName)
 	}
 
 	if err := base.ReConfigure(newConfig, register); err != nil {
-		return errors.Wrapf(err, "could not reconfigure module %v", base.Name())
+		return errors.Wrapf(err, "could not reconfigure module %v", moduleName)
 	}
+
+	logger.Debugf("configuration for module %v modified because xpack.enabled was set to true", moduleName)
 
 	return nil
 }

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -128,7 +128,7 @@ func FixTimestampField(m common.MapStr, field string) error {
 	return nil
 }
 
-func ReconfigureXPackEnabledMetricSets(base *mb.BaseModule, metricsets []string) error {
+func ReConfigureXPackEnabledMetricSets(base mb.Module, metricsets []string, register *mb.Register) error {
 	config := struct {
 		Metricsets   []string `config:"metricsets"`
 		XPackEnabled bool     `config:"xpack.enabled"`
@@ -155,7 +155,7 @@ func ReconfigureXPackEnabledMetricSets(base *mb.BaseModule, metricsets []string)
 		return err
 	}
 
-	if err := base.Reconfigure(newConfig); err != nil {
+	if err := base.ReConfigure(newConfig, register); err != nil {
 		return err
 	}
 

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -143,7 +143,7 @@ func TestFixTimestampField(t *testing.T) {
 	}
 }
 
-func TestReconfigureXPackEnabledMetricSets(t *testing.T) {
+func TestConfigureModule(t *testing.T) {
 	mockRegistry := mb.NewRegister()
 
 	const moduleName = "test_module"

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -201,11 +201,11 @@ func TestConfigureModule(t *testing.T) {
 				require.Fail(t, "expecting module to be base module")
 			}
 
-			err = ConfigureModule(bm, test.xpackEnabledMetricsets, logp.L())
+			newM, err := NewModule(bm, test.xpackEnabledMetricsets, logp.L())
 			require.NoError(t, err)
 
 			var newConfig metricSetConfig
-			err = bm.UnpackConfig(&newConfig)
+			err = newM.UnpackConfig(&newConfig)
 			require.NoError(t, err)
 			require.Equal(t, test.newConfig, newConfig)
 		})

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -199,7 +201,7 @@ func TestConfigureModule(t *testing.T) {
 				require.Fail(t, "expecting module to be base module")
 			}
 
-			err = ConfigureModule(bm, test.xpackEnabledMetricsets, mockRegistry)
+			err = ConfigureModule(bm, test.xpackEnabledMetricsets, logp.L())
 			require.NoError(t, err)
 
 			var newConfig metricSetConfig

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -101,7 +101,7 @@ func TestFixTimestampField(t *testing.T) {
 		{
 			"converts float64s in scientific notation to ints",
 			map[string]interface{}{
-				"foo": 1.571284349E12,
+				"foo": 1.571284349e12,
 			},
 			map[string]interface{}{
 				"foo": 1571284349000,

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -21,12 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -194,11 +194,16 @@ func TestReconfigureXPackEnabledMetricSets(t *testing.T) {
 			m, _, err := mb.NewModule(cfg, mockRegistry)
 			require.NoError(t, err)
 
-			err = ConfigureModule(m, test.xpackEnabledMetricsets, mockRegistry)
+			bm, ok := m.(*mb.BaseModule)
+			if !ok {
+				require.Fail(t, "expecting module to be base module")
+			}
+
+			err = ConfigureModule(bm, test.xpackEnabledMetricsets, mockRegistry)
 			require.NoError(t, err)
 
 			var newConfig metricSetConfig
-			err = m.UnpackConfig(&newConfig)
+			err = bm.UnpackConfig(&newConfig)
 			require.NoError(t, err)
 			require.Equal(t, test.newConfig, newConfig)
 		})

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -139,4 +141,82 @@ func TestFixTimestampField(t *testing.T) {
 			assert.Equal(t, test.ExpectedValue, test.OriginalValue)
 		})
 	}
+}
+
+func TestReconfigureXPackEnabledMetricSets(t *testing.T) {
+	mockRegistry := mb.NewRegister()
+
+	const moduleName = "test_module"
+
+	err := mockRegistry.AddMetricSet(moduleName, "foo", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "bar", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "qux", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "baz", mockMetricSetFactory)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		initConfig             metricSetConfig
+		xpackEnabledMetricsets []string
+		newConfig              metricSetConfig
+	}{
+		"no_xpack_enabled": {
+			metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"foo", "bar"},
+			},
+			[]string{"baz", "qux", "foo"},
+			metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"foo", "bar"},
+			},
+		},
+		"xpack_enabled": {
+			metricSetConfig{
+				Module:       moduleName,
+				XPackEnabled: true,
+				MetricSets:   []string{"foo", "bar"},
+			},
+			[]string{"baz", "qux", "foo"},
+			metricSetConfig{
+				Module:       moduleName,
+				XPackEnabled: true,
+				MetricSets:   []string{"baz", "qux", "foo"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := common.MustNewConfigFrom(test.initConfig)
+			m, _, err := mb.NewModule(cfg, mockRegistry)
+			require.NoError(t, err)
+
+			err = ReConfigureXPackEnabledMetricSets(m, test.xpackEnabledMetricsets, mockRegistry)
+			require.NoError(t, err)
+
+			var newConfig metricSetConfig
+			err = m.UnpackConfig(&newConfig)
+			require.NoError(t, err)
+			require.Equal(t, test.newConfig, newConfig)
+		})
+	}
+}
+
+type mockMetricSet struct {
+	mb.BaseMetricSet
+}
+
+func (m *mockMetricSet) Fetch(r mb.ReporterV2) error { return nil }
+
+type metricSetConfig struct {
+	Module       string   `config:"module"`
+	MetricSets   []string `config:"metricsets"`
+	XPackEnabled bool     `config:"xpack.enabled"`
+}
+
+func mockMetricSetFactory(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	return &mockMetricSet{base}, nil
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -194,7 +194,7 @@ func TestReconfigureXPackEnabledMetricSets(t *testing.T) {
 			m, _, err := mb.NewModule(cfg, mockRegistry)
 			require.NoError(t, err)
 
-			err = ReConfigureXPackEnabledMetricSets(m, test.xpackEnabledMetricsets, mockRegistry)
+			err = ConfigureModule(m, test.xpackEnabledMetricsets, mockRegistry)
 			require.NoError(t, err)
 
 			var newConfig metricSetConfig

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -63,17 +63,9 @@ const (
 
 // Module is the common interface for all Module implementations.
 type Module interface {
-	// Name returns the name of the Module.
-	Name() string
-
-	// Config returns the ModuleConfig used to create the Module.
-	Config() ModuleConfig
-
-	// UnpackConfig unpacks the raw module config to the given object.
-	UnpackConfig(to interface{}) error
-
-	// ReConfigure reconfigures the module with the new configuration object.
-	ReConfigure(config *common.Config, register *Register) error
+	Name() string                      // Name returns the name of the Module.
+	Config() ModuleConfig              // Config returns the ModuleConfig used to create the Module.
+	UnpackConfig(to interface{}) error // UnpackConfig unpacks the raw module config to the given object.
 }
 
 // BaseModule implements the Module interface.

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -63,10 +63,17 @@ const (
 
 // Module is the common interface for all Module implementations.
 type Module interface {
-	Name() string                                                // Name returns the name of the Module.
-	Config() ModuleConfig                                        // Config returns the ModuleConfig used to create the Module.
-	UnpackConfig(to interface{}) error                           // UnpackConfig unpacks the raw module config to the given object.
-	ReConfigure(config *common.Config, register *Register) error // ReConfigure reconfigures the module with the new configuration object.
+	// Name returns the name of the Module.
+	Name() string
+
+	// Config returns the ModuleConfig used to create the Module.
+	Config() ModuleConfig
+
+	// UnpackConfig unpacks the raw module config to the given object.
+	UnpackConfig(to interface{}) error
+
+	// ReConfigure reconfigures the module with the new configuration object.
+	ReConfigure(config *common.Config, register *Register) error
 }
 
 // BaseModule implements the Module interface.

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -63,9 +63,10 @@ const (
 
 // Module is the common interface for all Module implementations.
 type Module interface {
-	Name() string                      // Name returns the name of the Module.
-	Config() ModuleConfig              // Config returns the ModuleConfig used to create the Module.
-	UnpackConfig(to interface{}) error // UnpackConfig unpacks the raw module config to the given object.
+	Name() string                                                // Name returns the name of the Module.
+	Config() ModuleConfig                                        // Config returns the ModuleConfig used to create the Module.
+	UnpackConfig(to interface{}) error                           // UnpackConfig unpacks the raw module config to the given object.
+	ReConfigure(config *common.Config, register *Register) error // ReConfigure reconfigures the module with the new configuration object.
 }
 
 // BaseModule implements the Module interface.

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -96,7 +96,8 @@ func (m *BaseModule) UnpackConfig(to interface{}) error {
 	return m.rawConfig.Unpack(to)
 }
 
-// ReConfigure re-configures the module with the given raw configuration
+// ReConfigure re-configures the module with the given raw configuration. Intended to
+// be called from module factories.
 func (m *BaseModule) ReConfigure(config *common.Config, register *Register) error {
 	currName := m.name
 	currConfig := m.config

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -27,6 +27,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
@@ -92,6 +94,16 @@ func (m *BaseModule) Config() ModuleConfig { return m.config }
 // UnpackConfig unpacks the raw module config to the given object.
 func (m *BaseModule) UnpackConfig(to interface{}) error {
 	return m.rawConfig.Unpack(to)
+}
+
+func (m *BaseModule) Reconfigure(config *common.Config) error {
+	newM, err := newBaseModuleFromConfig(config)
+	if err != nil {
+		return errors.Wrapf(err, "could not reconfigure module %v", m.Name())
+	}
+
+	*m = newM
+	return nil
 }
 
 // MetricSet interfaces

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -96,9 +96,9 @@ func (m *BaseModule) UnpackConfig(to interface{}) error {
 	return m.rawConfig.Unpack(to)
 }
 
-// ReConfigure re-configures the module with the given raw configuration. Intended to
+// Reconfigure re-configures the module with the given raw configuration. Intended to
 // be called from module factories.
-func (m *BaseModule) ReConfigure(config *common.Config, register *Register) error {
+func (m *BaseModule) Reconfigure(config *common.Config, register *Register) error {
 	currName := m.name
 	currConfig := m.config
 	currRawConfig := m.rawConfig

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -465,16 +465,20 @@ func TestModuleReConfigure(t *testing.T) {
 			require.NoError(t, err)
 
 			err = m.ReConfigure(common.MustNewConfigFrom(test.newConfig), mockRegistry)
+
+			var expectedNewConfig metricSetConfig
 			if test.expectedErrMsg == "" {
 				require.NoError(t, err)
-
-				var actualNewConfig metricSetConfig
-				err = m.UnpackConfig(&actualNewConfig)
-				require.NoError(t, err)
-				require.Equal(t, test.expectedConfig, actualNewConfig)
+				expectedNewConfig = test.expectedConfig
 			} else {
 				require.Equal(t, test.expectedErrMsg, err.Error())
+				expectedNewConfig = initConfig
 			}
+
+			var actualNewConfig metricSetConfig
+			err = m.UnpackConfig(&actualNewConfig)
+			require.NoError(t, err)
+			require.Equal(t, expectedNewConfig, actualNewConfig)
 
 		})
 	}

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -409,11 +409,7 @@ func TestModuleConfigQueryParams(t *testing.T) {
 	assert.NotEqual(t, "&", res[len(res)-1])
 }
 
-<<<<<<< HEAD
 func TestBaseModuleWithConfig(t *testing.T) {
-=======
-func TestModuleReConfigure(t *testing.T) {
->>>>>>> Adding tests for ReConfigure() / making it part of Module interface
 	mockRegistry := NewRegister()
 
 	const moduleName = "test_module"
@@ -471,12 +467,18 @@ func TestModuleReConfigure(t *testing.T) {
 			if err == nil {
 				var actualNewConfig metricSetConfig
 				err = newBM.UnpackConfig(&actualNewConfig)
+
 				require.NoError(t, err)
-				require.Equal(t, test.expectedConfig, actualNewConfig)
+				expectedNewConfig = test.expectedConfig
 			} else {
 				require.Equal(t, test.expectedErrMsg, err.Error())
 				require.Nil(t, newBM)
 			}
+
+			var actualNewConfig metricSetConfig
+			err = m.UnpackConfig(&actualNewConfig)
+			require.NoError(t, err)
+			require.Equal(t, expectedNewConfig, actualNewConfig)
 
 		})
 	}

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -467,19 +467,12 @@ func TestBaseModuleWithConfig(t *testing.T) {
 			if err == nil {
 				var actualNewConfig metricSetConfig
 				err = newBM.UnpackConfig(&actualNewConfig)
-
 				require.NoError(t, err)
-				expectedNewConfig = test.expectedConfig
+				require.Equal(t, test.expectedConfig, actualNewConfig)
 			} else {
 				require.Equal(t, test.expectedErrMsg, err.Error())
 				require.Nil(t, newBM)
 			}
-
-			var actualNewConfig metricSetConfig
-			err = newBM.UnpackConfig(&actualNewConfig)
-			require.NoError(t, err)
-			require.Equal(t, expectedNewConfig, actualNewConfig)
-
 		})
 	}
 }

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -409,7 +409,7 @@ func TestModuleConfigQueryParams(t *testing.T) {
 	assert.NotEqual(t, "&", res[len(res)-1])
 }
 
-func TestModuleReconfigure(t *testing.T) {
+func TestBaseModuleWithConfig(t *testing.T) {
 	mockRegistry := NewRegister()
 
 	const moduleName = "test_module"
@@ -464,7 +464,12 @@ func TestModuleReconfigure(t *testing.T) {
 			m, _, err := NewModule(common.MustNewConfigFrom(initConfig), mockRegistry)
 			require.NoError(t, err)
 
-			err = m.Reconfigure(common.MustNewConfigFrom(test.newConfig), mockRegistry)
+			bm, ok := m.(*BaseModule)
+			if !ok {
+				require.Fail(t, "expecting module to be base module")
+			}
+
+			newBM, err := bm.WithConfig(common.MustNewConfigFrom(test.newConfig), mockRegistry)
 
 			var expectedNewConfig metricSetConfig
 			if test.expectedErrMsg == "" {
@@ -476,7 +481,7 @@ func TestModuleReconfigure(t *testing.T) {
 			}
 
 			var actualNewConfig metricSetConfig
-			err = m.UnpackConfig(&actualNewConfig)
+			err = newBM.UnpackConfig(&actualNewConfig)
 			require.NoError(t, err)
 			require.Equal(t, expectedNewConfig, actualNewConfig)
 

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -409,7 +409,7 @@ func TestModuleConfigQueryParams(t *testing.T) {
 	assert.NotEqual(t, "&", res[len(res)-1])
 }
 
-func TestModuleReConfigure(t *testing.T) {
+func TestModuleReconfigure(t *testing.T) {
 	mockRegistry := NewRegister()
 
 	const moduleName = "test_module"
@@ -464,7 +464,7 @@ func TestModuleReConfigure(t *testing.T) {
 			m, _, err := NewModule(common.MustNewConfigFrom(initConfig), mockRegistry)
 			require.NoError(t, err)
 
-			err = m.ReConfigure(common.MustNewConfigFrom(test.newConfig), mockRegistry)
+			err = m.Reconfigure(common.MustNewConfigFrom(test.newConfig), mockRegistry)
 
 			var expectedNewConfig metricSetConfig
 			if test.expectedErrMsg == "" {

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -409,7 +409,11 @@ func TestModuleConfigQueryParams(t *testing.T) {
 	assert.NotEqual(t, "&", res[len(res)-1])
 }
 
+<<<<<<< HEAD
 func TestBaseModuleWithConfig(t *testing.T) {
+=======
+func TestModuleReConfigure(t *testing.T) {
+>>>>>>> Adding tests for ReConfigure() / making it part of Module interface
 	mockRegistry := NewRegister()
 
 	const moduleName = "test_module"

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -476,7 +476,7 @@ func TestBaseModuleWithConfig(t *testing.T) {
 			}
 
 			var actualNewConfig metricSetConfig
-			err = m.UnpackConfig(&actualNewConfig)
+			err = newBM.UnpackConfig(&actualNewConfig)
 			require.NoError(t, err)
 			require.Equal(t, expectedNewConfig, actualNewConfig)
 

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -69,9 +69,10 @@ type TestModule struct {
 	RawConfig *common.Config
 }
 
-func (m *TestModule) Name() string                      { return m.ModName }
-func (m *TestModule) Config() mb.ModuleConfig           { return m.ModConfig }
-func (m *TestModule) UnpackConfig(to interface{}) error { return m.RawConfig.Unpack(to) }
+func (m *TestModule) Name() string                                                   { return m.ModName }
+func (m *TestModule) Config() mb.ModuleConfig                                        { return m.ModConfig }
+func (m *TestModule) UnpackConfig(to interface{}) error                              { return m.RawConfig.Unpack(to) }
+func (m *TestModule) ReConfigure(config *common.Config, register *mb.Register) error { return nil }
 
 func NewTestModule(t testing.TB, config interface{}) *TestModule {
 	c, err := common.NewConfigFrom(config)

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -69,10 +69,9 @@ type TestModule struct {
 	RawConfig *common.Config
 }
 
-func (m *TestModule) Name() string                                                   { return m.ModName }
-func (m *TestModule) Config() mb.ModuleConfig                                        { return m.ModConfig }
-func (m *TestModule) UnpackConfig(to interface{}) error                              { return m.RawConfig.Unpack(to) }
-func (m *TestModule) ReConfigure(config *common.Config, register *mb.Register) error { return nil }
+func (m *TestModule) Name() string                      { return m.ModName }
+func (m *TestModule) Config() mb.ModuleConfig           { return m.ModConfig }
+func (m *TestModule) UnpackConfig(to interface{}) error { return m.RawConfig.Unpack(to) }
 
 func NewTestModule(t testing.TB, config interface{}) *TestModule {
 	c, err := common.NewConfigFrom(config)

--- a/metricbeat/module/beat/_meta/config-xpack.yml
+++ b/metricbeat/module/beat/_meta/config-xpack.yml
@@ -1,10 +1,7 @@
 - module: beat
-  metricsets:
-    - stats
-    - state
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:5066"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -11,4 +11,4 @@ The `beat` module work with {beats} 7.3.0 and later.
 The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
-metricbeat modules enable beat-xpack`.
+`metricbeat modules enable beat-xpack`.

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -1,12 +1,15 @@
-There are two modules that collect metrics about any Beat or other software based on libbeat:
-
-* The `beat` module tracks only the high-level metrics. The default metricsets in
-this module are `state` and `stats`.
-* The `beat-xpack` module enables you to monitor more Beat metrics with our
-{stack} {monitor-features}. The metricsets automatically configured by this module
-are `state` and `stats`.
+The `beat` module collects metrics about any Beat or other software based on libbeat.
 
 [float]
 === Compatibility
 
-Both modules work with {ls} 7.3.0 and later.
+The `beat` module work with {beats} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
+metricbeat modules enable beat-xpack`.
+

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -3,7 +3,7 @@ The `beat` module collects metrics about any Beat or other software based on lib
 [float]
 === Compatibility
 
-The `beat` module work with {beats} 7.3.0 and later.
+The `beat` module works with {beats} 7.3.0 and later.
 
 [float]
 === Usage for Stack Monitoring

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -12,4 +12,3 @@ The `beat` module can be used to collect metrics shown in our {stack} {monitor-f
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
 metricbeat modules enable beat-xpack`.
-

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -1,10 +1,12 @@
-The Beat module contains a minimal set of metrics to enable monitoring of any Beat or other software based on libbeat across
-multiple versions. To monitor more Beat metrics, use our {stack}
-{monitor-features}.
+There are two modules that collect metrics about any Beat or other software based on libbeat:
 
-The default metricsets are `state` and `stats`.
+* The `beat` module tracks only the high-level metrics. The default metricsets in
+this module are `state` and `stats`.
+* The `beat-xpack` module enables you to monitor more Beat metrics with our
+{stack} {monitor-features}. The metricsets automatically configured by this module
+are `state` and `stats`.
 
 [float]
 === Compatibility
 
-The Beat module works with Beats 7.3.0 and later.
+Both modules work with {ls} 7.3.0 and later.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
-
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
+	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -39,7 +39,8 @@ func init() {
 
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, mb.Registry); err != nil {
+	logger := logp.NewLogger(ModuleName)
+	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, mb.Registry, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
@@ -39,12 +37,7 @@ func init() {
 
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, logger); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
-	}
-
-	return &base, nil
+	return elastic.NewModule(&base, []string{"state", "stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -22,7 +22,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
+
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
@@ -45,37 +46,8 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 
 // Reconfigure module with required metricsets if xpack.enabled = true.
 func reconfigure(base *mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// No special configuration is needed if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	var raw common.MapStr
-	if err := base.UnpackConfig(&raw); err != nil {
-		return err
-	}
-
-	// These metricsets are exactly the ones required if xpack.enabled == true
-	raw["metricsets"] = []string{"state", "stats"}
-
-	newConfig, err := common.NewConfigFrom(raw)
-	if err != nil {
-		return err
-	}
-
-	if err := base.Reconfigure(newConfig); err != nil {
-		return err
-	}
-
-	return nil
+	metricSets := []string{"state", "stats"}
+	return elastic.ReconfigureXPackEnabledMetricSets(base, metricSets)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
@@ -35,19 +37,13 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := reconfigure(&base); err != nil {
-		return nil, err
+	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, mb.Registry); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 
 	return &base, nil
-}
-
-// ReConfigure module with required metricsets if xpack.enabled = true.
-func reconfigure(base *mb.BaseModule) error {
-	metricSets := []string{"state", "stats"}
-	return elastic.ReConfigureXPackEnabledMetricSets(base, metricSets, mb.Registry)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -44,10 +44,10 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	return &base, nil
 }
 
-// Reconfigure module with required metricsets if xpack.enabled = true.
+// ReConfigure module with required metricsets if xpack.enabled = true.
 func reconfigure(base *mb.BaseModule) error {
 	metricSets := []string{"state", "stats"}
-	return elastic.ReconfigureXPackEnabledMetricSets(base, metricSets)
+	return elastic.ReConfigureXPackEnabledMetricSets(base, metricSets, mb.Registry)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -40,7 +40,7 @@ func init() {
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
 	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, mb.Registry, logger); err != nil {
+	if err := elastic.ConfigureModule(&base, []string{"state", "stats"}, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/beat/beat_test.go
+++ b/metricbeat/module/beat/beat_test.go
@@ -24,6 +24,8 @@ import (
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/metricbeat/module/beat"
+
+	// Make sure metricsets are registered in mb.Registry
 	_ "github.com/elastic/beats/v7/metricbeat/module/beat/state"
 	_ "github.com/elastic/beats/v7/metricbeat/module/beat/stats"
 )
@@ -40,8 +42,7 @@ func TestXPackEnabledMetricsets(t *testing.T) {
 	for _, ms := range metricSets {
 		name := ms.Name()
 		switch name {
-		case "state":
-		case "stats":
+		case "state", "stats":
 		default:
 			t.Errorf("unexpected metricset name = %v", name)
 		}

--- a/metricbeat/module/beat/beat_test.go
+++ b/metricbeat/module/beat/beat_test.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/module/beat"
+	_ "github.com/elastic/beats/v7/metricbeat/module/beat/state"
+	_ "github.com/elastic/beats/v7/metricbeat/module/beat/stats"
+)
+
+func TestXPackEnabledMetricsets(t *testing.T) {
+	config := map[string]interface{}{
+		"module":        beat.ModuleName,
+		"hosts":         []string{"foobar:5066"},
+		"xpack.enabled": true,
+	}
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	require.Len(t, metricSets, 2)
+	for _, ms := range metricSets {
+		name := ms.Name()
+		switch name {
+		case "state":
+		case "stats":
+		default:
+			t.Errorf("unexpected metricset name = %v", name)
+		}
+	}
+}

--- a/metricbeat/module/elasticsearch/_meta/config-xpack.yml
+++ b/metricbeat/module/elasticsearch/_meta/config-xpack.yml
@@ -1,17 +1,7 @@
 - module: elasticsearch
-  metricsets:
-    - ccr
-    - cluster_stats
-    - enrich
-    - index
-    - index_recovery
-    - index_summary
-    - ml_job
-    - node_stats
-    - shard
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,14 +1,14 @@
-There are two modules that collect metrics about {es}: 
+There are two modules that collect metrics about {es}:
 
-* The Elasticsearch module contains a minimal set of metrics to enable
+* The `elasticsearch` module contains a minimal set of metrics to enable
 monitoring of Elasticsearch across multiple versions. The default metricsets in
 this module are `node` and `node_stats`.
-* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
-`index_summary`, `ml_job`, `node_stats`, and `shard`.
+* The `elasticsearch-xpack` module enables you to monitor more {es}
+metrics with our {stack} {monitor-features}. The metricsets automatically
+configured by this module are `ccr`, `cluster_stats`, `enrich`, ``index`,
+`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compatibility
 
-The Elasticsearch module works with Elasticsearch 6.7.0 and later.
+Both modules work with {es} 6.7.0 and later.

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,14 +1,14 @@
-There are two modules that collect metrics about {es}:
-
-* The `elasticsearch` module contains a minimal set of metrics to enable
-monitoring of Elasticsearch across multiple versions. The default metricsets in
-this module are `node` and `node_stats`.
-* The `elasticsearch-xpack` module enables you to monitor more {es}
-metrics with our {stack} {monitor-features}. The metricsets automatically
-configured by this module are `ccr`, `cluster_stats`, `enrich`, ``index`,
-`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
+The `elasticsearch` module collects metrics about {es}.
 
 [float]
 === Compatibility
 
-Both modules work with {es} 6.7.0 and later.
+The `elasticsearch` module works with {es} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -25,13 +25,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/mb"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
+	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
 func init() {
@@ -43,6 +43,7 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
+	logger := logp.NewLogger(ModuleName)
 	xpackEnabledMetricSets := []string{
 		"ccr",
 		"enrich",
@@ -54,7 +55,7 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		"node_stats",
 		"shard",
 	}
-	if err := elastic.ConfigureModule(&base, xpackEnabledMetricSets, mb.Registry); err != nil {
+	if err := elastic.ConfigureModule(&base, xpackEnabledMetricSets, mb.Registry, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -43,6 +43,7 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
+	logger := logp.NewLogger(ModuleName)
 	xpackEnabledMetricSets := []string{
 		"ccr",
 		"enrich",

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -55,7 +55,7 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		"node_stats",
 		"shard",
 	}
-	if err := elastic.ConfigureModule(&base, xpackEnabledMetricSets, mb.Registry, logger); err != nil {
+	if err := elastic.ConfigureModule(&base, xpackEnabledMetricSets, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -43,7 +43,6 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	logger := logp.NewLogger(ModuleName)
 	xpackEnabledMetricSets := []string{
 		"ccr",
 		"enrich",

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -43,7 +43,6 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	logger := logp.NewLogger(ModuleName)
 	xpackEnabledMetricSets := []string{
 		"ccr",
 		"enrich",
@@ -55,11 +54,7 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		"node_stats",
 		"shard",
 	}
-	if err := elastic.ConfigureModule(&base, xpackEnabledMetricSets, logger); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
-	}
-
-	return &base, nil
+	return elastic.NewModule(&base, xpackEnabledMetricSets, logp.NewLogger(ModuleName))
 }
 
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.

--- a/metricbeat/module/elasticsearch/elasticsearch_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package logstash_test
+package elasticsearch_test
 
 import (
 	"testing"
@@ -23,61 +23,34 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-	"github.com/elastic/beats/v7/metricbeat/module/logstash"
+	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 
 	// Make sure metricsets are registered in mb.Registry
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node"
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/ccr"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/cluster_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/enrich"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index_recovery"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index_summary"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/ml_job"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/node_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/shard"
 )
 
-func TestGetVertexClusterUUID(t *testing.T) {
-	tests := map[string]struct {
-		vertex              map[string]interface{}
-		overrideClusterUUID string
-		expectedClusterUUID string
-	}{
-		"vertex_and_override": {
-			map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			"o",
-			"v",
-		},
-		"vertex_only": {
-			vertex: map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			expectedClusterUUID: "v",
-		},
-		"override_only": {
-			overrideClusterUUID: "o",
-			expectedClusterUUID: "o",
-		},
-		"none": {
-			expectedClusterUUID: "",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
-		})
-	}
-}
-
-func TestXPackEnabledMetricSets(t *testing.T) {
+func TestXPackEnabledMetricsets(t *testing.T) {
 	config := map[string]interface{}{
-		"module":        logstash.ModuleName,
-		"hosts":         []string{"foobar:9600"},
+		"module":        elasticsearch.ModuleName,
+		"hosts":         []string{"foobar:9200"},
 		"xpack.enabled": true,
 	}
 
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
-	require.Len(t, metricSets, 2)
+	require.Len(t, metricSets, 9)
 	for _, ms := range metricSets {
 		name := ms.Name()
 		switch name {
-		case "node", "node_stats":
+		case "ccr", "enrich", "cluster_stats", "index", "index_recovery",
+			"index_summary", "ml_job", "node_stats", "shard":
 		default:
 			t.Errorf("unexpected metricset name = %v", name)
 		}

--- a/metricbeat/module/kibana/_meta/config-xpack.yml
+++ b/metricbeat/module/kibana/_meta/config-xpack.yml
@@ -1,9 +1,7 @@
 - module: kibana
-  metricsets:
-    - stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:5601"]
   #basepath: ""
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,11 +1,12 @@
-There are two modules that collect metrics about {kib}: 
+There are two modules that collect metrics about {kib}:
 
-* The Kibana module tracks only the high-level metrics. The default metricset in
+* The `kibana` module tracks only the high-level metrics. The default metricset in
 this module is `status`.
-* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{stack} {monitor-features}. The default metricset in this module is `stats`.
+* The `kibana-xpack` module enables you to monitor more {kib} metrics with our
+{stack} {monitor-features}. The metricset automatically configured by this module is
+`stats`.
 
 [float]
 === Compatibility
 
-The Kibana module works with Kibana 6.7.0 and later.
+Both modules work with {kib} 6.7.0 and later.

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,12 +1,14 @@
-There are two modules that collect metrics about {kib}:
-
-* The `kibana` module tracks only the high-level metrics. The default metricset in
-this module is `status`.
-* The `kibana-xpack` module enables you to monitor more {kib} metrics with our
-{stack} {monitor-features}. The metricset automatically configured by this module is
-`stats`.
+The `kibana` module collects metrics about {kib}.
 
 [float]
 === Compatibility
 
-Both modules work with {kib} 6.7.0 and later.
+The `kibana` module works with {kib} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
+`metricbeat modules enable kibana-xpack`.

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -39,39 +39,13 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
-		return nil, err
+	if err := elastic.ConfigureModule(&base, []string{"stats"}, mb.Registry); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 
 	return &base, nil
-}
-
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// Nothing to validate if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	expectedXPackMetricsets := []string{
-		"stats",
-	}
-
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
-	}
-
-	return nil
 }
 
 // ModuleName is the name of this module

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -23,8 +23,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
@@ -41,12 +39,7 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"stats"}, logger); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
-	}
-
-	return &base, nil
+	return elastic.NewModule(&base, []string{"stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -42,7 +42,7 @@ func init() {
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
 	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"stats"}, mb.Registry, logger); err != nil {
+	if err := elastic.ConfigureModule(&base, []string{"stats"}, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
-
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -41,7 +41,8 @@ func init() {
 
 // NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := elastic.ConfigureModule(&base, []string{"stats"}, mb.Registry); err != nil {
+	logger := logp.NewLogger(ModuleName)
+	if err := elastic.ConfigureModule(&base, []string{"stats"}, mb.Registry, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,12 +20,13 @@ package kibana_test
 import (
 	"testing"
 
-	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/metricbeat/module/kibana"
+
+	// Make sure metricsets are registered in mb.Registry
 	_ "github.com/elastic/beats/v7/metricbeat/module/kibana/stats"
 )
 

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,6 +20,8 @@ package kibana_test
 import (
 	"testing"
 
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,8 +20,6 @@ package kibana_test
 import (
 	"testing"
 
-	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -15,14 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package kibana
+package kibana_test
 
 import (
 	"testing"
 
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/metricbeat/module/kibana"
+	_ "github.com/elastic/beats/v7/metricbeat/module/kibana/stats"
 )
 
 func TestIsStatsAPIAvailable(t *testing.T) {
@@ -37,7 +41,19 @@ func TestIsStatsAPIAvailable(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := IsStatsAPIAvailable(common.MustNewVersion(test.input))
+		actual := kibana.IsStatsAPIAvailable(common.MustNewVersion(test.input))
 		require.Equal(t, test.expected, actual)
 	}
+}
+
+func TestXPackEnabledMetricsets(t *testing.T) {
+	config := map[string]interface{}{
+		"module":        kibana.ModuleName,
+		"hosts":         []string{"foobar:5601"},
+		"xpack.enabled": true,
+	}
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	require.Len(t, metricSets, 1)
+	require.Equal(t, "stats", metricSets[0].Name())
 }

--- a/metricbeat/module/logstash/_meta/config-xpack.yml
+++ b/metricbeat/module/logstash/_meta/config-xpack.yml
@@ -1,9 +1,6 @@
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:9600"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -1,8 +1,12 @@
-This is the Logstash module.
+There are two modules that collect metrics about {ls}:
 
-The default metricsets are `node` and `node_stats`.
+* The `logstash` module tracks only the high-level metrics. The default metricsets in
+this module are `node` and `node_stats`.
+* The `logstash-xpack` module enables you to monitor more {ls} metrics with our
+{stack} {monitor-features}. The metricsets automatically configured by this module
+are `node` and `node_stats`.
 
 [float]
 === Compatibility
 
-The Logstash module works with Logstash 7.3.0 and later.
+Both modules work with {ls} 7.3.0 and later.

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -1,12 +1,14 @@
-There are two modules that collect metrics about {ls}:
-
-* The `logstash` module tracks only the high-level metrics. The default metricsets in
-this module are `node` and `node_stats`.
-* The `logstash-xpack` module enables you to monitor more {ls} metrics with our
-{stack} {monitor-features}. The metricsets automatically configured by this module
-are `node` and `node_stats`.
+The `logstash` module collects metrics about {ls}.
 
 [float]
 === Compatibility
 
-Both modules work with {ls} 7.3.0 and later.
+The `logstash` module works with {ls} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
+`metricbeat modules enable logstash-xpack`.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -48,37 +48,8 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 
 // Reconfigure module with required metricsets if xpack.enabled = true.
 func reconfigure(base *mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// No special configuration is needed if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	var raw common.MapStr
-	if err := base.UnpackConfig(&raw); err != nil {
-		return err
-	}
-
-	// These metricsets are exactly the ones required if xpack.enabled == true
-	raw["metricsets"] = []string{"node", "node_stats"}
-
-	newConfig, err := common.NewConfigFrom(raw)
-	if err != nil {
-		return err
-	}
-
-	if err := base.Reconfigure(newConfig); err != nil {
-		return err
-	}
-
-	return nil
+	metricSets := []string{"node", "node_stats"}
+	return elastic.ReconfigureXPackEnabledMetricSets(base, metricSets)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -37,19 +37,13 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := reconfigure(&base); err != nil {
-		return nil, err
+	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, mb.Registry); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 
 	return &base, nil
-}
-
-// ReConfigure module with required metricsets if xpack.enabled = true.
-func reconfigure(base *mb.BaseModule) error {
-	metricSets := []string{"node", "node_stats"}
-	return elastic.ReConfigureXPackEnabledMetricSets(base, metricSets, mb.Registry)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -39,15 +39,15 @@ func init() {
 
 // NewModule creates a new module after performing validation.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
+	if err := reconfigure(&base); err != nil {
 		return nil, err
 	}
 
 	return &base, nil
 }
 
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
+// Reconfigure module with required metricsets if xpack.enabled = true.
+func reconfigure(base *mb.BaseModule) error {
 	config := struct {
 		Metricsets   []string `config:"metricsets"`
 		XPackEnabled bool     `config:"xpack.enabled"`
@@ -56,18 +56,26 @@ func validateXPackMetricsets(base mb.BaseModule) error {
 		return err
 	}
 
-	// Nothing to validate if xpack.enabled != true
+	// No special configuration is needed if xpack.enabled != true
 	if !config.XPackEnabled {
 		return nil
 	}
 
-	expectedXPackMetricsets := []string{
-		"node",
-		"node_stats",
+	var raw common.MapStr
+	if err := base.UnpackConfig(&raw); err != nil {
+		return err
 	}
 
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
+	// These metricsets are exactly the ones required if xpack.enabled == true
+	raw["metricsets"] = []string{"node", "node_stats"}
+
+	newConfig, err := common.NewConfigFrom(raw)
+	if err != nil {
+		return err
+	}
+
+	if err := base.Reconfigure(newConfig); err != nil {
+		return err
 	}
 
 	return nil

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -40,12 +40,7 @@ func init() {
 
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, logger); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
-	}
-
-	return &base, nil
+	return elastic.NewModule(&base, []string{"node", "node_stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -41,7 +41,7 @@ func init() {
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
 	logger := logp.NewLogger(ModuleName)
-	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, mb.Registry, logger); err != nil {
+	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -46,10 +46,10 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	return &base, nil
 }
 
-// Reconfigure module with required metricsets if xpack.enabled = true.
+// ReConfigure module with required metricsets if xpack.enabled = true.
 func reconfigure(base *mb.BaseModule) error {
 	metricSets := []string{"node", "node_stats"}
-	return elastic.ReconfigureXPackEnabledMetricSets(base, metricSets)
+	return elastic.ReConfigureXPackEnabledMetricSets(base, metricSets, mb.Registry)
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -39,7 +40,8 @@ func init() {
 
 // NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, mb.Registry); err != nil {
+	logger := logp.NewLogger(ModuleName)
+	if err := elastic.ConfigureModule(&base, []string{"node", "node_stats"}, mb.Registry, logger); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error configuring %v module", ModuleName))
 	}
 

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -63,7 +63,7 @@ func TestGetVertexClusterUUID(t *testing.T) {
 	}
 }
 
-func TestXPackEnabledMetricsets(t *testing.T) {
+func TestXPackEnabledMetricSets(t *testing.T) {
 	config := map[string]interface{}{
 		"module":        logstash.ModuleName,
 		"hosts":         []string{"foobar:9600"},

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -15,11 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package logstash
+package logstash_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/module/logstash"
+	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node"
+	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node_stats"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,7 +59,27 @@ func TestGetVertexClusterUUID(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expectedClusterUUID, GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
+			assert.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
 		})
+	}
+}
+
+func TestXPackEnabledMetricsets(t *testing.T) {
+	config := map[string]interface{}{
+		"module":        logstash.ModuleName,
+		"hosts":         []string{"foobar:9600"},
+		"xpack.enabled": true,
+	}
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	require.Len(t, metricSets, 2)
+	for _, ms := range metricSets {
+		name := ms.Name()
+		switch name {
+		case "node":
+		case "node_stats":
+		default:
+			t.Errorf("unexpected metricset name = %v", name)
+		}
 	}
 }

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/module/logstash"
 	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node"
 	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node_stats"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVertexClusterUUID(t *testing.T) {
@@ -59,7 +58,7 @@ func TestGetVertexClusterUUID(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
+			require.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
 		})
 	}
 }

--- a/metricbeat/modules.d/beat-xpack.yml.disabled
+++ b/metricbeat/modules.d/beat-xpack.yml.disabled
@@ -2,12 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-beat.html
 
 - module: beat
-  metricsets:
-    - stats
-    - state
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:5066"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
@@ -2,19 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
-  metricsets:
-    - ccr
-    - cluster_stats
-    - enrich
-    - index
-    - index_recovery
-    - index_summary
-    - ml_job
-    - node_stats
-    - shard
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/modules.d/kibana-xpack.yml.disabled
+++ b/metricbeat/modules.d/kibana-xpack.yml.disabled
@@ -2,11 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
 
 - module: kibana
-  metricsets:
-    - stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:5601"]
   #basepath: ""
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/modules.d/logstash-xpack.yml.disabled
+++ b/metricbeat/modules.d/logstash-xpack.yml.disabled
@@ -2,11 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
 
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:9600"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true


### PR DESCRIPTION
## What does this PR do?

Metricbeat offers four Elastic stack modules that can be used to collect and index data intended for the Stack Monitoring UI in Kibana: `elasticsearch`, `kibana`, `logstash`, and `beat`.

Each of these modules' configurations accepts an optional boolean flag, `xpack.enabled`. By default, this flag is not set, in which case it's default value, `false` is used. When this flat is set to `true`, this signals to the modules that they are to be used for the express purpose of collecting data for the Stack Monitoring UI in Kibana. In this case, specific metricsets in the module must be enabled, as the UI expects data collected by these metricsets to function properly.

This PR makes it so that if `xpack.enabled: true` is set in a stack module's configuration, the required metricsets are automatically enabled in the module's configuration.

## Why is it important?

Without such automatic configuration the user must manually configure exactly the required metricsets when `xpack.enabled: true` is set.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes elastic/beats#16471
