### PR TITLE
ci: comment PRs with the build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -593,6 +593,11 @@ pipeline {
       }
     }
   }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: true)
+    }
+  }
 }
 
 def makeTarget(String context, String target, boolean clean = true) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/tests-reporting') _
 
 pipeline {
   agent { label 'ubuntu && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/tests-reporting') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu && immutable' }


### PR DESCRIPTION
## What does this PR do?

Enhance the build reporting with a message in the PR that contains the build status for the last commit. It does reuse the message.

## Why is it important?

One place to analyse the build status

## Author's Checklist

- [x] Disable email notifications that are based on the build status by default.?
- [x] Support another service account

## How to test this PR locally

See the comments that are generated on the fly. https://github.com/elastic/beats/pull/17971#issuecomment-619919815