### PR TITLE
[docs] Add release highlights for 7.7

### DIFF
--- a/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
@@ -7,8 +7,8 @@
 Each release of {beats} brings new features and product improvements. 
 Following are the most notable features and enhancements in 7.7.
 
-For a complete list of related highlights, see the 
-https://www.elastic.co/blog/elastic-observability-7-6-0-released[Observability 7.7 release blog].
+//For a complete list of related highlights, see the 
+//https://www.elastic.co/blog/elastic-observability-7-7-0-released[Observability 7.7 release blog].
 
 For a list of bug fixes and other changes, see the {beats}
 <<breaking-changes-7.7, Breaking Changes>> and <<release-notes, Release Notes>>.

--- a/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
@@ -81,7 +81,7 @@ for monitoring additional services:
 * The {metricbeat-ref}/metricbeat-metricset-googlecloud-pubsub.html[`pubsub`]
 metricset connects to the Stackdriver API and collects metrics for topics,
 subscriptions, and snapshots used by a specified account. 
-* The {metricbeat-ref}/metricbeat-metricset-googlecloud-loadbalancer.html[`loadbalancer`]
+* The {metricbeat-ref}/metricbeat-metricset-googlecloud-loadbalancing.html[`loadbalancing`]
 metricset captures load balancing performance metrics for HTTP(S), TCP, and UDP
 applications.
 

--- a/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
@@ -102,6 +102,10 @@ In {filebeat}, the new
 {filebeat-ref}/filebeat-input-cloudfoundry.html[`cloudfoundry`] input collects
 http access logs, container logs, and error logs from Cloud Foundry.
 
+To learn how to run {beats} on Cloud Foundry, see:
+
+* {metricbeat-ref}/running-on-cloudfoundry.html[Run {metricbeat} on Cloud Foundry]
+* {filebeat-ref}/running-on-cloudfoundry.html[Run {filebeat} on Cloud Foundry]
 
 [float]
 [role="xpack"]

--- a/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.7.0.asciidoc
@@ -18,9 +18,131 @@ For a list of bug fixes and other changes, see the {beats}
 
 // tag::notable-highlights[]
 
-//[float]
-//==== highlight
+[float]
+[role="xpack"]
+==== Azure Kubernetes and container monitoring
 
