### PR TITLE
Cherry-pick #17667 to 7.7: Fix filebeat documentation and s3 input error messages

### DIFF
--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -141,10 +141,10 @@ AWS credential profile name.
 *`var.access_key_id`*::
 First part of access key.
 
-*`var.access_key_id`*::
+*`var.secret_access_key`*::
 Second part of access key.
 
-*`var.access_key_id`*::
+*`var.session_token`*::
 Required when using temporary security credentials.
 
 [float]

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -202,7 +202,7 @@ func (p *s3Input) run(svcSQS sqsiface.ClientAPI, svcS3 s3iface.ClientAPI, visibi
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == awssdk.ErrCodeRequestCanceled {
 				continue
 			}
-			p.logger.Error("failed to receive message from SQS: ", err)
+			p.logger.Error("SQS ReceiveMessageRequest failed: ", err)
 			time.Sleep(time.Duration(waitTimeSecond) * time.Second)
 			continue
 		}
@@ -278,7 +278,7 @@ func (p *s3Input) processorKeepAlive(svcSQS sqsiface.ClientAPI, message sqs.Mess
 				p.logger.Warn("Processing message failed, updating visibility timeout")
 				err := p.changeVisibilityTimeout(queueURL, visibilityTimeout, svcSQS, message.ReceiptHandle)
 				if err != nil {
-					p.logger.Error(errors.Wrap(err, "change message visibility failed"))
+					p.logger.Error(errors.Wrap(err, "SQS ChangeMessageVisibilityRequest failed"))
 				}
 				p.logger.Infof("Message visibility timeout updated to %v", visibilityTimeout)
 			} else {
@@ -299,7 +299,7 @@ func (p *s3Input) processorKeepAlive(svcSQS sqsiface.ClientAPI, message sqs.Mess
 			// still ongoing, then change visibility timeout.
 			err := p.changeVisibilityTimeout(queueURL, visibilityTimeout, svcSQS, message.ReceiptHandle)
 			if err != nil {
-				p.logger.Error(errors.Wrap(err, "change message visibility failed"))
+				p.logger.Error(errors.Wrap(err, "SQS ChangeMessageVisibilityRequest failed"))
 			}
 			p.logger.Infof("Message visibility timeout updated to %v seconds", visibilityTimeout)
 		}
@@ -411,7 +411,7 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 			// If the SDK can determine the request or retry delay was canceled
 			// by a context the ErrCodeRequestCanceled error will be returned.
 			if awsErr.Code() == awssdk.ErrCodeRequestCanceled {
-				err = errors.Wrap(err, "GetObject request canceled")
+				err = errors.Wrap(err, "S3 GetObjectRequest canceled")
 				p.logger.Error(err)
 				return err
 			}
@@ -421,7 +421,7 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 				return nil
 			}
 		}
-		return errors.Wrap(err, "s3 get object request failed")
+		return errors.Wrap(err, "S3 GetObjectRequest failed")
 	}
 
 	defer resp.Body.Close()
@@ -588,7 +588,7 @@ func (p *s3Input) deleteMessage(queueURL string, messagesReceiptHandle string, s
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == awssdk.ErrCodeRequestCanceled {
 			return nil
 		}
-		return errors.Wrap(err, "DeleteMessageRequest failed")
+		return errors.Wrap(err, "SQS DeleteMessageRequest failed")
 	}
 	return nil
 }

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -136,10 +136,10 @@ AWS credential profile name.
 *`var.access_key_id`*::
 First part of access key.
 
-*`var.access_key_id`*::
+*`var.secret_access_key`*::
 Second part of access key.
 
-*`var.access_key_id`*::
+*`var.session_token`*::
 Required when using temporary security credentials.
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #17667 to 7.7 branch. Original message: 

This PR is to fix some documentation typo and improve error messages in s3 input.
