### PR TITLE
Cherry-pick #17590 to 7.x: [Metricbeat] Fix azure storage overview dashboard

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -192,6 +192,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix aws.s3.bucket.name terms_field in s3 overview dashboard. {pull}17542[17542]
 - Fix Unix socket path in memcached. {pull}17512[17512]
 - Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
+- Fix azure storage dashboards. {pull}17590[17590]
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-blob-storage-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-blob-storage-overview.json
@@ -23,11 +23,8 @@
                   "type": "phrase"
                 },
                 "query": {
-                  "match": {
-                    "azure.namespace": {
-                      "query": "Microsoft.Storage/storageAccounts/blobServices",
-                      "type": "phrase"
-                    }
+                  "match_phrase": {
+                    "azure.namespace": "Microsoft.Storage/storageAccounts/blobServices"
                   }
                 }
               }
@@ -56,7 +53,7 @@
             },
             "panelIndex": "ed5f5642-c94a-481b-a8c2-7dfe4c6a4f05",
             "panelRefName": "panel_0",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -72,7 +69,7 @@
             "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
             "panelRefName": "panel_1",
             "title": "Availability",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -87,7 +84,7 @@
             },
             "panelIndex": "0c873134-b025-487d-be81-f727dbff0174",
             "panelRefName": "panel_2",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -102,7 +99,7 @@
             },
             "panelIndex": "41faed50-ba96-4484-b6dc-71ed3e2d3427",
             "panelRefName": "panel_3",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -118,7 +115,7 @@
             "panelIndex": "1d623c03-4d02-4a81-b91e-49e82e112016",
             "panelRefName": "panel_4",
             "title": "Transactions",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -133,7 +130,7 @@
             },
             "panelIndex": "ff6441f8-d66d-4399-bae5-25d3d861b299",
             "panelRefName": "panel_5",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -149,7 +146,7 @@
             "panelIndex": "87066244-7840-4555-9d12-026d64977f1a",
             "panelRefName": "panel_6",
             "title": "Success Server Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -165,7 +162,7 @@
             "panelIndex": "756da375-e6a2-4668-af43-0cd294878254",
             "panelRefName": "panel_7",
             "title": "Success E2E Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -180,7 +177,7 @@
             },
             "panelIndex": "34aa5ce7-4f4b-4712-836f-3765e7c3fb3f",
             "panelRefName": "panel_8",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -196,7 +193,7 @@
             "panelIndex": "a715fafc-ca38-410c-9253-12ba506eabc0",
             "panelRefName": "panel_9",
             "title": "Egress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -212,7 +209,7 @@
             "panelIndex": "75f72920-be71-47a9-a967-f1c862ab2961",
             "panelRefName": "panel_10",
             "title": "Ingress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           }
         ],
         "timeRestore": false,
@@ -286,8 +283,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-10T10:16:36.469Z",
-      "version": "WzMxMjYsMV0="
+      "updated_at": "2020-04-07T17:37:19.062Z",
+      "version": "WzI0ODAsNF0="
     },
     {
       "attributes": {
@@ -317,12 +314,12 @@
       },
       "id": "e4b25ee0-32f6-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:02:08.721Z",
-      "version": "WzI1NDcsMV0="
+      "updated_at": "2020-04-07T17:04:23.213Z",
+      "version": "WzE1OTMsNF0="
     },
     {
       "attributes": {
@@ -423,12 +420,12 @@
       },
       "id": "40dbc0d0-32e3-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T17:00:24.400Z",
-      "version": "WzMwOTgsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjcsNF0="
     },
     {
       "attributes": {
@@ -503,7 +500,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.blobcapacity.avg",
+                    "field": "azure.storage.blob_capacity.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -530,12 +527,12 @@
       },
       "id": "17ee2920-3391-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T10:13:26.031Z",
-      "version": "WzMxMjQsMV0="
+      "updated_at": "2020-04-07T17:35:44.618Z",
+      "version": "WzI0NjAsNF0="
     },
     {
       "attributes": {
@@ -606,7 +603,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.blobcount.avg",
+                    "field": "azure.storage.blob_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -633,12 +630,12 @@
       },
       "id": "55936920-3391-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:25:33.336Z",
-      "version": "WzMxNTAsMV0="
+      "updated_at": "2020-04-07T17:36:21.027Z",
+      "version": "WzI0NzEsNF0="
     },
     {
       "attributes": {
@@ -694,7 +691,8 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.responsetype",
+                "terms_field": "azure.dimensions.response_type",
+                "terms_order_by": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
                 "type": "timeseries",
                 "value_template": "{{value}}"
               }
@@ -710,12 +708,12 @@
       },
       "id": "553f9320-32e9-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:07:12.722Z",
