### PR TITLE
fix: mount Docker credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -662,8 +662,6 @@ def withBeatsEnv(boolean archive, Closure body) {
     unstash 'source'
     if(isDockerInstalled()){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-      // FIXME workaround until we fix the packer cache
-      // Retry to avoid DDoS detection from the server
     }
     dir("${env.BASE_DIR}") {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -660,13 +660,13 @@ def withBeatsEnv(boolean archive, Closure body) {
   ]) {
     deleteDir()
     unstash 'source'
-    if(os == 'linux'){
+    if(isDockerInstalled()){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       // FIXME workaround until we fix the packer cache
       // Retry to avoid DDoS detection from the server
       retry(3) {
         sleep randomNumber(min: 2, max: 5)
-        sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
+        //sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
       }
     }
     dir("${env.BASE_DIR}") {
@@ -966,4 +966,8 @@ def setGitConfig(){
       git config user.name "beatsmachine"
     fi
   ''')
+}
+
+def isDockerInstalled(){
+  return sh(label: 'check for Docker', script: 'command -v docker', returnStatus: true)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -664,10 +664,6 @@ def withBeatsEnv(boolean archive, Closure body) {
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       // FIXME workaround until we fix the packer cache
       // Retry to avoid DDoS detection from the server
-      retry(3) {
-        sleep randomNumber(min: 2, max: 5)
-        //sh 'docker pull docker.elastic.co/observability-ci/database-enterprise:12.2.0.1'
-      }
     }
     dir("${env.BASE_DIR}") {
       sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ${PWD}/../..:/go/src/github.com/elastic/beats/
       - /var/run/docker.sock:/var/run/docker.sock
+      - ${HOME}/.docker:/root/.docker:ro
     network_mode: host
     command: make
 


### PR DESCRIPTION
## What does this PR do?

It adds the Docker credentials to the Docker compose.

## Why is it important?

We need to login in our registry to grab some Docker images. Removes the `docker pull` introduced on https://github.com/elastic/beats/pull/17620