-//Description
+We've enhanced the {metricbeat} Azure module with three new metricsets
+for monitoring Microsoft Azure container services:
+{metricbeat-ref}/metricbeat-metricset-azure-container_instance.html[`container_instance`],
+{metricbeat-ref}/metricbeat-metricset-azure-container_registry.html[`container_registry`], and
+{metricbeat-ref}/metricbeat-metricset-azure-container_service.html[`container_service`].
+These metricsets collect metrics from the following services:
+
+* Azure Kubernetes Service
+* Azure Container Instances
+* Azure Container Registry
+
+Each metricset comes with a dashboard that makes it easy to get started
+monitoring Azure containers.
+
+[float]
+[role="xpack"]
+==== AWS VPCs, Lambdas, and DynamoDB monitoring
+
+In the {metricbeat} AWS module, we've added support for monitoring
+mission-critical services in the Amazon VPC ecosystem:
+
+* The {metricbeat-ref}/metricbeat-metricset-aws-natgateway.html[`natgateway`]
+metricset enables you to monitor NAT gateway services to gain a
+better perspective on how web applications or services are performing.
+* The {metricbeat-ref}/metricbeat-metricset-aws-natgateway.html[`transitgateway`]
+metricset collects metrics sent to CloudWatch by VPC when requests are flowing
+through the gateway. 
+* The {metricbeat-ref}/metricbeat-metricset-aws-vpn.html[`vpn`] metricset
+enables you to monitor VPN tunnels. VPN metric data is automatically sent to
+CloudWatch as it becomes available.
+
+Also new in this release, the
+{metricbeat-ref}/metricbeat-metricset-aws-lambda.html[`lambda`] metricset monitors
+Lambda functions across multiple accounts and regions. The metricset collects
+metrics such as total invocations, errors, duration, throttles, dead-letter queue
+errors, and iterator age for stream-based invocations. You can use these metrics
+to configure alerts to respond to events such as changes in performance and
+error rates. 
+
+We’ve also added the
+{metricbeat-ref}/metricbeat-metricset-aws-dynamodb.html[`dynamodb`] metricset to
+monitor AWS DynamoDB instances. This metricset collects metrics, such as request
+latency, transaction conflicts, provisioned and consumed capacity, and many
+others.    
+
+For Amazon Aurora users, we've enhanced the
+{metricbeat-ref}/metricbeat-metricset-aws-rds.html[`rds`] metricset to collect
+metrics about your Aurora instances.
+
+[float]
+[role="xpack"]
+==== Google Cloud Platform (GCP) Pub/Sub and Load Balancer monitoring
+
+We've enhanced the {metricbeat} Google Cloud Platform module with support
+for monitoring additional services:
+
+* The {metricbeat-ref}/metricbeat-metricset-googlecloud-pubsub.html[`pubsub`]
+metricset connects to the Stackdriver API and collects metrics for topics,
+subscriptions, and snapshots used by a specified account. 
+* The {metricbeat-ref}/metricbeat-metricset-googlecloud-loadbalancer.html[`loadbalancer`]
+metricset captures load balancing performance metrics for HTTP(S), TCP, and UDP
+applications.
+
+[float]
+[role="xpack"]
+==== Pivotal Cloud Foundry (PCF) monitoring
+
+We continue to expand coverage of container platforms by adding support for
+Pivotal Cloud Foundry. 
+
+The new {metricbeat}
+{metricbeat-ref}/metricbeat-module-cloudfoundry.html[Cloudfoundry module]
+connects to the Cloud Foundry API and pulls container, counter, and value
+metrics from it. These metrics are stored in `cloudfoundry.container`,
+`cloudfoundry.counter` and `cloudfoundry.value` metricsets.
+
+In {filebeat}, the new
+{filebeat-ref}/filebeat-input-cloudfoundry.html[`cloudfoundry`] input collects
+http access logs, container logs, and error logs from Cloud Foundry.
+
+
+[float]
+[role="xpack"]
+==== IBM MQ monitoring
+
+Prior to this release, we offered support in {filebeat} for collecting and
+parsing queue manager error logs from IBM MQ.
+
+In this release, we’ve added the missing piece: metrics. The new {metricbeat}
+{metricbeat-ref}/metricbeat-module-ibmmq.html[IBM MQ module] pulls status
+information for the Queue Manager, which is responsible for maintaining queues
+and ensuring that messages in the queues reach their destination.
+
+[float]
+[role="xpack"]
+====  Redis Enterprise monitoring
+
+In addition to our existing Redis module, which focuses on the open source
+version of the database, we’ve added the new {metricbeat}
+{metricbeat-ref}/metricbeat-module-redisenterprise.html[Redis Enterprise] module
+to monitor features such as nodes and proxies in a Redis cluster.
+
+[float]
+[role="xpack"]
+====  Istio monitoring
+
+For Istio users, we've introduced the {metricbeat}
+{metricbeat-ref}/metricbeat-module-istio.html[Istio module] to
+collect metrics about service traffic (in, out, and within a service mesh),
+control-plane metrics for Istio Pilot, Galley, Mixer components, and much
+more.
+
+[float]
+==== ECS field improvements in {filebeat}
+
+The {ecs-ref}/index.html[Elastic Common Schema] (ECS) defines a common set of
+fields to be used when storing event data in {es}.
+
+In 7.7, we've improved ECS field mappings in numerous {filebeat} modules,
+making it easier for you to analyze, visualize, and correlate data across
+events. For a list of affected modules, see the 
+<<release-notes,Release Notes>> for 7.7.0.
 
 // end::notable-highlights[]


### PR DESCRIPTION
Adds Beats release highlights for version 7.7.

To do:

- [ ] Update link to observability blog when it's live.