### PR TITLE
Metricbeat redis: add config.epr.yml

### DIFF
--- a/metricbeat/module/redis/_meta/config.epr.yml
+++ b/metricbeat/module/redis/_meta/config.epr.yml
@@ -1,0 +1,21 @@
+- module: redis
+  metricsets:
+    - info
+    - key
+    - keyspace
+  period: 10s
+
+  # Redis hosts
+  hosts: ["127.0.0.1:6379"]
+
+  # Redis AUTH password. Empty by default.
+  password: test
+
+  # The duration to remain idle before closing connections
+  idle_timeout: 20s
+
+  # Network type to be used for redis connection. Default: tcp
+  network: tcp
+
+  # Max number of concurrent connections. Default: 10
+  maxconn: 10


### PR DESCRIPTION
This PR adds the `config.epr.yml` file to the Metricbeat mysql module.

It support the module importing process by the `import-beats` script in the EPR.

Similar issue in the past: https://github.com/elastic/beats/pull/17323