### PR TITLE
ci: set git user configuration if it is not set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -673,6 +673,7 @@ def withBeatsEnv(boolean archive, Closure body) {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")
       sh(label: "Install docker-compose ${DOCKER_COMPOSE_VERSION}", script: ".ci/scripts/install-docker-compose.sh")
       sh(label: "Install Mage", script: "make mage")
+      setGitConfig()
       try {
         if(!params.dry_run){
           body()
@@ -954,4 +955,13 @@ def getVendorPatterns(beatName){
     """)
   }
   return output?.split('\n').collect{ item -> item as String }
+}
+
+def setGitConfig(){
+  sh(label: 'check git config', script: '''
+    if [ -z "$(git config --get user.email)" ]; then
+      git config user.email "58790750+beatsmachine@users.noreply.github.com"
+      git config user.name "beatsmachine"
+    fi
+  ''')
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -673,6 +673,8 @@ def withBeatsEnv(boolean archive, Closure body) {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")
       sh(label: "Install docker-compose ${DOCKER_COMPOSE_VERSION}", script: ".ci/scripts/install-docker-compose.sh")
       sh(label: "Install Mage", script: "make mage")
+      // TODO (2020-04-07): This is a work-around to fix the Beat generator tests.
+      // See https://github.com/elastic/beats/issues/17787.
       setGitConfig()
       try {
         if(!params.dry_run){
@@ -960,7 +962,7 @@ def getVendorPatterns(beatName){
 def setGitConfig(){
   sh(label: 'check git config', script: '''
     if [ -z "$(git config --get user.email)" ]; then
-      git config user.email "58790750+beatsmachine@users.noreply.github.com"
+      git config user.email "beatsmachine@users.noreply.github.com"
       git config user.name "beatsmachine"
     fi
   ''')


### PR DESCRIPTION
## What does this PR do?

It checks for git configuration and setup it if there is no configuration.

## Why is it important?

It seems needed for some command in the build system.

```
[2020-04-17T08:47:40.738Z] Metricset test created.
[2020-04-17T08:47:40.738Z] vendor/github.com/elastic/beats/v7/metricbeat/Makefile:84: warning: overriding commands for target `integration-tests'
[2020-04-17T08:47:40.738Z] vendor/github.com/elastic/beats/v7/libbeat/scripts/Makefile:216: warning: ignoring old commands for target `integration-tests'
[2020-04-17T08:48:17.399Z] Generated fields.yml for testmetricbeat to /private/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/src/beatpath/testmetricbeat/fields.yml
[2020-04-17T08:48:21.385Z] Generated fields.yml for testmetricbeat to /private/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/src/beatpath/testmetricbeat/build/fields/fields.all.yml
[2020-04-17T08:48:46.899Z] WARNING: You are using pip version 19.2.3, however version 20.0.2 is available.
[2020-04-17T08:48:46.899Z] You should consider upgrading via the 'pip install --upgrade pip' command.
[2020-04-17T08:48:49.915Z] cp: module/*/_meta/kibana/*: No such file or directory
[2020-04-17T08:48:49.915Z] make[1]: [kibana] Error 1 (ignored)
[2020-04-17T08:49:04.967Z] exec: go list -m
[2020-04-17T08:49:35.189Z] 
[2020-04-17T08:49:35.189Z] *** Please tell me who you are.
[2020-04-17T08:49:35.189Z] 
[2020-04-17T08:49:35.189Z] Run
[2020-04-17T08:49:35.189Z] 
[2020-04-17T08:49:35.189Z]   git config --global user.email "you@example.com"
[2020-04-17T08:49:35.189Z]   git config --global user.name "Your Name"
[2020-04-17T08:49:35.189Z] 
[2020-04-17T08:49:35.189Z] to set your account's default identity.
[2020-04-17T08:49:35.189Z] Omit --global to set the identity only in this repository.
[2020-04-17T08:49:35.189Z] 
[2020-04-17T08:49:35.189Z] fatal: unable to auto-detect email address (got 'jenkins@worker-c07ll940dwyl.(none)')
[2020-04-17T08:49:35.189Z] Error: running "git commit -q -m Initial commit, Add generated files" failed with exit code 128
[2020-04-17T08:49:35.189Z] make: *** [prepare-test] Error 128
```