### PR TITLE
fix: correct common_bash script path

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -7,7 +7,7 @@
 source /usr/local/bin/bash_standard_lib.sh
 
 # shellcheck disable=SC1091
-source ./script/common.bash
+source ./dev-tools/common.bash
 
 # Docker images used on Dockerfiles 2019-07-12
 # aerospike:3.9.0


### PR DESCRIPTION
## What does this PR do?

It corrects the path to import common bash functions from a script.

## Why is it important?

Currently the script does not get the Go version so it can not pull the cross-build Docker images.