### PR TITLE
Cherry-pick #17855 to 7.x: Make monitoring settings configurable by fleet 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -33,3 +33,4 @@
 - Introduced `mage demo` command {pull}17312[17312]
 - Display the stability of the agent at enroll and start.  {pull}17336[17336]
 - Expose stream.* variables in events {pull}17468[17468]
+- Monitoring configuration reloadable {pull}17855[17855]

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/retry"
 )
@@ -36,9 +36,6 @@ func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.
 		DownloadConfig: &artifact.Config{
 			InstallPath: installPath,
 		},
-		MonitoringConfig: &monitoring.Config{
-			MonitorMetrics: false,
-		},
 	}
 
 	cfg, err := config.NewConfigFrom(operatorConfig)
@@ -56,7 +53,7 @@ func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.
 		t.Fatal(err)
 	}
 
-	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, installer, stateResolver, nil)
+	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, installer, stateResolver, nil, noop.NewMonitor())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/config/config.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/config/config.go
@@ -6,7 +6,6 @@ package config
 
 import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/retry"
 )
@@ -17,6 +16,4 @@ type Config struct {
 	RetryConfig   *retry.Config   `yaml:"retry" config:"retry"`
 
 	DownloadConfig *artifact.Config `yaml:"download" config:"download"`
-
-	MonitoringConfig *monitoring.Config `yaml:"settings.monitoring" config:"settings.monitoring"`
 }

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -9,29 +9,18 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configrequest"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring"
 )
 
 const (
 	monitoringName          = "FLEET_MONITORING"
-	settingsKey             = "settings"
-	monitoringKey           = "monitoring"
 	outputKey               = "output"
 	monitoringEnabledSubkey = "enabled"
 )
 
 func (o *Operator) handleStartSidecar(s configrequest.Step) (result error) {
-	cfg, err := getConfigFromStep(s)
-	if err != nil {
-		return errors.New(err,
-			errors.TypeConfig,
-			"operator.handleStartSidecar failed to retrieve config from step")
-	}
-
 	// if monitoring is disabled and running stop it
-	if isEnabled := isMonitoringEnabled(o.logger, cfg); !isEnabled {
+	if !o.monitor.IsMonitoringEnabled() {
 		if o.isMonitoring {
 			o.logger.Info("operator.handleStartSidecar: monitoring is running and disabled, proceeding to stop")
 			return o.handleStopSidecar(s)
@@ -97,42 +86,6 @@ func monitoringTags() map[app.Tag]string {
 	}
 }
 
-func isMonitoringEnabled(logger *logger.Logger, cfg map[string]interface{}) bool {
-	settingsVal, found := cfg[settingsKey]
-	if !found {
-		logger.Error("operator.isMonitoringEnabled: settings not found in config")
-		return false
-	}
-
-	settingsMap, ok := settingsVal.(map[string]interface{})
-	if !ok {
-		logger.Error("operator.isMonitoringEnabled: settings not a map")
-		return false
-	}
-
-	monitoringVal, found := settingsMap[monitoringKey]
-	if !found {
-		logger.Error("operator.isMonitoringEnabled: settings.monitoring not found in config")
-		return false
-	}
-
-	monitoringMap, ok := monitoringVal.(map[string]interface{})
-	if !ok {
-		logger.Error("operator.isMonitoringEnabled: settings.monitoring not a map")
-		return false
-	}
-
-	enabledVal, found := monitoringMap[monitoringEnabledSubkey]
-	if !found {
-		logger.Infof("operator.isMonitoringEnabled: monitoring.enabled key not found: %v", monitoringMap)
-		return false
-	}
-
-	enabled, ok := enabledVal.(bool)
-
-	return enabled && ok
-}
-
 func (o *Operator) getMonitoringSteps(step configrequest.Step) []configrequest.Step {
 	// get output
 	config, err := getConfigFromStep(step)
@@ -159,13 +112,13 @@ func (o *Operator) getMonitoringSteps(step configrequest.Step) []configrequest.S
 		return nil
 	}
 
-	return o.generateMonitoringSteps(o.config.MonitoringConfig, step.Version, output)
+	return o.generateMonitoringSteps(step.Version, output)
 }
 
-func (o *Operator) generateMonitoringSteps(cfg *monitoring.Config, version string, output interface{}) []configrequest.Step {
+func (o *Operator) generateMonitoringSteps(version string, output interface{}) []configrequest.Step {
 	var steps []configrequest.Step
 
-	if cfg.MonitorLogs {
+	if o.monitor.WatchLogs() {
 		fbConfig, any := o.getMonitoringFilebeatConfig(output)
 		stepID := configrequest.StepRun
 		if !any {
@@ -183,7 +136,7 @@ func (o *Operator) generateMonitoringSteps(cfg *monitoring.Config, version strin
 		steps = append(steps, filebeatStep)
 	}
 
-	if cfg.MonitorMetrics {
+	if o.monitor.WatchMetrics() {
 		mbConfig, any := o.getMonitoringMetricbeatConfig(output)
 		stepID := configrequest.StepRun
 		if !any {
@@ -217,6 +170,7 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 				map[string]interface{}{
 					"type":  "log",
 					"paths": paths,
+					"index": "logs-agent-default",
 				},
 			},
 		},
@@ -242,6 +196,7 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 					"metricsets": []string{"stats", "state"},
 					"period":     "10s",
 					"hosts":      hosts,
+					"index":      "metrics-agent-default",
 				},
 			},
 		},
@@ -260,7 +215,7 @@ func (o *Operator) getLogFilePaths() []string {
 	defer o.appsLock.Unlock()
 
 	for _, a := range o.apps {
-		logPath := a.Monitor().LogPath()
+		logPath := a.Monitor().LogPath(a.Name(), o.pipelineID)
 		if logPath != "" {
 			paths = append(paths, logPath)
 		}
@@ -276,7 +231,7 @@ func (o *Operator) getMetricbeatEndpoints() []string {
 	defer o.appsLock.Unlock()
 
 	for _, a := range o.apps {
-		metricEndpoint := a.Monitor().MetricsPathPrefixed()
+		metricEndpoint := a.Monitor().MetricsPathPrefixed(a.Name(), o.pipelineID)
 		if metricEndpoint != "" {
 			endpoints = append(endpoints, metricEndpoint)
 		}

--- a/x-pack/elastic-agent/pkg/core/plugin/app/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/app.go
@@ -139,7 +139,7 @@ func (a *Application) Stop() {
 		}
 
 		// cleanup drops
-		a.monitor.Cleanup()
+		a.monitor.Cleanup(a.name, a.pipelineID)
 	}
 }
 
@@ -199,7 +199,7 @@ func (a *Application) waitProc(proc *os.Process) <-chan *os.ProcessState {
 }
 
 func (a *Application) reportCrash(ctx context.Context) {
-	a.monitor.Cleanup()
+	a.monitor.Cleanup(a.name, a.pipelineID)
 
 	// TODO: reporting crash
 	if a.failureReporter != nil {

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -12,60 +12,84 @@ import (
 	"unicode"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	monitoringConfig "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/config"
 )
 
 const httpPlusPrefix = "http+"
 
+type wrappedConfig struct {
+	MonitoringConfig *monitoringConfig.MonitoringConfig `config:"settings.monitoring" yaml:"settings.monitoring"`
+}
+
 // Monitor is a monitoring interface providing information about the way
 // how beat is monitored
 type Monitor struct {
-	pipelineID string
-
-	process            string
-	monitoringEndpoint string
-	loggingPath        string
-
-	monitorLogs    bool
-	monitorMetrics bool
+	operatingSystem string
+	config          *monitoringConfig.MonitoringConfig
+	installPath     string
 }
 
 // NewMonitor creates a beats monitor.
-func NewMonitor(process, pipelineID string, downloadConfig *artifact.Config, monitorLogs, monitorMetrics bool) *Monitor {
-	var monitoringEndpoint, loggingPath string
-
-	if monitorMetrics {
-		monitoringEndpoint = getMonitoringEndpoint(process, downloadConfig.OS(), pipelineID)
-	}
-	if monitorLogs {
-		loggingPath = getLoggingFileDirectory(downloadConfig.InstallPath, downloadConfig.OS(), pipelineID)
-	}
-
+func NewMonitor(downloadConfig *artifact.Config) *Monitor {
 	return &Monitor{
-		pipelineID:         pipelineID,
-		process:            process,
-		monitoringEndpoint: monitoringEndpoint,
-		loggingPath:        loggingPath,
-		monitorLogs:        monitorLogs,
-		monitorMetrics:     monitorMetrics,
+		operatingSystem: downloadConfig.OS(),
+		installPath:     downloadConfig.InstallPath,
+		config:          &monitoringConfig.MonitoringConfig{},
 	}
+}
+
+// Reload reloads state of the monitoring based on config.
+func (b *Monitor) Reload(rawConfig *config.Config) error {
+	cfg := &wrappedConfig{}
+	if err := rawConfig.Unpack(&cfg); err != nil {
+		return err
+	}
+
+	b.config = cfg.MonitoringConfig
+	return nil
+}
+
+// IsMonitoringEnabled returns true if monitoring is enabled.
+func (b *Monitor) IsMonitoringEnabled() bool { return b.config.Enabled }
+
+// WatchLogs returns true if monitoring is enabled and monitor should watch logs.
+func (b *Monitor) WatchLogs() bool { return b.config.Enabled && b.config.MonitorLogs }
+
+// WatchMetrics returns true if monitoring is enabled and monitor should watch metrics.
+func (b *Monitor) WatchMetrics() bool { return b.config.Enabled && b.config.MonitorMetrics }
+
+func (b *Monitor) generateMonitoringEndpoint(process, pipelineID string) string {
+	return getMonitoringEndpoint(process, b.operatingSystem, pipelineID)
+}
+
+func (b *Monitor) generateLoggingFile(process, pipelineID string) string {
+	return getLoggingFile(process, b.operatingSystem, b.installPath, pipelineID)
+}
+
+func (b *Monitor) generateLoggingPath(process, pipelineID string) string {
+	return filepath.Dir(b.generateLoggingFile(process, pipelineID))
+
 }
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *Monitor) EnrichArgs(args []string) []string {
+func (b *Monitor) EnrichArgs(process, pipelineID string, args []string) []string {
 	appendix := make([]string, 0, 7)
 
-	if b.monitoringEndpoint != "" {
+	monitoringEndpoint := b.generateMonitoringEndpoint(process, pipelineID)
+	if monitoringEndpoint != "" {
 		appendix = append(appendix,
 			"-E", "http.enabled=true",
-			"-E", "http.host="+b.monitoringEndpoint,
+			"-E", "http.host="+monitoringEndpoint,
 		)
 	}
 
-	if b.loggingPath != "" {
+	loggingPath := b.generateLoggingPath(process, pipelineID)
+	if loggingPath != "" {
 		appendix = append(appendix,
-			"-E", "logging.files.path="+b.loggingPath,
-			"-E", "logging.files.name="+b.process,
+			"-E", "logging.files.path="+loggingPath,
+			"-E", "logging.files.name="+process,
 			"-E", "logging.files.keepfiles=7",
 			"-E", "logging.files.permission=0644",
 			"-E", "logging.files.interval=1h",
@@ -76,9 +100,9 @@ func (b *Monitor) EnrichArgs(args []string) []string {
 }
 
 // Cleanup removes
-func (b *Monitor) Cleanup() error {
+func (b *Monitor) Cleanup(process, pipelineID string) error {
 	// do not cleanup logs, they might not be all processed
-	drop := b.monitoringDrop()
+	drop := b.monitoringDrop(process, pipelineID)
 	if drop == "" {
 		return nil
 	}
@@ -87,9 +111,9 @@ func (b *Monitor) Cleanup() error {
 }
 
 // Prepare executes steps in order for monitoring to work correctly
-func (b *Monitor) Prepare(uid, gid int) error {
-	drops := []string{b.loggingPath}
-	if drop := b.monitoringDrop(); drop != "" {
+func (b *Monitor) Prepare(process, pipelineID string, uid, gid int) error {
+	drops := []string{b.generateLoggingPath(process, pipelineID)}
+	if drop := b.monitoringDrop(process, pipelineID); drop != "" {
 		drops = append(drops, drop)
 	}
 
@@ -120,31 +144,31 @@ func (b *Monitor) Prepare(uid, gid int) error {
 
 // LogPath describes a path where application stores logs. Empty if
 // application is not monitorable
-func (b *Monitor) LogPath() string {
-	if !b.monitorLogs {
+func (b *Monitor) LogPath(process, pipelineID string) string {
+	if !b.WatchLogs() {
 		return ""
 	}
 
-	return b.loggingPath
+	return b.generateLoggingFile(process, pipelineID)
 }
 
 // MetricsPath describes a location where application exposes metrics
 // collectable by metricbeat.
-func (b *Monitor) MetricsPath() string {
-	if !b.monitorMetrics {
+func (b *Monitor) MetricsPath(process, pipelineID string) string {
+	if !b.WatchMetrics() {
 		return ""
 	}
 
-	return b.monitoringEndpoint
+	return b.generateMonitoringEndpoint(process, pipelineID)
 }
 
 // MetricsPathPrefixed return metrics path prefixed with http+ prefix.
-func (b *Monitor) MetricsPathPrefixed() string {
-	return httpPlusPrefix + b.MetricsPath()
+func (b *Monitor) MetricsPathPrefixed(process, pipelineID string) string {
+	return httpPlusPrefix + b.MetricsPath(process, pipelineID)
 }
 
-func (b *Monitor) monitoringDrop() string {
-	return monitoringDrop(b.monitoringEndpoint)
+func (b *Monitor) monitoringDrop(process, pipelineID string) string {
+	return monitoringDrop(b.generateMonitoringEndpoint(process, pipelineID))
 }
 
 func monitoringDrop(path string) (drop string) {

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/config/config.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/config/config.go
@@ -2,10 +2,11 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package monitoring
+package config
 
-// Config describes a configuration of a monitoring
-type Config struct {
+// MonitoringConfig describes a configuration of a monitoring
+type MonitoringConfig struct {
+	Enabled        bool `yaml:"enabled" config:"enabled"`
 	MonitorLogs    bool `yaml:"logs" config:"logs"`
 	MonitorMetrics bool `yaml:"metrics" config:"metrics"`
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/monitor.go
@@ -6,27 +6,35 @@ package monitoring
 
 import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop"
 )
 
 // Monitor is a monitoring interface providing information about the way
 // how application is monitored
 type Monitor interface {
-	EnrichArgs([]string) []string
-	Prepare(uid, gid int) error
-	Cleanup() error
-	LogPath() string
-	MetricsPath() string
-	MetricsPathPrefixed() string
+	LogPath(process, pipelineID string) string
+	MetricsPath(process, pipelineID string) string
+	MetricsPathPrefixed(process, pipelineID string) string
+
+	Prepare(process, pipelineID string, uid, gid int) error
+	EnrichArgs(string, string, []string) []string
+	Cleanup(process, pipelineID string) error
+	Reload(cfg *config.Config) error
+	IsMonitoringEnabled() bool
+	WatchLogs() bool
+	WatchMetrics() bool
+}
+
+type wrappedConfig struct {
+	DownloadConfig *artifact.Config `yaml:"download" config:"download"`
 }
 
 // NewMonitor creates a monitor based on a process configuration.
-func NewMonitor(isMonitorable bool, process, pipelineID string, downloadConfig *artifact.Config, monitorLogs, monitorMetrics bool) Monitor {
-	if !isMonitorable {
-		return noop.NewMonitor()
+func NewMonitor(config *config.Config) (Monitor, error) {
+	cfg := &wrappedConfig{}
+	if err := config.Unpack(&cfg); err != nil {
+		return nil, err
 	}
-
-	// so far we support only beats monitoring
-	return beats.NewMonitor(process, pipelineID, downloadConfig, monitorLogs, monitorMetrics)
+	return beats.NewMonitor(cfg.DownloadConfig), nil
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop/noop_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop/noop_monitor.go
@@ -4,6 +4,8 @@
 
 package noop
 
+import "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+
 // Monitor is a monitoring interface providing information about the way
 // how beat is monitored
 type Monitor struct {
@@ -16,33 +18,45 @@ func NewMonitor() *Monitor {
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *Monitor) EnrichArgs(args []string) []string {
+func (b *Monitor) EnrichArgs(_ string, _ string, args []string) []string {
 	return args
 }
 
 // Cleanup cleans up all drops.
-func (b *Monitor) Cleanup() error {
+func (b *Monitor) Cleanup(string, string) error {
 	return nil
 }
 
 // Prepare executes steps in order for monitoring to work correctly
-func (b *Monitor) Prepare(uid, gid int) error {
+func (b *Monitor) Prepare(string, string, int, int) error {
 	return nil
 }
 
 // LogPath describes a path where application stores logs. Empty if
 // application is not monitorable
-func (b *Monitor) LogPath() string {
+func (b *Monitor) LogPath(string, string) string {
 	return ""
 }
 
 // MetricsPath describes a location where application exposes metrics
 // collectable by metricbeat.
-func (b *Monitor) MetricsPath() string {
+func (b *Monitor) MetricsPath(string, string) string {
 	return ""
 }
 
 // MetricsPathPrefixed return metrics path prefixed with http+ prefix.
-func (b *Monitor) MetricsPathPrefixed() string {
+func (b *Monitor) MetricsPathPrefixed(string, string) string {
 	return ""
 }
+
+// Reload reloads state based on configuration.
+func (b *Monitor) Reload(cfg *config.Config) error { return nil }
+
+// IsMonitoringEnabled returns true if monitoring is configured.
+func (b *Monitor) IsMonitoringEnabled() bool { return false }
+
+// WatchLogs return true if monitoring is configured and monitoring logs is enabled.
+func (b *Monitor) WatchLogs() bool { return false }
+
+// WatchMetrics return true if monitoring is configured and monitoring metrics is enabled.
+func (b *Monitor) WatchMetrics() bool { return false }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/start.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/start.go
@@ -57,7 +57,7 @@ func (a *Application) Start(ctx context.Context, cfg map[string]interface{}) (er
 		}
 	}()
 
-	if err := a.monitor.Prepare(a.uid, a.gid); err != nil {
+	if err := a.monitor.Prepare(a.name, a.pipelineID, a.uid, a.gid); err != nil {
 		return err
 	}
 
@@ -80,7 +80,7 @@ func (a *Application) Start(ctx context.Context, cfg map[string]interface{}) (er
 		a.limiter.Add()
 	}
 
-	spec.Args = a.monitor.EnrichArgs(spec.Args)
+	spec.Args = a.monitor.EnrichArgs(a.name, a.pipelineID, spec.Args)
 
 	// specify beat name to avoid data lock conflicts
 	// as for https://github.com/elastic/beats/v7/pull/14030 more than one instance


### PR DESCRIPTION
Cherry-pick of PR #17855 to 7.x branch. Original message:

## What does this PR do?

This PR performs a bit difficult refactor where it goes from monitor per app to central monitor as initial idea of having option for each app to be monitorable or not is not planned. Now we have central setting saying monitor or not. 

This central monitoring component holds information about whether monitor or not or which part do we need to monitor (logs/metrics). 
On config change state of this component is updated first and then applications will pick them up and act accordingly. 

Reload is also happening when config is coming from fleet. Up until now it as static setting on load which operator was fed at the start time. 

## Why is it important?

To enable setting this config from fleet and change the value during runtime.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


By default monitoring beats are feeding `metricbeat-{version}-{date}` or `filebeat-{version}-{date}` indices. When testing in standalone (using default credentials) this works correctly with fleet we lack permissions on these and publishing fails:

```
reason":"action [indices:admin/create] is unauthorized for API key id [tPA_mHEBM0-54aIPYncP] of user [fleet_enroll]"
```

^^ cc @nchaulet 

I tested few scenarios:

#### Test 1: 
Standalone, monitoring enabled
Result: starts FB and MB, indices created and with data

#### Test 2: 
Standalone, monitoring disabled
Result: monitoring not started, indices not created

#### Test 3 
Standalone, monitoring disabled to enabled (reload test)
Result: initially nothing started, after config change starts FB and MB, indices created and with data

#### Test 4: 
Fleet, monitoring disabled
Result: monitoring not started, indices not created

#### Test 5: 
Fleet, monitoring enabled
Result: starts FB and MB, indices *NOT* created
*FAILS on permissions*



Full event message:
```
Cannot index event publisher.Event{Content:beat.Event{Timestamp:time.Time{wall:0xbf9f91d881b898f8, ext:2136232096, loc:(*time.Location)(0x8341c40)}, Meta:null, Fields:{"agent":{"ephemeral_id":"5ee51551-a05f-460b-b2e1-5b6b83f6c8d7","hostname":"***redacted***","id":"879ad112-7d5d-4a8f-bc01-c497560152c2","type":"filebeat","version":"8.0.0"},"container":{"id":"filebeat"},"ecs":{"version":"1.5.0"},"host":{"architecture":"x86_64","hostname":"***redacted***","id":"FC609F24-07E1-54EA-8E33-56F9D5A7A97E","ip":["***mac-redacted***","***ip-redacted***","***mac-redacted***"],"mac":["***redacted-mac-array***"],"name":"***redacted***","os":{"build":"18G3020","family":"darwin","kernel":"18.7.0","name":"Mac OS X","platform":"darwin","version":"10.14.6"}},"input":{"type":"log"},"log":{"file":{"path":"/var/log/elastic-agent/default/filebeat"},"offset":0},"message":"2020-04-20T18:37:50.125+0200\tINFO\tinstance/beat.go:609\tHome path: [***redacted***/data/install/filebeat-8.0.0-darwin-x86_64] Config path: [***redacted***/data/install/filebeat-8.0.0-darwin-x86_64] Data path: [***redacted***/data/default/filebeat--8.0.0] Logs path: [***redacted***/data/install/filebeat-8.0.0-darwin-x86_64/logs]"}, Private:file.State{Id:"", Finished:false, Fileinfo:(*os.fileStat)(0xc0004e1520), Source:"/var/log/elastic-agent/default/filebeat", Offset:377, Timestamp:time.Time{wall:0xbf9f91d880b123a8, ext:2118966292, loc:(*time.Location)(0x8341c40)}, TTL:-1, Type:"log", Meta:map[string]string(nil), FileStateOS:file.StateOS{Inode:0x221c054, Device:0x1000004}}, TimeSeries:false}, Flags:0x1, Cache:publisher.EventCache{m:common.MapStr(nil)}} (status=403): {"type":"security_exception","reason":"action [indices:admin/create] is unauthorized for API key id [tPA_mHEBM0-54aIPYncP] of user [fleet_enroll]"}
```