### PR TITLE
[7.x] Update stale references to _xpack to refer to _license instead (#18030)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,6 +98,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Do not rotate log files on startup when interval is configured and rotateonstartup is disabled. {pull}17613[17613]
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix goroutine leak and Elasticsearch output file descriptor leak when output reloading is in use. {issue}10491[10491] {pull}17381[17381]
+- Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/licenser/elastic_fetcher.go
+++ b/x-pack/libbeat/licenser/elastic_fetcher.go
@@ -18,9 +18,9 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-const xPackURL = "/_license"
+const licenseURL = "/_license"
 
-// params defaults query parameters to send to the '_xpack' endpoint by default we only need
+// params defaults query parameters to send to the '_license' endpoint by default we only need
 // machine parseable data.
 var params = map[string]string{
 	"human": "false",
@@ -88,12 +88,12 @@ func NewElasticFetcher(client esclient) *ElasticFetcher {
 	return &ElasticFetcher{client: client, log: logp.NewLogger("elasticfetcher")}
 }
 
-// Fetch retrieves the license information from an Elasticsearch Client, it will call the `_xpack`
-// end point and will return a parsed license. If the `_xpack` endpoint is unreacheable we will
+// Fetch retrieves the license information from an Elasticsearch Client, it will call the `_license`
+// endpoint and will return a parsed license. If the `_license` endpoint is unreacheable we will
 // return the OSS License otherwise we return an error.
 func (f *ElasticFetcher) Fetch() (*License, error) {
-	status, body, err := f.client.Request("GET", xPackURL, "", params, nil)
-	// When we are running an OSS release of elasticsearch the _xpack endpoint will return a 405,
+	status, body, err := f.client.Request("GET", licenseURL, "", params, nil)
+	// When we are running an OSS release of elasticsearch the _license endpoint will return a 405,
 	// "Method Not Allowed", so we return the default OSS license.
 	if status == http.StatusBadRequest {
 		f.log.Debug("Received 'Bad request' (400) response from server, fallback to OSS license")

--- a/x-pack/libbeat/licenser/es_callback.go
+++ b/x-pack/libbeat/licenser/es_callback.go
@@ -30,7 +30,7 @@ func Enforce(name string, checks ...CheckFunc) {
 		license, err := fetcher.Fetch()
 
 		if err != nil {
-			return errors.Wrapf(err, "cannot retrieve the elasticsearch license from the /_xpack endpoint, "+
+			return errors.Wrapf(err, "cannot retrieve the elasticsearch license from the /_license endpoint, "+
 				"%s requires the default distribution of Elasticsearch. Please make the endpoint accessible "+
 				"to %s so it can verify the license.", name, name)
 		}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update stale references to _xpack to refer to _license instead  (#18030)