### PR TITLE
Cherry-pick #17749 to 7.x: Fix setup.dashboards.index not working

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -96,6 +96,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bug with `monitoring.cluster_uuid` setting not always being exposed via GET /state Beats API. {issue}16732[16732] {pull}17420[17420]
 - Fix building on FreeBSD by removing build flags from `add_cloudfoundry_metadata` processor. {pull}17486[17486]
 - Do not rotate log files on startup when interval is configured and rotateonstartup is disabled. {pull}17613[17613]
+- Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -41,32 +43,50 @@ type JSONFormat struct {
 	Objects []JSONObject `json:"objects"`
 }
 
-func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapStr {
+func ReplaceIndexInIndexPattern(index string, content common.MapStr) (err error) {
 	if index == "" {
-		return content
+		return nil
 	}
 
-	objects, ok := content["objects"].([]interface{})
+	list, ok := content["objects"]
 	if !ok {
-		return content
+		return errors.New("empty index pattern")
 	}
 
-	// change index pattern name
-	for i, object := range objects {
-		objectMap, ok := object.(map[string]interface{})
-		if !ok {
-			continue
+	updateObject := func(obj common.MapStr) {
+		// This uses Put instead of DeepUpdate to avoid modifying types for
+		// inner objects. (DeepUpdate will replace maps with MapStr).
+		obj.Put("id", index)
+		// Only overwrite title if it exists.
+		if _, err := obj.GetValue("attributes.title"); err == nil {
+			obj.Put("attributes.title", index)
 		}
-
-		objectMap["id"] = index
-		if attributes, ok := objectMap["attributes"].(map[string]interface{}); ok {
-			attributes["title"] = index
-		}
-		objects[i] = objectMap
 	}
-	content["objects"] = objects
 
-	return content
+	switch v := list.(type) {
+	case []interface{}:
+		for _, objIf := range v {
+			switch obj := objIf.(type) {
+			case common.MapStr:
+				updateObject(obj)
+			case map[string]interface{}:
+				updateObject(obj)
+			default:
+				return errors.Errorf("index pattern object has unexpected type %T", v)
+			}
+		}
+	case []map[string]interface{}:
+		for _, obj := range v {
+			updateObject(obj)
+		}
+	case []common.MapStr:
+		for _, obj := range v {
+			updateObject(obj)
+		}
+	default:
+		return errors.Errorf("index pattern objects have unexpected type %T", v)
+	}
+	return nil
 }
 
 func replaceIndexInSearchObject(index string, savedObject string) (string, error) {

--- a/libbeat/dashboards/modify_json_test.go
+++ b/libbeat/dashboards/modify_json_test.go
@@ -111,3 +111,137 @@ func TestReplaceIndexInDashboardObject(t *testing.T) {
 		assert.Equal(t, test.expected, result)
 	}
 }
+
+func TestReplaceIndexInIndexPattern(t *testing.T) {
+	// Test that replacing of index name in index pattern works no matter
+	// what the inner types are (MapStr, map[string]interface{} or interface{}).
+	// Also ensures that the inner types are not modified after replacement.
+	tests := []struct {
+		title    string
+		input    common.MapStr
+		index    string
+		expected common.MapStr
+	}{
+		{
+			title: "Replace in []interface(map).map",
+			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": map[string]interface{}{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": map[string]interface{}{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			title: "Replace in []interface(map).mapstr",
+			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			title: "Replace in []map.mapstr",
+			input: common.MapStr{"objects": []map[string]interface{}{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []map[string]interface{}{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			title: "Replace in []mapstr.mapstr",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				}}}},
+		},
+		{
+			title: "Replace in []mapstr.interface(mapstr)",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+				"attributes": interface{}(common.MapStr{
+					"title":         "phonybeat-*",
+					"timeFieldName": "@timestamp",
+				})}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+				"attributes": interface{}(common.MapStr{
+					"title":         "otherindex-*",
+					"timeFieldName": "@timestamp",
+				})}}},
+		},
+		{
+			title: "Do not create missing attributes",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"id":   "phonybeat-*",
+				"type": "index-pattern",
+			}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+			}}},
+		},
+		{
+			title: "Create missing id",
+			input: common.MapStr{"objects": []common.MapStr{{
+				"type": "index-pattern",
+			}}},
+			index: "otherindex-*",
+			expected: common.MapStr{"objects": []common.MapStr{{
+				"id":   "otherindex-*",
+				"type": "index-pattern",
+			}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			err := ReplaceIndexInIndexPattern(test.index, test.input)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, test.input)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #17749 to 7.x branch. Original message: 

Due to type casting nightmare, the `setup.dashboards.index` configuration option to replace the index name in use for dashboards and index pattern wasn't being honored, resulting in `beatname-*` always in use.


Fixes: elastic/beats#14019
