### PR TITLE
Cherry-pick #18005 to 7.x: Disable repository expiration checks in Journalbeat builds

### DIFF
--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -193,7 +193,15 @@ func installDependencies(arch string, pkgs ...string) error {
 		return err
 	}
 
-	params := append([]string{"install", "-y", "--no-install-recommends"}, pkgs...)
+	params := append([]string{"install", "-y",
+		"--no-install-recommends",
+
+		// Journalbeat is built with old versions of Debian that don't update
+		// their repositories, so they have expired keys.
+		// Allow unauthenticated packages.
+		// This was not enough: "-o", "Acquire::Check-Valid-Until=false",
+		"--allow-unauthenticated",
+	}, pkgs...)
 	return sh.Run("apt-get", params...)
 }
 


### PR DESCRIPTION
Cherry-pick of PR #18005 to 7.x branch. Original message: 

Journalbeat builds are failing in all branches with errors like the following one:
```
W: GPG error: http://archive.debian.org jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
WARNING: The following packages cannot be authenticated!
  liblzma5:i386 libgpg-error0:i386
E: There are problems and -y was used without --force-yes
Error: running "apt-get install -y --no-install-recommends -o Acquire::Check-Valid-Until=false libsystemd-dev:i386 libsystemd0:i386 libgcrypt20:i386" failed with exit code 100
```
Jessie repositories are not updated anymore and their keys got outdated a couple of days ago.
```
# apt-key list | grep expired
pub   4096R/46925553 2012-04-27 [expired: 2020-04-25]
pub   4096R/65FFB764 2012-05-08 [expired: 2019-05-07]
```
I tried to disable only expiration checks with `-o Acquire::Check-Valid-Until=false` but it was not enough.

I am disabling all authentication checks for packages installation during Journalbeat builds. We should review this in a follow up, so we don't build with unauthenticated packages.