### PR TITLE
Cherry-pick #17659 to 7.x: Add config option to select a different azure cloud env in the azure-eventhub input and azure module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -330,6 +330,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings for mysql module. {issue}16172[16172] {pull}17491[17491]
 - Release Google Cloud module as GA. {pull}17511[17511]
 - Update filebeat httpjson input to support pagination via Header and Okta module. {pull}16354[16354]
+- Add config option to select a different azure cloud env in the azure-eventhub input and azure module. {issue}17649[17649] {pull}17659[17659]
+- Added new Checkpoint Syslog filebeat module. {pull}17682[17682]
+- Improve ECS categorization field mappings for nats module. {issue}16173[16173] {pull}17550[17550]
 - Enhance `elasticsearch/server` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17714[17714]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -331,8 +331,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release Google Cloud module as GA. {pull}17511[17511]
 - Update filebeat httpjson input to support pagination via Header and Okta module. {pull}16354[16354]
 - Add config option to select a different azure cloud env in the azure-eventhub input and azure module. {issue}17649[17649] {pull}17659[17659]
-- Added new Checkpoint Syslog filebeat module. {pull}17682[17682]
-- Improve ECS categorization field mappings for nats module. {issue}16173[16173] {pull}17550[17550]
 - Enhance `elasticsearch/server` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17714[17714]
 
 *Heartbeat*

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -43,6 +43,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
       connection_string: ""
       storage_account: ""
       storage_account_key: ""
+      resource_manager_endpoint: ""
 
    auditlogs:
      enabled: false
@@ -52,6 +53,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        connection_string: ""
        storage_account: ""
        storage_account_key: ""
+       resource_manager_endpoint: ""
 
    signinlogs:
      enabled: false
@@ -61,6 +63,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        connection_string: ""
        storage_account: ""
        storage_account_key: ""
+       resource_manager_endpoint: ""
 
 ```
 
@@ -89,6 +92,16 @@ The name of the storage account the state/offsets will be stored and updated.
 `storage_account_key` ::
 _string_
 The storage account key, this key will be used to authorize access to data in your storage account.
+
+`resource_manager_endpoint` ::
+_string_
+Optional, by default we are using the azure public environment, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
+Ex:
+https://management.chinacloudapi.cn/ for azure ChinaCloud
+https://management.microsoftazure.de/ for azure GermanCloud
+https://management.azure.com/ for azure PublicCloud
+https://management.usgovcloudapi.net/ for azure USGovernmentCloud
+Users can also use this in case of a Hybrid Cloud model, where one may define their own endpoints.
 
 include::../include/what-happens.asciidoc[]
 

--- a/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
@@ -28,6 +28,8 @@ Example configuration:
   storage_account: "azureeph"
   storage_account_key: "....."
   storage_account_container: ""
+  resource_manager_endpoint: ""
+
 ----
 
 ==== Configuration options
@@ -36,7 +38,7 @@ The `azure-eventhub` input supports the following configuration:
 
 ==== `eventhub`
 
-The name of the eventhub users would like to read from.
+The name of the eventhub users would like to read from, field required.
 
 ==== `consumer_group`
 
@@ -50,14 +52,23 @@ A Blob Storage account is required in order to store/retrieve/update the offset 
 
 ==== `storage_account`
 
-The name of the storage account.
+The name of the storage account. Required.
 
 ==== `storage_account_key`
 
-The storage account key, this key will be used to authorize access to data in your storage account.
+The storage account key, this key will be used to authorize access to data in your storage account, option is required.
 
 ==== `storage_account_container`
 
 Optional, the name of the storage account container you would like to store the offset information in.
 
+==== `resource_manager_endpoint`
+
+Optional, by default we are using the azure public environment, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
+Ex:
+https://management.chinacloudapi.cn/ for azure ChinaCloud
+https://management.microsoftazure.de/ for azure GermanCloud
+https://management.azure.com/ for azure PublicCloud
+https://management.usgovcloudapi.net/ for azure USGovernmentCloud
+Users can also use this in case of a Hybrid Cloud model, where one may define their own endpoints.
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -306,15 +306,15 @@ filebeat.modules:
   activitylogs:
     enabled: true
     var:
-      # Eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
+      # eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
       eventhub: "insights-operational-logs"
-      # Consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
+      # consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
       consumer_group: "$Default"
       # the connection string required to communicate with Event Hubs, steps to generate one here https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
       connection_string: ""
-      # the name of the storage account the state/offsets will be stored and updated.
+      # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
-      #The storage account key, this key will be used to authorize access to data in your storage account.
+      # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 
   auditlogs:

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -17,6 +17,8 @@ type azureInputConfig struct {
 	SAName      string `config:"storage_account"`
 	SAKey       string `config:"storage_account_key"`
 	SAContainer string `config:"storage_account_container"`
+	// by default the azure public environment is used, to override, users can provide a specific resource manager endpoint
+	OverrideEnvironment string `config:"resource_manager_endpoint"`
 }
 
 const ephContainerName = "filebeat"

--- a/x-pack/filebeat/input/azureeventhub/eph_test.go
+++ b/x-pack/filebeat/input/azureeventhub/eph_test.go
@@ -7,6 +7,8 @@ package azureeventhub
 import (
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/azure"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,4 +27,18 @@ func TestRunWithEPH(t *testing.T) {
 	// decoding error when key is invalid
 	err := input.runWithEPH()
 	assert.Error(t, err, '7')
+}
+
+func TestGetAzureEnvironment(t *testing.T) {
+	resMan := ""
+	env, err := getAzureEnvironment(resMan)
+	assert.NoError(t, err)
+	assert.Equal(t, env, azure.PublicCloud)
+	resMan = "https://management.microsoftazure.de/"
+	env, err = getAzureEnvironment(resMan)
+	assert.NoError(t, err)
+	assert.Equal(t, env, azure.GermanCloud)
+	resMan = "http://management.invalidhybrid.com/"
+	env, err = getAzureEnvironment(resMan)
+	assert.Errorf(t, err, "invalid character 'F' looking for beginning of value")
 }

--- a/x-pack/filebeat/module/azure/_meta/config.yml
+++ b/x-pack/filebeat/module/azure/_meta/config.yml
@@ -3,15 +3,15 @@
   activitylogs:
     enabled: true
     var:
-      # Eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
+      # eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
       eventhub: "insights-operational-logs"
-      # Consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
+      # consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
       consumer_group: "$Default"
       # the connection string required to communicate with Event Hubs, steps to generate one here https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
       connection_string: ""
-      # the name of the storage account the state/offsets will be stored and updated.
+      # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
-      #The storage account key, this key will be used to authorize access to data in your storage account.
+      # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 
   auditlogs:

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -38,6 +38,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
       connection_string: ""
       storage_account: ""
       storage_account_key: ""
+      resource_manager_endpoint: ""
 
    auditlogs:
      enabled: false
@@ -47,6 +48,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        connection_string: ""
        storage_account: ""
        storage_account_key: ""
+       resource_manager_endpoint: ""
 
    signinlogs:
      enabled: false
@@ -56,6 +58,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        connection_string: ""
        storage_account: ""
        storage_account_key: ""
+       resource_manager_endpoint: ""
 
 ```
 
