### PR TITLE
fix: disable workaround on macos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -662,7 +662,7 @@ def withBeatsEnv(boolean archive, Closure body) {
     unstash 'source'
     if(os == 'linux'){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-      // FIXME workaround untill we fix the packer cache
+      // FIXME workaround until we fix the packer cache
       // Retry to avoid DDoS detection from the server
       retry(3) {
         sleep randomNumber(min: 2, max: 5)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -663,7 +663,11 @@ def withBeatsEnv(boolean archive, Closure body) {
     if(os == 'linux'){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       // FIXME workaround untill we fix the packer cache
-      sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
+      // Retry to avoid DDoS detection from the server
+      retry(3) {
+        sleep randomNumber(min: 2, max: 5)
+        sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
+      }
     }
     dir("${env.BASE_DIR}") {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -660,9 +660,11 @@ def withBeatsEnv(boolean archive, Closure body) {
   ]) {
     deleteDir()
     unstash 'source'
-    dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-    // FIXME workaround untill we fix the packer cache
-    sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
+    if(os == 'linux'){
+      dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+      // FIXME workaround untill we fix the packer cache
+      sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
+    }
     dir("${env.BASE_DIR}") {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")
       sh(label: "Install docker-compose ${DOCKER_COMPOSE_VERSION}", script: ".ci/scripts/install-docker-compose.sh")


### PR DESCRIPTION
## What does this PR do?

It disables docker login and a workaround to pull a Docker image on Mac OS.

## Why is it important?

Mac OS workers do not have Docker installed so the commands fail, breaking the build.