### PR TITLE
Cherry-pick #17658 to 7.x: Add support for IAM role arn in aws config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -252,6 +252,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update supported versions of `redis` output. {pull}17198[17198]
 - Update documentation for system.process.memory fields to include clarification on Windows os's. {pull}17268[17268]
 - Add `urldecode` processor to for decoding URL-encoded fields. {pull}17505[17505]
+- Add support for AWS IAM `role_arn` in credentials config. {pull}17658[17658] {issue}12464[12464]
 
 *Auditbeat*
 

--- a/filebeat/docs/aws-credentials-examples.asciidoc
+++ b/filebeat/docs/aws-credentials-examples.asciidoc
@@ -22,6 +22,16 @@ filebeat.inputs:
   session_token: '${AWS_SESSION_TOKEN:""}'
 ----
 
+* Use IAM role ARN
++
+[source,yaml]
+----
+filebeat.inputs:
+- type: s3
+  queue_url: https://sqs.us-east-1.amazonaws.com/123/test-queue
+  role_arn: arn:aws:iam::123456789012:role/test-mb
+----
+
 * Use shared AWS credentials file
 +
 [source,yaml]

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -27,7 +27,8 @@ that represent actions taken by a user, role or AWS service.
 
 The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `access_key_id`, `secret_access_key` and/or
-`session_token`, or use shared AWS credentials file.
+`session_token`, or use `role_arn` AWS IAM role, or use shared AWS credentials file.
+
 Please see <<aws-credentials-options,AWS credentials options>> for more details.
 
 include::../include/gs-link.asciidoc[]
@@ -51,6 +52,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   cloudwatch:
     enabled: false
@@ -63,6 +65,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   ec2:
     enabled: false
@@ -75,6 +78,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   elb:
     enabled: false
@@ -87,6 +91,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   s3access:
     enabled: false
@@ -99,6 +104,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   vpcflow:
     enabled: false
@@ -111,6 +117,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 ----
 
 *`var.queue_url`*::
@@ -146,6 +153,9 @@ Second part of access key.
 
 *`var.session_token`*::
 Required when using temporary security credentials.
+
+*`var.role_arn`*::
+AWS IAM Role to assume.
 
 [float]
 === cloudtrail fileset

--- a/metricbeat/docs/aws-credentials-examples.asciidoc
+++ b/metricbeat/docs/aws-credentials-examples.asciidoc
@@ -26,6 +26,18 @@ metricbeat.modules:
   session_token: '${AWS_SESSION_TOKEN:""}'
 ----
 
+* Use IAM role ARN
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  role_arn: arn:aws:iam::123456789012:role/test-mb
+----
+
 * Use shared AWS credentials file
 +
 [source,yaml]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -127,6 +127,9 @@ filebeat.modules:
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   cloudwatch:
     enabled: false
 
@@ -157,6 +160,9 @@ filebeat.modules:
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   ec2:
     enabled: false
@@ -189,6 +195,9 @@ filebeat.modules:
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   elb:
     enabled: false
 
@@ -219,6 +228,9 @@ filebeat.modules:
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   s3access:
     enabled: false
@@ -251,6 +263,9 @@ filebeat.modules:
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   vpcflow:
     enabled: false
 
@@ -281,6 +296,9 @@ filebeat.modules:
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
 #-------------------------------- Azure Module --------------------------------
 - module: azure

--- a/x-pack/filebeat/module/aws/_meta/config.yml
+++ b/x-pack/filebeat/module/aws/_meta/config.yml
@@ -30,6 +30,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   cloudwatch:
     enabled: false
 
@@ -60,6 +63,9 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   ec2:
     enabled: false
@@ -92,6 +98,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   elb:
     enabled: false
 
@@ -122,6 +131,9 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   s3access:
     enabled: false
@@ -154,6 +166,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   vpcflow:
     enabled: false
 
