### PR TITLE
Fix setup.dashboards.index not working

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -76,6 +76,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix building on FreeBSD by removing build flags from `add_cloudfoundry_metadata` processor. {pull}17486[17486]
 - Do not rotate log files on startup when interval is configured and rotateonstartup is disabled. {pull}17613[17613]
 - Fix goroutine leak and Elasticsearch output file descriptor leak when output reloading is in use. {issue}10491[10491] {pull}17381[17381]
+- Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -57,7 +57,10 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) (err error)
 		// This uses Put instead of DeepUpdate to avoid modifying types for
 		// inner objects. (DeepUpdate will replace maps with MapStr).
 		obj.Put("id", index)
-		obj.Put("attributes.title", index)
+		// Only overwrite title if it exists.
+		if _, err := obj.GetValue("attributes.title"); err == nil {
+			obj.Put("attributes.title", index)
+		}
 	}
 
 	switch v := list.(type) {

--- a/libbeat/dashboards/modify_json_test.go
+++ b/libbeat/dashboards/modify_json_test.go
@@ -117,11 +117,13 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 	// what the inner types are (MapStr, map[string]interface{} or interface{}).
 	// Also ensures that the inner types are not modified after replacement.
 	tests := []struct {
+		title    string
 		input    common.MapStr
 		index    string
 		expected common.MapStr
 	}{
 		{
+			title: "Replace in []interface(map).map",
 			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
@@ -139,6 +141,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 				}}}},
 		},
 		{
+			title: "Replace in []interface(map).mapstr",
 			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
@@ -156,6 +159,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 				}}}},
 		},
 		{
+			title: "Replace in []map.mapstr",
 			input: common.MapStr{"objects": []map[string]interface{}{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
@@ -173,6 +177,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 				}}}},
 		},
 		{
+			title: "Replace in []mapstr.mapstr",
 			input: common.MapStr{"objects": []common.MapStr{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
@@ -190,6 +195,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 				}}}},
 		},
 		{
+			title: "Replace in []mapstr.interface(mapstr)",
 			input: common.MapStr{"objects": []common.MapStr{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
@@ -206,11 +212,36 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				})}}},
 		},
+		{
+			title: "Do not create missing attributes",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+			}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+			}}},
+		},
+		{
+			title: "Create missing id",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"type": "index-pattern",
+			}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+			}}},
+		},
 	}
 
 	for _, test := range tests {
-		err := ReplaceIndexInIndexPattern(test.index, test.input)
-		assert.NoError(t, err)
-		assert.Equal(t, test.expected, test.input)
+		t.Run(test.title, func(t *testing.T) {
+			err := ReplaceIndexInIndexPattern(test.index, test.input)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, test.input)
+		})
 	}
 }

--- a/libbeat/dashboards/modify_json_test.go
+++ b/libbeat/dashboards/modify_json_test.go
@@ -111,3 +111,106 @@ func TestReplaceIndexInDashboardObject(t *testing.T) {
 		assert.Equal(t, test.expected, result)
 	}
 }
+
+func TestReplaceIndexInIndexPattern(t *testing.T) {
+	// Test that replacing of index name in index pattern works no matter
+	// what the inner types are (MapStr, map[string]interface{} or interface{}).
+	// Also ensures that the inner types are not modified after replacement.
+	tests := []struct {
+		input    common.MapStr
+		index    string
+		expected common.MapStr
+	}{
+		{
+			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": map[string]interface{}{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": map[string]interface{}{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			input: common.MapStr{"objects": []map[string]interface{}{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []map[string]interface{}{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": interface{}(common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				})}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": interface{}(common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				})}}},
+		},
+	}
+
+	for _, test := range tests {
+		err := ReplaceIndexInIndexPattern(test.index, test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, test.input)
+	}
+}


### PR DESCRIPTION
Due to type casting nightmare, the `setup.dashboards.index` configuration option to replace the index name in use for dashboards and index pattern wasn't being honored, resulting in `beatname-*` always in use.


Fixes: elastic/beats#14019
