### PR TITLE
[Filebeat] Align test assumptions with renamed pipeline files

### DIFF
--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -56,7 +56,7 @@ func TestLoadManifestNginx(t *testing.T) {
 	manifest, err := fs.readManifest()
 	assert.NoError(t, err)
 	assert.Equal(t, manifest.ModuleVersion, "1.0")
-	assert.Equal(t, manifest.IngestPipeline, []string{"ingest/default.json"})
+	assert.Equal(t, manifest.IngestPipeline, []string{"ingest/pipeline.yml"})
 	assert.Equal(t, manifest.Input, "config/nginx-access.yml")
 
 	vars := manifest.Vars
@@ -189,7 +189,7 @@ func TestGetInputConfigNginx(t *testing.T) {
 	assert.True(t, cfg.HasField("pipeline"))
 	pipelineID, err := cfg.String("pipeline", -1)
 	assert.NoError(t, err)
-	assert.Equal(t, "filebeat-5.2.0-nginx-access-default", pipelineID)
+	assert.Equal(t, "filebeat-5.2.0-nginx-access-pipeline", pipelineID)
 }
 
 func TestGetInputConfigNginxOverrides(t *testing.T) {
@@ -217,7 +217,7 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 
 				pipelineID, err := c.String("pipeline", -1)
 				assert.NoError(t, err)
-				assert.Equal(t, "filebeat-5.2.0-nginx-access-default", pipelineID)
+				assert.Equal(t, "filebeat-5.2.0-nginx-access-pipeline", pipelineID)
 			},
 		},
 		"pipeline": {
@@ -276,7 +276,7 @@ func TestGetPipelineNginx(t *testing.T) {
 	assert.Len(t, pipelines, 1)
 
 	pipeline := pipelines[0]
-	assert.Equal(t, "filebeat-5.2.0-nginx-access-default", pipeline.id)
+	assert.Equal(t, "filebeat-5.2.0-nginx-access-pipeline", pipeline.id)
 	assert.Contains(t, pipeline.contents, "description")
 	assert.Contains(t, pipeline.contents, "processors")
 }

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -95,7 +95,7 @@ func TestSetupNginx(t *testing.T) {
 		t.Skip("Skip tests because ingest is missing in this elasticsearch version: ", client.GetVersion())
 	}
 
-	client.Request("DELETE", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-default", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-pipeline", "", nil, nil)
 	client.Request("DELETE", "/_ingest/pipeline/filebeat-5.2.0-nginx-error-pipeline", "", nil, nil)
 
 	modulesPath, err := filepath.Abs("../module")
@@ -115,7 +115,7 @@ func TestSetupNginx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-default", "", nil, nil)
+	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-pipeline", "", nil, nil)
 	assert.Equal(t, 200, status)
 	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-error-pipeline", "", nil, nil)
 	assert.Equal(t, 200, status)

--- a/filebeat/scripts/tester/main.go
+++ b/filebeat/scripts/tester/main.go
@@ -185,7 +185,7 @@ func getPipelinePath(path, modulesPath string) ([]string, error) {
 		module := parts[0]
 		fileset := parts[1]
 
-		pathToPipeline := filepath.Join(modulesPath, module, fileset, "ingest", "pipeline.json")
+		pathToPipeline := filepath.Join(modulesPath, module, fileset, "ingest", "pipeline.yml")
 		_, err := os.Stat(pathToPipeline)
 		if err != nil {
 			return nil, fmt.Errorf("Cannot find pipeline in %s: %v %v\n", path, err, pathToPipeline)
@@ -199,7 +199,7 @@ func getPipelinePath(path, modulesPath string) ([]string, error) {
 			return nil, err
 		}
 		for _, f := range files {
-			isPipelineFile := strings.HasSuffix(f.Name(), ".json")
+			isPipelineFile := strings.HasSuffix(f.Name(), ".yml")
 			if isPipelineFile {
 				fullPath := filepath.Join(path, f.Name())
 				paths = append(paths, fullPath)
@@ -211,7 +211,7 @@ func getPipelinePath(path, modulesPath string) ([]string, error) {
 		return paths, nil
 	}
 
-	isPipelineFile := strings.HasSuffix(path, ".json")
+	isPipelineFile := strings.HasSuffix(path, ".yml")
 	if isPipelineFile {
 		return []string{path}, nil
 	}

--- a/filebeat/scripts/tester/main_test.go
+++ b/filebeat/scripts/tester/main_test.go
@@ -29,7 +29,7 @@ func TestGetPipelinePath(t *testing.T) {
 		count        int
 	}{
 		{
-			pipelinePath: "../../module/postgresql/log/ingest/pipeline.json",
+			pipelinePath: "../../module/postgresql/log/ingest/pipeline.yml",
 			count:        1,
 		},
 		{


### PR DESCRIPTION
## What does this PR do?
pipeline files for nginx & postgresql moved from json
to yaml.  These tests had assumptions about the filename
of these pipelines.  This PR updates those assumptions.

## Why is it important?
mage goUnitTest is failing

## Checklist
- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally
```
mage goUnitTest
```

