### PR TITLE
Cherry-pick #17384 to 7.7: Improve prometheus remote_write docs

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ remote_write:
 TIP: In order to assure the health of the whole queue, the following two configuration
  https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
 
-- `max_shards`: Sets the maximum number of paralelism with which Prometheus will try to send samples to Metricbeat.
+- `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Metricbeat.
 It is recommended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
 Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
 Metricbeat can actually achieve is the optimal queue configuration.

--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -7,6 +7,23 @@ remote_write:
   - url: "http://localhost:9201/write"
 ------------------------------------------------------------------------------
 
+
+TIP: In order to assure the health of the whole queue, the following two configuration
+ https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
+
+- `max_shards`: Sets the maximum number of paralelism with which Prometheus will try to send samples to Metricbeat.
+It is recommended that this setting should be equal to the number of cores of the machine where Metricbeat runs.
+Metricbeat can handle connections in parallel and hence setting `max_shards` to the number of parallelism that
+Metricbeat can actually achieve is the optimal queue configuration.
+- `max_samples_per_send`: Sets the number of samples to batch together for each send. Recommended values are
+between 100 (default) and 1000. Having a bigger batch can lead to improved throughput and in more efficient
+storage since Metricbeat groups metrics with the same labels into same event documents.
+However this will increase the memory usage of Metricbeat.
+- `capacity`: It is recommended to set capacity to 3-5 times `max_samples_per_send`.
+Capacity sets the number of samples that are queued in memory per shard, and hence capacity should be high enough so as to
+be able to cover `max_samples_per_send`.
+
+
 Metrics sent to the http endpoint will be put by default under the `prometheus.metrics` prefix with their labels under `prometheus.labels`.
 A basic configuration would look like:
 


### PR DESCRIPTION
Cherry-pick of PR #17384 to 7.7 branch. Original message: 

## What does this PR do?
This PR adds a section in the docs of Prometheus remote_write metricset which points to Prometheus remote_write configuration parameters so as to efficiently tune the queue according to each case and system.


## Why is it important?
To make sure how one can solve issues like this one -> https://github.com/elastic/beats/issues/17079#issuecomment-604994432