### PR TITLE
Update image used to build Journalbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,7 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Journalbeat*
 
-- Improve parsing of syslog.pid in journalbeat to strip the username when present {pull}16116[16116]
+- Build journalbeat with systemd 232 (Debian 9), it may stop working with older versions. {pull}18008[18008]
 
 
 *Metricbeat*
@@ -124,6 +124,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Journalbeat*
 
+- Improve parsing of syslog.pid in journalbeat to strip the username when present {pull}16116[16116]
 
 *Metricbeat*
 
@@ -281,6 +282,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 
 *Journalbeat*
+
 
 *Metricbeat*
 

--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -210,7 +210,7 @@ func selectImage(platform string) (string, error) {
 	case platform == "linux/s390x":
 		tagSuffix = "s390x"
 	case strings.HasPrefix(platform, "linux"):
-		tagSuffix = "main-debian8"
+		tagSuffix = "main"
 	}
 
 	goVersion, err := devtools.GoVersion()


### PR DESCRIPTION
Image used to build Journalbeat is based on Debian 8, that is not supported
anymore and its repository keys have expired. As they are not going to be
updated anymore it is not possible to properly authenticate packages.
Update image used for Journalbeat.