### PR TITLE
Revert Logstash test image version to `8.0.0-SNAPSHOT`

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -17,7 +17,7 @@ services:
     - "indices.id_field_data.enabled=true"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash@sha256:e01cf165142edf8d67485115b938c94deeda66153e9516aa2ce69ee417c5fc33
+    image: docker.elastic.co/logstash/logstash:8.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600


### PR DESCRIPTION
Follow up to https://github.com/elastic/beats/pull/15568/files#r368532847.