-      "version": "WzI0NzAsMV0="
+      "updated_at": "2020-04-07T17:29:35.827Z",
+      "version": "WzIzODMsNF0="
     },
     {
       "attributes": {
@@ -792,7 +790,7 @@
       },
       "id": "acced050-32d1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -812,8 +810,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:20:37.248Z",
-      "version": "WzI1NjksMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NzIsNF0="
     },
     {
       "attributes": {
@@ -859,7 +857,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successserverlatency.avg",
+                    "field": "azure.storage.success_server_latency.avg",
                     "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
                     "type": "avg"
                   }
@@ -869,8 +867,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -885,12 +884,12 @@
       },
       "id": "81f16b40-32ea-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:23:09.217Z",
-      "version": "WzI0ODEsMV0="
+      "updated_at": "2020-04-07T17:15:09.491Z",
+      "version": "WzIxNzYsNF0="
     },
     {
       "attributes": {
@@ -936,7 +935,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successe2elatency.avg",
+                    "field": "azure.storage.success_e2elatency.avg",
                     "id": "da4459b2-32ea-11ea-be35-cb10be813609",
                     "type": "avg"
                   }
@@ -946,8 +945,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -962,12 +962,12 @@
       },
       "id": "685fbeb0-32eb-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:47:10.336Z",
-      "version": "WzI0OTcsMV0="
+      "updated_at": "2020-04-07T17:28:09.199Z",
+      "version": "WzIzMzUsNF0="
     },
     {
       "attributes": {
@@ -1038,7 +1038,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.containercount.avg",
+                    "field": "azure.storage.container_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -1065,12 +1065,12 @@
       },
       "id": "9e991b10-3391-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:26:07.517Z",
-      "version": "WzMxNTIsMV0="
+      "updated_at": "2020-04-07T17:36:35.970Z",
+      "version": "WzI0NzUsNF0="
     },
     {
       "attributes": {
@@ -1159,7 +1159,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1176,12 +1176,12 @@
       },
       "id": "599c62c0-32d7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:09:18.141Z",
-      "version": "WzI0NDUsMV0="
+      "updated_at": "2020-04-07T17:21:03.231Z",
+      "version": "WzIyNzIsNF0="
     },
     {
       "attributes": {
@@ -1270,7 +1270,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1287,13 +1287,13 @@
       },
       "id": "4eaef260-32e1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:12:17.417Z",
-      "version": "WzI0NDgsMV0="
+      "updated_at": "2020-04-07T17:21:51.411Z",
+      "version": "WzIyODMsNF0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.7.0"
 }

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-file-storage-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-file-storage-overview.json
@@ -23,11 +23,8 @@
                   "type": "phrase"
                 },
                 "query": {
-                  "match": {
-                    "azure.namespace": {
-                      "query": "Microsoft.Storage/storageAccounts/fileServices",
-                      "type": "phrase"
-                    }
+                  "match_phrase": {
+                    "azure.namespace": "Microsoft.Storage/storageAccounts/fileServices"
                   }
                 }
               }
