### PR TITLE
Cherry-pick #17606 to 7.7: Add privileged option so as mb to access data dir in Openshift

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -194,6 +194,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix vsphere VM dashboard host aggregation visualizations. {pull}17555[17555]
 - Fix azure storage dashboards. {pull}17590[17590]
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
+- Add privileged option so as mb to access data dir in Openshift. {pull}17606[17606]
 - Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
 
 *Packetbeat*

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -138,6 +138,8 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
         resources:
           limits:
             memory: 200Mi

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -46,6 +46,8 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
Cherry-pick of PR #17606 to 7.7 branch. Original message: 

## What does this PR do?

This PR adds `privileged: true` in `securityContext` of Metricbeat Daemonset spec file so as to enable access to `data` volume added in #17429.

Tested with `minishift v1.34.2+83ebaab`.


## Why is it important?

Metricbeat is not able to start in Openshift without this option:
```
oc -n kube-system logs -f metricbeat-zsfwt
2020-04-06T10:58:56.615Z        INFO    instance/beat.go:622    Home path: [/usr/share/metricbeat] Config path: [/usr/share/metricbeat] Data path: [/usr/share/metricbeat/data] Logs path: [/usr/share/metricbeat/logs]
2020-04-06T10:58:56.615Z        INFO    instance/beat.go:372    metricbeat stopped.
2020-04-06T10:58:56.616Z        ERROR   instance/beat.go:933    Exiting: Failed to create Beat meta file: open /usr/share/metricbeat/data/meta.json.new: permission denied
```

Related to https://github.com/elastic/beats/issues/17516.

cc: @exekias @jsoriano @blakerouse 