### PR TITLE
Reduce dependencies in Crawler

### DIFF
--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -21,20 +21,18 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input"
-	"github.com/elastic/beats/v7/filebeat/input/file"
-	"github.com/elastic/beats/v7/filebeat/registrar"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/mitchellh/hashstructure"
 )
 
 type crawler struct {
-	inputs          map[uint64]*input.Runner
+	log             *logp.Logger
+	inputs          map[uint64]cfgfile.Runner
 	inputConfigs    []*common.Config
-	out             channel.Factory
 	wg              sync.WaitGroup
 	inputsFactory   cfgfile.RunnerFactory
 	modulesFactory  cfgfile.RunnerFactory
@@ -46,14 +44,13 @@ type crawler struct {
 
 func newCrawler(
 	inputFactory, module cfgfile.RunnerFactory,
-	out channel.Factory,
 	inputConfigs []*common.Config,
 	beatDone chan struct{},
 	once bool,
 ) (*crawler, error) {
 	return &crawler{
-		out:            out,
-		inputs:         map[uint64]*input.Runner{},
+		log:            logp.NewLogger("crawler"),
+		inputs:         map[uint64]cfgfile.Runner{},
 		inputsFactory:  inputFactory,
 		modulesFactory: module,
 		inputConfigs:   inputConfigs,
@@ -65,16 +62,16 @@ func newCrawler(
 // Start starts the crawler with all inputs
 func (c *crawler) Start(
 	pipeline beat.Pipeline,
-	r *registrar.Registrar,
 	configInputs *common.Config,
 	configModules *common.Config,
 ) error {
+	log := c.log
 
-	logp.Info("Loading Inputs: %v", len(c.inputConfigs))
+	log.Infof("Loading Inputs: %v", len(c.inputConfigs))
 
 	// Prospect the globs/paths given on the command line and launch harvesters
 	for _, inputConfig := range c.inputConfigs {
-		err := c.startInput(pipeline, inputConfig, r.GetStates())
+		err := c.startInput(pipeline, inputConfig)
 		if err != nil {
 			return fmt.Errorf("starting input failed: %+v", err)
 		}
@@ -107,7 +104,7 @@ func (c *crawler) Start(
 		}()
 	}
 
-	logp.Info("Loading and starting Inputs completed. Enabled inputs: %v", len(c.inputs))
+	log.Infof("Loading and starting Inputs completed. Enabled inputs: %v", len(c.inputs))
 
 	return nil
 }
@@ -115,26 +112,33 @@ func (c *crawler) Start(
 func (c *crawler) startInput(
 	pipeline beat.Pipeline,
 	config *common.Config,
-	states []file.State,
 ) error {
 	if !config.Enabled() {
 		return nil
 	}
 
-	connector := c.out(pipeline)
-	p, err := input.New(config, connector, c.beatDone, states, nil)
+	var h map[string]interface{}
+	config.Unpack(&h)
+	id, err := hashstructure.Hash(h, nil)
 	if err != nil {
-		return fmt.Errorf("Error while initializing input: %s", err)
+		return fmt.Errorf("can not compute id from configuration: %v", err)
 	}
-	p.Once = c.once
-
-	if _, ok := c.inputs[p.ID]; ok {
-		return fmt.Errorf("Input with same ID already exists: %d", p.ID)
+	if _, ok := c.inputs[id]; ok {
+		return fmt.Errorf("input with same ID already exists: %v", id)
 	}
 
-	c.inputs[p.ID] = p
+	runner, err := c.inputsFactory.Create(pipeline, config, nil)
+	if err != nil {
+		return fmt.Errorf("Error while initializing input: %+v", err)
+	}
+	if inputRunner, ok := runner.(*input.Runner); ok {
+		inputRunner.Once = c.once
+	}
 
-	p.Start()
+	c.inputs[id] = runner
+
+	c.log.Info("Starting input (ID: %d)", id)
+	runner.Start()
 
 	return nil
 }
@@ -151,9 +155,13 @@ func (c *crawler) Stop() {
 	}
 
 	logp.Info("Stopping %v inputs", len(c.inputs))
-	for _, p := range c.inputs {
-		// Stop inputs in parallel
-		asyncWaitStop(p.Stop)
+	// Stop inputs in parallel
+	for id, p := range c.inputs {
+		id, p := id, p
+		asyncWaitStop(func() {
+			c.log.Infof("Stopping input: %d", id)
+			p.Stop()
+		})
 	}
 
 	if c.inputReloader != nil {

--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/mitchellh/hashstructure"
+
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/mitchellh/hashstructure"
 )
 
 type crawler struct {

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -249,7 +249,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	inputLoader := input.NewRunnerFactory(pipelineConnector, registrar, fb.done)
 	moduleLoader := fileset.NewFactory(inputLoader, b.Info, pipelineLoaderFactory, config.OverwritePipelines)
 
-	crawler, err := newCrawler(inputLoader, moduleLoader, pipelineConnector, config.Inputs, fb.done, *once)
+	crawler, err := newCrawler(inputLoader, moduleLoader, config.Inputs, fb.done, *once)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)
 		return err
@@ -283,7 +283,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		logp.Debug("modules", "Existing Ingest pipelines will be updated")
 	}
 
-	err = crawler.Start(b.Publisher, registrar, config.ConfigInput, config.ConfigModules)
+	err = crawler.Start(b.Publisher, config.ConfigInput, config.ConfigModules)
 	if err != nil {
 		crawler.Stop()
 		return fmt.Errorf("Failed to start crawler: %+v", err)

--- a/filebeat/input/input.go
+++ b/filebeat/input/input.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mitchellh/hashstructure"
-
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -52,7 +50,6 @@ type Runner struct {
 	input    Input
 	done     chan struct{}
 	wg       *sync.WaitGroup
-	ID       uint64
 	Once     bool
 	beatDone chan struct{}
 }
@@ -75,13 +72,6 @@ func New(
 
 	var err error
 	if err = conf.Unpack(&input.config); err != nil {
-		return nil, err
-	}
-
-	var h map[string]interface{}
-	conf.Unpack(&h)
-	input.ID, err = hashstructure.Hash(h, nil)
-	if err != nil {
 		return nil, err
 	}
 
@@ -111,7 +101,6 @@ func New(
 // Start starts the input
 func (p *Runner) Start() {
 	p.wg.Add(1)
-	logp.Info("Starting input of type: %v; ID: %d ", p.config.Type, p.ID)
 
 	onceWg := sync.WaitGroup{}
 	if p.Once {
@@ -164,8 +153,6 @@ func (p *Runner) Stop() {
 }
 
 func (p *Runner) stop() {
-	logp.Info("Stopping Input: %d", p.ID)
-
 	// In case of once, it will be waited until harvesters close itself
 	if p.Once {
 		p.input.Wait()
@@ -175,5 +162,5 @@ func (p *Runner) stop() {
 }
 
 func (p *Runner) String() string {
-	return fmt.Sprintf("input [type=%s, ID=%d]", p.config.Type, p.ID)
+	return fmt.Sprintf("input [type=%s]", p.config.Type)
 }

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1086,7 +1086,7 @@ class Test(BaseTest):
         # Wait until inputs are started
         self.wait_until(
             lambda: self.log_contains_count(
-                "Starting input of type: log", logfile="filebeat2.log") >= 1,
+                "Starting input", logfile="filebeat2.log") >= 1,
             max_timeout=10)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

The crawler creates active inputs for static configuration, starts
config file reloading, and starts the module loader.
With this change the crawler has no direct dependency (well, reduced) on
input.Input anymore, but will use the `Runner` interface, even for
statically configured inputs.
This also reduces dependencies, as most plumbing is already done by the
inputs.RunnerFactory and must not be duplicated by the crawler anymore.

The input.Runner used to compute a 'ID' by hashing the inputs
configuration. The ID was public, to be used by the crawler only.
Instead of having the input compute the ID, it is the crawler who will
compute the input ID now.

While reducing dependencies, I replaced `logp.Info` calls with an internal `logp.Logger` instance for logging purposes.

Note: the cfgfile RunnerList maintains its own set of IDs. The crawler
and RunnerList each used to use the ID to check for 'duplicate'
configurations, but because the IDs are not 'shred' duplication
detection is not across the Beat.
ID detection is actively used by input config file reloading and auto
discvovery only, in order to check if an input still needs to be
running, are shall shut down.

## Why is it important?

Reduce dependencies and responsibilities in the crawler, while centering input configuration and running more around the RunnerFactory and Runner interfaces only. This changes makes it easier to integrate with alternative RunnerFactory implementations in the future.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~