### PR TITLE
[DOCS] cd into correct directory before invoking mage.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -241,6 +241,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
+- Fix `mage GenerateCustomBeat` instructions for a new beat {pull}17679[17679]
 
 *Auditbeat*
 

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -120,7 +120,6 @@ Now create a directory under $GOPATH for your repository and change to the new d
 [source,shell]
 --------------------
 mkdir ${GOPATH}/src/github.com/{user}
-cd ${GOPATH}/src/github.com/{user}
 --------------------
 
 Run the mage script to generate the custom beat:
@@ -128,6 +127,7 @@ Run the mage script to generate the custom beat:
 
 [source,shell]
 --------------------
+cd ${GOPATH}/src/github.com/elastic/beats
 mage GenerateCustomBeat
 --------------------
 


### PR DESCRIPTION
Relates elastic/beats#14409

The docs for creating a new beat are currently wrong as they tell you to `cd` into your github home directory before calling `mage GenerateCustomBeat`. This gives the error `No .go files marked with the mage build tag in this directory.`.

This PR updates the docs so the reader will create their github home directory, then `cd` into the beats directory before running Mage.