@@ -56,7 +53,7 @@
             },
             "panelIndex": "ee131d2d-7ab5-4434-9e3b-230759c3e5ff",
             "panelRefName": "panel_0",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -72,7 +69,7 @@
             "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
             "panelRefName": "panel_1",
             "title": "Availability",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -87,7 +84,7 @@
             },
             "panelIndex": "b24e3e0d-a748-4bb9-ad71-e0de392e2696",
             "panelRefName": "panel_2",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -102,7 +99,7 @@
             },
             "panelIndex": "8131dfcd-2c52-4641-8259-2f4f2e7558d0",
             "panelRefName": "panel_3",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -117,7 +114,7 @@
             },
             "panelIndex": "49233089-be1d-4cda-9ccf-2815152e1016",
             "panelRefName": "panel_4",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -133,7 +130,7 @@
             "panelIndex": "1d623c03-4d02-4a81-b91e-49e82e112016",
             "panelRefName": "panel_5",
             "title": "Transactions",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -148,7 +145,7 @@
             },
             "panelIndex": "ff6441f8-d66d-4399-bae5-25d3d861b299",
             "panelRefName": "panel_6",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -164,7 +161,7 @@
             "panelIndex": "87066244-7840-4555-9d12-026d64977f1a",
             "panelRefName": "panel_7",
             "title": "Success Server Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -180,7 +177,7 @@
             "panelIndex": "756da375-e6a2-4668-af43-0cd294878254",
             "panelRefName": "panel_8",
             "title": "Success E2E Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -195,7 +192,7 @@
             },
             "panelIndex": "2d5c6c0f-f4d2-44fb-b7e5-1a855b75e40f",
             "panelRefName": "panel_9",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -210,7 +207,7 @@
             },
             "panelIndex": "c6792441-37b6-4ef4-ad8b-21f137b2f0b4",
             "panelRefName": "panel_10",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -226,7 +223,7 @@
             "panelIndex": "a715fafc-ca38-410c-9253-12ba506eabc0",
             "panelRefName": "panel_11",
             "title": "Egress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -242,7 +239,7 @@
             "panelIndex": "75f72920-be71-47a9-a967-f1c862ab2961",
             "panelRefName": "panel_12",
             "title": "Ingress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           }
         ],
         "timeRestore": false,
@@ -326,8 +323,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-10T11:09:50.757Z",
-      "version": "WzMxMzksMV0="
+      "updated_at": "2020-04-07T17:45:34.658Z",
+      "version": "WzI1NjcsNF0="
     },
     {
       "attributes": {
@@ -357,12 +354,12 @@
       },
       "id": "f18a7cb0-32f6-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:15:13.827Z",
-      "version": "WzI1NjMsMV0="
+      "updated_at": "2020-04-07T17:04:27.299Z",
+      "version": "WzE2MjcsNF0="
     },
     {
       "attributes": {
@@ -463,12 +460,12 @@
       },
       "id": "40dbc0d0-32e3-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T17:00:24.400Z",
-      "version": "WzMwOTgsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjcsNF0="
     },
     {
       "attributes": {
@@ -543,7 +540,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.filecapacity.avg",
+                    "field": "azure.storage.file_capacity.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -570,12 +567,12 @@
       },
       "id": "453965a0-3393-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T10:23:40.282Z",
-      "version": "WzMxMzEsMV0="
+      "updated_at": "2020-04-07T17:44:50.934Z",
+      "version": "WzI1NTEsNF0="
     },
     {
       "attributes": {
@@ -646,7 +643,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.filecount.avg",
+                    "field": "azure.storage.file_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -673,12 +670,12 @@
       },
       "id": "722ef2f0-3393-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:23:36.203Z",
-      "version": "WzMxNDYsMV0="
+      "updated_at": "2020-04-07T17:45:14.875Z",
+      "version": "WzI1NjMsNF0="
     },
     {
       "attributes": {
@@ -749,7 +746,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.filesharecount.avg",
+                    "field": "azure.storage.file_share_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -776,12 +773,12 @@
       },
       "id": "a4bf9710-3393-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:24:04.442Z",
-      "version": "WzMxNDcsMV0="
+      "updated_at": "2020-04-07T17:45:25.865Z",
+      "version": "WzI1NjYsNF0="
     },
     {
       "attributes": {
@@ -837,7 +834,8 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.responsetype",
+                "terms_field": "azure.dimensions.response_type",
+                "terms_order_by": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
                 "type": "timeseries",
                 "value_template": "{{value}}"
               }
@@ -853,12 +851,12 @@
       },
       "id": "553f9320-32e9-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:07:12.722Z",
-      "version": "WzI0NzAsMV0="
+      "updated_at": "2020-04-07T17:29:35.827Z",
+      "version": "WzIzODMsNF0="
     },
     {
       "attributes": {
@@ -935,7 +933,7 @@
       },
       "id": "acced050-32d1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -955,8 +953,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:20:37.248Z",
-      "version": "WzI1NjksMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NzIsNF0="
     },
     {
       "attributes": {
@@ -1002,7 +1000,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successserverlatency.avg",
+                    "field": "azure.storage.success_server_latency.avg",
                     "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
                     "type": "avg"
                   }
@@ -1012,8 +1010,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -1028,12 +1027,12 @@
       },
       "id": "81f16b40-32ea-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:23:09.217Z",
