### PR TITLE
Update Security docs to handle new roles / spaces / app perms

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
+:beat_kib_app: {kib} Logs
 :has_ml_jobs: yes
 :has_central_config:
 :has_solutions:

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
+:beat_kib_app: {kib} Uptime
 :deb_os:
 :rpm_os:
 :mac_os:

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -22,15 +22,18 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
+  name: "MY THING"
+  hosts: ["https://elastic.co"]
+  ssl.verification_mode: none
+  schedule: "@every 5s"
+  timeout: 5s
+  check.response.status: [200, 302, 400, 401, 403, 404]
 
-  # List or urls to query
-  urls: ["http://localhost:9200"]
-
-  # Configure task schedule
-  schedule: '@every 10s'
-
-  # Total test connection and data exchange timeout
-  #timeout: 16s
+processors:
+  - add_observer_metadata: 
+      geo: 
+        name: "${GEO_NAME}"
+        location: "37.926868, -78.024902"
 
 #==================== Elasticsearch template setting ==========================
 
@@ -55,6 +58,18 @@ setup.template.settings:
 #  env: staging
 
 
+#============================== Dashboards =====================================
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards is disabled by default and can be enabled either by setting the
+# options here or by using the `setup` command.
+#setup.dashboards.enabled: false
+
+# The URL from where to download the dashboards archive. By default this URL
+# has a value which is computed based on the Beat name and version. For released
+# versions, this URL points to the dashboard archive on the artifacts.elastic.co
+# website.
+#setup.dashboards.url:
+
 #============================== Kibana =====================================
 
 # Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
@@ -74,7 +89,7 @@ setup.kibana:
 
 #============================= Elastic Cloud ==================================
 
-# These settings simplify using Heartbeat with the Elastic Cloud (https://cloud.elastic.co/).
+# These settings simplify using heartbeat with the Elastic Cloud (https://cloud.elastic.co/).
 
 # The cloud.id setting overwrites the `output.elasticsearch.hosts` and
 # `setup.kibana.host` options.
@@ -89,19 +104,8 @@ setup.kibana:
 
 # Configure what output to use when sending the data collected by the beat.
 
-#-------------------------- Elasticsearch output ------------------------------
-output.elasticsearch:
-  # Array of hosts to connect to.
-  hosts: ["localhost:9200"]
 
-  # Protocol - either `http` (default) or `https`.
-  #protocol: "https"
-
-  # Authentication credentials - either API key or username/password.
-  #api_key: "id:api_key"
-  #username: "elastic"
-  #password: "changeme"
-
+output.console: ~
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts
@@ -119,16 +123,6 @@ output.elasticsearch:
 
 #================================ Processors =====================================
 
-processors:
-  - add_observer_metadata:
-  # Optional, but recommended geo settings for the location Heartbeat is running in
-  #geo:
-    # Token describing this location
-    #name: us-east-1a
-
-    # Lat, Lon "
-    #location: "37.926868, -78.024902"
-
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
@@ -140,18 +134,13 @@ processors:
 # "publish", "service".
 #logging.selectors: ["*"]
 
-#============================== X-Pack Monitoring ===============================
+#============================== Xpack Monitoring ===============================
 # heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
 
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
-
-# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
-# Heartbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
-# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
-#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -22,18 +22,15 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
-  name: "MY THING"
-  hosts: ["https://elastic.co"]
-  ssl.verification_mode: none
-  schedule: "@every 5s"
-  timeout: 5s
-  check.response.status: [200, 302, 400, 401, 403, 404]
 
-processors:
-  - add_observer_metadata: 
-      geo: 
-        name: "${GEO_NAME}"
-        location: "37.926868, -78.024902"
+  # List or urls to query
+  urls: ["http://localhost:9200"]
+
+  # Configure task schedule
+  schedule: '@every 10s'
+
+  # Total test connection and data exchange timeout
+  #timeout: 16s
 
 #==================== Elasticsearch template setting ==========================
 
@@ -58,18 +55,6 @@ setup.template.settings:
 #  env: staging
 
 
-#============================== Dashboards =====================================
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards is disabled by default and can be enabled either by setting the
-# options here or by using the `setup` command.
-#setup.dashboards.enabled: false
-
-# The URL from where to download the dashboards archive. By default this URL
-# has a value which is computed based on the Beat name and version. For released
-# versions, this URL points to the dashboard archive on the artifacts.elastic.co
-# website.
-#setup.dashboards.url:
-
 #============================== Kibana =====================================
 
 # Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
