### PR TITLE
Collect bulk indexing stats for Elasticsearch metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -361,6 +361,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add aggregation aligner as a config parameter for googlecloud stackdriver metricset. {issue}17141[[17141] {pull}17719[17719]
 - Move the perfmon metricset to GA. {issue}16608[16608] {pull}17879[17879]
 - Add static mapping for metricsets under aws module. {pull}17614[17614] {pull}17650[17650]
+- Collect new `bulk` indexing metrics from Elasticsearch when `xpack.enabled:true` is set. {issue} {pull}17992[17992]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -65,6 +65,9 @@ var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 // EnrichStatsAPIAvailableVersion is the version of Elasticsearch since when the Enrich stats API is available.
 var EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
 
+// BulkStatsAvailableVersion is the version since when bulk indexing stats are available
+var BulkStatsAvailableVersion = common.MustNewVersion("7.8.0")
+
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	s "github.com/elastic/beats/v7/libbeat/common/schema"
+	c "github.com/elastic/beats/v7/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
@@ -106,6 +108,14 @@ type License struct {
 type licenseWrapper struct {
 	License License `json:"license"`
 }
+
+var BulkStatsDict = c.Dict("bulk", s.Schema{
+	"total_operations":     c.Int("total_operations"),
+	"total_time_in_millis": c.Int("total_time_in_millis"),
+	"total_size_in_bytes":  c.Int("total_size_in_bytes"),
+	"avg_time_in_millis":   c.Int("avg_time_in_millis"),
+	"avg_size_in_bytes":    c.Int("avg_size_in_bytes"),
+}, c.DictOptional)
 
 // GetClusterID fetches cluster id for given nodeID.
 func GetClusterID(http *helper.HTTP, uri string, nodeID string) (string, error) {

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -65,6 +65,7 @@ type indexStats struct {
 		IndexTimeInMillis    int `json:"index_time_in_millis"`
 		ThrottleTimeInMillis int `json:"throttle_time_in_millis"`
 	} `json:"indexing"`
+	Bulk   bulkStats `json:"bulk"`
 	Merges struct {
 		TotalSizeInBytes int `json:"total_size_in_bytes"`
 	} `json:"merges"`
@@ -118,6 +119,14 @@ type shardStats struct {
 
 	Initializing int `json:"initializing"`
 	Relocating   int `json:"relocating"`
+}
+
+type bulkStats struct {
+	TotalOperations   int `json:"total_operations"`
+	TotalTimeInMillis int `json:"total_time_in_millis"`
+	TotalSizeInBytes  int `json:"total_size_in_bytes"`
+	AvgTimeInMillis   int `json:"throttle_time_in_millis"`
+	AvgSizeInBytes    int `json:"avg_size_in_bytes"`
 }
 
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -107,7 +107,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 }
 
 func (m *MetricSet) updateServiceURI(esVersion common.Version) error {
-	u, err := getServiceURI(esVersion)
+	u, err := getServiceURI(m.GetURI(), esVersion)
 	if err != nil {
 		return err
 	}
@@ -117,8 +117,7 @@ func (m *MetricSet) updateServiceURI(esVersion common.Version) error {
 
 }
 
-func getServiceURI(esVersion common.Version) (string, error) {
-	currURI := statsPath
+func getServiceURI(currURI string, esVersion common.Version) (string, error) {
 	if esVersion.LessThan(elasticsearch.BulkStatsAvailableVersion) {
 		// Can't request bulk stats so don't change service URI
 		return currURI, nil

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 const (
-	statsMetrics = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
+	statsMetrics = "docs,fielddata,indexing,bulk,merge,search,segments,store,refresh,query_cache,request_cache"
 	statsPath    = "/_stats/" + statsMetrics + "?filter_path=indices"
 )
 

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package index
+
+import (
+	"strings"
+	"testing"
+	"testing/quick"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServiceURI(t *testing.T) {
+	tests := map[string]struct {
+		esVersion   *common.Version
+		expectedURI string
+	}{
+		"bulk_stats_unavailable": {
+			esVersion:   common.MustNewVersion("7.7.0"),
+			expectedURI: statsPath,
+		},
+		"bulk_stats_available": {
+			esVersion:   common.MustNewVersion("7.8.0"),
+			expectedURI: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newURI, err := getServiceURI(*test.esVersion)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedURI, newURI)
+		})
+	}
+}
+
+func TestGetServiceURIMultipleCalls(t *testing.T) {
+	err := quick.Check(func(r uint) bool {
+		numCalls := 2 + (r % 10) // between 2 and 11
+
+		var uri string
+		var err error
+		for i := uint(0); i < numCalls; i++ {
+			uri, err = getServiceURI(*common.MustNewVersion("7.8.0"))
+			if err != nil {
+				return false
+			}
+		}
+
+		return err == nil && uri == strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1)
+	}, nil)
+	require.NoError(t, err)
+}

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -29,25 +29,24 @@ import (
 
 func TestGetServiceURI(t *testing.T) {
 	tests := map[string]struct {
-		esVersion   *common.Version
-		expectedURI string
+		esVersion    *common.Version
+		expectedPath string
 	}{
 		"bulk_stats_unavailable": {
-			esVersion:   common.MustNewVersion("7.7.0"),
-			expectedURI: "http://eshost:9200" + statsPath,
+			esVersion:    common.MustNewVersion("7.7.0"),
+			expectedPath: statsPath,
 		},
 		"bulk_stats_available": {
-			esVersion:   common.MustNewVersion("7.8.0"),
-			expectedURI: strings.Replace("http://eshost:9200"+statsPath, statsMetrics, statsMetrics+",bulk", 1),
+			esVersion:    common.MustNewVersion("7.8.0"),
+			expectedPath: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			currURI := "http://eshost:9200" + statsPath
-			newURI, err := getServiceURI(currURI, *test.esVersion)
+			newURI, err := getServicePath(*test.esVersion)
 			require.NoError(t, err)
-			require.Equal(t, test.expectedURI, newURI)
+			require.Equal(t, test.expectedPath, newURI)
 		})
 	}
 }
@@ -59,14 +58,13 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 		var uri string
 		var err error
 		for i := uint(0); i < numCalls; i++ {
-			currURI := "http://eshost:9200" + statsPath
-			uri, err = getServiceURI(currURI, *common.MustNewVersion("7.8.0"))
+			uri, err = getServicePath(*common.MustNewVersion("7.8.0"))
 			if err != nil {
 				return false
 			}
 		}
 
-		return err == nil && uri == strings.Replace("http://eshost:9200"+statsPath, statsMetrics, statsMetrics+",bulk", 1)
+		return err == nil && uri == strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1)
 	}, nil)
 	require.NoError(t, err)
 }

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -34,17 +34,18 @@ func TestGetServiceURI(t *testing.T) {
 	}{
 		"bulk_stats_unavailable": {
 			esVersion:   common.MustNewVersion("7.7.0"),
-			expectedURI: statsPath,
+			expectedURI: "http://eshost:9200" + statsPath,
 		},
 		"bulk_stats_available": {
 			esVersion:   common.MustNewVersion("7.8.0"),
-			expectedURI: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
+			expectedURI: strings.Replace("http://eshost:9200"+statsPath, statsMetrics, statsMetrics+",bulk", 1),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			newURI, err := getServiceURI(*test.esVersion)
+			currURI := "http://eshost:9200" + statsPath
+			newURI, err := getServiceURI(currURI, *test.esVersion)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedURI, newURI)
 		})
