### PR TITLE
[7.x] Allow auto-configuration of Metricbeat stack modules for stack monitoring (#17609)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -416,6 +416,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Reference kubernetes manifests mount data directory from the host when running metricbeat as daemonset, so data persist between executions in the same node. {pull}17429[17429]
 - Add more detailed error messages, system tests and small refactoring to the service metricset in windows. {pull}17725[17725]
 - Move the perfmon metricset to GA. {issue}16608[16608] {pull}17879[17879]
+- Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -5,16 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-beat]]
 == Beat module
 
-The Beat module contains a minimal set of metrics to enable monitoring of any Beat or other software based on libbeat across
-multiple versions. To monitor more Beat metrics, use our {stack}
-{monitor-features}.
-
-The default metricsets are `state` and `stats`.
+The `beat` module collects metrics about any Beat or other software based on libbeat.
 
 [float]
 === Compatibility
 
-The Beat module works with Beats 7.3.0 and later.
+The `beat` module works with {beats} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
+`metricbeat modules enable beat-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,20 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-There are two modules that collect metrics about {es}: 
-
-* The Elasticsearch module contains a minimal set of metrics to enable
-monitoring of Elasticsearch across multiple versions. The default metricsets in
-this module are `node` and `node_stats`.
-* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
-`index_summary`, `ml_job`, `node_stats`, and `shard`.
+The `elasticsearch` module collects metrics about {es}.
 
 [float]
 === Compatibility
 
-The Elasticsearch module works with Elasticsearch 6.7.0 and later.
+The `elasticsearch` module works with {es} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,17 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-kibana]]
 == Kibana module
 
-There are two modules that collect metrics about {kib}: 
-
-* The Kibana module tracks only the high-level metrics. The default metricset in
-this module is `status`.
-* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{stack} {monitor-features}. The default metricset in this module is `stats`.
+The `kibana` module collects metrics about {kib}.
 
 [float]
 === Compatibility
 
-The Kibana module works with Kibana 6.7.0 and later.
+The `kibana` module works with {kib} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
+`metricbeat modules enable kibana-xpack`.
 
 
 [float]

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -5,14 +5,20 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-logstash]]
 == Logstash module
 
-This is the Logstash module.
-
-The default metricsets are `node` and `node_stats`.
+The `logstash` module collects metrics about {ls}.
 
 [float]
 === Compatibility
 
-The Logstash module works with Logstash 7.3.0 and later.
+The `logstash` module works with {ls} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
+`metricbeat modules enable logstash-xpack`.
 
 
 [float]

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -126,4 +128,43 @@ func FixTimestampField(m common.MapStr, field string) error {
 		return err
 	}
 	return nil
+}
+
+// NewModule returns a new Elastic stack module with the appropriate metricsets configured.
+func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, logger *logp.Logger) (*mb.BaseModule, error) {
+	moduleName := base.Name()
+
+	config := struct {
+		XPackEnabled bool `config:"xpack.enabled"`
+	}{}
+	if err := base.UnpackConfig(&config); err != nil {
+		return nil, errors.Wrapf(err, "could not unpack configuration for module %v", moduleName)
+	}
+
+	// No special configuration is needed if xpack.enabled != true
+	if !config.XPackEnabled {
+		return base, nil
+	}
+
+	var raw common.MapStr
+	if err := base.UnpackConfig(&raw); err != nil {
+		return nil, errors.Wrapf(err, "could not unpack configuration for module %v", moduleName)
+	}
+
+	// These metricsets are exactly the ones required if xpack.enabled == true
+	raw["metricsets"] = xpackEnabledMetricsets
+
+	newConfig, err := common.NewConfigFrom(raw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create new configuration for module %v", moduleName)
+	}
+
+	newModule, err := base.WithConfig(*newConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not reconfigure module %v", moduleName)
+	}
+
+	logger.Debugf("Configuration for module %v modified because xpack.enabled was set to true", moduleName)
+
+	return newModule, nil
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -22,7 +22,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -97,7 +100,7 @@ func TestFixTimestampField(t *testing.T) {
 		{
 			"converts float64s in scientific notation to ints",
 			map[string]interface{}{
-				"foo": 1.571284349E12,
+				"foo": 1.571284349e12,
 			},
 			map[string]interface{}{
 				"foo": 1571284349000,
@@ -139,4 +142,87 @@ func TestFixTimestampField(t *testing.T) {
 			assert.Equal(t, test.ExpectedValue, test.OriginalValue)
 		})
 	}
+}
+
+func TestConfigureModule(t *testing.T) {
+	mockRegistry := mb.NewRegister()
+
+	const moduleName = "test_module"
+
+	err := mockRegistry.AddMetricSet(moduleName, "foo", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "bar", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "qux", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "baz", mockMetricSetFactory)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		initConfig             metricSetConfig
+		xpackEnabledMetricsets []string
+		newConfig              metricSetConfig
+	}{
+		"no_xpack_enabled": {
+			metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"foo", "bar"},
+			},
+			[]string{"baz", "qux", "foo"},
+			metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"foo", "bar"},
+			},
+		},
+		"xpack_enabled": {
+			metricSetConfig{
+				Module:       moduleName,
+				XPackEnabled: true,
+				MetricSets:   []string{"foo", "bar"},
+			},
+			[]string{"baz", "qux", "foo"},
+			metricSetConfig{
+				Module:       moduleName,
+				XPackEnabled: true,
+				MetricSets:   []string{"baz", "qux", "foo"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := common.MustNewConfigFrom(test.initConfig)
+			m, _, err := mb.NewModule(cfg, mockRegistry)
+			require.NoError(t, err)
+
+			bm, ok := m.(*mb.BaseModule)
+			if !ok {
+				require.Fail(t, "expecting module to be base module")
+			}
+
+			newM, err := NewModule(bm, test.xpackEnabledMetricsets, logp.L())
+			require.NoError(t, err)
+
+			var newConfig metricSetConfig
+			err = newM.UnpackConfig(&newConfig)
+			require.NoError(t, err)
+			require.Equal(t, test.newConfig, newConfig)
+		})
+	}
+}
+
+type mockMetricSet struct {
+	mb.BaseMetricSet
+}
+
+func (m *mockMetricSet) Fetch(r mb.ReporterV2) error { return nil }
+
+type metricSetConfig struct {
+	Module       string   `config:"module"`
+	MetricSets   []string `config:"metricsets"`
+	XPackEnabled bool     `config:"xpack.enabled"`
+}
+
+func mockMetricSetFactory(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	return &mockMetricSet{base}, nil
 }

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -27,6 +27,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
@@ -92,6 +94,40 @@ func (m *BaseModule) Config() ModuleConfig { return m.config }
 // UnpackConfig unpacks the raw module config to the given object.
 func (m *BaseModule) UnpackConfig(to interface{}) error {
 	return m.rawConfig.Unpack(to)
+}
+
+// WithConfig re-configures the module with the given raw configuration and returns a
+// copy of the module.
+// Intended to be called from module factories. Note that if metricsets are specified
+// in the new configuration, those metricsets must already be registered with
+// mb.Registry.
+func (m *BaseModule) WithConfig(config common.Config) (*BaseModule, error) {
+	var chkConfig struct {
+		Module string `config:"module"`
+	}
+	if err := config.Unpack(&chkConfig); err != nil {
+		return nil, errors.Wrap(err, "error parsing new module configuration")
+	}
+
+	// Don't allow module name change
+	if chkConfig.Module != "" && chkConfig.Module != m.name {
+		return nil, fmt.Errorf("cannot change module name from %v to %v", m.name, chkConfig.Module)
+	}
+
+	if err := config.SetString("module", -1, m.name); err != nil {
+		return nil, errors.Wrap(err, "unable to set existing module name in new configuration")
+	}
+
+	newBM := &BaseModule{
+		name:      m.name,
+		rawConfig: &config,
+	}
+
+	if err := config.Unpack(&newBM.config); err != nil {
+		return nil, errors.Wrap(err, "error parsing new module configuration")
+	}
+
+	return newBM, nil
 }
 
 // MetricSet interfaces

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -20,12 +20,14 @@
 package mb
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/common"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 type testModule struct {
@@ -405,4 +407,87 @@ func TestModuleConfigQueryParams(t *testing.T) {
 	assert.NotContains(t, res, "%")
 	assert.NotEqual(t, "&", res[0])
 	assert.NotEqual(t, "&", res[len(res)-1])
+}
+
+func TestBaseModuleWithConfig(t *testing.T) {
+	mockRegistry := NewRegister()
+
+	const moduleName = "test_module"
+
+	err := mockRegistry.AddMetricSet(moduleName, "foo", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "bar", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "qux", mockMetricSetFactory)
+	require.NoError(t, err)
+	err = mockRegistry.AddMetricSet(moduleName, "baz", mockMetricSetFactory)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		newConfig      metricSetConfig
+		expectedConfig metricSetConfig
+		expectedErrMsg string
+	}{
+		"metricsets": {
+			metricSetConfig{
+				MetricSets: []string{"qux", "baz", "bar"},
+			},
+			metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"qux", "baz", "bar"},
+			},
+			"",
+		},
+		"module_name": {
+			metricSetConfig{
+				Module: "new_test_module",
+			},
+			metricSetConfig{},
+			fmt.Sprintf("cannot change module name from %v to %v", moduleName, "new_test_module"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			initConfig := metricSetConfig{
+				Module:     moduleName,
+				MetricSets: []string{"foo", "bar"},
+			}
+
+			m, _, err := NewModule(common.MustNewConfigFrom(initConfig), mockRegistry)
+			require.NoError(t, err)
+
+			bm, ok := m.(*BaseModule)
+			if !ok {
+				require.Fail(t, "expecting module to be base module")
+			}
+
+			newBM, err := bm.WithConfig(*common.MustNewConfigFrom(test.newConfig))
+
+			if err == nil {
+				var actualNewConfig metricSetConfig
+				err = newBM.UnpackConfig(&actualNewConfig)
+				require.NoError(t, err)
+				require.Equal(t, test.expectedConfig, actualNewConfig)
+			} else {
+				require.Equal(t, test.expectedErrMsg, err.Error())
+				require.Nil(t, newBM)
+			}
+		})
+	}
+}
+
+type mockMetricSet struct {
+	BaseMetricSet
+}
+
+func (m *mockMetricSet) Fetch(r ReporterV2) error { return nil }
+
+type metricSetConfig struct {
+	Module     string   `config:"module"`
+	MetricSets []string `config:"metricsets"`
+}
+
+func mockMetricSetFactory(base BaseMetricSet) (MetricSet, error) {
+	return &mockMetricSet{base}, nil
 }

--- a/metricbeat/module/beat/_meta/config-xpack.yml
+++ b/metricbeat/module/beat/_meta/config-xpack.yml
@@ -1,10 +1,7 @@
 - module: beat
-  metricsets:
-    - stats
-    - state
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:5066"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -1,10 +1,14 @@
-The Beat module contains a minimal set of metrics to enable monitoring of any Beat or other software based on libbeat across
-multiple versions. To monitor more Beat metrics, use our {stack}
-{monitor-features}.
-
-The default metricsets are `state` and `stats`.
+The `beat` module collects metrics about any Beat or other software based on libbeat.
 
 [float]
 === Compatibility
 
-The Beat module works with Beats 7.3.0 and later.
+The `beat` module works with {beats} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
+`metricbeat modules enable beat-xpack`.

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
-
-	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
+	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -36,40 +35,9 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
-		return nil, err
-	}
-
-	return &base, nil
-}
-
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// Nothing to validate if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	expectedXPackMetricsets := []string{
-		"state",
-		"stats",
-	}
-
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
-	}
-
-	return nil
+	return elastic.NewModule(&base, []string{"state", "stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/beat/beat_test.go
+++ b/metricbeat/module/beat/beat_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package logstash_test
+package beat_test
 
 import (
 	"testing"
@@ -23,52 +23,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-	"github.com/elastic/beats/v7/metricbeat/module/logstash"
+	"github.com/elastic/beats/v7/metricbeat/module/beat"
 
 	// Make sure metricsets are registered in mb.Registry
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node"
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/beat/state"
+	_ "github.com/elastic/beats/v7/metricbeat/module/beat/stats"
 )
 
-func TestGetVertexClusterUUID(t *testing.T) {
-	tests := map[string]struct {
-		vertex              map[string]interface{}
-		overrideClusterUUID string
-		expectedClusterUUID string
-	}{
-		"vertex_and_override": {
-			map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			"o",
-			"v",
-		},
-		"vertex_only": {
-			vertex: map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			expectedClusterUUID: "v",
-		},
-		"override_only": {
-			overrideClusterUUID: "o",
-			expectedClusterUUID: "o",
-		},
-		"none": {
-			expectedClusterUUID: "",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
-		})
-	}
-}
-
-func TestXPackEnabledMetricSets(t *testing.T) {
+func TestXPackEnabledMetricsets(t *testing.T) {
 	config := map[string]interface{}{
-		"module":        logstash.ModuleName,
-		"hosts":         []string{"foobar:9600"},
+		"module":        beat.ModuleName,
+		"hosts":         []string{"foobar:5066"},
 		"xpack.enabled": true,
 	}
 
@@ -77,7 +42,7 @@ func TestXPackEnabledMetricSets(t *testing.T) {
 	for _, ms := range metricSets {
 		name := ms.Name()
 		switch name {
-		case "node", "node_stats":
+		case "state", "stats":
 		default:
 			t.Errorf("unexpected metricset name = %v", name)
 		}

--- a/metricbeat/module/elasticsearch/_meta/config-xpack.yml
+++ b/metricbeat/module/elasticsearch/_meta/config-xpack.yml
@@ -1,17 +1,7 @@
 - module: elasticsearch
-  metricsets:
-    - ccr
-    - cluster_stats
-    - enrich
-    - index
-    - index_recovery
-    - index_summary
-    - ml_job
-    - node_stats
-    - shard
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,14 +1,14 @@
-There are two modules that collect metrics about {es}: 
-
-* The Elasticsearch module contains a minimal set of metrics to enable
-monitoring of Elasticsearch across multiple versions. The default metricsets in
-this module are `node` and `node_stats`.
-* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
-metrics with our {stack} {monitor-features}. The default metricsets in this
-module are `ccr`, `cluster_stats`, `enrich`, ``index`, `index_recovery`,
-`index_summary`, `ml_job`, `node_stats`, and `shard`.
+The `elasticsearch` module collects metrics about {es}.
 
 [float]
 === Compatibility
 