@@ -89,7 +74,7 @@ setup.kibana:
 
 #============================= Elastic Cloud ==================================
 
-# These settings simplify using heartbeat with the Elastic Cloud (https://cloud.elastic.co/).
+# These settings simplify using Heartbeat with the Elastic Cloud (https://cloud.elastic.co/).
 
 # The cloud.id setting overwrites the `output.elasticsearch.hosts` and
 # `setup.kibana.host` options.
@@ -104,8 +89,19 @@ setup.kibana:
 
 # Configure what output to use when sending the data collected by the beat.
 
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
 
-output.console: ~
+  # Protocol - either `http` (default) or `https`.
+  #protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts
@@ -123,6 +119,16 @@ output.console: ~
 
 #================================ Processors =====================================
 
+processors:
+  - add_observer_metadata:
+  # Optional, but recommended geo settings for the location Heartbeat is running in
+  #geo:
+    # Token describing this location
+    #name: us-east-1a
+
+    # Lat, Lon "
+    #location: "37.926868, -78.024902"
+
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
@@ -134,13 +140,18 @@ output.console: ~
 # "publish", "service".
 #logging.selectors: ["*"]
 
-#============================== Xpack Monitoring ===============================
+#============================== X-Pack Monitoring ===============================
 # heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
 
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Heartbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
+:beat_kib_app: {kib} Logs
 :deb_os:
 :rpm_os:
 :linux_os:

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -29,11 +29,11 @@ strategy.
 
 IMPORTANT: Setting up {beatname_uc} is an admin-level task that requires extra
 privileges. As a best practice, grant the setup role to administrators only, and
-use a less restrictive role for event publishing.  
+use a less restrictive role for event publishing.
 
 Administrators who set up {beatname_uc} typically need to load mappings,
 dashboards, and other objects used to index data into {es} and visualize it in
-{kib}. 
+{kib}.
 
 To grant users the required privileges:
 
