### PR TITLE
Cherry-pick #17913 to 7.x: [Metricbeat] allow partial region and zone in googlecloud module config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -419,6 +419,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Reference kubernetes manifests mount data directory from the host when running metricbeat as daemonset, so data persist between executions in the same node. {pull}17429[17429]
 - Add more detailed error messages, system tests and small refactoring to the service metricset in windows. {pull}17725[17725]
 - Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]
+- Allow partial region and zone name in googlecloud module config. {pull}17913[17913]
 - Add aggregation aligner as a config parameter for googlecloud stackdriver metricset. {issue}17141[[17141] {pull}17719[17719]
 - Move the perfmon metricset to GA. {issue}16608[16608] {pull}17879[17879]
 - Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]

--- a/metricbeat/docs/modules/googlecloud.asciidoc
+++ b/metricbeat/docs/modules/googlecloud.asciidoc
@@ -17,15 +17,15 @@ Note: extra GCP charges on Stackdriver Monitoring API requests will be generated
 This is a list of the possible module parameters you can tune:
 
 * *zone*: A single string with the zone you want to monitor like `us-central1-a`.
-Or you can specific a partial zone name like `us-central1-`, which will monitor
-all zones start with `us-central1-`: `us-central1-a`, `us-central1-b`,
-`us-central1-c` and `us-central1-f`.
+Or you can specific a partial zone name like `us-central1-` or `us-central1-*`,
+which will monitor all zones start with `us-central1-`: `us-central1-a`,
+`us-central1-b`, `us-central1-c` and `us-central1-f`.
 Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP zones]
 for zones that are available in GCP.
 
 * *region*: A single string with the region you want to monitor like `us-central1`.
 This will enable monitoring for all zones under this region. Or you can specific
-a partial region name like `us-east`, which will monitor all regions start with
+a partial region name like `us-east` or `us-east*`, which will monitor all regions start with
 `us-east`: `us-east1` and `us-east4`. If both region and zone are configured,
 only region will be used.
 Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP regions]
@@ -33,9 +33,12 @@ for regions that are available in GCP.
 
 * *project_id*: A single string with your GCP Project ID
 
-* *credentials_file_path*: A single string pointing to the JSON file path reachable by Metricbeat that you have created using IAM.
+* *credentials_file_path*: A single string pointing to the JSON file path
+reachable by Metricbeat that you have created using IAM.
 
-* *exclude_labels*: (`true`/`false` default `false`) Do not extract extra labels and metadata information from Metricsets and fetch metrics onlly. At the moment, *labels and metadata extraction is only supported* in Compute Metricset.
+* *exclude_labels*: (`true`/`false` default `false`) Do not extract extra labels
+and metadata information from metricsets and fetch metrics only. At the moment,
+*labels and metadata extraction is only supported* in `compute` metricset.
 
 * *period*: A single time duration specified for this module collection frequency.
 

--- a/metricbeat/docs/modules/googlecloud.asciidoc
+++ b/metricbeat/docs/modules/googlecloud.asciidoc
@@ -16,9 +16,20 @@ Note: extra GCP charges on Stackdriver Monitoring API requests will be generated
 == Module config and parameters
 This is a list of the possible module parameters you can tune:
 
-* *zone*: A single string with the zone you want to monitor like "us-central1-a". If you need to fetch from multiple regions, you have to setup a different configuration for each (but you don't need a new instance of Metricbeat running)
+* *zone*: A single string with the zone you want to monitor like `us-central1-a`.
+Or you can specific a partial zone name like `us-central1-`, which will monitor
+all zones start with `us-central1-`: `us-central1-a`, `us-central1-b`,
+`us-central1-c` and `us-central1-f`.
+Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP zones]
+for zones that are available in GCP.
 
-* *region*: A single string with the region you want to monitor like "us-central1". This will enable monitoring for all zones under this region.
+* *region*: A single string with the region you want to monitor like `us-central1`.
+This will enable monitoring for all zones under this region. Or you can specific
+a partial region name like `us-east`, which will monitor all regions start with
+`us-east`: `us-east1` and `us-east4`. If both region and zone are configured,
+only region will be used.
+Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP regions]
+for regions that are available in GCP.
 
 * *project_id*: A single string with your GCP Project ID
 
@@ -27,6 +38,56 @@ This is a list of the possible module parameters you can tune:
 * *exclude_labels*: (`true`/`false` default `false`) Do not extract extra labels and metadata information from Metricsets and fetch metrics onlly. At the moment, *labels and metadata extraction is only supported* in Compute Metricset.
 
 * *period*: A single time duration specified for this module collection frequency.
