### PR TITLE
Cherry-pick #18020 to 7.x: Fix generated metricbeat so create-metricset works.

### DIFF
--- a/generator/_templates/metricbeat/{beat}/magefile.go
+++ b/generator/_templates/metricbeat/{beat}/magefile.go
@@ -16,6 +16,9 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	"github.com/elastic/beats/v7/generator/common/beatgen"
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
+
+	// mage:import
+	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"
 )
 
 func init() {

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -3,6 +3,6 @@ ES_BEATS ?= ..
 include $(ES_BEATS)/dev-tools/make/mage.mk
 
 # Creates a new metricset. Requires the params MODULE and METRICSET
-.PHONY: create-metricset	
+.PHONY: create-metricset
 create-metricset:
 	mage createMetricset

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
@@ -48,6 +47,8 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
+	// mage:import
+	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"
 )
 
 func init() {
@@ -196,30 +197,4 @@ func PythonIntegTest(ctx context.Context) error {
 		mg.Deps(devtools.BuildSystemTestBinary)
 		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
 	})
-}
-
-// CreateMetricset creates a new metricset.
-//
-// Required ENV variables:
-// * MODULE: Name of the module
-// * METRICSET: Name of the metricset
-func CreateMetricset(ctx context.Context) error {
-	ve, err := devtools.PythonVirtualenv()
-	if err != nil {
-		return err
-	}
-	python, err := devtools.LookVirtualenvPath(ve, "python")
-	if err != nil {
-		return err
-	}
-	path, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	_, err = sh.Exec(
-		map[string]string{}, os.Stdout, os.Stderr, python, "scripts/create_metricset.py",
-		"--path", path, "--module", os.Getenv("MODULE"), "--metricset", os.Getenv("METRICSET"),
-	)
-	return err
 }

--- a/metricbeat/scripts/mage/target/metricset/metricset.go
+++ b/metricbeat/scripts/mage/target/metricset/metricset.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metricset
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/sh"
+
+	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+)
+
+// CreateMetricset creates a new metricset.
+//
+// Required ENV variables:
+// * MODULE: Name of the module
+// * METRICSET: Name of the metricset
+func CreateMetricset() error {
+	ve, err := devtools.PythonVirtualenv()
+	if err != nil {
+		return err
+	}
+	python, err := devtools.LookVirtualenvPath(ve, "python")
+	if err != nil {
+		return err
+	}
+	beatsDir, err := devtools.ElasticBeatsDir()
+	if err != nil {
+		return err
+	}
+	scriptPath := filepath.Join(beatsDir, "metricbeat", "scripts", "create_metricset.py")
+
+	_, err = sh.Exec(
+		map[string]string{}, os.Stdout, os.Stderr, python, scriptPath,
+		"--path", devtools.CWD(), "--module", os.Getenv("MODULE"), "--metricset", os.Getenv("METRICSET"),
+	)
+	return err
+}

--- a/x-pack/metricbeat/Makefile
+++ b/x-pack/metricbeat/Makefile
@@ -1,3 +1,8 @@
 ES_BEATS ?= ../..
 
 include $(ES_BEATS)/dev-tools/make/mage.mk
+
+# Creates a new metricset. Requires the params MODULE and METRICSET
+.PHONY: create-metricset
+create-metricset:
+	mage createMetricset

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -24,6 +24,8 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
+	// mage:import
+	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"
 )
 
 func init() {


### PR DESCRIPTION
Cherry-pick of PR #18020 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the `make -C generator/_templates/metricbeat test` so that `make create-metricset` works inside of the generated custom metricbeat.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Both so `create-metricset` works on the generated beat and so the CI passes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

