### PR TITLE
Update Kafka versions

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -27,7 +27,7 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 [float]
 === Compatibility
 
-This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
+This module is tested with Kafka 0.10.2.1, 1.1.0, 2.1.1, and 2.2.2.
 
 The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
 

--- a/metricbeat/module/kafka/README.md
+++ b/metricbeat/module/kafka/README.md
@@ -14,7 +14,7 @@ To bring this container up simply run the tests for Kafka module:
 After the tests have been completed, the Kafka container should be still running. Verify with:
 
 ```console
-707b50334835    docker.elastic.co/integrations-ci/beats-kafka:2.1.1-2  "/run.sh"        2 minutes ago    Up 2 minutes (healthy)  2181/tcp, 0.0.0.0:32785->8774/tcp, 0.0.0.0:32784->8775/tcp, 0.0.0.0:32783->8779/tcp, 0.0.0.0:32782->9092/tcp  kafka_a035cf4c6889705a_kafka_1
+707b50334835    docker.elastic.co/integrations-ci/beats-kafka:2.2.2-2  "/run.sh"        2 minutes ago    Up 2 minutes (healthy)  2181/tcp, 0.0.0.0:32785->8774/tcp, 0.0.0.0:32784->8775/tcp, 0.0.0.0:32783->8779/tcp, 0.0.0.0:32782->9092/tcp  kafka_a035cf4c6889705a_kafka_1
 ```
 
 In order to identify to which port the Broker is listening on one should check in the logs of the container and find 

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -20,7 +20,7 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 [float]
 === Compatibility
 
-This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
+This module is tested with Kafka 0.10.2.1, 1.1.0, 2.1.1, and 2.2.2.
 
 The Broker, Producer, Consumer metricsets require <<metricbeat-module-jolokia,Jolokia>> to fetch JMX metrics. Refer to the link for Jolokia's compatibility notes.
 

--- a/metricbeat/module/kafka/_meta/supported-versions.yml
+++ b/metricbeat/module/kafka/_meta/supported-versions.yml
@@ -1,4 +1,5 @@
 variants:
+  - KAFKA_VERSION: 2.2.2
   - KAFKA_VERSION: 2.1.1
   - KAFKA_VERSION: 2.0.0
   - KAFKA_VERSION: 1.1.0

--- a/metricbeat/module/kafka/broker/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/broker/_meta/docs.asciidoc
@@ -2,7 +2,7 @@ This metricset periodically fetches JMX metrics from Kafka Broker JMX.
 
 [float]
 === Compatibility
-The module has been tested with Kafka 2.1.1. Other versions are expected to work.
+The module has been tested with Kafka 2.1.1 and 2.2.2. Other versions are expected to work.
 
 [float]
 === Usage

--- a/metricbeat/module/kafka/consumer/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/consumer/_meta/docs.asciidoc
@@ -2,7 +2,7 @@ This metricset periodically fetches JMX metrics from Kafka Consumers implemented
 
 [float]
 === Compatibility
-The module has been tested with Kafka 2.1.1. Other versions are expected to work.
+The module has been tested with Kafka 2.1.1 and 2.2.2. Other versions are expected to work.
 
 [float]
 === Usage

--- a/metricbeat/module/kafka/docker-compose.yml
+++ b/metricbeat/module/kafka/docker-compose.yml
@@ -2,11 +2,11 @@ version: '2.3'
 
 services:
   kafka:
-    image: docker.elastic.co/integrations-ci/beats-kafka:${KAFKA_VERSION:-2.1.1}-2
+    image: docker.elastic.co/integrations-ci/beats-kafka:${KAFKA_VERSION:-2.2.2}-2
     build:
       context: ./_meta
       args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-2.1.1}
+        KAFKA_VERSION: ${KAFKA_VERSION:-2.2.2}
     ports:
       - 9092
       - 8779

--- a/metricbeat/module/kafka/producer/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/producer/_meta/docs.asciidoc
@@ -2,7 +2,7 @@ This metricset periodically fetches JMX metrics from Kafka Producers implemented
 
 [float]
 === Compatibility
-The module has been tested with Kafka 2.1.1. Other versions are expected to work.
+The module has been tested with Kafka 2.1.1 and 2.2.2. Other versions are expected to work.
 
 [float]
 === Usage

--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -4,7 +4,7 @@ ENV KAFKA_HOME /kafka
 # The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
 ENV KAFKA_ADVERTISED_HOST kafka
 ENV KAFKA_LOGS_DIR="/kafka-logs"
-ENV KAFKA_VERSION 2.1.1
+ENV KAFKA_VERSION 2.2.2
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 


### PR DESCRIPTION
## What does this PR do?

Updates the version of Kafka we use in our tests.

## Why is it important?

The `libbeat` CI job has been failing the past few days with this error:

```

[2020-04-19T19:37:28.974Z] Step 9/15 : RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz     "http://mirror.easyname.ch/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" &&     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1

[2020-04-19T19:37:28.975Z]  ---> Running in 3dc3dbc4603f

[2020-04-19T19:37:29.914Z] 

[2020-04-19T19:37:29.915Z] gzip: stdin: not in gzip format

[2020-04-19T19:37:29.915Z] tar: Child returned status 1

[2020-04-19T19:37:29.915Z] tar: Error is not recoverable: exiting now

[2020-04-19T19:37:29.915Z] Removing intermediate container 3dc3dbc4603f

[2020-04-19T19:37:29.915Z] Service 'kafka' failed to build: The command '/bin/sh -c mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz     "http://mirror.easyname.ch/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" &&     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1' returned a non-zero code: 2

[2020-04-19T19:37:29.915Z] scripts/Makefile:405: recipe for target 'build-image' failed

[2020-04-19T19:37:29.915Z] make[1]: *** [build-image] Error 1

[2020-04-19T19:37:29.915Z] make[1]: Leaving directory '/var/lib/jenkins/workspace/Beats_beats-beats-mbp_PR-17381/src/github.com/elastic/beats/libbeat'

[2020-04-19T19:37:29.915Z] scripts/Makefile:305: recipe for target 'testsuite' failed

[2020-04-19T19:37:29.915Z] make: *** [testsuite] Error 2
```

Visiting http://mirror.easyname.ch/apache/kafka/ shows that the `2.1.1` sub-folder is no longer available, which is causing the failure seen in the CI logs. The next version available is `2.2.2` so this PR updates the Kafka version in our codebase to `2.2.2`.

## Checklist

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`~
