### PR TITLE
Cherry-pick #17637 to 7.7: Add privileged option for Auditbeat in Openshift

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -196,6 +196,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
 - Add privileged option so as mb to access data dir in Openshift. {pull}17606[17606]
 - Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
+- Add privileged option for Auditbeat in Openshift {pull}17637[17637]
 - Fix storage metricset to allow config without region/zone. {issue}17623[17623] {pull}17624[17624]
 
 *Packetbeat*

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -133,6 +133,8 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
           capabilities:
             add:
               # Capabilities needed for auditd module

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -46,6 +46,8 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
           capabilities:
             add:
               # Capabilities needed for auditd module


### PR DESCRIPTION
Cherry-pick of PR #17637 to 7.7 branch. Original message: 

## What does this PR do?
This PR adds privileged: true in securityContext of Auditbeat Daemonset spec file so as to enable access to hostPath volumes.

Tested with minishift v1.34.2+83ebaab.

## Why is it important?
Auditbeat is not able to start in Openshift without this option:

```
failed to open log file "/var/log/pods/9f2293ae-7a5e-11ea-8e28-08002709c05c/auditbeat/4.log": open /var/log/pods/9f2293ae-7a5e-11ea-8e28-08002709c05c/auditbeat/4.log: no such file or directory
```

Related to https://github.com/elastic/beats/pull/17606 and https://github.com/elastic/beats/issues/17516 

cc: @jsoriano 