-The Elasticsearch module works with Elasticsearch 6.7.0 and later.
+The `elasticsearch` module works with {es} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -25,13 +25,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/mb"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
+	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
 func init() {
@@ -41,31 +41,9 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
-		return nil, err
-	}
-
-	return &base, nil
-}
-
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// Nothing to validate if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	expectedXPackMetricsets := []string{
+	xpackEnabledMetricSets := []string{
 		"ccr",
 		"enrich",
 		"cluster_stats",
@@ -76,12 +54,7 @@ func validateXPackMetricsets(base mb.BaseModule) error {
 		"node_stats",
 		"shard",
 	}
-
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
-	}
-
-	return nil
+	return elastic.NewModule(&base, xpackEnabledMetricSets, logp.NewLogger(ModuleName))
 }
 
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.

--- a/metricbeat/module/elasticsearch/elasticsearch_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package logstash_test
+package elasticsearch_test
 
 import (
 	"testing"
@@ -23,61 +23,34 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-	"github.com/elastic/beats/v7/metricbeat/module/logstash"
+	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 
 	// Make sure metricsets are registered in mb.Registry
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node"
-	_ "github.com/elastic/beats/v7/metricbeat/module/logstash/node_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/ccr"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/cluster_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/enrich"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index_recovery"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/index_summary"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/ml_job"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/node_stats"
+	_ "github.com/elastic/beats/v7/metricbeat/module/elasticsearch/shard"
 )
 
