### PR TITLE
Fix script.cache.max_size typo in Cisco module docs

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -294,7 +294,7 @@ parameters on your Elasticsearch cluster:
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.
 
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
+- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
   Increase to at least `200` if using both filesets or other script-heavy modules.
 
 [float]

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -289,7 +289,7 @@ parameters on your Elasticsearch cluster:
 - {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
   Increase to at least `100/5m`.
 
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache_max_size]:
+- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
   Increase to at least `200` if using both filesets or other script-heavy modules.
 
 [float]


### PR DESCRIPTION
## What does this PR do?

Fix a typo in the Filebeat Cisco module docs. The setting is script.cache.max_size and not script.cache_max_size.

Fixes #17856