-      "version": "WzI0ODEsMV0="
+      "updated_at": "2020-04-07T17:15:09.491Z",
+      "version": "WzIxNzYsNF0="
     },
     {
       "attributes": {
@@ -1079,7 +1078,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successe2elatency.avg",
+                    "field": "azure.storage.success_e2elatency.avg",
                     "id": "da4459b2-32ea-11ea-be35-cb10be813609",
                     "type": "avg"
                   }
@@ -1089,8 +1088,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -1105,12 +1105,12 @@
       },
       "id": "685fbeb0-32eb-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:47:10.336Z",
-      "version": "WzI0OTcsMV0="
+      "updated_at": "2020-04-07T17:28:09.199Z",
+      "version": "WzIzMzUsNF0="
     },
     {
       "attributes": {
@@ -1185,7 +1185,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.filesharesnapshotcount.avg",
+                    "field": "azure.storage.file_share_snapshot_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -1212,12 +1212,12 @@
       },
       "id": "09a6f150-3399-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:24:54.035Z",
-      "version": "WzMxNDksMV0="
+      "updated_at": "2020-04-07T17:43:27.381Z",
+      "version": "WzI1MjUsNF0="
     },
     {
       "attributes": {
@@ -1292,7 +1292,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.filesharesnapshotsize.avg",
+                    "field": "azure.storage.file_share_snapshot_size.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -1319,12 +1319,12 @@
       },
       "id": "241a55e0-3399-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T12:05:22.305Z",
-      "version": "WzMxNzIsMV0="
+      "updated_at": "2020-04-07T17:44:18.919Z",
+      "version": "WzI1NDIsNF0="
     },
     {
       "attributes": {
@@ -1413,7 +1413,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1430,12 +1430,12 @@
       },
       "id": "599c62c0-32d7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:09:18.141Z",
-      "version": "WzI0NDUsMV0="
+      "updated_at": "2020-04-07T17:21:03.231Z",
+      "version": "WzIyNzIsNF0="
     },
     {
       "attributes": {
@@ -1524,7 +1524,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1541,13 +1541,13 @@
       },
       "id": "4eaef260-32e1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:12:17.417Z",
-      "version": "WzI0NDgsMV0="
+      "updated_at": "2020-04-07T17:21:51.411Z",
+      "version": "WzIyODMsNF0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.7.0"
 }

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-queue-storage-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-queue-storage-overview.json
@@ -23,11 +23,8 @@
                   "type": "phrase"
                 },
                 "query": {
-                  "match": {
-                    "azure.namespace": {
-                      "query": "Microsoft.Storage/storageAccounts/queueServices",
-                      "type": "phrase"
-                    }
+                  "match_phrase": {
+                    "azure.namespace": "Microsoft.Storage/storageAccounts/queueServices"
                   }
                 }
               }
@@ -56,7 +53,7 @@
             },
             "panelIndex": "933a427d-a8b7-48ff-ac53-337f32b340ea",
             "panelRefName": "panel_0",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -72,7 +69,7 @@
             "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
             "panelRefName": "panel_1",
             "title": "Availability",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -87,7 +84,7 @@
             },
             "panelIndex": "0b4107a7-6a3d-4092-9813-00edb56bc838",
             "panelRefName": "panel_2",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -102,7 +99,7 @@
             },
             "panelIndex": "cf022a47-2314-4ab6-b397-b1d860944179",
             "panelRefName": "panel_3",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -117,7 +114,7 @@
             },
             "panelIndex": "9d84188c-5a30-41ac-81cc-fe4fed360dd3",
             "panelRefName": "panel_4",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -133,7 +130,7 @@
             "panelIndex": "1d623c03-4d02-4a81-b91e-49e82e112016",
             "panelRefName": "panel_5",
             "title": "Transactions",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -148,7 +145,7 @@
             },
             "panelIndex": "ff6441f8-d66d-4399-bae5-25d3d861b299",
             "panelRefName": "panel_6",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -164,7 +161,7 @@
             "panelIndex": "87066244-7840-4555-9d12-026d64977f1a",
             "panelRefName": "panel_7",
             "title": "Success Server Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -180,7 +177,7 @@
             "panelIndex": "756da375-e6a2-4668-af43-0cd294878254",
             "panelRefName": "panel_8",
             "title": "Success E2E Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -196,7 +193,7 @@
             "panelIndex": "a715fafc-ca38-410c-9253-12ba506eabc0",
             "panelRefName": "panel_9",
             "title": "Egress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -212,7 +209,7 @@
             "panelIndex": "75f72920-be71-47a9-a967-f1c862ab2961",
             "panelRefName": "panel_10",
             "title": "Ingress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           }
         ],
         "timeRestore": false,
