### PR TITLE
Cherry-pick #17608 to 7.6: [Metricbeat] Fix "ID" event generator of Google Cloud module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,6 +68,15 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix diskio issue for windows 32 bit on disk_performance struct alignment. {issue}16680[16680]
 - Reduce memory usage in `elasticsearch/index` metricset. {issue}16503[16503] {pull}16538[16538]
 - Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
+- Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
+- Fix how we filter services by name in system/service {pull}17400[17400]
+- Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
+- check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
+- Fix aws.s3.bucket.name terms_field in s3 overview dashboard. {pull}17542[17542]
+- Fix Unix socket path in memcached. {pull}17512[17512]
+- Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
+- Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
+- Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,14 +68,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix diskio issue for windows 32 bit on disk_performance struct alignment. {issue}16680[16680]
 - Reduce memory usage in `elasticsearch/index` metricset. {issue}16503[16503] {pull}16538[16538]
 - Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
-- Combine cloudwatch aggregated metrics into single event. {pull}17345[17345]
-- Fix how we filter services by name in system/service {pull}17400[17400]
-- Fix cloudwatch metricset missing tags collection. {issue}17419[17419] {pull}17424[17424]
-- check if cpuOptions field is nil in DescribeInstances output in ec2 metricset. {pull}17418[17418]
-- Fix aws.s3.bucket.name terms_field in s3 overview dashboard. {pull}17542[17542]
-- Fix Unix socket path in memcached. {pull}17512[17512]
-- Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
-- Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
 - Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/timeseries.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/timeseries.go
@@ -25,7 +25,7 @@ func (m *MetricSet) timeSeriesGrouped(ctx context.Context, gcpService googleclou
 			return nil, err
 		}
 
-		sdCollectorInputData := googlecloud.NewStackdriverCollectorInputData(ts, m.config.ProjectID, m.config.Zone, m.config.Region)
+		sdCollectorInputData := googlecloud.NewStackdriverCollectorInputData(ts, m.config.ProjectID, m.config.Zone)
 		if gcpService == nil {
 			metadataService = googlecloud.NewStackdriverMetadataServiceForTimeSeries(ts)
 		}

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/timeseries.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/timeseries.go
@@ -17,28 +17,29 @@ import (
 func (m *MetricSet) timeSeriesGrouped(ctx context.Context, gcpService googlecloud.MetadataService, tss []*monitoringpb.TimeSeries, e *incomingFieldExtractor) (map[string][]KeyValuePoint, error) {
 	eventGroups := make(map[string][]KeyValuePoint)
 
-	for _, ts := range tss {
-		if gcpService == nil {
-			gcpService = googlecloud.NewStackdriverMetadataServiceForTimeSeries(ts)
-		}
+	metadataService := gcpService
 
+	for _, ts := range tss {
 		keyValues, err := e.extractTimeSeriesMetricValues(ts)
 		if err != nil {
 			return nil, err
 		}
 
-		sdCollectorInputData := googlecloud.NewStackdriverCollectorInputData(ts, m.config.ProjectID, m.config.Zone)
+		sdCollectorInputData := googlecloud.NewStackdriverCollectorInputData(ts, m.config.ProjectID, m.config.Zone, m.config.Region)
+		if gcpService == nil {
+			metadataService = googlecloud.NewStackdriverMetadataServiceForTimeSeries(ts)
+		}
 
 		for i := range keyValues {
 			sdCollectorInputData.Timestamp = &keyValues[i].Timestamp
 
-			id, err := gcpService.ID(ctx, sdCollectorInputData)
+			id, err := metadataService.ID(ctx, sdCollectorInputData)
 			if err != nil {
 				m.Logger().Errorf("error trying to retrieve ID from metric event '%v'", err)
 				continue
 			}
 
-			metadataCollectorData, err := gcpService.Metadata(ctx, sdCollectorInputData.TimeSeries)
+			metadataCollectorData, err := metadataService.Metadata(ctx, sdCollectorInputData.TimeSeries)
 			if err != nil {
 				m.Logger().Error("error trying to retrieve labels from metric event")
 				continue


### PR DESCRIPTION
Cherry-pick of PR #17608 to 7.6 branch. Original message: 

Fixes that ID that is generated for each TimeSeries event returned by Google Cloud. Fixes https://github.com/elastic/beats/issues/17160

![image](https://user-images.githubusercontent.com/4249331/78779975-32a9bd80-799e-11ea-88c9-4c930fa66bd3.png)

