### PR TITLE
Cherry-pick #17666 to 7.x: [libbeat] Fix dropped queue feature metadata / remove unused helper

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -35,6 +35,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Require logger as first parameter for `outputs.elasticsearch.client#BulkReadItemStatus`. {pull}16761[16761]
 - Extract Elasticsearch client logic from `outputs/elasticsearch` package into new `esclientleg` package. {pull}16150[16150]
 - Rename `queue.BufferConfig.Events` to `queue.BufferConfig.MaxEvents`. {pull}17622[17622]
+- Remove `queue.Feature` and replace `queue.RegisterType` with `queue.RegisterQueueType`. {pull}17666[17666]
 
 ==== Bugfixes
 

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -27,15 +27,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
-// Feature exposes a memory queue.
-var Feature = queue.Feature("mem",
-	create,
-	feature.MakeDetails(
-		"Memory queue",
-		"Buffer events in memory before sending to the output.",
-		feature.Stable),
-)
-
 type broker struct {
 	done chan struct{}
 
@@ -81,7 +72,13 @@ type chanList struct {
 }
 
 func init() {
-	queue.RegisterType("mem", create)
+	queue.RegisterQueueType(
+		"mem",
+		create,
+		feature.MakeDetails(
+			"Memory queue",
+			"Buffer events in memory before sending to the output.",
+			feature.Stable))
 }
 
 func create(

--- a/libbeat/publisher/queue/queue_reg.go
+++ b/libbeat/publisher/queue/queue_reg.go
@@ -22,12 +22,11 @@ import (
 )
 
 // Namespace is the feature namespace for queue definition.
-var Namespace = "libbeat.queue"
+const Namespace = "libbeat.queue"
 
-// RegisterType registers a new queue type.
-func RegisterType(name string, fn Factory) {
-	f := Feature(name, fn, feature.MakeDetails(name, "", feature.Undefined))
-	feature.MustRegister(f)
+// RegisterQueueType registers a new queue type.
+func RegisterQueueType(name string, factory Factory, details feature.Details) {
+	feature.MustRegister(feature.New(Namespace, name, factory, details))
 }
 
 // FindFactory retrieves a queue types constructor. Returns nil if queue type is unknown
@@ -42,9 +41,4 @@ func FindFactory(name string) Factory {
 	}
 
 	return factory
-}
-
-// Feature creates a new type of queue.
-func Feature(name string, factory Factory, description feature.Details) *feature.Feature {
-	return feature.New(Namespace, name, factory, description)
 }

--- a/libbeat/publisher/queue/spool/module.go
+++ b/libbeat/publisher/queue/spool/module.go
@@ -27,16 +27,14 @@ import (
 	"github.com/elastic/go-txfile"
 )
 
-// Feature exposes a spooling to disk queue.
-var Feature = queue.Feature("spool", create,
-	feature.MakeDetails(
-		"Memory queue",
-		"Buffer events in memory before sending to the output.",
-		feature.Beta),
-)
-
 func init() {
-	queue.RegisterType("spool", create)
+	queue.RegisterQueueType(
+		"spool",
+		create,
+		feature.MakeDetails(
+			"Disk spool",
+			"Buffer events in disk spool before sending to the output.",
+			feature.Beta))
 }
 
 func create(


### PR DESCRIPTION
Cherry-pick of PR #17666 to 7.x branch. Original message: 

## What does this PR do?

Feature metadata for queues was being defined in the code but then discarded rather than passed to the registration call. This also gave the impression of registry setup happening twice when in fact only one call took effect. This PR cleans up the queue registry helper functions and fixes the call sites.

This PR has no user-visible effects.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