@@ -286,8 +283,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-10T11:36:59.617Z",
-      "version": "WzMxNjMsMV0="
+      "updated_at": "2020-04-07T17:57:17.584Z",
+      "version": "WzI3MjAsNF0="
     },
     {
       "attributes": {
@@ -317,12 +314,12 @@
       },
       "id": "09f05e00-32f7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:13:07.703Z",
-      "version": "WzI1NjAsMV0="
+      "updated_at": "2020-04-07T17:04:28.324Z",
+      "version": "WzE2NDEsNF0="
     },
     {
       "attributes": {
@@ -423,12 +420,12 @@
       },
       "id": "40dbc0d0-32e3-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T17:00:24.400Z",
-      "version": "WzMwOTgsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjcsNF0="
     },
     {
       "attributes": {
@@ -503,7 +500,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.queuecapacity.avg",
+                    "field": "azure.storage.queue_capacity.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -530,12 +527,12 @@
       },
       "id": "e159b990-339c-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:32:27.688Z",
-      "version": "WzMxNTgsMV0="
+      "updated_at": "2020-04-07T17:56:48.523Z",
+      "version": "WzI3MTUsNF0="
     },
     {
       "attributes": {
@@ -606,7 +603,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.queuemessagecount.avg",
+                    "field": "azure.storage.queue_message_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -633,12 +630,12 @@
       },
       "id": "2bedaca0-339d-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:34:32.809Z",
-      "version": "WzMxNjEsMV0="
+      "updated_at": "2020-04-07T17:57:02.052Z",
+      "version": "WzI3MTcsNF0="
     },
     {
       "attributes": {
@@ -709,7 +706,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.queuecount.avg",
+                    "field": "azure.storage.queue_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -736,12 +733,12 @@
       },
       "id": "0241cc10-339d-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:33:22.897Z",
-      "version": "WzMxNjAsMV0="
+      "updated_at": "2020-04-07T17:57:12.002Z",
+      "version": "WzI3MTksNF0="
     },
     {
       "attributes": {
@@ -797,7 +794,8 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.responsetype",
+                "terms_field": "azure.dimensions.response_type",
+                "terms_order_by": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
                 "type": "timeseries",
                 "value_template": "{{value}}"
               }
@@ -813,12 +811,12 @@
       },
       "id": "553f9320-32e9-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:07:12.722Z",
-      "version": "WzI0NzAsMV0="
+      "updated_at": "2020-04-07T17:29:35.827Z",
+      "version": "WzIzODMsNF0="
     },
     {
       "attributes": {
@@ -895,7 +893,7 @@
       },
       "id": "acced050-32d1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -915,8 +913,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:20:37.248Z",
-      "version": "WzI1NjksMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NzIsNF0="
     },
     {
       "attributes": {
@@ -962,7 +960,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successserverlatency.avg",
+                    "field": "azure.storage.success_server_latency.avg",
                     "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
                     "type": "avg"
                   }
@@ -972,8 +970,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -988,12 +987,12 @@
       },
       "id": "81f16b40-32ea-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:23:09.217Z",
-      "version": "WzI0ODEsMV0="
+      "updated_at": "2020-04-07T17:15:09.491Z",
+      "version": "WzIxNzYsNF0="
     },
     {
       "attributes": {
@@ -1039,7 +1038,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successe2elatency.avg",
+                    "field": "azure.storage.success_e2elatency.avg",
                     "id": "da4459b2-32ea-11ea-be35-cb10be813609",
                     "type": "avg"
                   }
@@ -1049,8 +1048,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -1065,12 +1065,12 @@
       },
       "id": "685fbeb0-32eb-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:47:10.336Z",
