### PR TITLE
Output reloading: ensure all events get eventually published

### DIFF
--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -152,7 +152,6 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 	log.Debug("start pipeline event consumer")
 
 	var (
-		oid    uint
 		out    workQueue
 		batch  *Batch
 		paused = true
@@ -173,7 +172,6 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 		paused = c.paused()
 		if !paused && c.out != nil && batch != nil {
 			out = c.out.workQueue
-			oid = c.out.id
 		} else if paused && c.out != nil && batch != nil {
 			lf("paused but have batch of %v events\n", len(batch.events))
 			//batch.Cancelled()
@@ -186,7 +184,6 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 	for {
 		if !paused && c.out != nil && consumer != nil && batch == nil {
 			out = c.out.workQueue
-			oid = c.out.id
 			queueBatch, err := consumer.Get(c.out.batchSize)
 			if err != nil {
 				out = nil
@@ -223,7 +220,7 @@ func (c *eventConsumer) loop(consumer queue.Consumer) {
 			handleSignal(sig)
 		case out <- batch:
 			if batch != nil {
-				lf("in event consumer: sent batch of %v events to output workQueue (worker ID = %v)\n", len(batch.Events()), oid)
+				lf("in event consumer: sent batch of %v events to output workQueue\n", len(batch.Events()))
 			}
 			batch = nil
 		}

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -150,8 +150,10 @@ func (c *outputController) Set(outGrp outputs.Group) {
 		for drained := false; !drained; {
 			select {
 			case b := <-c.out.workQueue:
+				ln("draining batches from old workqueue to new workqueue...")
 				queue <- b
 			default:
+				ln("workqueue is already drained")
 				drained = true
 			}
 		}

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -59,7 +59,7 @@ func TestOutputReload(t *testing.T) {
 			var publishedCount atomic.Uint
 			countingPublishFn := func(batch publisher.Batch) error {
 				publishedCount.Add(uint(len(batch.Events())))
-				fmt.Printf("published now: %v, so far: %v\n", len(batch.Events()), publishedCount.Load())
+				lf("in test: published now: %v, so far: %v\n", len(batch.Events()), publishedCount.Load())
 				return nil
 			}
 
@@ -91,10 +91,10 @@ func TestOutputReload(t *testing.T) {
 				out := outputs.Group{
 					Clients: []outputs.Client{outputClient},
 				}
-				fmt.Println("reloading output...")
+				ln("in test code: reloading output...")
 				pipeline.output.Set(out)
 
-				//time.Sleep(4 * time.Millisecond)
+				//time.Sleep(1 * time.Millisecond)
 			}
 
 			wg.Wait()

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -59,7 +59,7 @@ func TestOutputReload(t *testing.T) {
 			var publishedCount atomic.Uint
 			countingPublishFn := func(batch publisher.Batch) error {
 				publishedCount.Add(uint(len(batch.Events())))
-				lf("in test: published now: %v, so far: %v\n", len(batch.Events()), publishedCount.Load())
+				lf("in test: published now: %v, so far: %v", len(batch.Events()), publishedCount.Load())
 				return nil
 			}
 
@@ -91,7 +91,7 @@ func TestOutputReload(t *testing.T) {
 				out := outputs.Group{
 					Clients: []outputs.Client{outputClient},
 				}
-				ln("in test code: reloading output...")
+				lf("in test code: reloading output...")
 				pipeline.output.Set(out)
 			}
 

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -42,7 +42,7 @@ func TestOutputReload(t *testing.T) {
 
 	for name, ctor := range tests {
 		t.Run(name, func(t *testing.T) {
-			seedPRNG(t)
+			//seedPRNG(t)
 
 			numEventsToPublish := uint(20000)
 			numOutputReloads := uint(500)
@@ -93,8 +93,6 @@ func TestOutputReload(t *testing.T) {
 				}
 				ln("in test code: reloading output...")
 				pipeline.output.Set(out)
-
-				//time.Sleep(1 * time.Millisecond)
 			}
 
 			wg.Wait()

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common/atomic"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputReload(t *testing.T) {
+	tests := map[string]func(mockPublishFn) outputs.Client{
+		"client":         newMockClient,
+		"network_client": newMockNetworkClient,
+	}
+
+	for name, ctor := range tests {
+		t.Run(name, func(t *testing.T) {
+			seedPRNG(t)
+
+			numEventsToPublish := uint(20000)
+			numOutputReloads := uint(50)
+
+			queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
+				return memqueue.NewQueue(
+					logp.L(),
+					memqueue.Settings{
+						ACKListener: ackListener,
+						Events:      int(numEventsToPublish),
+					}), nil
+			}
+
+			var publishedCount atomic.Uint
+			countingPublishFn := func(batch publisher.Batch) error {
+				publishedCount.Add(uint(len(batch.Events())))
+				fmt.Printf("published so far: %v\n", publishedCount.Load())
+				return nil
+			}
+
+			pipeline, err := New(
+				beat.Info{},
+				Monitors{},
+				queueFactory,
+				outputs.Group{},
+				Settings{},
+			)
+			require.NoError(t, err)
+			defer pipeline.Close()
+
+			pipelineClient, err := pipeline.Connect()
+			require.NoError(t, err)
+			defer pipelineClient.Close()
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				for i := uint(0); i < numEventsToPublish; i++ {
+					pipelineClient.Publish(beat.Event{})
+				}
+				wg.Done()
+			}()
+
+			for i := uint(0); i < numOutputReloads; i++ {
+				outputClient := ctor(countingPublishFn)
+				out := outputs.Group{
+					Clients: []outputs.Client{outputClient},
+				}
+				fmt.Println("reloading output...")
+				pipeline.output.Set(out)
+			}
+
+			wg.Wait()
+
+			timeout := 5 * time.Second
+			success := waitUntilTrue(timeout, func() bool {
+				return uint(numEventsToPublish) == publishedCount.Load()
+			})
+			if !success {
+				fmt.Printf(
+					"numOutputReloads = %v, numEventsToPublish = %v, publishedCounted = %v\n",
+					numOutputReloads, numEventsToPublish, publishedCount.Load(),
+				)
+			}
+			require.True(t, success)
+		})
+	}
+}

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -45,7 +45,7 @@ func TestOutputReload(t *testing.T) {
 			seedPRNG(t)
 
 			numEventsToPublish := uint(20000)
-			numOutputReloads := uint(50)
+			numOutputReloads := uint(500)
 
 			queueFactory := func(ackListener queue.ACKListener) (queue.Queue, error) {
 				return memqueue.NewQueue(
@@ -93,6 +93,8 @@ func TestOutputReload(t *testing.T) {
 				}
 				fmt.Println("reloading output...")
 				pipeline.output.Set(out)
+
+				//time.Sleep(4 * time.Millisecond)
 			}
 
 			wg.Wait()

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -36,8 +36,8 @@ import (
 
 func TestOutputReload(t *testing.T) {
 	tests := map[string]func(mockPublishFn) outputs.Client{
-		"client":         newMockClient,
-		"network_client": newMockNetworkClient,
+		"client": newMockClient,
+		//"network_client": newMockNetworkClient,
 	}
 
 	for name, ctor := range tests {
@@ -59,7 +59,7 @@ func TestOutputReload(t *testing.T) {
 			var publishedCount atomic.Uint
 			countingPublishFn := func(batch publisher.Batch) error {
 				publishedCount.Add(uint(len(batch.Events())))
-				fmt.Printf("published so far: %v\n", publishedCount.Load())
+				fmt.Printf("published now: %v, so far: %v\n", len(batch.Events()), publishedCount.Load())
 				return nil
 			}
 

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -36,8 +36,8 @@ import (
 
 func TestOutputReload(t *testing.T) {
 	tests := map[string]func(mockPublishFn) outputs.Client{
-		"client": newMockClient,
-		//"network_client": newMockNetworkClient,
+		"client":         newMockClient,
+		"network_client": newMockNetworkClient,
 	}
 
 	for name, ctor := range tests {

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -91,9 +91,9 @@ func (w *worker) close() {
 	w.closed.Store(true)
 	w.lf("w.inflight == nil: %#v\n", w.inflight == nil)
 	if w.inflight != nil {
-		w.ln("waiting for inflight events to drain")
+		w.ln("waiting for inflight events to publish")
 		<-w.inflight
-		w.ln("inflight events drained")
+		w.ln("inflight events published")
 	}
 }
 
@@ -103,6 +103,9 @@ func (w *clientWorker) Close() error {
 }
 
 func (w *clientWorker) run() {
+	defer func() {
+		w.ln("clientWorker closed")
+	}()
 	for !w.closed.Load() {
 		for batch := range w.qu {
 			if w.closed.Load() {
@@ -128,7 +131,6 @@ func (w *clientWorker) run() {
 			close(w.inflight)
 		}
 	}
-	w.ln("clientWorker closed")
 }
 
 func (w *netClientWorker) Close() error {

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -71,6 +71,7 @@ func (w *clientWorker) run() {
 		for batch := range w.qu {
 			if w.closed.Load() {
 				if batch != nil {
+					fmt.Printf("canceling batch of %v events\n", len(batch.events))
 					batch.Cancelled()
 				}
 				return
@@ -84,6 +85,7 @@ func (w *clientWorker) run() {
 			}
 		}
 	}
+	fmt.Println("clientWorker closed")
 }
 
 func (w *netClientWorker) Close() error {

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -108,16 +108,17 @@ func (w *clientWorker) run() {
 	}()
 	for !w.closed.Load() {
 		for batch := range w.qu {
+			if batch == nil {
+				continue
+			}
+
+			w.lf("received batch of %v events\n", len(batch.events))
 			if w.closed.Load() {
 				if batch != nil {
 					w.lf("canceling batch of %v events\n", len(batch.events))
 					batch.Cancelled()
 				}
 				return
-			}
-
-			if batch == nil {
-				continue
 			}
 
 			w.observer.outBatchSend(len(batch.events))

--- a/libbeat/publisher/pipeline/output.go
+++ b/libbeat/publisher/pipeline/output.go
@@ -18,6 +18,8 @@
 package pipeline
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -76,6 +78,7 @@ func (w *clientWorker) run() {
 
 			w.observer.outBatchSend(len(batch.events))
 
+			fmt.Printf("in clientWorker, about to publish %v events\n", len(batch.events))
 			if err := w.client.Publish(batch); err != nil {
 				break
 			}

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -171,8 +171,10 @@ func (r *retryer) loop() {
 					consumerBlocked = blockConsumer(numOutputs, len(buffer))
 					if consumerBlocked {
 						log.Info("retryer: send wait signal to consumer")
+						lf("retryer: send wait signal to consumer")
 						r.consumer.sigWait()
 						log.Info("  done")
+						lf("  done")
 					}
 				}
 			}
@@ -194,8 +196,10 @@ func (r *retryer) loop() {
 				consumerBlocked = blockConsumer(numOutputs, len(buffer))
 				if !consumerBlocked {
 					log.Info("retryer: send unwait-signal to consumer")
+					lf("retryer: send unwait-signal to consumer")
 					r.consumer.sigUnWait()
 					log.Info("  done")
+					lf("  done")
 				}
 			}
 
@@ -215,7 +219,7 @@ func (r *retryer) loop() {
 func blockConsumer(numOutputs, numBatches int) bool {
 	block := numBatches/3 >= numOutputs
 	if block {
-		lf("in retry: blocking consumer: numBatches/3 = %v, numOutputs = %v\n", numBatches/3, numOutputs)
+		lf("in retry: blocking consumer: numBatches/3 = %v, numOutputs = %v", numBatches/3, numOutputs)
 	}
 	return block
 }

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -213,7 +213,11 @@ func (r *retryer) loop() {
 }
 
 func blockConsumer(numOutputs, numBatches int) bool {
-	return numBatches/3 >= numOutputs
+	block := numBatches/3 >= numOutputs
+	if block {
+		lf("in retry: blocking consumer: numBatches/3 = %v, numOutputs = %v\n", numBatches/3, numOutputs)
+	}
+	return block
 }
 
 func decBatch(batch *Batch) {

--- a/libbeat/publisher/queue/memqueue/eventloop.go
+++ b/libbeat/publisher/queue/memqueue/eventloop.go
@@ -102,7 +102,6 @@ func (l *directEventLoop) run() {
 			return
 
 		case req := <-l.events: // producer pushing new event
-			//fmt.Println("producer pushing new event")
 			l.handleInsert(&req)
 
 		case req := <-l.pubCancel: // producer cancelling active events
@@ -203,7 +202,6 @@ func (l *directEventLoop) handleConsumer(req *getRequest) {
 	ackCH := newACKChan(l.ackSeq, start, count, l.buf.buf.clients)
 	l.ackSeq++
 
-	fmt.Printf("in memqueue eventloop: returning %v events to consumer\n", len(buf))
 	req.resp <- getResponse{ackCH, buf}
 	l.pendingACKs.append(ackCH)
 	l.schedACKS = l.broker.scheduledACKs

--- a/libbeat/publisher/queue/memqueue/eventloop.go
+++ b/libbeat/publisher/queue/memqueue/eventloop.go
@@ -102,6 +102,7 @@ func (l *directEventLoop) run() {
 			return
 
 		case req := <-l.events: // producer pushing new event
+			//fmt.Println("producer pushing new event")
 			l.handleInsert(&req)
 
 		case req := <-l.pubCancel: // producer cancelling active events
@@ -202,6 +203,7 @@ func (l *directEventLoop) handleConsumer(req *getRequest) {
 	ackCH := newACKChan(l.ackSeq, start, count, l.buf.buf.clients)
 	l.ackSeq++
 
+	fmt.Printf("returning %v events to consumer\n", len(buf))
 	req.resp <- getResponse{ackCH, buf}
 	l.pendingACKs.append(ackCH)
 	l.schedACKS = l.broker.scheduledACKs

--- a/libbeat/publisher/queue/memqueue/eventloop.go
+++ b/libbeat/publisher/queue/memqueue/eventloop.go
@@ -203,7 +203,7 @@ func (l *directEventLoop) handleConsumer(req *getRequest) {
 	ackCH := newACKChan(l.ackSeq, start, count, l.buf.buf.clients)
 	l.ackSeq++
 
-	fmt.Printf("returning %v events to consumer\n", len(buf))
+	fmt.Printf("in memqueue eventloop: returning %v events to consumer\n", len(buf))
 	req.resp <- getResponse{ackCH, buf}
 	l.pendingACKs.append(ackCH)
 	l.schedACKS = l.broker.scheduledACKs


### PR DESCRIPTION
**NOTE: This PR is VERY MUCH a WIP. It is not intended to be reviewed at this point. At this point, it is primarily being used for debugging the event publishing flow with output reloading.**

## What does this PR do?

This PR adds a unit test for output reloading. The test reloads the output multiple times, very quickly, and checks if all events are eventually published.

## Why is it important?

If the output is reloaded multiple times very quickly, not all events seem to get published eventually. This PR adds a test that proves it so we can then work towards a fix.
