### PR TITLE
Cherry-pick #15668 to 7.x: Support application default credentials (ADC) for Google Pub/Sub

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -327,6 +327,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release Google Cloud module as GA. {pull}17511[17511]
 - Update filebeat httpjson input to support pagination via Header and Okta module. {pull}16354[16354]
 - Enhance `elasticsearch/server` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17714[17714]
+- Add support for Google Application Default Credentials to the Google Pub/Sub input and Google Cloud modules. {pull}15668[15668]
+- Enhance `elasticsearch/deprecation` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17728[17728]
+- Enhance `elasticsearch/slowlog` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17729[17729]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-google-pubsub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-google-pubsub.asciidoc
@@ -79,15 +79,18 @@ unprocessed messages. Default is 1000.
 ==== `credentials_file`
 
 Path to a JSON file containing the credentials and key used to subscribe.
-One credential option must be set.
+As an alternative you can use the `credentials_json` config option or rely on
+https://cloud.google.com/docs/authentication/production[Google Application
+Default Credentials] (ADC).
 
 [float]
 ==== `credentials_json`
 
 JSON blob containing the credentials and key used to subscribe. This can be as
 an alternative to `credentials_file` if you want to embed the credential data
-within your config file or put the information into a keystore. One credential
-option must be set.
+within your config file or put the information into a keystore. You may also use
+https://cloud.google.com/docs/authentication/production[Google Application
+Default Credentials] (ADC).
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/input/googlepubsub/config_test.go
+++ b/x-pack/filebeat/input/googlepubsub/config_test.go
@@ -1,0 +1,34 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package googlepubsub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const googleApplicationCredentialsVar = "GOOGLE_APPLICATION_CREDENTIALS"
+
+func TestConfigValidateGoogleAppDefaultCreds(t *testing.T) {
+	// Return the environment variables to their original state.
+	original, found := os.LookupEnv(googleApplicationCredentialsVar)
+	defer func() {
+		if found {
+			os.Setenv(googleApplicationCredentialsVar, original)
+		} else {
+			os.Unsetenv(googleApplicationCredentialsVar)
+		}
+	}()
+
+	// Validate that it finds the application default credentials and does
+	// not trigger a config validation error because credentials were not
+	// set in the config.
+	os.Setenv(googleApplicationCredentialsVar, filepath.Clean("testdata/fake.json"))
+	c := defaultConfig()
+	assert.NoError(t, c.Validate())
+}

--- a/x-pack/filebeat/input/googlepubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/googlepubsub/pubsub_test.go
@@ -203,7 +203,7 @@ func defaultTestConfig() *common.Config {
 			"name":   emulatorSubscription,
 			"create": true,
 		},
-		"credentials_file": "NONE FOR EMULATOR TESTING",
+		"credentials_file": "testdata/fake.json",
 	})
 }
 

--- a/x-pack/filebeat/input/googlepubsub/testdata/fake.json
+++ b/x-pack/filebeat/input/googlepubsub/testdata/fake.json
@@ -1,0 +1,12 @@
+{
+    "type": "service_account",
+    "project_id": "foo",
+    "private_key_id": "x",
+    "private_key": "",
+    "client_email": "foo@bar.com",
+    "client_id": "0",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://foo.bar/path"
+}

--- a/x-pack/filebeat/module/googlecloud/audit/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/audit/config/input.yml
@@ -4,7 +4,12 @@ type: google-pubsub
 project_id: {{ .project_id }}
 topic: {{ .topic }}
 subscription.name: {{ .subscription_name }}
+{{ if .credentials_file }}
 credentials_file: {{ .credentials_file }}
+{{ end }}
+{{ if .credentials_json }}
+credentials_json: {{ .credentials_json }}
+{{ end }}
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/googlecloud/audit/manifest.yml
+++ b/x-pack/filebeat/module/googlecloud/audit/manifest.yml
@@ -10,7 +10,7 @@ var:
   - name: subscription_name
     default: filebeat-googlecloud-audit
   - name: credentials_file
-    default: googlecloud-audit-reader-service-identity.json
+  - name: credentials_json
   - name: keep_original_message
     default: false
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/googlecloud/firewall/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/firewall/config/input.yml
@@ -4,7 +4,12 @@ type: google-pubsub
 project_id: {{ .project_id }}
 topic: {{ .topic }}
 subscription.name: {{ .subscription_name }}
+{{ if .credentials_file }}
 credentials_file: {{ .credentials_file }}
+{{ end }}
+{{ if .credentials_json }}
+credentials_json: {{ .credentials_json }}
+{{ end }}
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/googlecloud/firewall/manifest.yml
+++ b/x-pack/filebeat/module/googlecloud/firewall/manifest.yml
@@ -10,7 +10,7 @@ var:
   - name: subscription_name
     default: filebeat-googlecloud-firewall
   - name: credentials_file
-    default: googlecloud-firewall-reader-service-identity.json
+  - name: credentials_json
   - name: debug
     default: false
   - name: keep_original_message

--- a/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
@@ -4,7 +4,12 @@ type: google-pubsub
 project_id: {{ .project_id }}
 topic: {{ .topic }}
 subscription.name: {{ .subscription_name }}
+{{ if .credentials_file }}
 credentials_file: {{ .credentials_file }}
+{{ end }}
+{{ if .credentials_json }}
+credentials_json: {{ .credentials_json }}
+{{ end }}
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/googlecloud/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/googlecloud/vpcflow/manifest.yml
@@ -10,7 +10,7 @@ var:
   - name: subscription_name
     default: filebeat-googlecloud-vpcflow
   - name: credentials_file
-    default: googlecloud-vpcflow-reader-service-identity.json
+  - name: credentials_json
   - name: keep_original_message
     default: false
 ingest_pipeline: ingest/pipeline.yml


### PR DESCRIPTION
Cherry-pick of PR #15668 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Update the Google Pub/Sub input to support reading Application Default Credentials
(ADC) in addition to the credentials_file and credentials_json config options.

If neither config option is set then it will attempt to search for the default credentials.
Generally this means reading the GOOGLE_APPLICATION_CREDENTIALS environment
variable plus searching a few other well known locations.

The googlecloud module was updates to support all three authentication mechanisms.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change, Filebeat requires a path to a file with credentials to be provided in its config and is unable to use for example a default service account.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Upload the Filebeat binary to a GCP instance created with default config
1. Run the binary configured to read from PubSub, but do not provide any credentials
1. Filebeat should be able to detect that it's on GCP and use ADC (get a token for the default service account for the VM from the metadata server)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/15667

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

Sending logs to Elastic from PubSub queue

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