@@ -58,13 +59,14 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 		var uri string
 		var err error
 		for i := uint(0); i < numCalls; i++ {
-			uri, err = getServiceURI(*common.MustNewVersion("7.8.0"))
+			currURI := "http://eshost:9200" + statsPath
+			uri, err = getServiceURI(currURI, *common.MustNewVersion("7.8.0"))
 			if err != nil {
 				return false
 			}
 		}
 
-		return err == nil && uri == strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1)
+		return err == nil && uri == strings.Replace("http://eshost:9200"+statsPath, statsMetrics, statsMetrics+",bulk", 1)
 	}, nil)
 	require.NoError(t, err)
 }

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -51,11 +51,20 @@ var (
 			"is_throttled":            c.Bool("is_throttled"),
 			"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
 		}),
+		"bulk": bulkDict,
 		"search": c.Dict("search", s.Schema{
 			"query_total":          c.Int("query_total"),
 			"query_time_in_millis": c.Int("query_time_in_millis"),
 		}),
 	}
+
+	bulkDict = c.Dict("bulk", s.Schema{
+		"total_operations":     c.Int("total_operations"),
+		"total_time_in_millis": c.Int("total_time_in_millis"),
+		"total_size_in_bytes":  c.Int("total_size_in_bytes"),
+		"avg_time_in_millis":   c.Int("avg_time_in_millis"),
+		"avg_size_in_bytes":    c.Int("avg_size_in_bytes"),
+	}, c.DictOptional)
 )
 
 func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -51,20 +51,12 @@ var (
 			"is_throttled":            c.Bool("is_throttled"),
 			"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
 		}),
