### PR TITLE
Cherry-pick #17751 to 7.x: [Agent] Windows spawning process fix 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -18,6 +18,7 @@
 - Fixed merge of config {pull}17399[17399]
 - Handle abs paths on windows correctly {pull}17461[17461]
 - Improved cancellation of agent {pull}17318[17318]
+- Fixed process spawning on Windows {pull}17751[17751]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/plugin/process/cmd.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/cmd.go
@@ -10,6 +10,7 @@ package process
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
@@ -18,6 +19,7 @@ func getCmd(logger *logger.Logger, path string, env []string, uid, gid int, arg 
 	cmd := exec.Command(path, arg...)
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, env...)
+	cmd.Dir = filepath.Dir(path)
 
 	return cmd
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/process/process.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/process.go
@@ -191,14 +191,17 @@ func pushCredentials(w io.Writer, c *Creds) error {
 
 	credbytes, err := yaml.Marshal(c)
 	if err != nil {
-		return err
+		return errors.New(err, "decoding credentials")
 	}
 
 	_, err = w.Write(credbytes)
+	if err != nil {
+		return errors.New(err, "passing credentials failed")
+	}
 
 	// this gives beat with grpc a bit of time to spin up a goroutine and start a server.
 	// should be ok until we come up with more clever solution.
 	// Issue: https://github.com/elastic/beats/v7/issues/15634
 	<-time.After(1500 * time.Millisecond)
-	return err
+	return nil
 }


### PR DESCRIPTION
Cherry-pick of PR #17751 to 7.x branch. Original message:

## What does this PR do?

When windows process is spawned its WD is set to agents WD. this fixes it so beat can pick up default config out of its directory

## Why is it important?

Without this beat tries to lookup for default config e.g metricbeat.yml in an agents home dir. This config is not there so it fails.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
