### PR TITLE
Cherry-pick #17886 to 7.x: [Heartbeat] Add id/name to all YML examples, fix geo defaults

### DIFF
--- a/heartbeat/_meta/beat.reference.yml
+++ b/heartbeat/_meta/beat.reference.yml
@@ -25,8 +25,11 @@ heartbeat.monitors:
 - type: icmp # monitor type `icmp` (requires root) uses ICMP Echo Request to ping
              # configured hosts
 
-  # Monitor name used for job name and document type.
-  #name: icmp
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
+
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: my-icmp-monitor
 
   # Enable/Disable monitor
   #enabled: true
@@ -89,9 +92,11 @@ heartbeat.monitors:
 
 - type: tcp # monitor type `tcp`. Connect via TCP and optionally verify endpoint
             # by sending/receiving a custom payload
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
 
-  # Monitor name used for job name and document type
-  #name: tcp
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: my-tcp-monitor
 
   # Enable/Disable monitor
   #enabled: true
@@ -165,9 +170,11 @@ heartbeat.monitors:
   #keep_null: false
 
 - type: http # monitor type `http`. Connect via HTTP an optionally verify response
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-http-monitor
 
-  # Monitor name used for job name and document type
-  #name: http
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My Monitor
 
   # Enable/Disable monitor
   #enabled: true

--- a/heartbeat/_meta/beat.yml
+++ b/heartbeat/_meta/beat.yml
@@ -22,13 +22,14 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
-
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My Monitor
   # List or urls to query
   urls: ["http://localhost:9200"]
-
   # Configure task schedule
   schedule: '@every 10s'
-
   # Total test connection and data exchange timeout
   #timeout: 16s
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -25,8 +25,11 @@ heartbeat.monitors:
 - type: icmp # monitor type `icmp` (requires root) uses ICMP Echo Request to ping
              # configured hosts
 
-  # Monitor name used for job name and document type.
-  #name: icmp
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
+
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: my-icmp-monitor
 
   # Enable/Disable monitor
   #enabled: true
@@ -89,9 +92,11 @@ heartbeat.monitors:
 
 - type: tcp # monitor type `tcp`. Connect via TCP and optionally verify endpoint
             # by sending/receiving a custom payload
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
 
-  # Monitor name used for job name and document type
-  #name: tcp
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: my-tcp-monitor
 
   # Enable/Disable monitor
   #enabled: true
@@ -165,9 +170,11 @@ heartbeat.monitors:
   #keep_null: false
 
 - type: http # monitor type `http`. Connect via HTTP an optionally verify response
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-http-monitor
 
-  # Monitor name used for job name and document type
-  #name: http
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My Monitor
 
   # Enable/Disable monitor
   #enabled: true

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -22,13 +22,14 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
-
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-monitor
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My Monitor
   # List or urls to query
   urls: ["http://localhost:9200"]
-
   # Configure task schedule
   schedule: '@every 10s'
-
   # Total test connection and data exchange timeout
   #timeout: 16s
 
@@ -121,13 +122,12 @@ output.elasticsearch:
 
 processors:
   - add_observer_metadata:
-  # Optional, but recommended geo settings for the location Heartbeat is running in
-  #geo:
-    # Token describing this location
-    #name: us-east-1a
-
-    # Lat, Lon "
-    #location: "37.926868, -78.024902"
+      # Optional, but recommended geo settings for the location Heartbeat is running in
+      #geo:
+        # Token describing this location
+        #name: us-east-1a
+        # Lat, Lon "
+        #location: "37.926868, -78.024902"
 
 #================================ Logging =====================================
 

--- a/heartbeat/monitors.d/sample.http.yml.disabled
+++ b/heartbeat/monitors.d/sample.http.yml.disabled
@@ -4,9 +4,11 @@
 # be loaded.
 
 - type: http # monitor type `http`. Connect via HTTP an optionally verify response
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-http-monitor
 
-  # Monitor name used for job name and document type
-  #name: http
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My HTTP Monitor
 
   # Enable/Disable monitor
   #enabled: true

--- a/heartbeat/monitors.d/sample.icmp.yml.disabled
+++ b/heartbeat/monitors.d/sample.icmp.yml.disabled
@@ -4,16 +4,17 @@
 # be loaded.
 
 - type: icmp # monitor type `icmp` (requires root) uses ICMP Echo Request to ping
-  # configured hosts
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-icmp-monitor
 
-  # Monitor name used for job name and document type.
-  #name: icmp
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My ICMP Monitor
 
   # Enable/Disable monitor
   #enabled: true
 
   # Configure task schedule using cron-like syntax
-  schedule: '*/5 * * * * * *' # exactly every 5 seconds like 10:00:00, 10:00:05, ...
+  schedule: '@every 5s' # every 5 seconds from start of beat
 
   # List of hosts to ping
   hosts: ["localhost"]

--- a/heartbeat/monitors.d/sample.tcp.yml.disabled
+++ b/heartbeat/monitors.d/sample.tcp.yml.disabled
@@ -6,6 +6,12 @@
 - type: tcp # monitor type `tcp`. Connect via TCP and optionally verify endpoint
   # by sending/receiving a custom payload
 
+  # ID used to uniquely identify this monitor in elasticsearch even if the config changes
+  id: my-tcp-monitor
+
+  # Human readable display name for this service in Uptime UI and elsewhere
+  name: My TCP monitor
+
   # Monitor name used for job name and document type
   #name: tcp
 

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -106,13 +106,12 @@ processors:
 {{else}}
 processors:
   - add_observer_metadata:
-  # Optional, but recommended geo settings for the location {{ .BeatName | title }} is running in
-  #geo:
-    # Token describing this location
-    #name: us-east-1a
-
-    # Lat, Lon "
-    #location: "37.926868, -78.024902"
+      # Optional, but recommended geo settings for the location {{ .BeatName | title }} is running in
+      #geo:
+        # Token describing this location
+        #name: us-east-1a
+        # Lat, Lon "
+        #location: "37.926868, -78.024902"
 {{end}}
 #================================ Logging =====================================
 


### PR DESCRIPTION
Cherry-pick of PR #17886 to 7.x branch. Original message: 

This patch fixes https://github.com/elastic/beats/issues/16460 by using the `id` and `name` fields in all our examples. Customers should always set these. The only reason we don't require them is backwards compat concerns with earlier 7.x heartbeats.

Frequently on the forum we find that people haven't set these options when they really should. We took one step forward in #17694 and this completes the story.

This patch also fixes the indentation of the `add_observer_metadata` example in `heartbeat.yml`. Prior to this uncommenting it would not yield a valid config, due it being at the wrong indent level.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

- [x] Try using the default `heartbeat.yml` it should run without error
- [x] Try uncommenting the `add_observer_metadata` options in heartbeat.yml, it should work
- [x] Try removing `disabled` from all configs in `configs.d` to run them, they should all work
