### PR TITLE
[docs] Add breaking changes for 7.7

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -16,11 +16,12 @@
 ====  Environment variables can no longer reference other environment variables
 
 Environment variables are still supported in the {beats} configuration.
-However, starting in Version 7.7.0, you can no longer reference an environment
-variable that references another environment variable.
+However, starting in Version 7.7.0, an environment variable cannot reference
+another environment variable or event in the configuration.
 
-For example, if you set `export NAME=${COMPANY_NAME}`, you cannot use
-`name: ${NAME}` in the configuration.
+For example, if you have `export VAR1=${VAR2}` and use `var: ${VAR1}` in
+the configuration, the configuration results in `var: "${VAR2}"`, where
+`${VAR2}` is not expanded.
 
 [float]
 ==== Docker and kubernetes processors no longer allowed in script processor

--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -12,9 +12,25 @@
 
 //tag::notable-breaking-changes[]
 
-//[float]
-//==== Breaking change
+[float]
+====  Environment variables can no longer reference other environment variables
 
-//Description
+Environment variables are still supported in the {beats} configuration.
+However, starting in Version 7.7.0, you can no longer reference an environment
+variable that references another environment variable.
+
+For example, if you set `export NAME=${COMPANY_NAME}`, you cannot use
+`name: ${NAME}` in the configuration.
+
+[float]
+==== Docker and kubernetes processors no longer allowed in script processor
+
+Prior to this release, it was possible to use the `add_docker_metadata` and
+`add_kubernetes_metadata` processors in the `script` processor. This was not a
+good practice because it sometimes resulted in memory and file descriptor leaks.
+
+Starting in version 7.7.0, scripts that use these processors will fail. To
+resolve this problem, define the processors in your configuration instead of the
+script.
 
 // end::notable-breaking-changes[]

--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -20,7 +20,7 @@ However, starting in Version 7.7.0, an environment variable cannot reference
 another environment variable or event in the configuration.
 
 For example, if you have `export VAR1=${VAR2}` and use `var: ${VAR1}` in
-the configuration, the configuration results in `var: "${VAR2}"`, where
+the configuration, this results in `var: "${VAR2}"`, where
 `${VAR2}` is not expanded.
 
 [float]


### PR DESCRIPTION
Adds documentation for all PRs returned by https://github.com/elastic/beats/pulls?q=is%3Apr+is%3Aclosed+label%3A%22breaking+change%22+label%3Av7.7.0