### PR TITLE
Make it possible to disable host metadata

### DIFF
--- a/libbeat/processors/actions/add_fields_test.go
+++ b/libbeat/processors/actions/add_fields_test.go
@@ -42,6 +42,12 @@ func TestAddFields(t *testing.T) {
 			},
 			cfg: single(`{add_fields: {target: my, fields: {field: test}}}`),
 		},
+		"@metadata target": {
+			event:    common.MapStr{},
+			want:     common.MapStr{},
+			wantMeta: common.MapStr{"field": "test"},
+			cfg:      single(`{add_fields: {target: '@metadata', fields: {field: test}}}`),
+		},
 		"overwrite existing field": {
 			event: common.MapStr{
 				"fields": common.MapStr{"field": "old"},

--- a/libbeat/processors/actions/common_test.go
+++ b/libbeat/processors/actions/common_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 type testCase struct {
-	event common.MapStr
-	want  common.MapStr
-	cfg   []string
+	event    common.MapStr
+	want     common.MapStr
+	wantMeta common.MapStr
+	cfg      []string
 }
 
 func testProcessors(t *testing.T, cases map[string]testCase) {
@@ -63,6 +64,7 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 			}
 
 			assert.Equal(t, test.want, current.Fields)
+			assert.Equal(t, test.wantMeta, current.Meta)
 		})
 	}
 }

--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -18,6 +18,19 @@ exclude_files: [".gz$"]
 tags: {{.tags}}
 
 processors:
+  - add_fields:
+      target: '@metadata'
+      fields:
+        internal:
+          disable_host_metadata: true
+
+  - add_fields:
+      target: 'observer'
+      fields:
+        type: firewall
+        vendor: Palo Alto Networks
+        product: PAN-OS
+
   - add_locale: ~
 
   - decode_csv_fields:


### PR DESCRIPTION
## What does this PR do?

This provides a way to disable the addition of host metadata without introducing a breaking change. By setting `@metadata.internal.distable_host_metadata=true` in an event this will disable the addition of `host.name` by libbeat and disable `add_host_metadata` if it exists in the pipeline.

This can be removed in 8.0 if/when we disable `host.name` is libbeat and modify the default Beat configurations.

## Why is it important?

ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Some data sources only forward data and it would be incorrect to set `host.*` fields.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Relates elastic/beats#13920