@@ -84,6 +87,16 @@ The name of the storage account the state/offsets will be stored and updated.
 `storage_account_key` ::
 _string_
 The storage account key, this key will be used to authorize access to data in your storage account.
+
+`resource_manager_endpoint` ::
+_string_
+Optional, by default we are using the azure public environment, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
+Ex:
+https://management.chinacloudapi.cn/ for azure ChinaCloud
+https://management.microsoftazure.de/ for azure GermanCloud
+https://management.azure.com/ for azure PublicCloud
+https://management.usgovcloudapi.net/ for azure USGovernmentCloud
+Users can also use this in case of a Hybrid Cloud model, where one may define their own endpoints.
 
 include::../include/what-happens.asciidoc[]
 

--- a/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
@@ -4,3 +4,4 @@ eventhub: {{ .eventhub }}
 consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/activitylogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: resource_manager_endpoint
 
 ingest_pipeline:
   - ingest/pipeline.json

--- a/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
@@ -4,4 +4,5 @@ eventhub: {{ .eventhub }}
 consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}
 

--- a/x-pack/filebeat/module/azure/auditlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: resource_manager_endpoint
 
 ingest_pipeline:
   - ingest/pipeline.json

--- a/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
@@ -4,3 +4,4 @@ eventhub: {{ .eventhub }}
 consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/signinlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: resource_manager_endpoint
 
 ingest_pipeline:
   - ingest/pipeline.json

--- a/x-pack/filebeat/modules.d/azure.yml.disabled
+++ b/x-pack/filebeat/modules.d/azure.yml.disabled
@@ -6,15 +6,15 @@
   activitylogs:
     enabled: true
     var:
-      # Eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
+      # eventhub name containing the activity logs, overwrite he default value if the logs are exported in a different eventhub
       eventhub: "insights-operational-logs"
-      # Consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
+      # consumer group name that has access to the event hub, we advise creating a dedicated consumer group for the azure module
       consumer_group: "$Default"
       # the connection string required to communicate with Event Hubs, steps to generate one here https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
       connection_string: ""
-      # the name of the storage account the state/offsets will be stored and updated.
+      # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
-      #The storage account key, this key will be used to authorize access to data in your storage account.
+      # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 
   auditlogs:


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17659 to 7.x branch. Original message:

## What does this PR do?

Adds `override_resource_manager_endpoint` config option to select a different azure cloud env in the azure-eventhub input and azure module. 
Users should enter the resource manager endpoint in this case.
Ex:
	`https://management.chinacloudapi.cn/`:        azure.ChinaCloud,
	`https://management.microsoftazure.de/`:       azure.GermanCloud,
	`https://management.azure.com/`:       azure.PublicCloud,
	`https://management.usgovcloudapi.net/`: azure.USGovernmentCloud,

## Why is it important?

To support other azure cloud env besides the public one

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes elastic/beats#17649
