### PR TITLE
[docs] Remove incorrect tag

### DIFF
--- a/filebeat/docs/modules/activemq.asciidoc
+++ b/filebeat/docs/modules/activemq.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == ActiveMQ module
 
-ga[]
-
 This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]

--- a/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
@@ -5,8 +5,6 @@
 
 == ActiveMQ module
 
-ga[]
-
 This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]


### PR DESCRIPTION
We have a `beta[]` tag, but we don't have a `ga[]` tag. Everything that's not tagged as beta is assumed to be GA.