### PR TITLE
Move git checkout to stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,26 +32,16 @@ pipeline {
     booleanParam(name: 'dry_run', defaultValue: false, description: 'Skip build steps, it is for testing pipeline flow')
   }
   stages {
-    /**
-     Checkout the code and stash it, to use it on other stages.
-    */
-    stage('Checkout') {
+    stage('Lint'){
       options { skipDefaultCheckout() }
       steps {
-        deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        checkoutBeats()
         dir("${BASE_DIR}"){
           loadConfigEnvVars()
         }
         whenTrue(params.debug){
           dumpFilteredEnvironment()
         }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-      }
-    }
-    stage('Lint'){
-      options { skipDefaultCheckout() }
-      steps {
         makeTarget("Lint", "check")
       }
     }
@@ -68,6 +58,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Elastic Agent x-pack Linux", "x-pack/elastic-agent", "build test")
           }
         }
@@ -82,6 +73,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTargetWin("Elastic Agent x-pack Windows Unit test", "x-pack/elastic-agent", "build unitTest")
           }
         }
@@ -96,6 +88,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Elastic Agent x-pack Mac OS X", "x-pack/elastic-agent", "build unitTest")
           }
         }
@@ -110,6 +103,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             makeTarget("Filebeat oss Linux", "-C filebeat testsuite")
           }
         }
@@ -123,6 +117,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Filebeat x-pack Linux", "x-pack/filebeat", "update build test")
           }
         }
@@ -136,6 +131,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Filebeat oss Mac OS X", "filebeat", "build unitTest")
           }
         }
@@ -149,6 +145,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTargetWin("Filebeat oss Windows Unit test", "filebeat", "build unitTest")
           }
         }
@@ -164,6 +161,7 @@ pipeline {
           stages {
             stage('Heartbeat oss'){
               steps {
+                checkoutBeats()
                 makeTarget("Heartbeat oss Linux", "-C heartbeat testsuite")
               }
             }
@@ -177,6 +175,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTarget("Heartbeat oss Mac OS X", "heartbeat", "build unitTest")
               }
             }
@@ -190,6 +189,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTargetWin("Heartbeat oss Windows Unit test", "heartbeat", "build unitTest")
               }
             }
@@ -207,11 +207,13 @@ pipeline {
           stages {
             stage('Auditbeat Linux'){
               steps {
+                checkoutBeats()
                 makeTarget("Auditbeat oss Linux", "-C auditbeat testsuite")
               }
             }
             stage('Auditbeat crosscompile'){
               steps {
+                checkoutBeats()
                 makeTarget("Auditbeat oss crosscompile", "-C auditbeat crosscompile")
               }
             }
@@ -225,6 +227,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTarget("Auditbeat oss Mac OS X", "auditbeat", "build unitTest")
               }
             }
@@ -238,6 +241,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTargetWin("Auditbeat Windows Unit test", "auditbeat", "build unitTest")
               }
             }
@@ -253,6 +257,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Auditbeat x-pack Linux", "x-pack/auditbeat", "update build test")
           }
         }
@@ -268,16 +273,19 @@ pipeline {
           stages {
             stage('Libbeat oss'){
               steps {
+                checkoutBeats()
                 makeTarget("Libbeat oss Linux", "-C libbeat testsuite")
               }
             }
             stage('Libbeat crosscompile'){
               steps {
+                checkoutBeats()
                 makeTarget("Libbeat oss crosscompile", "-C libbeat crosscompile")
               }
             }
             stage('Libbeat stress-tests'){
               steps {
+                checkoutBeats()
                 makeTarget("Libbeat stress-tests", "STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests")
               }
             }
@@ -293,6 +301,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             makeTarget("Libbeat x-pack Linux", "-C x-pack/libbeat testsuite")
           }
         }
@@ -306,6 +315,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Metricbeat OSS linux/amd64 (unitTest)", "metricbeat", "build unitTest")
           }
         }
@@ -319,6 +329,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Metricbeat OSS linux/amd64 (integTest)", "metricbeat", "integTest")
           }
         }
@@ -332,6 +343,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Metricbeat x-pack Linux", "x-pack/metricbeat", "build test")
           }
         }
@@ -345,6 +357,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             makeTarget("Metricbeat OSS crosscompile", "-C metricbeat crosscompile")
           }
         }