@@ -63,7 +63,7 @@ endif::has_ml_jobs[]
 |Index
 |`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
- 
+
 ifdef::has_ml_jobs[]
 |Index
 |`read` on +{beat_default_index_prefix}-*+ indices
@@ -78,13 +78,13 @@ NOTE: These instructions assume that you are using the default name for
 match your index naming pattern.
 
 . Assign the *setup role*, along with the following built-in roles, to users who
-need to set up {beatname_uc}: 
+need to set up {beatname_uc}:
 +
 [options="header"]
 |====
 |Role | Purpose
 
-|`kibana_user`
+|`kibana_admin`
 |Load dependencies, such as example dashboards, if available, into {kib}
 
 |`ingest_admin`
@@ -109,9 +109,9 @@ Omit any roles that aren't relevant in your environment.
 {security} provides built-in users and roles for monitoring. The privileges and
 roles needed depend on the method used to collect monitoring data.
 
-[IMPORTANT] 
+[IMPORTANT]
 .Important note for {ecloud} users
-==== 
+====
 Built-in users are not available when running our
 https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
 on {ecloud}. To send monitoring data securely, create a monitoring user and
@@ -152,7 +152,7 @@ If you don't use the +{beat_monitoring_user}+ user:
 |====
 
 . Assign the *monitoring role*, along with the following built-in roles, to
-users who need to monitor {beatname_uc}: 
+users who need to monitor {beatname_uc}:
 +
 [options="header"]
 |====
@@ -184,7 +184,7 @@ If you don't use the `remote_monitoring_user` user:
 . Create a user on the production cluster who will collect and send monitoring
 information.
 
-. Assign the following roles to the user: 
+. Assign the following roles to the user:
 +
 [options="header"]
 |====
@@ -216,7 +216,7 @@ endif::serverless[]
 Users who publish events to {es} need to create and write to {beatname_uc}
 indices. To minimize the privileges required by the writer role, use the
 <<privileges-to-setup-beats,setup role>> to pre-load dependencies. This section
-assumes that you've pre-loaded dependencies. 
+assumes that you've pre-loaded dependencies.
 
 ifndef::no_ilm[]
 When using ILM, turn off the ILM setup check in the {beatname_uc} config file before
@@ -243,7 +243,7 @@ NOTE: The `monitor` cluster privilege and the `create_doc` privilege on
 ifndef::apm-server[]
 |Cluster
 |`monitor`
-|Retrieve cluster details (e.g. version) 
+|Retrieve cluster details (e.g. version)
 endif::apm-server[]
 
 ifndef::no_ilm[]
@@ -283,7 +283,7 @@ endif::apm-server[]
 . Assign the *writer role* to users who will index events into {es}.
 
 [[kibana-user-privileges]]
-==== Grant privileges and roles needed to read {beatname_uc} data
+==== Grant privileges and roles needed to read {beatname_uc} data from Kibana
 
 {kib} users typically need to view dashboards and visualizations that contain
 {beatname_uc} data. These users might also need to create and edit dashboards
@@ -308,6 +308,13 @@ the following privilege:
 |Read data indexed by {beatname_uc}
 |====
 
+. Add {kibana-ref}/kibana-privileges.html[{kib} privileges] for the {kib} apps
+the user will need to access within the appropriate {kib} spaces. This typically comprises the
+ifdef::beat_kib_app[]
+{beat_kib_app},
+endif::[]
+Dashboard, Visualize, and Discover apps.
+
 . Assign the *reader role*, along with the following built-in roles, to
 users who need to read {beatname_uc} data:
 +
@@ -315,17 +322,16 @@ users who need to read {beatname_uc} data:
 |====
 |Role | Purpose
 
-|`kibana_user` or `kibana_dashboard_only_user`
-|Use {kib}. `kibana_dashboard_only_user` grants read-only access to dashboards.
+| `monitoring_user`
+| Allow users to monitor the health of the beat itself. Only assign this role to users who manage the {uc_beatname}.
 
 ifdef::has_central_config[]
 |`beats_admin`
 |Create and manage configurations in Beats central management. Only assign this
 role to users who need to use Beats central management.
++
 endif::[]
 |====
-+
-Omit any roles that aren't relevant in your environment.
 endif::apm-server[]
 
 ifdef::apm-server[]
@@ -340,7 +346,7 @@ data:
 |Use the APM UI
 
 |`admin`
-|Read and update APM Agent configuration via Kibana
+|Read and update APM Agent configuration via {kib}
 |====
 endif::apm-server[]
 

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -29,7 +29,7 @@ strategy.
 
 IMPORTANT: Setting up {beatname_uc} is an admin-level task that requires extra
 privileges. As a best practice, grant the setup role to administrators only, and
-use a less restrictive role for event publishing.
+use a more restrictive role for event publishing.
 
 Administrators who set up {beatname_uc} typically need to load mappings,
 dashboards, and other objects used to index data into {es} and visualize it in

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -306,13 +306,18 @@ the following privilege:
 |Index
 |`read` on +{beat_default_index_prefix}-*+ indices
 |Read data indexed by {beatname_uc}
+
+| Spaces
+| `Read` or `All` on Dashboards, Visualize and Discover
+| Allow the user to view, edit, and create dashboards, as well as browse data.
+
+ifdef::beat_kib_app[]
+| Spaces
+| `Read` or `All` on {beat_kib_app}
+| Allow the use of {beat_kib_app}
+endif::[]
 |====
 
-. Add {kibana-ref}/kibana-privileges.html[{kib} privileges] for the {kib} apps
-the user will need to access within the appropriate {kib} spaces. This typically comprises the
-ifdef::beat_kib_app[]
-{beat_kib_app},
-endif::[]
 Dashboard, Visualize, and Discover apps.
 
 . Assign the *reader role*, along with the following built-in roles, to

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -318,8 +318,6 @@ ifdef::beat_kib_app[]
 endif::[]
 |====
 
-Dashboard, Visualize, and Discover apps.
-
 . Assign the *reader role*, along with the following built-in roles, to
 users who need to read {beatname_uc} data:
 +

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -16,6 +16,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :github_repo_name: beats
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
+:beat_kib_app: {kib} Metrics
 :has_central_config:
 :has_solutions:
 :has_docker_label_ex:


### PR DESCRIPTION
In this PR I've updated the security docs to stop using the deprecated `kibana_user` role, and rely on Kibana privileges instead. 