### PR TITLE
Cherry-pick #17624 to 7.x: [Metricbeat] allow empty region/zone config param for storage metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -197,6 +197,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
 - Add privileged option so as mb to access data dir in Openshift. {pull}17606[17606]
 - Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
+- Fix storage metricset to allow config without region/zone. {issue}17623[17623] {pull}17624[17624]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
@@ -148,6 +148,11 @@ func validatePeriodForGCP(d time.Duration) (err error) {
 }
 
 func (c *config) Validate() error {
+	// storage metricset does not require region or zone config parameter.
+	if c.ServiceName == "storage" {
+		return nil
+	}
+
 	if c.Region == "" && c.Zone == "" {
 		return errors.New("region and zone in Google Cloud config file cannot both be empty")
 	}


### PR DESCRIPTION
Cherry-pick of PR #17624 to 7.x branch. Original message: 

## What does this PR do?

This PR is to allow storage metricset with no region/zone config parameter because based on the documentation: `If no region is specified, it will return metrics from all buckets.`
https://github.com/elastic/beats/blob/master/x-pack/metricbeat/module/googlecloud/storage/_meta/docs.asciidoc

## Why is it important?

GCP storage has two different classes, regional and multi-regional. When user wants to get storage metrics using Metricbeat for regional storage resources, a region/zone name can be specified in config. But if a region/zone is specified, no metrics can be queried from multi-regional storage resources. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Make sure your google cloud platform account has multiple storage accounts: both regional and multi-regional ones.
2. Enable googlecloud module and modify googlecloud.yml to use:
```
- module: googlecloud
  metricsets:
    - storage
  project_id: elastic-observability
  credentials_file_path: "/Users/kaiyansheng/Downloads/elastic-observability-d17781618202.json"
  exclude_labels: false
  period: 300s
```
3. Start metricbeat and you should see metrics collected from both multi-regional and regional storage resources.

## Related issues

Closes https://github.com/elastic/beats/issues/17623

## Screenshots

Here is a screenshot for showing metrics collected from all regions with config:
```
- module: googlecloud
  metricsets:
    - storage
  project_id: elastic-observability
  credentials_file_path: "/Users/kaiyansheng/Downloads/elastic-observability-d17781618202.json"
  exclude_labels: false
  period: 300s
```
<img width="2091" alt="Screen Shot 2020-04-08 at 3 30 13 PM" src="https://user-images.githubusercontent.com/14081635/78835722-e8c8d380-79ad-11ea-8873-61e961d67a0c.png">

