### PR TITLE
Cherry-pick #17765 to 7.x: [Agent] Rename the User-Agent string from Beats Agent to Elastic Agent

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -18,6 +18,7 @@
 - Fixed merge of config {pull}17399[17399]
 - Handle abs paths on windows correctly {pull}17461[17461]
 - Improved cancellation of agent {pull}17318[17318]
+- Rename the User-Agent string from Beats Agent to Elastic Agent. {pull}17765[17765]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/fleetapi/client_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/client_test.go
@@ -107,14 +107,14 @@ func TestHTTPClient(t *testing.T) {
 		},
 	))
 
-	t.Run("Fleet user agent", withServer(
+	t.Run("Elastic Agent User-Agent string", withServer(
 		func(t *testing.T) *http.ServeMux {
 			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintf(w, msg)
-				require.Equal(t, r.Header.Get("User-Agent"), "Beat Agent v8.0.0")
+				require.Equal(t, r.Header.Get("User-Agent"), "Elastic Agent v8.0.0")
 			})
 			return mux
 		}, func(t *testing.T, host string) {

--- a/x-pack/elastic-agent/pkg/fleetapi/round_trippers.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/round_trippers.go
@@ -28,7 +28,7 @@ func (r *FleetUserAgentRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 // NewFleetUserAgentRoundTripper returns a  FleetUserAgentRoundTripper that actually wrap the
 // existing UserAgentRoundTripper with a specific string.
 func NewFleetUserAgentRoundTripper(wrapped http.RoundTripper, version string) http.RoundTripper {
-	const name = "Beat Agent"
+	const name = "Elastic Agent"
 	return &FleetUserAgentRoundTripper{
 		rt: kibana.NewUserAgentRoundTripper(wrapped, name+" v"+version),
 	}


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17765 to 7.x branch. Original message: 

When we changed the name of the agent to Elastic Agent we forgot to
update the User-Agent string send on every request.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