-func TestGetVertexClusterUUID(t *testing.T) {
-	tests := map[string]struct {
-		vertex              map[string]interface{}
-		overrideClusterUUID string
-		expectedClusterUUID string
-	}{
-		"vertex_and_override": {
-			map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			"o",
-			"v",
-		},
-		"vertex_only": {
-			vertex: map[string]interface{}{
-				"cluster_uuid": "v",
-			},
-			expectedClusterUUID: "v",
-		},
-		"override_only": {
-			overrideClusterUUID: "o",
-			expectedClusterUUID: "o",
-		},
-		"none": {
-			expectedClusterUUID: "",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.expectedClusterUUID, logstash.GetVertexClusterUUID(test.vertex, test.overrideClusterUUID))
-		})
-	}
-}
-
-func TestXPackEnabledMetricSets(t *testing.T) {
+func TestXPackEnabledMetricsets(t *testing.T) {
 	config := map[string]interface{}{
-		"module":        logstash.ModuleName,
-		"hosts":         []string{"foobar:9600"},
+		"module":        elasticsearch.ModuleName,
+		"hosts":         []string{"foobar:9200"},
 		"xpack.enabled": true,
 	}
 
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
-	require.Len(t, metricSets, 2)
+	require.Len(t, metricSets, 9)
 	for _, ms := range metricSets {
 		name := ms.Name()
 		switch name {
-		case "node", "node_stats":
+		case "ccr", "enrich", "cluster_stats", "index", "index_recovery",
+			"index_summary", "ml_job", "node_stats", "shard":
 		default:
 			t.Errorf("unexpected metricset name = %v", name)
 		}

--- a/metricbeat/module/kibana/_meta/config-xpack.yml
+++ b/metricbeat/module/kibana/_meta/config-xpack.yml
@@ -1,9 +1,7 @@
 - module: kibana
-  metricsets:
-    - stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:5601"]
   #basepath: ""
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,11 +1,14 @@
-There are two modules that collect metrics about {kib}: 
-
-* The Kibana module tracks only the high-level metrics. The default metricset in
-this module is `status`.
-* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
-{stack} {monitor-features}. The default metricset in this module is `stats`.
+The `kibana` module collects metrics about {kib}.
 
 [float]
 === Compatibility
 
-The Kibana module works with Kibana 6.7.0 and later.
+The `kibana` module works with {kib} 6.7.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
+`metricbeat modules enable kibana-xpack`.

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -23,10 +23,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
-
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -39,39 +37,9 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module.
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
-		return nil, err
-	}
-
-	return &base, nil
-}
-
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// Nothing to validate if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	expectedXPackMetricsets := []string{
-		"stats",
-	}
-
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
-	}
-
-	return nil
+	return elastic.NewModule(&base, []string{"stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package kibana
+package kibana_test
 
 import (
 	"testing"
@@ -23,6 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/module/kibana"
+
+	// Make sure metricsets are registered in mb.Registry
+	_ "github.com/elastic/beats/v7/metricbeat/module/kibana/stats"
 )
 
 func TestIsStatsAPIAvailable(t *testing.T) {
@@ -37,7 +42,19 @@ func TestIsStatsAPIAvailable(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := IsStatsAPIAvailable(common.MustNewVersion(test.input))
+		actual := kibana.IsStatsAPIAvailable(common.MustNewVersion(test.input))
 		require.Equal(t, test.expected, actual)
 	}
+}
+
+func TestXPackEnabledMetricsets(t *testing.T) {
+	config := map[string]interface{}{
+		"module":        kibana.ModuleName,
+		"hosts":         []string{"foobar:5601"},
+		"xpack.enabled": true,
+	}
+
+	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
+	require.Len(t, metricSets, 1)
+	require.Equal(t, "stats", metricSets[0].Name())
 }

--- a/metricbeat/module/logstash/_meta/config-xpack.yml
+++ b/metricbeat/module/logstash/_meta/config-xpack.yml
@@ -1,9 +1,6 @@
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:9600"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -1,8 +1,14 @@
-This is the Logstash module.
-
-The default metricsets are `node` and `node_stats`.
+The `logstash` module collects metrics about {ls}.
 
 [float]
 === Compatibility
 
-The Logstash module works with Logstash 7.3.0 and later.
+The `logstash` module works with {ls} 7.3.0 and later.
+
+[float]
+=== Usage for Stack Monitoring
+
+The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
+`metricbeat modules enable logstash-xpack`.

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -37,40 +38,9 @@ func init() {
 	}
 }
 
-// NewModule creates a new module after performing validation.
+// NewModule creates a new module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	if err := validateXPackMetricsets(base); err != nil {
-		return nil, err
-	}
-
-	return &base, nil
-}
-
-// Validate that correct metricsets have been specified if xpack.enabled = true.
-func validateXPackMetricsets(base mb.BaseModule) error {
-	config := struct {
-		Metricsets   []string `config:"metricsets"`
-		XPackEnabled bool     `config:"xpack.enabled"`
-	}{}
-	if err := base.UnpackConfig(&config); err != nil {
-		return err
-	}
-
-	// Nothing to validate if xpack.enabled != true
-	if !config.XPackEnabled {
-		return nil
-	}
-
-	expectedXPackMetricsets := []string{
-		"node",
-		"node_stats",
-	}
-
-	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
-		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
-	}
-
-	return nil
+	return elastic.NewModule(&base, []string{"node", "node_stats"}, logp.NewLogger(ModuleName))
 }
 
 // ModuleName is the name of this module.

