### PR TITLE
Give precedence to monitoring reporter hosts over output hosts

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 - Fix panic when assigning a key to a `nil` value in an event. {pull}18143[18143]
+- Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -127,9 +127,6 @@ func getReporterConfig(
 				return "", nil, err
 			}
 
-			outCfg.PrintDebugf("outCfg")
-			rc.PrintDebugf("rc")
-
 			merged, err := common.MergeConfigs(outCfg, rc)
 			if err != nil {
 				return "", nil, err

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -169,7 +169,7 @@ func collectSubObject(cfg *common.Config) *common.Config {
 
 func mergeHosts(merged, outCfg, reporterCfg *common.Config) error {
 	if merged == nil {
-		return nil
+		merged = common.NewConfig()
 	}
 
 	outputHosts := hostsCfg{}

--- a/libbeat/monitoring/report/report_test.go
+++ b/libbeat/monitoring/report/report_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package report
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeHosts(t *testing.T) {
+	tests := map[string]struct {
+		outCfg      *common.Config
+		reporterCfg *common.Config
+		expectedCfg *common.Config
+	}{
+		"no_hosts": {
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{}}),
+		},
+		"only_reporter_hosts": {
+			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+		},
+		"only_output_hosts": {
+			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
+		},
+		"equal_hosts": {
+			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
+			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+		},
+		"more_output_hosts": {
+			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
+			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1"}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1"}}),
+		},
+		"more_reporter_hosts": {
+			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1"}}),
+			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mergedCfg := common.MustNewConfigFrom(map[string]interface{}{})
+			err := mergeHosts(mergedCfg, test.outCfg, test.reporterCfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expectedCfg, mergedCfg)
+		})
+	}
+}

--- a/libbeat/monitoring/report/report_test.go
+++ b/libbeat/monitoring/report/report_test.go
@@ -20,8 +20,9 @@ package report
 import (
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 func TestMergeHosts(t *testing.T) {

--- a/libbeat/monitoring/report/report_test.go
+++ b/libbeat/monitoring/report/report_test.go
@@ -31,7 +31,7 @@ func TestMergeHosts(t *testing.T) {
 		expectedCfg *common.Config
 	}{
 		"no_hosts": {
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{}}),
+			expectedCfg: common.MustNewConfigFrom(map[string][]string{}),
 		},
 		"only_reporter_hosts": {
 			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),

--- a/libbeat/monitoring/report/report_test.go
+++ b/libbeat/monitoring/report/report_test.go
@@ -31,30 +31,30 @@ func TestMergeHosts(t *testing.T) {
 		expectedCfg *common.Config
 	}{
 		"no_hosts": {
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{}),
+			expectedCfg: newConfigWithHosts(),
 		},
 		"only_reporter_hosts": {
-			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
 		},
 		"only_output_hosts": {
-			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			expectedCfg: newConfigWithHosts("o1", "o2"),
 		},
 		"equal_hosts": {
-			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
-			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
 		},
 		"more_output_hosts": {
-			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1", "o2"}}),
-			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1"}}),
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1"}}),
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			reporterCfg: newConfigWithHosts("r1"),
+			expectedCfg: newConfigWithHosts("r1"),
 		},
 		"more_reporter_hosts": {
-			outCfg:      common.MustNewConfigFrom(map[string][]string{"hosts": []string{"o1"}}),
-			reporterCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
-			expectedCfg: common.MustNewConfigFrom(map[string][]string{"hosts": []string{"r1", "r2"}}),
+			outCfg:      newConfigWithHosts("o1"),
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
 		},
 	}
 
@@ -67,4 +67,11 @@ func TestMergeHosts(t *testing.T) {
 			require.Equal(t, test.expectedCfg, mergedCfg)
 		})
 	}
+}
+
+func newConfigWithHosts(hosts ...string) *common.Config {
+	if len(hosts) == 0 {
+		return common.MustNewConfigFrom(map[string][]string{})
+	}
+	return common.MustNewConfigFrom(map[string][]string{"hosts": hosts})
 }


### PR DESCRIPTION
## What does this PR do?

Ensures that monitoring reporter hosts, if set, get total precedence over their corresponding output reporter hosts.

## Why is it important?

When monitoring reporter hosts are configured, they should get precedence over their corresponding output hosts. The two lists of hosts should **not** be merged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Resolves elastic/beats#17937
