### PR TITLE
Cherry-pick #18062 to 7.x: Fix update target in metricbeat magefile.go to include collectDocs target

### DIFF
--- a/dev-tools/make/mage.mk
+++ b/dev-tools/make/mage.mk
@@ -67,3 +67,11 @@ update: mage
 .PHONY: crosscompile
 crosscompile: mage
 	mage crossBuild
+
+.PHONY: docs
+docs:
+	mage docs
+
+.PHONY: docs-preview
+docs-preview:
+	PREVIEW=1 $(MAKE) docs

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -143,7 +143,8 @@ func moduleFieldsGo() error {
 
 // Update is an alias for running fields, dashboards, config.
 func Update() {
-	mg.SerialDeps(Fields, Dashboards, Config,
+	mg.SerialDeps(
+		Fields, Dashboards, Config, CollectAll,
 		metricbeat.PrepareModulePackagingOSS,
 		metricbeat.GenerateOSSMetricbeatModuleIncludeListGo)
 }


### PR DESCRIPTION
Cherry-pick of PR #18062 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the `mage update` target in metricbeat to also call `mage collectDocs`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So the `docs/` are generate for metricbeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Calling `mage update` updates the documentation.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`$ mage update`

or

`$ make update`

