### PR TITLE
Cherry-pick #17858 to 7.x: Moved stream.* fields to top of event

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@
 - Rename the User-Agent string from Beats Agent to Elastic Agent. {pull}17765[17765]
 - Remove the kbn-version on each request to the Kibana API. {pull}17764[17764]
 - Make sure that the Elastic Agent connect over TLS in cloud. {pull}17843[17843]
+- Moved stream.* fields to top of event {pull}17858[17858]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
@@ -7,10 +7,11 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "stream"
           fields:
-            stream.type: logs
-            stream.dataset: generic
-            stream.namespace: default
+            type: logs
+            dataset: generic
+            namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
@@ -7,10 +7,11 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "stream"
           fields:
-            stream.type: logs
-            stream.dataset: generic
-            stream.namespace: default
+            type: logs
+            dataset: generic
+            namespace: default
 output:
   elasticsearch:
     enabled: true

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
@@ -8,10 +8,11 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "stream"
           fields:
-            stream.type: logs
-            stream.dataset: generic
-            stream.namespace: default
+            type: logs
+            dataset: generic
+            namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
@@ -9,10 +9,11 @@ filebeat:
       var: value
     processors:
       - add_fields:
+          target: "stream"
           fields:
-            stream.type: logs
-            stream.dataset: generic
-            stream.namespace: default
+            type: logs
+            dataset: generic
+            namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
@@ -6,10 +6,11 @@ metricbeat:
     hosts: ["http://127.0.0.1:8080"]
     processors:
     - add_fields:
+        target: "stream"
         fields:
-          stream.type: metrics
-          stream.dataset: docker.status
-          stream.namespace: default
+          type: metrics
+          dataset: docker.status
+          namespace: default
   - module: apache
     metricsets: [info]
     index: metrics-generic-testing
@@ -19,10 +20,11 @@ metricbeat:
           fields:
             should_be: first
       - add_fields:
+          target: "stream"
           fields:
-            stream.type: metrics
-            stream.dataset: generic
-            stream.namespace: testing
+            type: metrics
+            dataset: generic
+            namespace: testing
 output:
   elasticsearch:
     hosts: [127.0.0.1:9200, 127.0.0.1:9300]

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -523,10 +523,11 @@ func (r *InjectStreamProcessorRule) Apply(ast *AST) error {
 				}
 
 				processorMap := &Dict{value: make([]Node, 0)}
+				processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "stream"}})
 				processorMap.value = append(processorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
-					&Key{name: "stream.type", value: &StrVal{value: r.Type}},
-					&Key{name: "stream.namespace", value: &StrVal{value: namespace}},
-					&Key{name: "stream.dataset", value: &StrVal{value: dataset}},
+					&Key{name: "type", value: &StrVal{value: r.Type}},
+					&Key{name: "namespace", value: &StrVal{value: namespace}},
+					&Key{name: "dataset", value: &StrVal{value: dataset}},
 				}}})
 
 				addFieldsMap := &Dict{value: []Node{&Key{"add_fields", processorMap}}}


### PR DESCRIPTION
Cherry-pick of PR #17858 to 7.x branch. Original message:

## What does this PR do?

Modifies generated add_fields processor to include stream fields to top level not under fields.*

## Why is it important?

It is required

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

