### PR TITLE
[7.x] enable urldecode parallelizing test (#17601)

### DIFF
--- a/libbeat/processors/urldecode/urldecode_test.go
+++ b/libbeat/processors/urldecode/urldecode_test.go
@@ -188,7 +188,7 @@ func TestURLDecode(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.description, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 
 			f := &urlDecode{
 				log:    logp.NewLogger("urldecode"),


### PR DESCRIPTION
Backports the following commits to 7.x:
 - enable urldecode parallelizing test  (#17601)