### PR TITLE
Add a documentation item about $ resoltion in configs

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs:
+:no_keystore:
 
 include::{libbeat-dir}/shared-beats-attributes.asciidoc[]
 

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -96,11 +96,11 @@ or wrap the values in single quotation marks.
 
 [float]
 [[dollar-sign-strings]]
-== Avoid accidental template variable resolution
+=== Avoid accidental template variable resolution
 
-The templating engine that allows the beat config to resolve data from environment 
-variables can result in errors in strings wtih `$` characters. For example, if a 
-passord field contains `$$`, the engine will resolve this to `$`. To work around this,
+The templating engine that allows the config to resolve data from environment 
+variables can result in errors in strings with `$` characters. For example, if a 
+password field contains `$$`, the engine will resolve this to `$`. To work around this,
 either use the
 ifndef::standalone[]
 {filebeat-ref}/keystore.html[keystore]

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -104,10 +104,10 @@ password field contains `$$`, the engine will resolve this to `$`.
 
 To work around this,
 either use the
-ifndef::standalone[]
+ifdef::no_keystore[]
 {filebeat-ref}/keystore.html[keystore]
 endif::[]
-ifdef::standalone[]
+ifndef::no_keystore[]
 <<keystore>>
 endif::[]
 or escape all instances of

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -100,7 +100,9 @@ or wrap the values in single quotation marks.
 
 The templating engine that allows the config to resolve data from environment 
 variables can result in errors in strings with `$` characters. For example, if a 
-password field contains `$$`, the engine will resolve this to `$`. To work around this,
+password field contains `$$`, the engine will resolve this to `$`.
+
+To work around this,
 either use the
 ifndef::standalone[]
 {filebeat-ref}/keystore.html[keystore]

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -94,3 +94,19 @@ to an integer. If not, it's converted to a float.
 To prevent unwanted type conversions, avoid using leading zeros in field values,
 or wrap the values in single quotation marks.
 
+[float]
+[[dollar-sign-strings]]
+== Avoid accidental template variable resolution
+
+The templating engine that allows the beat config to resolve data from environment 
+variables can result in errors in strings wtih `$` characters. For example, if a 
+passord field contains `$$`, the engine will resolve this to `$`. To work around this,
+either use the
+ifndef::standalone[]
+{filebeat-ref}/keystore.html[keystore]
+endif::[]
+ifdef::standalone[]
+<<keystore>>
+endif::[]
+or escape all instances of
+`$` with `$$`.

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -33,6 +33,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :no_decode_csv_fields_processor:
 :no_script_processor:
 :no_timestamp_processor:
+:no_keystore:
 
 include::{libbeat-dir}/shared-beats-attributes.asciidoc[]
 


### PR DESCRIPTION

## What does this PR do?

This adds a blurb that explains some issues with`$` as used in config strings. This is the result of some user issues in discuss. I spent a lot of time banging my head against the wall with link formatting, as @dedemorton can attest to. We should make sure we're 100% on how the linking works before we merge.

## Why is it important?

So users don't get confused when their password with `$$` in it doesn't work.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
