### PR TITLE
ci: support GitHub PR approval to run in the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     PIPELINE_LOG_LEVEL = "INFO"
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
-    REFERENCE_REPO = '/var/lib/jenkins/.git-references/beats.git'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -40,7 +39,7 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: "${env.REFERENCE_REPO}")
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         dir("${BASE_DIR}"){
           loadConfigEnvVars()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     PIPELINE_LOG_LEVEL = "INFO"
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
+    REFERENCE_REPO = '/var/lib/jenkins/.git-references/beats.git'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -39,7 +40,7 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: "${env.REFERENCE_REPO}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         dir("${BASE_DIR}"){
           loadConfigEnvVars()


### PR DESCRIPTION
## What does this PR do?

Notify if it failed with the first time contributor check
~~Enable git reference repo for faster checkouts~~ (I'm afraid it seems is not as fast as I though! So reverted)

## Why is it important?

Easy to debug when a build has not been accepted yet to run in the CI

## Tests

### For the CI Approval GitHub check:

- If PR running on the CI has been approved then 

![image](https://user-images.githubusercontent.com/2871786/80573690-58a00c00-89f8-11ea-9f36-1101f9bb97d3.png)

- Otherwise the github check will fail

![image](https://user-images.githubusercontent.com/2871786/80593155-914fdd80-8a18-11ea-93ca-c5b7cdb6c12d.png)

### For the git reference repo:

Changes have been reverted

<details><summary>Expand to view</summary>
<p>

- With reference repo it takes 1 minutes

```
08:13:27  [Pipeline] checkout
08:13:27  using credential f6c7695a-671e-4f4f-a331-acdce44ff9ba
08:13:27  Cloning the remote Git repository
08:13:27  Using shallow clone with depth 5
08:13:27  Cloning repository git@github.com:elastic/beats.git
08:13:27   > git init /var/lib/jenkins/workspace/Beats_beats-beats-mbp_PR-18073/src/github.com/elastic/beats # timeout=10
08:13:27  Using reference repository: /var/lib/jenkins/.git-references/beats.git
08:13:27  Fetching upstream changes from git@github.com:elastic/beats.git
08:13:27   > git --version # timeout=10
08:13:27  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
08:13:27   > git fetch --tags --progress --depth=5 git@github.com:elastic/beats.git +refs/heads/*:refs/remotes/origin/* # timeout=10
08:13:56  Using shallow fetch with depth 5
08:13:56   > git config remote.origin.url git@github.com:elastic/beats.git # timeout=10
08:13:56   > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
08:13:56   > git config remote.origin.url git@github.com:elastic/beats.git # timeout=10
08:13:56  Fetching upstream changes from git@github.com:elastic/beats.git
08:13:56  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
08:13:56   > git fetch --tags --progress --depth=5 git@github.com:elastic/beats.git +refs/pull/18073/head:refs/remotes/origin/PR-18073 +refs/heads/master:refs/remotes/origin/master # timeout=10
08:14:22  Checking out Revision a6a20f3ad7ca6aead998a3dcbd712ad2999af0ce (origin/PR-18073)
08:14:24  Commit message: "ci: support GitHub check and reference repo"
08:14:24  First time build. Skipping changelog.
```

- Without, then it takes 20 seconds

```
08:44:49  [Pipeline] checkout
08:44:49  using credential f6c7695a-671e-4f4f-a331-acdce44ff9ba
08:44:49  Wiping out workspace first.
08:44:49  Cloning the remote Git repository
08:44:49  Using shallow clone with depth 3
08:44:49  Avoid fetching tags
08:44:50  Cloning repository git@github.com:elastic/beats.git
08:44:50   > git init /var/lib/jenkins/workspace/Beats_beats-beats-mbp_PR-18037/src/github.com/elastic/beats # timeout=10
08:44:50  Fetching upstream changes from git@github.com:elastic/beats.git
08:44:50   > git --version # timeout=10
08:44:50  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
08:44:50   > git fetch --no-tags --progress git@github.com:elastic/beats.git +refs/heads/*:refs/remotes/origin/* # timeout=15
08:45:03  Cleaning workspace
08:45:03  Using shallow fetch with depth 3
08:45:03  Pruning obsolete local branches
08:45:05  Merging remotes/origin/master commit f66b0797ccee458a52b5d578facdf1bd1e5e3f4a into PR head commit 0b073d8b1a00d7ef95c729a0b1642fcc73934722
08:45:03   > git config remote.origin.url git@github.com:elastic/beats.git # timeout=10
08:45:03   > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
08:45:03   > git config remote.origin.url git@github.com:elastic/beats.git # timeout=10
08:45:03   > git rev-parse --verify HEAD # timeout=10
08:45:03  No valid HEAD. Skipping the resetting
08:45:03   > git clean -fdx # timeout=10
08:45:03  Fetching upstream changes from git@github.com:elastic/beats.git
08:45:03  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
08:45:03   > git fetch --no-tags --progress --prune git@github.com:elastic/beats.git +refs/pull/18037/head:refs/remotes/origin/PR-18037 +refs/heads/master:refs/remotes/origin/master # timeout=15
08:45:05   > git config core.sparsecheckout # timeout=10
08:45:05   > git checkout -f 0b073d8b1a00d7ef95c729a0b1642fcc73934722 # timeout=15
08:45:08  Merge succeeded, producing 4f10435039ca1b54d3331eafe35b15184051f9a8
08:45:08  Checking out Revision 4f10435039ca1b54d3331eafe35b15184051f9a8 (PR-18037)
08:45:08  Commit message: "Merge commit 'f66b0797ccee458a52b5d578facdf1bd1e5e3f4a' into HEAD"
08:45:08  First time build. Skipping changelog.
08:45:08  Cleaning workspace
08:45:07   > git remote # timeout=10
08:45:07   > git config --get remote.origin.url # timeout=10
08:45:07  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
08:45:07   > git merge f66b0797ccee458a52b5d578facdf1bd1e5e3f4a # timeout=10
08:45:08   > git rev-parse HEAD^{commit} # timeout=10
08:45:08   > git config core.sparsecheckout # timeout=10
08:45:08   > git checkout -f 4f10435039ca1b54d3331eafe35b15184051f9a8 # timeout=15
08:45:08   > git rev-list --no-walk 3ca444a1d18c095e4998d4fc955f9a7289493c12 # timeout=10
08:45:08   > git rev-parse --verify HEAD # timeout=10
08:45:08  Resetting working tree
08:45:08   > git reset --hard # timeout=10
08:45:08   > git clean -fdx # timeout=10
```

</p>
</details>