### PR TITLE
Cherry-pick #17764 to 7.x: [Agent] Remove the hard version between Fleet and the Elastic Agent.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -18,6 +18,8 @@
 - Fixed merge of config {pull}17399[17399]
 - Handle abs paths on windows correctly {pull}17461[17461]
 - Improved cancellation of agent {pull}17318[17318]
+- Remove the kbn-version on each request to the Kibana API. {pull}17764[17764]
+
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -20,7 +20,6 @@
 - Improved cancellation of agent {pull}17318[17318]
 - Remove the kbn-version on each request to the Kibana API. {pull}17764[17764]
 
-
 ==== New features
 
 - Generate index name in a format type-dataset-namespace {pull}16903[16903]

--- a/x-pack/elastic-agent/pkg/fleetapi/client.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/client.go
@@ -34,7 +34,6 @@ type clienter interface {
 
 var baseRoundTrippers = func(rt http.RoundTripper) (http.RoundTripper, error) {
 	rt = NewFleetUserAgentRoundTripper(rt, release.Version())
-	rt = kibana.NewEnforceKibanaVersionRoundTripper(rt, release.Version())
 	return rt, nil
 }
 

--- a/x-pack/elastic-agent/pkg/fleetapi/client_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/client_test.go
@@ -17,42 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/kibana"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
 func TestHTTPClient(t *testing.T) {
 	ctx := context.Background()
-
-	t.Run("Ensure we validate the remote Kibana version is higher or equal", withServer(
-		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
-			mux := http.NewServeMux()
-			mux.HandleFunc("/echo-hello", authHandler(func(w http.ResponseWriter, r *http.Request) {
-				v := r.Header.Get("kbn-version")
-				assert.Equal(t, release.Version(), v)
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprintf(w, msg)
-			}, "abc123"))
-			return mux
-		}, func(t *testing.T, host string) {
-			cfg := &kibana.Config{
-				Host: host,
-			}
-
-			l, err := logger.New()
-			client, err := NewAuthWithConfig(l, "abc123", cfg)
-			require.NoError(t, err)
-			resp, err := client.Send(ctx, "GET", "/echo-hello", nil, nil, nil)
-			require.NoError(t, err)
-
-			body, err := ioutil.ReadAll(resp.Body)
-			require.NoError(t, err)
-			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
-		},
-	))
 
 	t.Run("API Key is valid", withServer(
 		func(t *testing.T) *http.ServeMux {

--- a/x-pack/elastic-agent/pkg/kibana/round_trippers.go
+++ b/x-pack/elastic-agent/pkg/kibana/round_trippers.go
@@ -138,7 +138,7 @@ func (r *EnforceKibanaVersionRoundTripper) RoundTrip(req *http.Request) (*http.R
 }
 
 // NewEnforceKibanaVersionRoundTripper enforce the remove endpoint to be a a certain version, if the
-// remove kibana is not equal or superior on the requested version the call will fail.
+// remote kibana is not equal the call will fail.
 func NewEnforceKibanaVersionRoundTripper(wrapped http.RoundTripper, version string) http.RoundTripper {
 	return &EnforceKibanaVersionRoundTripper{rt: wrapped, version: version}
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17764 to 7.x branch. Original message: 

This removes the check that Kibana was doing to enforce that the remote
version match the current version of Kibana. Instead, the Fleet API
should take the agent header version and ensure we can support it.

This allows the Kibana side to control the communication and the upgrade
more gracefully.

Fixes: elastic/beats#17761

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->



## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Test with a snapshot released of the Elastic-Agent.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
