### PR TITLE
[libbeat] Clarify field name / remove redundant semaphore creation

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -38,6 +38,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - The `libbeat/outputs/tls.go` file has been removed. All exported symbols in that file (`libbeat/outputs.*`) are now available as `libbeat/common/tlscommon.*`. {pull}16734[16734]
 - The newly generated Beats are using go modules to manage dependencies. {pull}16288[16288]
 - Extract Elasticsearch client logic from `outputs/elasticsearch` package into new `esclientleg` package. {pull}16150[16150]
+- Rename `queue.BufferConfig.Events` to `queue.BufferConfig.MaxEvents`. {pull}17622[17622]
 
 ==== Bugfixes
 

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -183,11 +183,7 @@ func New(
 		return nil, err
 	}
 
-	if count := p.queue.BufferConfig().Events; count > 0 {
-		p.eventSema = newSema(count)
-	}
-
-	maxEvents := p.queue.BufferConfig().Events
+	maxEvents := p.queue.BufferConfig().MaxEvents
 	if maxEvents <= 0 {
 		// Maximum number of events until acker starts blocking.
 		// Only active if pipeline can drop events.

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -191,7 +191,7 @@ func (b *broker) Close() error {
 
 func (b *broker) BufferConfig() queue.BufferConfig {
 	return queue.BufferConfig{
-		Events: b.bufSize,
+		MaxEvents: b.bufSize,
 	}
 }
 

--- a/libbeat/publisher/queue/queue.go
+++ b/libbeat/publisher/queue/queue.go
@@ -58,7 +58,9 @@ type Queue interface {
 // but still dropping events, the pipeline can use the buffer information,
 // to define an upper bound of events being active in the pipeline.
 type BufferConfig struct {
-	Events int // can be <= 0, if queue can not determine limit
+	// MaxEvents is the maximum number of events the queue can hold at capacity.
+	// A value <= 0 means there is no fixed limit.
+	MaxEvents int
 }
 
 // ProducerConfig as used by the Pipeline to configure some custom callbacks

--- a/libbeat/publisher/queue/spool/spool.go
+++ b/libbeat/publisher/queue/spool/spool.go
@@ -175,7 +175,7 @@ func (s *diskSpool) Close() error {
 
 // BufferConfig returns the queue initial buffer settings.
 func (s *diskSpool) BufferConfig() queue.BufferConfig {
-	return queue.BufferConfig{Events: -1}
+	return queue.BufferConfig{MaxEvents: -1}
 }
 
 // Producer creates a new queue producer for publishing events.


### PR DESCRIPTION
# What does this PR do?

Rename `queue.BufferConfig.Events` to `queue.BufferConfig.MaxEvents` to clarify its meaning, and remove a redundant check of it in `pipeline.go` that created the semaphore `Pipeline.eventSema` twice.

This PR has no user-visible effects.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.