### PR TITLE
[Filebeat] Don't bind to wildcard address in unit test

### DIFF
--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -213,7 +213,7 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 	to := func(message []byte, mt inputsource.NetworkMetadata) {
 		ch <- &info{message: string(message), mt: mt}
 	}
-	cfg, err := common.NewConfigFrom(map[string]interface{}{"host": ":0"})
+	cfg, err := common.NewConfigFrom(map[string]interface{}{"host": "127.0.0.1:0"})
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
## What does this PR do?

This changes the TCP input test to only bind to the loopback address for testing.

## Why is it important?

It prevents firewall security popups when testing on macOS.
