### PR TITLE
Cherry-pick #17608 to 7.7: [Metricbeat] Fix "ID" event generator of Google Cloud module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -192,6 +192,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Unix socket path in memcached. {pull}17512[17512]
 - Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
+- Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #17608 to 7.7 branch. Original message: 

Fixes that ID that is generated for each TimeSeries event returned by Google Cloud. Fixes https://github.com/elastic/beats/issues/17160

![image](https://user-images.githubusercontent.com/4249331/78779975-32a9bd80-799e-11ea-88c9-4c930fa66bd3.png)

