### PR TITLE
Metricbeat redis: add 'key.patterns' to config.epr.yml

### DIFF
--- a/metricbeat/module/redis/_meta/config.epr.yml
+++ b/metricbeat/module/redis/_meta/config.epr.yml
@@ -9,7 +9,7 @@
   hosts: ["127.0.0.1:6379"]
 
   # Redis AUTH password. Empty by default.
-  password: test
+  password: ""
 
   # The duration to remain idle before closing connections
   idle_timeout: 20s
@@ -19,3 +19,11 @@
 
   # Max number of concurrent connections. Default: 10
   maxconn: 10
+
+- module: redis
+  metricsets:
+    - key
+  key:
+    patterns:
+      - pattern: '*'
+        limit: 20


### PR DESCRIPTION
This PR adds `key.patterns` to the `config.epr.yml` in redis module.

Previous PR: https://github.com/elastic/beats/pull/17857