### PR TITLE
[Doc] Fix Filebeat MSSQL module doc

### DIFF
--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -25,7 +25,7 @@ file to override the default paths for Træfik logs:
 ["source","yaml",subs="attributes"]
 -----
 - module: mssql
-  access:
+  log:
     enabled: true
     var.paths: ["/var/opt/mssql/log/error*"]
 -----
@@ -35,7 +35,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.access.var.paths=[/var/opt/mssql/log/error*]"
+-M "mssql.log.var.paths=[/var/opt/mssql/log/error*]"
 -----
 
 //set the fileset name used in the included example

--- a/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
@@ -20,7 +20,7 @@ file to override the default paths for Træfik logs:
 ["source","yaml",subs="attributes"]
 -----
 - module: mssql
-  access:
+  log:
     enabled: true
     var.paths: ["/var/opt/mssql/log/error*"]
 -----
@@ -30,7 +30,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.access.var.paths=[/var/opt/mssql/log/error*]"
+-M "mssql.log.var.paths=[/var/opt/mssql/log/error*]"
 -----
 
 //set the fileset name used in the included example


### PR DESCRIPTION
## What does this PR do?

Fix Filebeat MSSQL module doc where `access` should be `log`.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Closes https://github.com/elastic/beats/issues/17741
