### PR TITLE
[Filebeat] 0 in syslog day format

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/beats/compare/v7.5.0...v7.5.1[View commits]
 - Change iis url path grok pattern from URIPATH to NOTSPACE. {issue}12710[12710] {pull}13225[13225] {issue}7951[7951] {pull}13378[13378] {pull}14754[14754]
 - Fix azure filesets test files. {issue}14185[14185] {pull}14235[14235]
 - Update Logstash module's Grok patterns to support Logstash 7.4 logs. {pull}14743[14743]
-- Allow for leading 0 in syslog day format {issue}16824[16824]
+- Allow for leading 0 in syslog day format as per {issue}16824[16824]
 
 *Metricbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v7.5.0...v7.5.1[View commits]
 - Change iis url path grok pattern from URIPATH to NOTSPACE. {issue}12710[12710] {pull}13225[13225] {issue}7951[7951] {pull}13378[13378] {pull}14754[14754]
 - Fix azure filesets test files. {issue}14185[14185] {pull}14235[14235]
 - Update Logstash module's Grok patterns to support Logstash 7.4 logs. {pull}14743[14743]
+- Allow for leading 0 in syslog day format {issue}16824[16824]
 
 *Metricbeat*
 

--- a/filebeat/input/syslog/syslog_rfc3164.rl
+++ b/filebeat/input/syslog/syslog_rfc3164.rl
@@ -19,6 +19,7 @@
   # Match: " 5" and "10" as the day
   multiple_digits_day = (([12][0-9]) | ("3"[01]))>tok %day;
   single_digit_day = [1-9]>tok %day;
+  # Support 'Aug 07' date format to support misinterpretations of rfc3164
   supported_multiple_digits_day = [0][0-9]>tok %day;
   day = (space? single_digit_day | multiple_digits_day | supported_multiple_digits_day);
 

--- a/filebeat/input/syslog/syslog_rfc3164.rl
+++ b/filebeat/input/syslog/syslog_rfc3164.rl
@@ -19,7 +19,8 @@
   # Match: " 5" and "10" as the day
   multiple_digits_day = (([12][0-9]) | ("3"[01]))>tok %day;
   single_digit_day = [1-9]>tok %day;
-  day = (space? single_digit_day | multiple_digits_day);
+  supported_multiple_digits_day = [0][0-9]>tok %day;
+  day = (space? single_digit_day | multiple_digits_day | supported_multiple_digits_day);
 
   # Match: hh:mm:ss (24 hr format)
   hour = ([01][0-9]|"2"[0-3])>tok %hour;


### PR DESCRIPTION
- Bug

## What does this PR do?
It adds the format 0x to be allowed in syslog #16824

## Why is it important?
#16824

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes #16824
