### PR TITLE
fix: trigger on 7.x branch changes

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -23,7 +23,7 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i)^\\/packaging$')
-    upstream('Beats/beats-beats-mbp/master')
+    upstream('Beats/beats-beats-mbp/7.x')
   }
   parameters {
     booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')


### PR DESCRIPTION
## What does this PR do?

It triggers the job on 7.x branch merges.

## Why is it important?

The current trigger is wrong.