--- a/metricbeat/modules.d/beat-xpack.yml.disabled
+++ b/metricbeat/modules.d/beat-xpack.yml.disabled
@@ -2,12 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.x/metricbeat-module-beat.html
 
 - module: beat
-  metricsets:
-    - stats
-    - state
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:5066"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
@@ -2,19 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.x/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
-  metricsets:
-    - ccr
-    - cluster_stats
-    - enrich
-    - index
-    - index_recovery
-    - index_summary
-    - ml_job
-    - node_stats
-    - shard
+  xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true
 

--- a/metricbeat/modules.d/kibana-xpack.yml.disabled
+++ b/metricbeat/modules.d/kibana-xpack.yml.disabled
@@ -2,11 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.x/metricbeat-module-kibana.html
 
 - module: kibana
-  metricsets:
-    - stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:5601"]
   #basepath: ""
   #username: "user"
   #password: "secret"
-  xpack.enabled: true

--- a/metricbeat/modules.d/logstash-xpack.yml.disabled
+++ b/metricbeat/modules.d/logstash-xpack.yml.disabled
@@ -2,11 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.x/metricbeat-module-logstash.html
 
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+  xpack.enabled: true
   period: 10s
   hosts: ["localhost:9600"]
   #username: "user"
   #password: "secret"
-  xpack.enabled: true


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Allow auto-configuration of Metricbeat stack modules for stack monitoring  (#17609)