### PR TITLE
test: enable couchbase

### DIFF
--- a/metricbeat/module/couchbase/test_couchbase.py
+++ b/metricbeat/module/couchbase/test_couchbase.py
@@ -7,13 +7,9 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 import metricbeat
 
 
-@unittest.skip("See https://github.com/elastic/beats/issues/14660")
 class Test(metricbeat.BaseTest):
 
-    # Commented out as part of skipping test. See https://github.com/elastic/beats/issues/14660.
-    # Otherwise, the tests are skipped but Docker Compose still tries to bring up
-    # the Couchbase service container and fails.
-    # COMPOSE_SERVICES = ['couchbase']
+    COMPOSE_SERVICES = ['couchbase']
     FIELDS = ['couchbase']
 
     @parameterized.expand([


### PR DESCRIPTION
## What does this PR do?

Enable the Couchbase test again.

## Why is it important?

The Couchbase test was disabled because it caused CI issues.

closes https://github.com/elastic/beats/issues/14562 https://github.com/elastic/beats/issues/14660
