### PR TITLE
Make a shallow git clone on Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: "${BASE_DIR}", shallow: true, depth: 1)
         dir("${BASE_DIR}"){
           loadConfigEnvVars()
         }


### PR DESCRIPTION
This should speed-up cloning and stashing of source code in Jenkins builds.