+
+[float]
+== Example configuration
+* `compute` metricset is enabled to collect metrics from `us-central1-a` zone
+in `elastic-observability` project.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+  zone: "us-central1-a"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
+
+* `compute` and `pubsub` metricsets are enabled to collect metrics from all zones
+under `us-central1` region in `elastic-observability` project.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+    - pubsub
+  region: "us-central1"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
+
+* `compute` metricset is enabled to collect metrics from all regions starts with
+`us-west` in `elastic-observability` project, which includes all zones under
+`us-west1`, `us-west2`, `us-west3` and `us-west4`.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+    - pubsub
+  region: "us-west"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
 
 [float]
 == Authentication, authorization and permissions.
@@ -134,6 +195,15 @@ metricbeat.modules:
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 300s
+
+- module: googlecloud
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
 ----
 
 [float]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -524,6 +524,15 @@ metricbeat.modules:
   exclude_labels: false
   period: 300s
 
+- module: googlecloud
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+
 #------------------------------- Graphite Module -------------------------------
 - module: graphite
   metricsets: ["server"]

--- a/x-pack/metricbeat/module/googlecloud/_meta/config.yml
+++ b/x-pack/metricbeat/module/googlecloud/_meta/config.yml
@@ -26,3 +26,12 @@
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 300s
+
+- module: googlecloud
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s

--- a/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
@@ -6,17 +6,81 @@ Note: extra GCP charges on Stackdriver Monitoring API requests will be generated
 == Module config and parameters
 This is a list of the possible module parameters you can tune:
 
-* *zone*: A single string with the zone you want to monitor like "us-central1-a". If you need to fetch from multiple regions, you have to setup a different configuration for each (but you don't need a new instance of Metricbeat running)
+* *zone*: A single string with the zone you want to monitor like `us-central1-a`.
+Or you can specific a partial zone name like `us-central1-` or `us-central1-*`,
+which will monitor all zones start with `us-central1-`: `us-central1-a`,
+`us-central1-b`, `us-central1-c` and `us-central1-f`.
+Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP zones]
+for zones that are available in GCP.
 
-* *region*: A single string with the region you want to monitor like "us-central1". This will enable monitoring for all zones under this region.
+* *region*: A single string with the region you want to monitor like `us-central1`.
+This will enable monitoring for all zones under this region. Or you can specific
+a partial region name like `us-east` or `us-east*`, which will monitor all regions start with
+`us-east`: `us-east1` and `us-east4`. If both region and zone are configured,
+only region will be used.
+Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP regions]
+for regions that are available in GCP.
 
 * *project_id*: A single string with your GCP Project ID
 
-* *credentials_file_path*: A single string pointing to the JSON file path reachable by Metricbeat that you have created using IAM.
+* *credentials_file_path*: A single string pointing to the JSON file path
+reachable by Metricbeat that you have created using IAM.
 
-* *exclude_labels*: (`true`/`false` default `false`) Do not extract extra labels and metadata information from Metricsets and fetch metrics onlly. At the moment, *labels and metadata extraction is only supported* in Compute Metricset.
+* *exclude_labels*: (`true`/`false` default `false`) Do not extract extra labels
+and metadata information from metricsets and fetch metrics only. At the moment,
+*labels and metadata extraction is only supported* in `compute` metricset.
 
 * *period*: A single time duration specified for this module collection frequency.