-      "version": "WzI0OTcsMV0="
+      "updated_at": "2020-04-07T17:28:09.199Z",
+      "version": "WzIzMzUsNF0="
     },
     {
       "attributes": {
@@ -1159,7 +1159,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1176,12 +1176,12 @@
       },
       "id": "599c62c0-32d7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:09:18.141Z",
-      "version": "WzI0NDUsMV0="
+      "updated_at": "2020-04-07T17:21:03.231Z",
+      "version": "WzIyNzIsNF0="
     },
     {
       "attributes": {
@@ -1270,7 +1270,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1287,13 +1287,13 @@
       },
       "id": "4eaef260-32e1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:12:17.417Z",
-      "version": "WzI0NDgsMV0="
+      "updated_at": "2020-04-07T17:21:51.411Z",
+      "version": "WzIyODMsNF0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.7.0"
 }

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-storage-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-storage-overview.json
@@ -277,8 +277,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-10T10:18:50.432Z",
-      "version": "WzMxMjgsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NTIsNF0="
     },
     {
       "attributes": {
@@ -308,12 +308,12 @@
       },
       "id": "fcc24d70-32f5-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:00:58.614Z",
-      "version": "WzI1NDUsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NTMsNF0="
     },
     {
       "attributes": {
@@ -414,12 +414,12 @@
       },
       "id": "40dbc0d0-32e3-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T17:00:24.400Z",
-      "version": "WzMwOTgsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjcsNF0="
     },
     {
       "attributes": {
@@ -521,12 +521,12 @@
       },
       "id": "634b83c0-32ee-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:43:23.772Z",
-      "version": "WzI0OTEsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NTUsNF0="
     },
     {
       "attributes": {
@@ -624,12 +624,12 @@
       },
       "id": "33d645e0-32ed-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:34:54.654Z",
-      "version": "WzI0ODQsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NTYsNF0="
     },
     {
       "attributes": {
@@ -727,12 +727,12 @@
       },
       "id": "2219de20-32ed-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:34:24.897Z",
-      "version": "WzI0ODMsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NTcsNF0="
     },
     {
       "attributes": {
@@ -788,7 +788,7 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.responsetype",
+                "terms_field": "azure.dimensions.response_type",
                 "type": "timeseries",
                 "value_template": "{{value}}"
               }
@@ -804,12 +804,12 @@
       },
       "id": "553f9320-32e9-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:07:12.722Z",
-      "version": "WzI0NzAsMV0="
+      "updated_at": "2020-04-07T17:17:21.500Z",
+      "version": "WzIyMjMsNF0="
     },
     {
       "attributes": {
@@ -886,7 +886,7 @@
       },
       "id": "acced050-32d1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -906,8 +906,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:20:37.248Z",
-      "version": "WzI1NjksMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NzIsNF0="
     },
     {
       "attributes": {
@@ -953,7 +953,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successserverlatency.avg",
+                    "field": "azure.storage.success_server_latency.avg",
                     "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
                     "type": "avg"
                   }
@@ -963,8 +963,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -979,12 +980,12 @@
       },
       "id": "81f16b40-32ea-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:23:09.217Z",
-      "version": "WzI0ODEsMV0="
+      "updated_at": "2020-04-07T17:15:09.491Z",
+      "version": "WzIxNzYsNF0="
     },
     {
       "attributes": {
@@ -1030,7 +1031,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successe2elatency.avg",
+                    "field": "azure.storage.success_e2elatency.avg",
                     "id": "da4459b2-32ea-11ea-be35-cb10be813609",
                     "type": "avg"
                   }
@@ -1040,8 +1041,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -1056,12 +1058,12 @@
       },
       "id": "685fbeb0-32eb-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:47:10.336Z",
-      "version": "WzI0OTcsMV0="
+      "updated_at": "2020-04-07T17:15:05.346Z",
+      "version": "WzIxNzUsNF0="
     },
     {
       "attributes": {
@@ -1163,12 +1165,12 @@
       },
       "id": "109ec950-32e6-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:44:22.782Z",
-      "version": "WzI0OTMsMV0="
+      "updated_at": "2020-04-07T17:04:29.344Z",
+      "version": "WzE2NjIsNF0="
     },
     {
       "attributes": {
@@ -1257,7 +1259,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1274,12 +1276,12 @@
       },
       "id": "599c62c0-32d7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:09:18.141Z",
-      "version": "WzI0NDUsMV0="
+      "updated_at": "2020-04-07T17:21:03.231Z",
+      "version": "WzIyNzIsNF0="
     },
     {
       "attributes": {
@@ -1368,7 +1370,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1385,13 +1387,13 @@
       },
       "id": "4eaef260-32e1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:12:17.417Z",
-      "version": "WzI0NDgsMV0="
+      "updated_at": "2020-04-07T17:21:51.411Z",
+      "version": "WzIyODMsNF0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.7.0"
 }