@@ -184,3 +199,6 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -22,7 +22,8 @@ that represent actions taken by a user, role or AWS service.
 
 The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `access_key_id`, `secret_access_key` and/or
-`session_token`, or use shared AWS credentials file.
+`session_token`, or use `role_arn` AWS IAM role, or use shared AWS credentials file.
+
 Please see <<aws-credentials-options,AWS credentials options>> for more details.
 
 include::../include/gs-link.asciidoc[]
@@ -46,6 +47,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   cloudwatch:
     enabled: false
@@ -58,6 +60,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   ec2:
     enabled: false
@@ -70,6 +73,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   elb:
     enabled: false
@@ -82,6 +86,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   s3access:
     enabled: false
@@ -94,6 +99,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   vpcflow:
     enabled: false
@@ -106,6 +112,7 @@ Example config:
     #var.visibility_timeout: 300s
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 ----
 
 *`var.queue_url`*::
@@ -141,6 +148,9 @@ Second part of access key.
 
 *`var.session_token`*::
 Required when using temporary security credentials.
+
+*`var.role_arn`*::
+AWS IAM Role to assume.
 
 [float]
 === cloudtrail fileset

--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -33,3 +33,7 @@ secret_access_key: {{ .secret_access_key }}
 {{ if .session_token }}
 session_token: {{ .session_token }}
 {{ end }}
+
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
@@ -32,3 +32,7 @@ secret_access_key: {{ .secret_access_key }}
 {{ if .session_token }}
 session_token: {{ .session_token }}
 {{ end }}
+
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/ec2/config/s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/s3.yml
@@ -32,3 +32,7 @@ secret_access_key: {{ .secret_access_key }}
 {{ if .session_token }}
 session_token: {{ .session_token }}
 {{ end }}
+
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/ec2/manifest.yml
+++ b/x-pack/filebeat/module/aws/ec2/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/elb/config/s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/s3.yml
@@ -32,3 +32,7 @@ secret_access_key: {{ .secret_access_key }}
 {{ if .session_token }}
 session_token: {{ .session_token }}
 {{ end }}
+
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/s3access/config/s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/s3.yml
@@ -32,3 +32,7 @@ secret_access_key: {{ .secret_access_key }}
 {{ if .session_token }}
 session_token: {{ .session_token }}
 {{ end }}
+
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -35,6 +35,10 @@ secret_access_key: {{ .secret_access_key }}
 session_token: {{ .session_token }}
 {{ end }}
 
+{{ if .role_arn }}
+role_arn: {{ .role_arn }}
+{{ end }}
+
 {{ else if eq .input "file" }}
 
 type: log

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -12,6 +12,7 @@ var:
   - name: access_key_id
   - name: secret_access_key
   - name: session_token
+  - name: role_arn
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -33,6 +33,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   cloudwatch:
     enabled: false
 
@@ -63,6 +66,9 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   ec2:
     enabled: false
@@ -95,6 +101,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   elb:
     enabled: false
 
@@ -125,6 +134,9 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
 
   s3access:
     enabled: false
@@ -157,6 +169,9 @@
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
 
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+
   vpcflow:
     enabled: false
 
@@ -187,3 +202,6 @@
 
     # Custom endpoint used to access AWS APIs
     #var.endpoint: amazonaws.com
+
+    # AWS IAM Role to assume
+    #var.role_arn: arn:aws:iam::123456789012:role/test-mb

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -8,6 +8,11 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
+	"github.com/aws/aws-sdk-go-v2/aws/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // ConfigAWS is a structure defined for AWS credentials
@@ -18,15 +23,20 @@ type ConfigAWS struct {
 	ProfileName          string `config:"credential_profile_name"`
 	SharedCredentialFile string `config:"shared_credential_file"`
 	Endpoint             string `config:"endpoint"`
+	RoleArn              string `config:"role_arn"`
 }
 
 // GetAWSCredentials function gets aws credentials from the config.
 // If access_key_id and secret_access_key are given, then use them as credentials.