-		"bulk": bulkDict,
+		"bulk": elasticsearch.BulkStatsDict,
 		"search": c.Dict("search", s.Schema{
 			"query_total":          c.Int("query_total"),
 			"query_time_in_millis": c.Int("query_time_in_millis"),
 		}),
 	}
-
-	bulkDict = c.Dict("bulk", s.Schema{
-		"total_operations":     c.Int("total_operations"),
-		"total_time_in_millis": c.Int("total_time_in_millis"),
-		"total_size_in_bytes":  c.Int("total_size_in_bytes"),
-		"avg_time_in_millis":   c.Int("avg_time_in_millis"),
-		"avg_size_in_bytes":    c.Int("avg_size_in_bytes"),
-	}, c.DictOptional)
 )
 
 func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -49,6 +49,7 @@ var (
 				"index_time_in_millis":    c.Int("index_time_in_millis"),
 				"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
 			}),
+			"bulk": elasticsearch.BulkStatsDict,
 			"search": c.Dict("search", s.Schema{
 				"query_total":          c.Int("query_total"),
 				"query_time_in_millis": c.Int("query_time_in_millis"),


### PR DESCRIPTION
## What does this PR do?

Collects new `bulk` indexing metrics being reported by Elasticsearch in the `index`, `index_summary`, and `node_stats` metricsets for the Stack Monitoring code path (i.e. when `xpack.enabled: true` is set in these metricsets' configurations). 

These metricsets correspond to `type:index_stats`, `type:indices_stats`, and `type:node_stats` documents, respectively,  in `.monitoring-es-*` indices used by the Stack Monitoring UI.

## Why is it important?

To restore parity between legacy internal collection and Metricbeat collection for Elasticsearch monitoring. The changes corresponding to this PR for legacy internal collection were made in https://github.com/elastic/elasticsearch/pull/52208.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works.
  - In addition to the unit test added in this PR, [parity tests](https://github.com/elastic/elastic-stack-testing/tree/master/playbooks/monitoring#stack-monitoring-parity-tests) already exist that are currently failing and should start passing once the changes in this PR are released.
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Run the latest `8.0.0-SNAPSHOT` build of Elasticsearch so it exposes the new `bulk` indexing metrics being collected by the code in this PR.
   ```
   docker pull docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
   docker run --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
   ```

2. Build Metricbeat with the changes in this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

3. Enable the `elasticsearch-xpack` module.
   ```
   metricbeat modules enable elasticsearch-xpack
   ```

4. Create a minimal Metricbeat configuration for testing.
   ```
   cat <<EOF > ./metricbeat.test.yml
   metricbeat.config.modules:
     path: \${path.config}/modules.d/*.yml
     reload.enabled: false

   output.console.enabled: true

   monitoring.elasticsearch:
     hosts: [ "localhost:9200" ]
   EOF
   ```

   Here, we only enable `monitoring.elasticsearch` to generate some bulk indexing requests to Elasticsearch so we can see non-zero bulk metrics.

5. Run Metricbeat with the minimal configuration and look for the new `bulk` indexing metrics' fields. You may need to run these for ~30 seconds for some bulk indexing to happen and corresponding metrics to be generated by Elasticsearch.
   1. For the `index` metricset, i.e.`type:index_stats` documents:
      ```
      ./metricbeat -c metricbeat.test.yml | jq 'select(.type == "index_stats") | .index_stats.total.bulk'
      ```
      ```
      ./metricbeat -c metricbeat.test.yml | jq 'select(.type == "index_stats") | .index_stats.primaries.bulk'
      ```
   1. For the `index_summary` metricset, i.e.`type:indices_stats` documents:
      ```
      ./metricbeat -c metricbeat.test.yml | jq 'select(.type == "indices_stats") | .indices_stats._all.total.bulk'
      ```
      ```
      ./metricbeat -c metricbeat.test.yml | jq 'select(.type == "indices_stats") | .indices_stats._all.primaries.bulk'
      ```
   1. For the `node_stats` metricset, i.e.`type:node_stats` documents:
      ```
      ./metricbeat -c metricbeat.test.yml | jq 'select(.type == "node_stats") | .node_stats.indices.bulk'
      ```

## Related issues
- Resolves elastic/beats#17977