+
+[float]
+== Example configuration
+* `compute` metricset is enabled to collect metrics from `us-central1-a` zone
+in `elastic-observability` project.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+  zone: "us-central1-a"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
+
+* `compute` and `pubsub` metricsets are enabled to collect metrics from all zones
+under `us-central1` region in `elastic-observability` project.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+    - pubsub
+  region: "us-central1"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
+
+* `compute` metricset is enabled to collect metrics from all regions starts with
+`us-west` in `elastic-observability` project, which includes all zones under
+`us-west1`, `us-west2`, `us-west3` and `us-west4`.
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - compute
+    - pubsub
+  region: "us-west"
+  project_id: "elastic-observability"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s
+----
 
 [float]
 == Authentication, authorization and permissions.

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester_test.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester_test.go
@@ -14,38 +14,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-func TestStringInSlice(t *testing.T) {
-	cases := []struct {
-		title          string
-		m              string
-		region         string
-		zone           string
-		expectedFilter string
-	}{
-		{
-			"construct filter with zone",
-			"compute.googleapis.com/instance/cpu/utilization",
-			"",
-			"us-east1-b",
-			"metric.type=\"compute.googleapis.com/instance/cpu/utilization\" AND resource.labels.zone = \"us-east1-b\"",
-		},
-		{
-			"construct filter with region",
-			"compute.googleapis.com/instance/cpu/utilization",
-			"us-east1",
-			"",
-			"metric.type=\"compute.googleapis.com/instance/cpu/utilization\" AND resource.labels.zone = starts_with(\"us-east1\")",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.title, func(t *testing.T) {
-			filter := constructFilter(c.m, c.region, c.zone)
-			assert.Equal(t, c.expectedFilter, filter)
-		})
-	}
-}
-
 func TestGetFilterForMetric(t *testing.T) {
 	var logger = logp.NewLogger("test")
 	cases := []struct {
@@ -58,7 +26,7 @@ func TestGetFilterForMetric(t *testing.T) {
 			"compute service with zone in config",
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			stackdriverMetricsRequester{config: config{Zone: "us-central1-a"}},
-			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = \"us-central1-a\"",
+			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = starts_with(\"us-central1-a\")",
 		},
 		{
 			"pubsub service with zone in config",
@@ -95,6 +63,30 @@ func TestGetFilterForMetric(t *testing.T) {
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			stackdriverMetricsRequester{config: config{Region: "us-central1", Zone: "us-central1-a"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = starts_with(\"us-central1\")",
+		},
+		{
+			"compute uptime with partial region",
+			"compute.googleapis.com/instance/uptime",
+			stackdriverMetricsRequester{config: config{Region: "us-west"}, logger: logger},
+			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west\")",
+		},
+		{
+			"compute uptime with partial zone",
+			"compute.googleapis.com/instance/uptime",
+			stackdriverMetricsRequester{config: config{Zone: "us-west1-"}, logger: logger},
+			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west1-\")",
+		},
+		{
+			"compute uptime with wildcard in region",
+			"compute.googleapis.com/instance/uptime",
+			stackdriverMetricsRequester{config: config{Region: "us-*"}, logger: logger},
+			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-\")",
+		},
+		{
+			"compute uptime with wildcard in zone",
+			"compute.googleapis.com/instance/uptime",
+			stackdriverMetricsRequester{config: config{Zone: "us-west1-*"}, logger: logger},
+			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west1-\")",
 		},
 	}
 

--- a/x-pack/metricbeat/modules.d/googlecloud.yml.disabled
+++ b/x-pack/metricbeat/modules.d/googlecloud.yml.disabled
@@ -29,3 +29,12 @@
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 300s
+
+- module: googlecloud
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 60s


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#17913 to 7.x branch. Original message: 

## What does this PR do?

This PR is to enable partial region and partial zone in googlecloud module config.  User can choose to use wildcard `*` or not. For example:
```
- module: googlecloud
  metricsets:
    - compute
  region: "us-west"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
```
This config will enable data collection from all regions start with `us-west`, which includes `us-west1`, `us-west2`, `us-west3` and `us-west4`.
 
```
- module: googlecloud
  metricsets:
    - compute
  region: "us-*"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
```
Similarly this config will enable data collection from all regions start with `us-`, which includes all regions starts with `us-west`, `us-east` and `us-central`.

## Why is it important?

This will allow users to not copy paste region/zone names when they want to monitor several regions/zones. If user wants to monitor all regions in both US and Europe, they still need to copy paste but that's very minimum. For example:
```
- module: googlecloud
  metricsets:
    - compute
  region: "us-*"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
- module: googlecloud
  metricsets:
    - compute
  region: "europe-*"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

There are two parts need to be tested. One for regions and another for zones.

- Test for regions:
Enable googlecloud with this config and you should see metrics collection from all regions start with `us-`.
```
- module: googlecloud
  metricsets:
    - compute
  region: "us-"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
```

- Test for zones:
Enable googlecloud with this config and you should see metrics collection from all zones start with `europe-west3-`, which includes `europe-west3-a`, `europe-west3-b` and `europe-west3-c`.
```
- module: googlecloud
  metricsets:
    - compute
  zone: "europe-west3-"
  project_id: "elastic-observability"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 60s
```

## Related issues

- Relates https://github.com/elastic/beats/issues/17835