@@ -358,6 +371,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTarget("Metricbeat OSS Mac OS X", "metricbeat", "build unitTest")
           }
         }
@@ -371,6 +385,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTargetWin("Metricbeat Windows Unit test", "metricbeat", "build unitTest")
           }
         }
@@ -386,6 +401,7 @@ pipeline {
           stages {
             stage('Packetbeat oss'){
               steps {
+                checkoutBeats()
                 makeTarget("Packetbeat oss Linux", "-C packetbeat testsuite")
               }
             }
@@ -403,6 +419,7 @@ pipeline {
           stages {
             stage('Dockerlogbeat'){
               steps {
+                checkoutBeats()
                 mageTarget("Elastic Docker Logging Driver Plugin unit tests", "x-pack/dockerlogbeat", "update build test")
               }
             }
@@ -420,6 +437,7 @@ pipeline {
           stages {
             stage('Winlogbeat oss'){
               steps {
+                checkoutBeats()
                 makeTarget("Winlogbeat oss crosscompile", "-C winlogbeat crosscompile")
               }
             }
@@ -433,6 +451,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTargetWin("Winlogbeat Windows Unit test", "winlogbeat", "build unitTest")
               }
             }
@@ -448,6 +467,7 @@ pipeline {
             }
           }
           steps {
+            checkoutBeats()
             mageTargetWin("Winlogbeat Windows Unit test", "x-pack/winlogbeat", "build unitTest")
           }
         }
@@ -463,6 +483,7 @@ pipeline {
           stages {
             stage('Functionbeat x-pack'){
               steps {
+                checkoutBeats()
                 mageTarget("Functionbeat x-pack Linux", "x-pack/functionbeat", "update build test")
                 withEnv(["GO_VERSION=1.13.1"]){
                   makeTarget("Functionbeat x-pack Linux", "-C x-pack/functionbeat test-gcp-functions")
@@ -479,6 +500,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTarget("Functionbeat x-pack Mac OS X", "x-pack/functionbeat", "build unitTest")
               }
             }
@@ -492,6 +514,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 mageTargetWin("Functionbeat Windows Unit test", "x-pack/functionbeat", "build unitTest")
               }
             }
@@ -509,6 +532,7 @@ pipeline {
           stages {
             stage('Journalbeat oss'){
               steps {
+                checkoutBeats()
                 makeTarget("Journalbeat Linux", "-C journalbeat testsuite")
               }
             }
@@ -526,12 +550,14 @@ pipeline {
           stages {
             stage('Generators Metricbeat Linux'){
               steps {
+                checkoutBeats()
                 makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test")
                 makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test-package")
               }
             }
             stage('Generators Beat Linux'){
               steps {
+                checkoutBeats()
                 makeTarget("Generators Beat Linux", "-C generator/_templates/beat test")
                 makeTarget("Generators Beat Linux", "-C generator/_templates/beat test-package")
               }
@@ -546,6 +572,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
               }
             }
@@ -559,6 +586,7 @@ pipeline {
                 }
               }
               steps {
+                checkoutBeats()
                 makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
               }
             }
@@ -580,6 +608,11 @@ pipeline {
       }
     }
   }
+}
+
+def checkoutBeats() {
+  deleteDir()
+  gitCheckout(basedir: "${BASE_DIR}")
 }
 
 def makeTarget(String context, String target, boolean clean = true) {
@@ -645,8 +678,6 @@ def withBeatsEnv(boolean archive, Closure body) {
     "TEST_TAGS=oracle",
     "DOCKER_PULL=0",
   ]) {
-    deleteDir()
-    unstash 'source'
     if(isDockerInstalled()){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
     }
@@ -688,8 +719,6 @@ def withBeatsEnvWin(Closure body) {
     "TEST_COVERAGE=true",
     "RACE_DETECTOR=true",
   ]){
-    deleteDir()
-    unstash 'source'
     dir("${env.BASE_DIR}"){
       bat(label: "Install Go/Mage/Python ${GO_VERSION}", script: ".ci/scripts/install-tools.bat")
       try {


### PR DESCRIPTION
Checkout takes about five minutes, and the unstash executed on each stage
takes between 6 and 15 minutes. Try to move checkout to stages to remove
the original checkout and reduce the time of each stage requiring the code.

With selective execution of stages is not so important to reuse checkouts
by stashing it and we can save a lot of time per build.