### PR TITLE
run mage fmt update on filebeat

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -28244,6 +28244,15 @@ type: keyword
 
 --
 
+*`panw.panos.action`*::
++
+--
+Action taken for the session.
+
+type: keyword
+
+--
+
 [[exported-fields-postgresql]]
 == PostgreSQL fields
 


### PR DESCRIPTION
## What does this PR do?

Rerun `mage fmt update` in filebeat to fix CI. This is introduced in https://github.com/elastic/beats/pull/17910.

```
[2020-04-23T14:58:45.299Z] Error: some files are not up-to-date. Run 'mage fmt update' then review and commit the changes. Modified: [filebeat/docs/fields.asciidoc]

[2020-04-23T14:58:45.299Z] ../libbeat/scripts/Makefile:151: recipe for target 'check' failed

[2020-04-23T14:58:45.299Z] make[1]: *** [check] Error 1

[2020-04-23T14:58:45.299Z] make[1]: Leaving directory '/var/lib/jenkins/workspace/Beats_beats-beats-mbp_PR-17943/src/github.com/elastic/beats/filebeat'

[2020-04-23T14:58:45.299Z] Makefile:98: recipe for target 'check' failed

[2020-04-23T14:58:45.299Z] make: *** [check] Error 1
```