### PR TITLE
[docs] Adds list of type changes to the 7.0 breaking changes docs

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.0.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.0.asciidoc
@@ -50,13 +50,10 @@ The Filebeat `apache2` module is renamed to `apache` in 7.0.
 
 include::./field-name-changes.asciidoc[]
 
-//end::notable-breaking-changes[]
-
 [float]
-==== Auditbeat type changes
+==== Field type changes
 
-The Auditbeat JSON data types produced by the output have been changed to align
-with the data types used in the Elasticsearch index template.
+The following fields have type changes in 7.0.
 
 .Auditbeat Type Changes in 7.0
 [frame="topbot",options="header"]
@@ -68,3 +65,42 @@ with the data types used in the Elasticsearch index template.
 |`process.ppid` |string |number
 |======================
 
+.Filebeat Type Changes in 7.0
+[frame="topbot",options="header"]
+|====
+|Field                         |Old Type  | New Type
+|`auditd.log.pid`              | keyword  | long
+|`auditd.log.ppid`             | keyword  | long
+|`elasticsearch.audit.request` | keyword  | object
+|`error.code`                  | keyword  | long
+|`haproxy.destination.ip`      | keyword  | ip
+|`mysql.slowlog.ip`            | keyword  | ip
+|`read_timestamp`              | keyword  | date
+|`source`                      | keyword  | object
+|`system.auth.groupadd.gid`    | long     | keyword
+|`system.auth.timestamp`       | keyword  | date
+|`system.auth.useradd.gid`     | long     | keyword
+|`system.auth.useradd.uid`     | long     | keyword
+|`system.syslog.pid`           | keyword  | long
+|`system.syslog.timestamp`     | keyword  | date
+|`user_agent.device`           | keyword  | object
+|====
+
+.Packetbeat Type Changes in 7.0
+[frame="topbot",options="header"]
+|====
+|Field                         | Old Type | New Type
+|`error.code`                  | keyword  | long
+|`final`                       | keyword  | boolean
+|`http.request.body`           | text     | object
+|`http.response.body`          | text     | object
+|`http.response.code` (renamed `http.response.status_code`)  | keyword | long
+|`real_ip`                     | keyword  | ip
+|`server`                      | keyword  | object
+|`service`                     | keyword  | object
+|`source.ip`                   | keyword  | ip
+|`source.port`                 | keyword  | long
+|`vlan`                        | keyword  | long
+|====
+
+//end::notable-breaking-changes[]


### PR DESCRIPTION
Adds list of type changes requested in https://github.com/elastic/beats/issues/11790.

elastic/beats#11790 has been open for a very long time. I was hoping the dev team would take ownership because the list of changed types is incomplete.

For the sake of getting what we know into the published docs, I'm opening this PR. I think, however, that this kind of documentation should be generated or at last maintained by the dev team when they make changes to field types or names.

@webmat Including you as a reviewer because you opened the original issue.

@urso Adding you to the review so we have a plan going forward to make sure this doesn't happen again.