### PR TITLE
[agent] Bind to localhost for unit tests

### DIFF
--- a/x-pack/elastic-agent/pkg/fleetapi/helper_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/helper_test.go
@@ -5,9 +5,8 @@
 package fleetapi
 
 import (
-	"net"
 	"net/http"
-	"strconv"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,15 +32,9 @@ func authHandler(handler http.HandlerFunc, apiKey string) http.HandlerFunc {
 
 func withServer(m func(t *testing.T) *http.ServeMux, test func(t *testing.T, host string)) func(t *testing.T) {
 	return func(t *testing.T) {
-		listener, err := net.Listen("tcp", ":0")
-		require.NoError(t, err)
-		defer listener.Close()
-
-		port := listener.Addr().(*net.TCPAddr).Port
-
-		go http.Serve(listener, m(t))
-
-		test(t, "localhost:"+strconv.Itoa(port))
+		s := httptest.NewServer(m(t))
+		defer s.Close()
+		test(t, s.Listener.Addr().String())
 	}
 }
 

--- a/x-pack/elastic-agent/pkg/kibana/client_test.go
+++ b/x-pack/elastic-agent/pkg/kibana/client_test.go
@@ -9,9 +9,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"strconv"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -272,15 +271,9 @@ func TestHTTPClient(t *testing.T) {
 
 func withServer(m func(t *testing.T) *http.ServeMux, test func(t *testing.T, host string)) func(t *testing.T) {
 	return func(t *testing.T) {
-		listener, err := net.Listen("tcp", ":0")
-		require.NoError(t, err)
-		defer listener.Close()
-
-		port := listener.Addr().(*net.TCPAddr).Port
-
-		go http.Serve(listener, m(t))
-
-		test(t, "localhost:"+strconv.Itoa(port))
+		s := httptest.NewServer(m(t))
+		defer s.Close()
+		test(t, s.Listener.Addr().String())
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Binding to the wildcard address in tests means anyone can connect
to them. And it causes firewall prompts on macOS.

This changes the tests to only bind to 127.0.0.1.

<img width="495" alt="Screen Shot 2020-04-21 at 3 21 54 PM" src="https://user-images.githubusercontent.com/4565752/79911367-34d43900-83ee-11ea-9817-8e230cd5996c.png">
