### PR TITLE
Cherry-pick #17933 to 7.x: Fix remote_write doc content

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -8,7 +8,7 @@ remote_write:
 ------------------------------------------------------------------------------
 
 
-TIP: In order to assure the health of the whole queue, the following two configuration
+TIP: In order to assure the health of the whole queue, the following configuration
  https://prometheus.io/docs/practices/remote_write/#parameters[parameters] should be considered:
 
 - `max_shards`: Sets the maximum number of parallelism with which Prometheus will try to send samples to Metricbeat.


### PR DESCRIPTION
Cherry-pick of PR #17933 to 7.x branch. Original message: 

## What does this PR do?
Small content fix. 
The docs mention about 2 parameters, but there are actually 3. 