### PR TITLE
[docs] Add missing HTTP JSON input

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -42,57 +42,57 @@ input type more than once. For example:
 
 You can configure {beatname_uc} to use the following inputs:
 
-* <<{beatname_lc}-input-log>>
-* <<{beatname_lc}-input-stdin>>
-* <<{beatname_lc}-input-container>>
-* <<{beatname_lc}-input-kafka>>
-* <<{beatname_lc}-input-redis>>
-* <<{beatname_lc}-input-udp>>
-* <<{beatname_lc}-input-docker>>
-* <<{beatname_lc}-input-tcp>>
-* <<{beatname_lc}-input-syslog>>
-* <<{beatname_lc}-input-mqtt>>
-* <<{beatname_lc}-input-s3>>
-* <<{beatname_lc}-input-netflow>>
-* <<{beatname_lc}-input-google-pubsub>>
 * <<{beatname_lc}-input-azure-eventhub>>
 * <<{beatname_lc}-input-cloudfoundry>>
-* <<{beatname_lc}-input-o365audit>>
+* <<{beatname_lc}-input-container>>
+* <<{beatname_lc}-input-docker>>
+* <<{beatname_lc}-input-google-pubsub>>
 * <<{beatname_lc}-input-httpjson>>
+* <<{beatname_lc}-input-kafka>>
+* <<{beatname_lc}-input-log>>
+* <<{beatname_lc}-input-mqtt>>
+* <<{beatname_lc}-input-netflow>>
+* <<{beatname_lc}-input-o365audit>>
+* <<{beatname_lc}-input-redis>>
+* <<{beatname_lc}-input-s3>>
+* <<{beatname_lc}-input-stdin>>
+* <<{beatname_lc}-input-syslog>>
+* <<{beatname_lc}-input-tcp>>
+* <<{beatname_lc}-input-udp>>
 
 
 include::multiline.asciidoc[]
-
-include::inputs/input-log.asciidoc[]
-
-include::inputs/input-stdin.asciidoc[]
-
-include::inputs/input-container.asciidoc[]
-
-include::inputs/input-kafka.asciidoc[]
-
-include::inputs/input-redis.asciidoc[]
-
-include::inputs/input-udp.asciidoc[]
-
-include::inputs/input-docker.asciidoc[]
-
-include::inputs/input-tcp.asciidoc[]
-
-include::inputs/input-syslog.asciidoc[]
-
-include::inputs/input-mqtt.asciidoc[]
-
-include::../../x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc[]
-
-include::../../x-pack/filebeat/docs/inputs/input-netflow.asciidoc[]
-
-include::../../x-pack/filebeat/docs/inputs/input-google-pubsub.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-cloudfoundry.asciidoc[]
 
-include::../../x-pack/filebeat/docs/inputs/input-o365audit.asciidoc[]
+include::inputs/input-container.asciidoc[]
+
+include::inputs/input-docker.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-google-pubsub.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-httpjson.asciidoc[]
+
+include::inputs/input-kafka.asciidoc[]
+
+include::inputs/input-log.asciidoc[]
+
+include::inputs/input-mqtt.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-netflow.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-o365audit.asciidoc[]
+
+include::inputs/input-redis.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc[]
+
+include::inputs/input-stdin.asciidoc[]
+
+include::inputs/input-syslog.asciidoc[]
+
+include::inputs/input-tcp.asciidoc[]
+
+include::inputs/input-udp.asciidoc[]

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -58,6 +58,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-azure-eventhub>>
 * <<{beatname_lc}-input-cloudfoundry>>
 * <<{beatname_lc}-input-o365audit>>
+* <<{beatname_lc}-input-httpjson>>
 
 
 include::multiline.asciidoc[]
@@ -93,3 +94,5 @@ include::../../x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc[]
 include::../../x-pack/filebeat/docs/inputs/input-cloudfoundry.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-o365audit.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-httpjson.asciidoc[]


### PR DESCRIPTION
Adds HTTP input to the list of includes.

@alakahakai I'm assuming that you meant to build this content, but let me know if for some reason you don't want it to show up in the published docs. 

Also let me know which versions this needs to be backported to.

(Note that I've also alphabetized the list of inputs because there are too many entries to sort by common usage. Put it in a separate commit.)