### PR TITLE
[Agent] Fixed injected log path to monitoring beat 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -22,6 +22,7 @@
 - Fix issues when running `mage package` for all the platforms. {pull}17767[17767]
 - Remove the kbn-version on each request to the Kibana API. {pull}17764[17764]
 - Fixed process spawning on Windows {pull}17751[17751]
+- Fixed injected log path to monitoring beat {pull}17833[17833]
 
 ==== New features
 

--- a/x-pack/elastic-agent/_meta/common.p2.yml
+++ b/x-pack/elastic-agent/_meta/common.p2.yml
@@ -112,7 +112,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/_meta/common.reference.p2.yml
+++ b/x-pack/elastic-agent/_meta/common.reference.p2.yml
@@ -112,7 +112,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/_meta/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.docker.yml
@@ -86,7 +86,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/_meta/elastic-agent.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.yml
@@ -87,7 +87,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -86,7 +86,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -117,7 +117,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -117,7 +117,7 @@ retry:
   # Default is false
   exponential: false
 
-monitoring:
+settings.monitoring:
   # enabled turns on monitoring of running processes
   enabled: false
   # enables log monitoring

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -225,6 +225,8 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 		},
 	}
 
+	o.logger.Debugf("monitoring configuration generated for filebeat: %v", result)
+
 	return result, true
 }
 
@@ -249,6 +251,8 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 			"elasticsearch": output,
 		},
 	}
+
+	o.logger.Debugf("monitoring configuration generated for metricbeat: %v", result)
 
 	return result, true
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -24,7 +24,7 @@ type Monitor struct {
 	process            string
 	monitoringEndpoint string
 	loggingPath        string
-	logginFile         string
+	loggingFile        string
 
 	monitorLogs    bool
 	monitorMetrics bool
@@ -48,7 +48,7 @@ func NewMonitor(process, pipelineID string, downloadConfig *artifact.Config, mon
 		process:            process,
 		monitoringEndpoint: monitoringEndpoint,
 		loggingPath:        loggingPath,
-		logginFile:         loggingFile,
+		loggingFile:        loggingFile,
 		monitorLogs:        monitorLogs,
 		monitorMetrics:     monitorMetrics,
 	}
@@ -129,7 +129,7 @@ func (b *Monitor) LogPath() string {
 		return ""
 	}
 
-	return b.logginFile
+	return b.loggingFile
 }
 
 // MetricsPath describes a location where application exposes metrics

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -125,7 +125,7 @@ func (b *Monitor) LogPath() string {
 		return ""
 	}
 
-	return b.loggingPath
+	return filepath.Join(b.loggingPath, b.process)
 }
 
 // MetricsPath describes a location where application exposes metrics

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -24,6 +24,7 @@ type Monitor struct {
 	process            string
 	monitoringEndpoint string
 	loggingPath        string
+	logginFile         string
 
 	monitorLogs    bool
 	monitorMetrics bool
@@ -31,13 +32,15 @@ type Monitor struct {
 
 // NewMonitor creates a beats monitor.
 func NewMonitor(process, pipelineID string, downloadConfig *artifact.Config, monitorLogs, monitorMetrics bool) *Monitor {
-	var monitoringEndpoint, loggingPath string
+	var monitoringEndpoint, loggingPath, loggingFile string
 
 	if monitorMetrics {
 		monitoringEndpoint = getMonitoringEndpoint(process, downloadConfig.OS(), pipelineID)
 	}
 	if monitorLogs {
-		loggingPath = getLoggingFileDirectory(downloadConfig.InstallPath, downloadConfig.OS(), pipelineID)
+		operatingSystem := downloadConfig.OS()
+		loggingFile = getLoggingFile(process, operatingSystem, downloadConfig.InstallPath, pipelineID)
+		loggingPath = filepath.Dir(loggingFile)
 	}
 
 	return &Monitor{
@@ -45,6 +48,7 @@ func NewMonitor(process, pipelineID string, downloadConfig *artifact.Config, mon
 		process:            process,
 		monitoringEndpoint: monitoringEndpoint,
 		loggingPath:        loggingPath,
+		logginFile:         loggingFile,
 		monitorLogs:        monitorLogs,
 		monitorMetrics:     monitorMetrics,
 	}
@@ -125,7 +129,7 @@ func (b *Monitor) LogPath() string {
 		return ""
 	}
 
-	return filepath.Join(b.loggingPath, b.process)
+	return b.logginFile
 }
 
 // MetricsPath describes a location where application exposes metrics

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
@@ -6,7 +6,6 @@ package beats
 
 import (
 	"fmt"
-	"path/filepath"
 )
 
 const (
@@ -35,8 +34,4 @@ func getLoggingFile(program, operatingSystem, installPath, pipelineID string) st
 	}
 
 	return fmt.Sprintf(logFileFormat, pipelineID, program)
-}
-
-func getLoggingFileDirectory(installPath, operatingSystem, pipelineID string) string {
-	return filepath.Dir(getLoggingFile("program", operatingSystem, installPath, pipelineID))
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
@@ -38,5 +38,5 @@ func getLoggingFile(program, operatingSystem, installPath, pipelineID string) st
 }
 
 func getLoggingFileDirectory(installPath, operatingSystem, pipelineID string) string {
-	return filepath.Base(getLoggingFile("program", operatingSystem, installPath, pipelineID))
+	return filepath.Dir(getLoggingFile("program", operatingSystem, installPath, pipelineID))
 }


### PR DESCRIPTION
## What does this PR do?

Incorrect path was passed to monitoring beat so it could not pick up files from log directory

## Why is it important?

To enable logs monitoring

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test

Package agent and run standalone with this config

```yaml
outputs:
  default:
    type: elasticsearch
    hosts: [127.0.0.1:9200]
    username: elastic
    password: changeme
datasources:
- id: system-1
  enabled: true
  use_output: default
  inputs:
  - type: system/metrics
    enabled: true
    streams:
    - id: system/metrics-system.core
      enabled: true
      dataset: system.core
      period: 10s
      metrics:
      - percentages
    - id: logs-system.syslog
      enabled: true
      dataset: system.syslog
      paths:
      - "/var/log/messages*"
      - "/var/log/syslog*"
  package:
    name: system
    version: 0.9.0  
settings.monitoring:
  use_output: default
  enabled: true
  logs: true
  metrics: true
management:
  mode: "local"
  fleet:
    access_token: ""
    kibana:
      host: "localhost:5601"
      ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
  reporting:
    log:
      format: "default"
    fleet:
      enabled: false
      reporting_threshold: 10000
      reporting_check_frequency_sec: 30
  reload:
    enabled: true
    period: 10s
download:
  sourceURI: "https://artifacts.elastic.co/downloads/beats/"
  target_directory: "${path.data}/downloads"
  timeout: 30s
  pgpfile: "${path.data}/elastic.pgp"
  install_path: "${path.data}/install"
process:
  min_port: 10000
  max_port: 30000
  spawn_timeout: 30s
retry:
  enabled: true
  retriesCount: 3
  delay: 30s
  maxDelay: 5m
  exponential: false


```

when you check `GET /_cat/indices/` in kibana you should see `filebeat-8.0.0-{date}` index created.