--- a/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-table-storage-overview.json
+++ b/x-pack/metricbeat/module/azure/_meta/kibana/7/dashboard/Metricbeat-azure-table-storage-overview.json
@@ -23,11 +23,8 @@
                   "type": "phrase"
                 },
                 "query": {
-                  "match": {
-                    "azure.namespace": {
-                      "query": "Microsoft.Storage/storageAccounts/tableServices",
-                      "type": "phrase"
-                    }
+                  "match_phrase": {
+                    "azure.namespace": "Microsoft.Storage/storageAccounts/tableServices"
                   }
                 }
               }
@@ -56,7 +53,7 @@
             },
             "panelIndex": "204cbabc-fafd-472c-b106-bd08f5262b1f",
             "panelRefName": "panel_0",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -72,7 +69,7 @@
             "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
             "panelRefName": "panel_1",
             "title": "Availability",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -87,7 +84,7 @@
             },
             "panelIndex": "15b7c108-0214-4af6-9719-fab59affafec",
             "panelRefName": "panel_2",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -102,7 +99,7 @@
             },
             "panelIndex": "4177a6e6-97d7-447e-bcf3-ee9c1d660bd8",
             "panelRefName": "panel_3",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -117,7 +114,7 @@
             },
             "panelIndex": "28d85d90-3881-4d1f-b60c-43b545fc9f0e",
             "panelRefName": "panel_4",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -133,7 +130,7 @@
             "panelIndex": "1d623c03-4d02-4a81-b91e-49e82e112016",
             "panelRefName": "panel_5",
             "title": "Transactions",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -148,7 +145,7 @@
             },
             "panelIndex": "ff6441f8-d66d-4399-bae5-25d3d861b299",
             "panelRefName": "panel_6",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -164,7 +161,7 @@
             "panelIndex": "87066244-7840-4555-9d12-026d64977f1a",
             "panelRefName": "panel_7",
             "title": "Success Server Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -180,7 +177,7 @@
             "panelIndex": "756da375-e6a2-4668-af43-0cd294878254",
             "panelRefName": "panel_8",
             "title": "Success E2E Latency",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -196,7 +193,7 @@
             "panelIndex": "a715fafc-ca38-410c-9253-12ba506eabc0",
             "panelRefName": "panel_9",
             "title": "Egress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -212,7 +209,7 @@
             "panelIndex": "75f72920-be71-47a9-a967-f1c862ab2961",
             "panelRefName": "panel_10",
             "title": "Ingress Traffic by APIName",
-            "version": "7.5.0"
+            "version": "7.7.0"
           }
         ],
         "timeRestore": false,
