### PR TITLE
Cherry-pick #16354 to 7.7: Update filebeat httpjson input to support pagination via Header and Okta module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,7 +315,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
 - Added access_key_id, secret_access_key and session_token into aws module config. {pull}17456[17456]
 - Release Google Cloud module as GA. {pull}17511[17511]
-- Improve ECS categorization field mappings in logstash module. {issue}16169[16169] {pull}16668[16668]
 - Update filebeat httpjson input to support pagination via Header and Okta module. {pull}16354[16354]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,6 +315,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added documentation for running Filebeat in Cloud Foundry. {pull}17275[17275]
 - Added access_key_id, secret_access_key and session_token into aws module config. {pull}17456[17456]
 - Release Google Cloud module as GA. {pull}17511[17511]
+- Improve ECS categorization field mappings in logstash module. {issue}16169[16169] {pull}16668[16668]
+- Update filebeat httpjson input to support pagination via Header and Okta module. {pull}16354[16354]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -92,15 +92,30 @@ If the HTTP API returns data in a JSON array, then this option can be set to dec
 from the array. Default: not used.
 
 [float]
+==== `no_http_body`
+
+If set, do not use HTTP request body. Default: false.
+
+[float]
 ==== `pagination.enabled`
 
-This option specifies whether pagination is enabled. Default: false.
+This option specifies whether pagination is enabled. Default: true.
 
 [float]
 ==== `pagination.extra_body_content`
 
 Any additional data that needs to be set in the HTTP pagination request can be specified in
 this JSON blob. Default: not used.
+
+[float]
+==== `pagination.header.field_name`
+
+The field name in the HTTP Header that is used for pagination control. 
+
+[float]
+==== `pagination.header.regex_pattern`
+
+The regular expression pattern to use for retrieving the pagination information from the HTTP Header field specified above.
 
 [float]
 ==== `pagination.id_field`
@@ -119,6 +134,22 @@ Required when pagination is enabled.
 
 This specifies the URL for sending pagination request. Required if the pagination URL is different 
 than the HTTP API URL.
+
+[float]
+==== `rate_limit.limit`
+
+This specifies the field in the HTTP Header of the response that specifies the total limit.
+
+[float]
+==== `rate_limit.remaining`
+
+This specifies the field in the HTTP Header of the response that specifies the remaining quota of the rate limit.
+
+[float]
+==== `rate_limit.reset`
+
+This specifies the field in the HTTP Header of the response that specifies the epoch time 
+when the rate limit will be reset.
 
 [float]
 ==== `ssl`

