### PR TITLE
Clarifying PKI auth settings for beats monitoring

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -109,9 +109,9 @@ monitoring:
 --------------------
 +
 You must specify the `username` as `""` explicitly so that
-{beatname_uc} does not attempt to authentication using a
-username and password (HTTP basic authentication) and relies
-on PKI authentication using the client certificate. See
+{beatname_uc} does not attempt to authenticate using a
+username and password (HTTP basic authentication) and instead
+relies on PKI authentication using the client certificate. See
 <<configuration-ssl>> for more information about SSL settings.
 
 ifndef::serverless[]

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -109,7 +109,9 @@ monitoring:
 --------------------
 +
 You must specify the `username` as `""` explicitly so that
-the username from the client certificate (`CN`) is used. See
+{beatname_uc} does not attempt to authentication using a
+username and password (HTTP basic authentication) and relies
+on PKI authentication using the client certificate. See
 <<configuration-ssl>> for more information about SSL settings.
 
 ifndef::serverless[]


### PR DESCRIPTION
The previous wording focused on how the "username" was resolved but this was
confusing because the change we're trying to make is to switch authentication
schemes (from HTTP basic auth to PKI client certs) rather than controlling
which username is used.

---

## What does this PR do?

Updates the docs that describe how to configure PKI auth for beats monitoring

## Why is it important?

The previous docs were misleading and a source of confusion

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
