### PR TITLE
Set the es_beats path when calling create_metricset.py.

### DIFF
--- a/metricbeat/scripts/mage/target/metricset/metricset.go
+++ b/metricbeat/scripts/mage/target/metricset/metricset.go
@@ -48,7 +48,8 @@ func CreateMetricset() error {
 
 	_, err = sh.Exec(
 		map[string]string{}, os.Stdout, os.Stderr, python, scriptPath,
-		"--path", devtools.CWD(), "--module", os.Getenv("MODULE"), "--metricset", os.Getenv("METRICSET"),
+		"--path", devtools.CWD(), "--es_beats", beatsDir,
+		"--module", os.Getenv("MODULE"), "--metricset", os.Getenv("METRICSET"),
 	)
 	return err
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes `mage createMetricset` to work inside of generated project. Without this change `--es_beat` would not be set.

**Note:** This will still fail the test, because sadly the test is using elastic/beats from `master`. So this must land then the tests will pass... hopefully... No way to know until it lands.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So `mage createMetricset` to work inside of generated project. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