@@ -286,8 +283,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-01-10T11:31:27.563Z",
-      "version": "WzMxNTYsMV0="
+      "updated_at": "2020-04-07T17:53:55.492Z",
+      "version": "WzI2NjYsNF0="
     },
     {
       "attributes": {
@@ -317,12 +314,12 @@
       },
       "id": "fdef3f40-32f6-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:10:13.713Z",
-      "version": "WzI1NTYsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjYsNF0="
     },
     {
       "attributes": {
@@ -423,12 +420,12 @@
       },
       "id": "40dbc0d0-32e3-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T17:00:24.400Z",
-      "version": "WzMwOTgsMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NjcsNF0="
     },
     {
       "attributes": {
@@ -503,7 +500,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.tablecapacity.avg",
+                    "field": "azure.storage.table_capacity.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -530,12 +527,12 @@
       },
       "id": "f528e6a0-339a-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:18:41.930Z",
-      "version": "WzMxNDEsMV0="
+      "updated_at": "2020-04-07T17:53:02.515Z",
+      "version": "WzI2NTQsNF0="
     },
     {
       "attributes": {
@@ -606,7 +603,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.tablecount.avg",
+                    "field": "azure.storage.table_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -633,12 +630,12 @@
       },
       "id": "43b31a20-339b-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:20:53.698Z",
-      "version": "WzMxNDMsMV0="
+      "updated_at": "2020-04-07T17:53:50.518Z",
+      "version": "WzI2NjUsNF0="
     },
     {
       "attributes": {
@@ -709,7 +706,7 @@
                 "line_width": 2,
                 "metrics": [
                   {
-                    "field": "azure.storage.tableentitycount.avg",
+                    "field": "azure.storage.table_entity_count.avg",
                     "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
                     "type": "avg"
                   }
@@ -736,12 +733,12 @@
       },
       "id": "5cbf5820-339c-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-10T11:28:45.217Z",
-      "version": "WzMxNTQsMV0="
+      "updated_at": "2020-04-07T17:53:46.270Z",
+      "version": "WzI2NjQsNF0="
     },
     {
       "attributes": {
@@ -797,7 +794,8 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.responsetype",
+                "terms_field": "azure.dimensions.response_type",
+                "terms_order_by": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
                 "type": "timeseries",
                 "value_template": "{{value}}"
               }
@@ -813,12 +811,12 @@
       },
       "id": "553f9320-32e9-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:07:12.722Z",
-      "version": "WzI0NzAsMV0="
+      "updated_at": "2020-04-07T17:29:35.827Z",
+      "version": "WzIzODMsNF0="
     },
     {
       "attributes": {
@@ -895,7 +893,7 @@
       },
       "id": "acced050-32d1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [
         {
@@ -915,8 +913,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-01-09T16:20:37.248Z",
-      "version": "WzI1NjksMV0="
+      "updated_at": "2020-04-07T17:04:30.376Z",
+      "version": "WzE2NzIsNF0="
     },
     {
       "attributes": {
@@ -962,7 +960,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successserverlatency.avg",
+                    "field": "azure.storage.success_server_latency.avg",
                     "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
                     "type": "avg"
                   }
@@ -972,8 +970,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -988,12 +987,12 @@
       },
       "id": "81f16b40-32ea-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:23:09.217Z",
-      "version": "WzI0ODEsMV0="
+      "updated_at": "2020-04-07T17:15:09.491Z",
+      "version": "WzIxNzYsNF0="
     },
     {
       "attributes": {
@@ -1039,7 +1038,7 @@
                 "line_width": "1",
                 "metrics": [
                   {
-                    "field": "azure.storage.successe2elatency.avg",
+                    "field": "azure.storage.success_e2elatency.avg",
                     "id": "da4459b2-32ea-11ea-be35-cb10be813609",
                     "type": "avg"
                   }
@@ -1049,8 +1048,9 @@
                 "split_color_mode": "rainbow",
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
+                "type": "timeseries",
                 "value_template": "{{value}} ms"
               }
             ],
@@ -1065,12 +1065,12 @@
       },
       "id": "685fbeb0-32eb-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T14:47:10.336Z",
-      "version": "WzI0OTcsMV0="
+      "updated_at": "2020-04-07T17:28:09.199Z",
+      "version": "WzIzMzUsNF0="
     },
     {
       "attributes": {
@@ -1159,7 +1159,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1176,12 +1176,12 @@
       },
       "id": "599c62c0-32d7-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:09:18.141Z",
-      "version": "WzI0NDUsMV0="
+      "updated_at": "2020-04-07T17:21:03.231Z",
+      "version": "WzIyNzIsNF0="
     },
     {
       "attributes": {
@@ -1270,7 +1270,7 @@
                 ],
                 "split_mode": "terms",
                 "stacked": "none",
-                "terms_field": "azure.dimensions.apiname",
+                "terms_field": "azure.dimensions.api_name",
                 "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
                 "type": "timeseries",
                 "value_template": "{{value}}"
@@ -1287,13 +1287,13 @@
       },
       "id": "4eaef260-32e1-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.4.2"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-01-09T13:12:17.417Z",
-      "version": "WzI0NDgsMV0="
+      "updated_at": "2020-04-07T17:21:51.411Z",
+      "version": "WzIyODMsNF0="
     }
   ],
-  "version": "7.5.0"
+  "version": "7.7.0"
 }


### PR DESCRIPTION
Cherry-pick of PR #17590 to 7.x branch. Original message: 

This PR is to fix azure storage related dashboards. For example the overview dashboard:
<img width="2557" alt="Screen Shot 2020-04-07 at 11 25 07 AM" src="https://user-images.githubusercontent.com/14081635/78700362-7929ea00-78c2-11ea-86bd-5d64840e34cb.png">