-// If not, then load from aws config file. If credential_profile_name is not
+// If role_arn is given, assume the IAM role instead.
+// If none of the above is given, then load from aws config file. If credential_profile_name is not
 // given, then load default profile from the aws config file.
 func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
+	logger := logp.NewLogger("get_aws_credentials")
+
 	// Check if accessKeyID or secretAccessKey or sessionToken is given from configuration
 	if config.AccessKeyID != "" || config.SecretAccessKey != "" || config.SessionToken != "" {
+		logger.Debug("Using access_key_id, secret_access_key and/or session_token for AWS credential")
 		awsConfig := defaults.Config()
 		awsCredentials := awssdk.Credentials{
 			AccessKeyID:     config.AccessKeyID,
@@ -43,14 +53,29 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 		return awsConfig, nil
 	}
 
-	// If accessKeyID, secretAccessKey or sessionToken is not given, then load from default config
+	// Assume IAM role if iam_role config parameter is given
+	if config.RoleArn != "" {
+		logger.Debug("Using role_arn for AWS credential")
+		awsConfig, err := external.LoadDefaultAWSConfig()
+		if err != nil {
+			return awsConfig, errors.Wrap(err, "external.LoadDefaultAWSConfig failed when using role_arn")
+		}
+		stsSvc := sts.New(awsConfig)
+		stsCredProvider := stscreds.NewAssumeRoleProvider(stsSvc, config.RoleArn)
+		awsConfig.Credentials = stsCredProvider
+		return awsConfig, nil
+	}
+
+	// If accessKeyID, secretAccessKey or sessionToken is not given, iam_role is not given, then load from default config
 	// Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 	// with more details.
 	// If credential_profile_name is empty, then default profile is used.
+	logger.Debug("Using shared credential profile for AWS credential")
 	var options []external.Config
 	if config.ProfileName != "" {
 		options = append(options, external.WithSharedConfigProfile(config.ProfileName))
 	}
+
 	// If shared_credential_file is empty, then external.LoadDefaultAWSConfig
 	// function will load AWS config from current user's home directory.
 	// Linux/OSX: "$HOME/.aws/credentials"
@@ -61,7 +86,7 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 
 	awsConfig, err := external.LoadDefaultAWSConfig(options...)
 	if err != nil {
-		return awsConfig, err
+		return awsConfig, errors.Wrap(err, "external.LoadDefaultAWSConfig failed when using shared credential profile")
 	}
 	return awsConfig, nil
 }

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -10,18 +10,26 @@ To configure AWS credentials, either put the credentials into the {beatname_uc} 
 * *credential_profile_name*: profile name in shared credentials file.
 * *shared_credential_file*: directory of the shared credentials file.
 * *endpoint*: URL of the entry point for an AWS web service.
+* *role_arn*: AWS IAM Role to assume.
 
 [float]
 ==== Supported Formats
-* Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or `AWS_SESSION_TOKEN`
+* Use `access_key_id`, `secret_access_key` and/or `session_token`
 
 Users can either put the credentials into metricbeat module configuration or use
 environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN` instead.
 
-include::../../../{beatname_lc}/docs/aws-credentials-examples.asciidoc[]
+* Use `role_arn`
 
-`credential_profile_name` is optional. If you use different credentials for
+If `access_key_id` and `secret_access_key` are not given, then {beatname_lc} will
+check for `role_arn`. `role_arn` is used to specify which AWS IAM role to assume
+for generating temporary credentials.
+
+* Use `credential_profile_name` and/or `shared_credential_file`
+
+If `access_key_id`, `secret_access_key` and `role_arn` are all not given, then
+{beatname_lc} will check for `credential_profile_name`. If you use different credentials for
 different tools or applications, you can use profiles to configure multiple
 access keys in the same configuration file. If there is no `credential_profile_name`
 given, the default profile will be used.
@@ -32,6 +40,8 @@ In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credenti
 For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
+
+include::../../../{beatname_lc}/docs/aws-credentials-examples.asciidoc[]
 
 [float]
 ==== AWS Credentials Types
@@ -47,9 +57,18 @@ https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-key
  and Secret Access Keys]
 for more details.
 
+* IAM role ARN
+
+An IAM role is an IAM identity that you can create in your account that has
+specific permissions that determine what the identity can and cannot do in AWS.
+A role does not have standard long-term credentials such as a password or access keys associated with it.
+Instead, when you assume a role, it provides you with temporary security credentials for your role session.
+IAM role Amazon Resource Name (ARN) can be used to specify which AWS IAM role to assume to generate temporary credentials.
+Please see https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[AssumeRole API documentation] for more details.
+
 * Temporary security credentials
 
-temporary security credentials has a limited lifetime and consists of an
+Temporary security credentials has a limited lifetime and consists of an
 access key ID, a secret access key, and a security token which typically returned
 from `GetSessionToken`. MFA-enabled IAM users would need to submit an MFA code
 while calling `GetSessionToken`. `default_region` identifies the AWS Region


### PR DESCRIPTION
Cherry-pick of PR #17658 to 7.x branch. Original message: 

## What does this PR do?

This PR is to add support for IAM role arn in AWS credentials config.

## Why is it important?

When user doesn't want to store any credentials for Metricbeat/Filebeat locally(for example in EC2 instance), it's better to leverage AWS IAM role.  A role does not have standard long-term credentials such as a password or access keys associated with it. Instead, when you assume a role, it provides you with temporary security credentials for your role session. IAM role Amazon Resource Name (ARN) can be used to specify which AWS IAM role to assume to generate temporary credentials. 

Using `role_arn` also solves reload temporary credential problem in https://github.com/elastic/beats/issues/17189.  `sts.NewAssumeRoleProvider` with `role_arn` input constructs and returns a credentials provider that will retrieve credentials by assuming a IAM role using STS. `AssumeRoleProvider` has a a function `retrieveFn`, which generates a new set of temporary credentials using STS. 

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Create IAM role in AWS console https://console.aws.amazon.com/iam/home#/roles
2. Attach IAM role with a policy like below to give permissions needed for testing Metricbeat and Filebeat:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "s3:GetObject",
                "sqs:ReceiveMessage"
            ],
            "Resource": [
                "arn:aws:s3:::test-fb-ks/*",
                "arn:aws:sqs:us-east-1:428152502467:test-fb-ks"
            ]
        },
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": "sqs:ChangeMessageVisibility",
            "Resource": "arn:aws:sqs:us-east-1:428152502467:test-fb-ks"
        },
        {
            "Sid": "VisualEditor2",
            "Effect": "Allow",
            "Action": "sqs:DeleteMessage",
            "Resource": "arn:aws:sqs:us-east-1:428152502467:test-fb-ks"
        },
        {
            "Sid": "VisualEditor3",
            "Effect": "Allow",
            "Action": [
                "sqs:ListQueues",
                "tag:GetResources",
                "ec2:DescribeInstances",
                "cloudwatch:GetMetricData",
                "ec2:DescribeRegions",
                "iam:ListAccountAliases",
                "sts:GetCallerIdentity",
                "cloudwatch:ListMetrics"
            ],
            "Resource": "*"
        }
    ]
}
```
3. Copy the role ARN, for example: `arn:aws:iam::428152502467:role/test-mb`
4. Enable Metricbeat aws module:
```
./metricbeat modules enable aws
```
5. Change `modules.d/aws.yml` to use `role_arn`:
```
- module: aws
  role_arn: arn:aws:iam::428152502467:role/test-mb
  period: 5m
  metricsets:
    - ec2
```
6. Start Metricbeat with `./metricbeat -e` and with the correct permissions in IAM role, ec2 metrics should be collected and sent to Elasticsearch.

## Related issues

- Closes elastic/beats#12464