--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -5,6 +5,7 @@
 package httpjson
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,25 +17,47 @@ import (
 
 // Config contains information about httpjson configuration
 type config struct {
-	APIKey            string            `config:"api_key"`
-	HTTPClientTimeout time.Duration     `config:"http_client_timeout"`
-	HTTPHeaders       common.MapStr     `config:"http_headers"`
-	HTTPMethod        string            `config:"http_method" validate:"required"`
-	HTTPRequestBody   common.MapStr     `config:"http_request_body"`
-	Interval          time.Duration     `config:"interval"`
-	JSONObjects       string            `config:"json_objects_array"`
-	Pagination        *Pagination       `config:"pagination"`
-	TLS               *tlscommon.Config `config:"ssl"`
-	URL               string            `config:"url" validate:"required"`
+	APIKey               string            `config:"api_key"`
+	AuthenticationScheme string            `config:"authentication_scheme"`
+	HTTPClientTimeout    time.Duration     `config:"http_client_timeout"`
+	HTTPHeaders          common.MapStr     `config:"http_headers"`
+	HTTPMethod           string            `config:"http_method" validate:"required"`
+	HTTPRequestBody      common.MapStr     `config:"http_request_body"`
+	Interval             time.Duration     `config:"interval"`
+	JSONObjects          string            `config:"json_objects_array"`
+	NoHTTPBody           bool              `config:"no_http_body"`
+	Pagination           *Pagination       `config:"pagination"`
+	RateLimit            *RateLimit        `config:"rate_limit"`
+	TLS                  *tlscommon.Config `config:"ssl"`
+	URL                  string            `config:"url" validate:"required"`
 }
 
 // Pagination contains information about httpjson pagination settings
 type Pagination struct {
-	IsEnabled        bool          `config:"enabled"`
+	Enabled          *bool         `config:"enabled"`
 	ExtraBodyContent common.MapStr `config:"extra_body_content"`
+	Header           *Header       `config:"header"`
 	IDField          string        `config:"id_field"`
 	RequestField     string        `config:"req_field"`
 	URL              string        `config:"url"`
+}
+
+// IsEnabled returns true if the `enable` field is set to true in the yaml.
+func (p *Pagination) IsEnabled() bool {
+	return p != nil && (p.Enabled == nil || *p.Enabled)
+}
+
+// HTTP Header information for pagination
+type Header struct {
+	FieldName    string         `config:"field_name" validate:"required"`
+	RegexPattern *regexp.Regexp `config:"regex_pattern" validate:"required"`
+}
+
+// HTTP Header Rate Limit information
+type RateLimit struct {
+	Limit     string `config:"limit"`
+	Reset     string `config:"reset"`
+	Remaining string `config:"remaining"`
 }
 
 func (c *config) Validate() error {
@@ -44,7 +67,22 @@ func (c *config) Validate() error {
 	case "POST":
 		break
 	default:
-		return errors.Errorf("httpjson input: Invalid http_method, %s - ", c.HTTPMethod)
+		return errors.Errorf("httpjson input: Invalid http_method, %s", c.HTTPMethod)
+	}
+	if c.NoHTTPBody {
+		if len(c.HTTPRequestBody) > 0 {
+			return errors.Errorf("invalid configuration: both no_http_body and http_request_body cannot be set simultaneously")
+		}
+		if c.Pagination != nil && (len(c.Pagination.ExtraBodyContent) > 0 || c.Pagination.RequestField != "") {
+			return errors.Errorf("invalid configuration: both no_http_body and pagination.extra_body_content or pagination.req_field cannot be set simultaneously")
+		}
+	}
+	if c.Pagination != nil {
+		if c.Pagination.Header != nil {
+			if c.Pagination.RequestField != "" || c.Pagination.IDField != "" || len(c.Pagination.ExtraBodyContent) > 0 {
+				return errors.Errorf("invalid configuration: both pagination.header and pagination.req_field or pagination.id_field or pagination.extra_body_content cannot be set simultaneously")
+			}
+		}
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/httpjson/httpjson_test.go
+++ b/x-pack/filebeat/input/httpjson/httpjson_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync"
 	"testing"
 
@@ -35,7 +36,7 @@ func testSetup(t *testing.T) {
 	})
 }
 
-func runTest(t *testing.T, isTLS bool, m map[string]interface{}, run func(input *httpjsonInput, out *stubOutleter, t *testing.T)) {
+func runTest(t *testing.T, isTLS bool, m map[string]interface{}, run func(input *HttpjsonInput, out *stubOutleter, t *testing.T)) {
 	testSetup(t)
 	// Create an http test server according to whether TLS is used
 	var newServer = httptest.NewServer
@@ -90,7 +91,7 @@ func runTest(t *testing.T, isTLS bool, m map[string]interface{}, run func(input 
 	if err != nil {
 		t.Fatal(err)
 	}
-	input := in.(*httpjsonInput)
+	input := in.(*HttpjsonInput)
 	defer input.Stop()
 
 	run(input, eventOutlet, t)
@@ -152,12 +153,191 @@ func (o *stubOutleter) OnEvent(event beat.Event) bool {
 
 // --- Test Cases
 
+func TestConfigValidationCase1(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method":       "GET",
+		"http_request_body": map[string]interface{}{"test": "abc"},
+		"no_http_body":      true,
+		"url":               "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. no_http_body and http_request_body cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase2(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method":  "GET",
+		"no_http_body": true,
+		"pagination":   map[string]interface{}{"extra_body_content": map[string]interface{}{"test": "abc"}},
+		"url":          "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. no_http_body and pagination.extra_body_content cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase3(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method":  "GET",
+		"no_http_body": true,
+		"pagination":   map[string]interface{}{"req_field": "abc"},
+		"url":          "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. no_http_body and pagination.req_field cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase4(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method": "GET",
+		"pagination":  map[string]interface{}{"header": map[string]interface{}{"field_name": "Link", "regex_pattern": "<([^>]+)>; *rel=\"next\"(?:,|$)"}, "req_field": "abc"},
+		"url":         "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. pagination.header and pagination.req_field cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase5(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method": "GET",
+		"pagination":  map[string]interface{}{"header": map[string]interface{}{"field_name": "Link", "regex_pattern": "<([^>]+)>; *rel=\"next\"(?:,|$)"}, "id_field": "abc"},
+		"url":         "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. pagination.header and pagination.id_field cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase6(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method": "GET",
+		"pagination":  map[string]interface{}{"header": map[string]interface{}{"field_name": "Link", "regex_pattern": "<([^>]+)>; *rel=\"next\"(?:,|$)"}, "extra_body_content": map[string]interface{}{"test": "abc"}},
+		"url":         "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. pagination.header and extra_body_content cannot coexist.")
+	}
+}
+
+func TestConfigValidationCase7(t *testing.T) {
+	m := map[string]interface{}{
+		"http_method":  "DELETE",
+		"no_http_body": true,
+		"url":          "localhost",
+	}
+	cfg := common.MustNewConfigFrom(m)
+	conf := defaultConfig()
+	if err := cfg.Unpack(&conf); err == nil {
+		t.Fatal("Configuration validation failed. http_method DELETE is not allowed.")
+	}
+}
+
+func TestGetNextLinkFromHeader(t *testing.T) {
+	header := make(http.Header)
+	header.Add("Link", "<https://dev-168980.okta.com/api/v1/logs>; rel=\"self\"")
+	header.Add("Link", "<https://dev-168980.okta.com/api/v1/logs?after=1581658181086_1>; rel=\"next\"")
+	re, _ := regexp.Compile("<([^>]+)>; *rel=\"next\"(?:,|$)")
+	url, err := getNextLinkFromHeader(header, "Link", re)
+	if url != "https://dev-168980.okta.com/api/v1/logs?after=1581658181086_1" {
+		t.Fatal("Failed to test getNextLinkFromHeader. URL " + url + " is not expected")
+	}
+	if err != nil {
+		t.Fatal("Failed to test getNextLinkFromHeader with error:", err)
+	}
+}
+
+func TestCreateRequestInfoFromBody(t *testing.T) {
+	m := map[string]interface{}{
+		"id": 100,
+	}
+	extraBodyContent := common.MapStr{"extra_body": "abc"}
+	ri, err := createRequestInfoFromBody(common.MapStr(m), "id", "pagination_id", extraBodyContent, "https://test-123", &RequestInfo{
+		URL:        "",
+		ContentMap: common.MapStr{},
+		Headers:    common.MapStr{},
+	})
+	if ri.URL != "https://test-123" {
+		t.Fatal("Failed to test createRequestInfoFromBody. URL should be https://test-123.")
+	}
+	p, err := ri.ContentMap.GetValue("pagination_id")
+	if err != nil {
+		t.Fatal("Failed to test createRequestInfoFromBody with error", err)
+	}
+	switch pt := p.(type) {
+	case int:
+		if pt != 100 {
+			t.Fatalf("Failed to test createRequestInfoFromBody. pagination_id value %d should be 100.", pt)
+		}
+	default:
+		t.Fatalf("Failed to test createRequestInfoFromBody. pagination_id value %T should be int.", pt)
+	}
+	b, err := ri.ContentMap.GetValue("extra_body")
+	if err != nil {
+		t.Fatal("Failed to test createRequestInfoFromBody with error", err)
+	}
+	switch bt := b.(type) {
+	case string:
+		if bt != "abc" {
+			t.Fatalf("Failed to test createRequestInfoFromBody. extra_body value %s does not match \"abc\".", bt)
+		}
+	default:
+		t.Fatalf("Failed to test createRequestInfoFromBody. extra_body type %T should be string.", bt)
+	}
+}
+
+func TestGetRateLimitCase1(t *testing.T) {
+	header := make(http.Header)
+	header.Add("X-Rate-Limit-Limit", "120")
+	header.Add("X-Rate-Limit-Remaining", "118")
+	header.Add("X-Rate-Limit-Reset", "1581658643")
+	rateLimit := &RateLimit{
+		Limit:     "X-Rate-Limit-Limit",
+		Reset:     "X-Rate-Limit-Reset",
+		Remaining: "X-Rate-Limit-Remaining",
+	}
+	epoch, err := getRateLimit(header, rateLimit)
+	if err != nil || epoch != 0 {
+		t.Fatal("Failed to test getRateLimit.")
+	}
+}
+
+func TestGetRateLimitCase2(t *testing.T) {
+	header := make(http.Header)
+	header.Add("X-Rate-Limit-Limit", "10")
+	header.Add("X-Rate-Limit-Remaining", "0")
+	header.Add("X-Rate-Limit-Reset", "1581658643")
+	rateLimit := &RateLimit{
+		Limit:     "X-Rate-Limit-Limit",
+		Reset:     "X-Rate-Limit-Reset",
+		Remaining: "X-Rate-Limit-Remaining",
+	}
+	epoch, err := getRateLimit(header, rateLimit)
+	if err != nil || epoch != 1581658643 {
+		t.Fatal("Failed to test getRateLimit.")
+	}
+}
+
 func TestGET(t *testing.T) {
 	m := map[string]interface{}{
 		"http_method": "GET",
 		"interval":    0,
 	}
-	runTest(t, false, m, func(input *httpjsonInput, out *stubOutleter, t *testing.T) {
+	runTest(t, false, m, func(input *HttpjsonInput, out *stubOutleter, t *testing.T) {
 		group, _ := errgroup.WithContext(context.Background())
 		group.Go(input.run)
 
@@ -179,7 +359,7 @@ func TestGetHTTPS(t *testing.T) {
 		"interval":              0,
 		"ssl.verification_mode": "none",
 	}
-	runTest(t, true, m, func(input *httpjsonInput, out *stubOutleter, t *testing.T) {
+	runTest(t, true, m, func(input *HttpjsonInput, out *stubOutleter, t *testing.T) {
 		group, _ := errgroup.WithContext(context.Background())
 		group.Go(input.run)
 
@@ -201,7 +381,7 @@ func TestPOST(t *testing.T) {
 		"http_request_body": map[string]interface{}{"test": "abc", "testNested": map[string]interface{}{"testNested1": 123}},
 		"interval":          0,
 	}
-	runTest(t, false, m, func(input *httpjsonInput, out *stubOutleter, t *testing.T) {
+	runTest(t, false, m, func(input *HttpjsonInput, out *stubOutleter, t *testing.T) {
 		group, _ := errgroup.WithContext(context.Background())
 		group.Go(input.run)
 
@@ -223,7 +403,7 @@ func TestRepeatedPOST(t *testing.T) {
 		"http_request_body": map[string]interface{}{"test": "abc", "testNested": map[string]interface{}{"testNested1": 123}},
 		"interval":          10 ^ 9,
 	}
-	runTest(t, false, m, func(input *httpjsonInput, out *stubOutleter, t *testing.T) {
+	runTest(t, false, m, func(input *HttpjsonInput, out *stubOutleter, t *testing.T) {
 		group, _ := errgroup.WithContext(context.Background())
 		group.Go(input.run)
 
@@ -244,7 +424,7 @@ func TestRunStop(t *testing.T) {
 		"http_method": "GET",
 		"interval":    0,
 	}
-	runTest(t, false, m, func(input *httpjsonInput, out *stubOutleter, t *testing.T) {
+	runTest(t, false, m, func(input *HttpjsonInput, out *stubOutleter, t *testing.T) {
 		input.Run()
 		input.Stop()
 		input.Run()


### PR DESCRIPTION
Cherry-pick of PR #16354 to 7.7 branch. Original message: 

Update filebeat httpjson input to support:

- Pagination via HTTP Header fields and regexp based matching
- Rate limit via HTTP Header fields
- Okta module