### PR TITLE
Cherry-pick #17927 to 7.x: Add Kerberos support to Elasticsearch output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -262,6 +262,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update documentation for system.process.memory fields to include clarification on Windows os's. {pull}17268[17268]
 - Add `urldecode` processor to for decoding URL-encoded fields. {pull}17505[17505]
 - Add support for AWS IAM `role_arn` in credentials config. {pull}17658[17658] {issue}12464[12464]
+- Add Kerberos support to Elasticsearch output. {pull}17927[17927]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -7940,6 +7940,15 @@ Apache License 2.0
 
 
 --------------------------------------------------------------------
+Dependency: gopkg.in/jcmturner/goidentity.v3
+Version: v3.0.0
+License type (autodetected): Apache-2.0
+./vendor/gopkg.in/jcmturner/goidentity.v3/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
 Dependency: gopkg.in/jcmturner/gokrb5.v7
 Version: v7.3.0
 License type (autodetected): Apache-2.0

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -526,6 +526,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -793,6 +814,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1379,6 +1403,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1232,6 +1232,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -1499,6 +1520,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -2085,6 +2109,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -180,7 +180,7 @@ func newSaramaConfig(config kafkaInputConfig) (*sarama.Config, error) {
 		k.Net.TLS.Config = tls.BuildModuleConfig("")
 	}
 
-	if config.Kerberos != nil {
+	if config.Kerberos.IsEnabled() {
 		cfgwarn.Beta("Kerberos authentication for Kafka is beta.")
 
 		k.Net.SASL.Enable = true

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb
 	google.golang.org/grpc v1.27.1
 	gopkg.in/inf.v0 v0.9.0
-	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v7 v7.3.0
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
 	gopkg.in/yaml.v2 v2.2.8
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -677,6 +677,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -944,6 +965,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1530,6 +1554,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -464,6 +464,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -731,6 +752,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1317,6 +1341,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -405,7 +405,7 @@ output.elasticsearch:
   # this allow you to ensure that a specific certificate is used to validate the chain of trust.
   #
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
-  #ssl.ca_sha256: ""
+  #ssl.ca_sha256
 
   # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
   #kerberos.enabled: true

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -405,7 +405,28 @@ output.elasticsearch:
   # this allow you to ensure that a specific certificate is used to validate the chain of trust.
   #
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
-  #ssl.ca_sha256
+  #ssl.ca_sha256: ""
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 {{if not .ExcludeLogstash}}
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
@@ -674,6 +695,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1260,6 +1284,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/libbeat/common/transport/kerberos/client.go
+++ b/libbeat/common/transport/kerberos/client.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kerberos
+
+import (
+	"fmt"
+	"net/http"
+
+	krbclient "gopkg.in/jcmturner/gokrb5.v7/client"
+	krbconfig "gopkg.in/jcmturner/gokrb5.v7/config"
+	"gopkg.in/jcmturner/gokrb5.v7/keytab"
+	"gopkg.in/jcmturner/gokrb5.v7/spnego"
+)
+
+type Client struct {
+	spClient *spnego.Client
+}
+
+func NewClient(config *Config, httpClient *http.Client, esurl string) (*Client, error) {
+	var krbClient *krbclient.Client
+	krbConf, err := krbconfig.Load(config.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Kerberos client: %+v", err)
+	}
+
+	switch config.AuthType {
+	case authKeytab:
+		kTab, err := keytab.Load(config.KeyTabPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load keytab file %s: %+v", config.KeyTabPath, err)
+		}
+		krbClient = krbclient.NewClientWithKeytab(config.Username, config.Realm, kTab, krbConf)
+	case authPassword:
+		krbClient = krbclient.NewClientWithPassword(config.Username, config.Realm, config.Password, krbConf)
+	default:
+		return nil, InvalidAuthType
+	}
+
+	return &Client{
+		spClient: spnego.NewClient(krbClient, httpClient, ""),
+	}, nil
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.spClient.Do(req)
+}
+
+func (c *Client) CloseIdleConnections() {
+	c.spClient.CloseIdleConnections()
+}

--- a/libbeat/docs/shared-kerberos-config.asciidoc
+++ b/libbeat/docs/shared-kerberos-config.asciidoc
@@ -1,0 +1,85 @@
+[[configuration-kerberos]]
+== Configure Kerberos
+
+You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
+
+The following encryption types are supported:
+
+* aes128-cts-hmac-sha1-96
+* aes128-cts-hmac-sha256-128
+* aes256-cts-hmac-sha1-96
+* aes256-cts-hmac-sha384-192
+* des3-cbc-sha1-kd
+* rc4-hmac
+
+Example output config with Kerberos password based authentication:
+
+[source,yaml]
+----
+output.elasticsearch.hosts: ["http://my-elasticsearch.elastic.co:9200"]
+output.elasticsearch.kerberos.auth_type: password
+output.elasticsearch.kerberos.username: "elastic"
+output.elasticsearch.kerberos.password: "changeme"
+output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
+output.elasticsearch.kerberos.realm: "ELASTIC.CO"
+----
+
+The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration
+it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+
+[float]
+=== Configuration options
+
+You can specify the following options in the `kerberos` section of the +{beatname_lc}.yml+ config file:
+
+[float]
+==== `enabled`
+
+The `enabled` setting can be used to enable the kerberos configuration by setting
+it to `false`. The default value is `true`.
+
+NOTE: Kerberos settings are disabled if either `enabled` is set to `false` or the
+`kerberos` section is missing.
+
+[float]
+==== `auth_type`
+
+There are two options to authenticate with Kerberos KDC: `password` and `keytab`.
+
+`password` expects the principal name and its password. When choosing `keytab`, you
+have to specify a princial name and a path to a keytab. The keytab must contain
+the keys of the selected principal. Otherwise, authentication will fail.
+
+[float]
+==== `config_path`
+
+You need to set the path to the `krb5.conf`, so +{beatname_lc} can find the Kerberos KDC to
+retrieve a ticket.
+
+[float]
+==== `username`
+
+Name of the principal used to connect to the output.
+
+[float]
+==== `password`
+
+If you configured `password` for `auth_type`, you have to provide a password
+for the selected principal.
+
+[float]
+==== `keytab`
+
+If you configured `keytab` for `auth_type`, you have to provide the path to the
+keytab of the selected principal.
+
+[float]
+==== `service_name`
+
+This option can only be configured for Kafka. It is the name of the Kafka service, usually `kafka`.
+
+[float]
+==== `realm`
+
+Name of the realm where the output resides.
+

--- a/libbeat/esleg/eslegclient/config.go
+++ b/libbeat/esleg/eslegclient/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
@@ -32,7 +33,8 @@ type config struct {
 	Params   map[string]string `config:"parameters"`
 	Headers  map[string]string `config:"headers"`
 
-	TLS *tlscommon.Config `config:"ssl"`
+	TLS      *tlscommon.Config `config:"ssl"`
+	Kerberos *kerberos.Config  `config:"kerberos"`
 
 	ProxyURL     string `config:"proxy_url"`
 	ProxyDisable bool   `config:"proxy_disable"`

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -28,17 +28,23 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport"
+	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/testing"
 )
+
+type esHTTPClient interface {
+	Do(req *http.Request) (resp *http.Response, err error)
+	CloseIdleConnections()
+}
 
 // Connection manages the connection for a given client.
 type Connection struct {
 	ConnectionSettings
 
 	Encoder BodyEncoder
-	HTTP    *http.Client
+	HTTP    esHTTPClient
 
 	version common.Version
 	log     *logp.Logger
@@ -55,7 +61,8 @@ type ConnectionSettings struct {
 	APIKey   string
 	Headers  map[string]string
 
-	TLS *tlscommon.TLSConfig
+	TLS      *tlscommon.TLSConfig
+	Kerberos *kerberos.Config
 
 	OnConnectCallback func() error
 	Observer          transport.IOStatser
@@ -120,20 +127,39 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 		}
 	}
 
-	return &Connection{
-		ConnectionSettings: s,
-		HTTP: &http.Client{
+	var httpClient esHTTPClient
+	httpClient = &http.Client{
+		Transport: &http.Transport{
+			Dial:            dialer.Dial,
+			DialTLS:         tlsDialer.Dial,
+			TLSClientConfig: s.TLS.ToConfig(),
+			Proxy:           proxy,
+			IdleConnTimeout: s.IdleConnTimeout,
+		},
+		Timeout: s.Timeout,
+	}
+
+	if s.Kerberos.IsEnabled() {
+		c := &http.Client{
 			Transport: &http.Transport{
 				Dial:            dialer.Dial,
-				DialTLS:         tlsDialer.Dial,
-				TLSClientConfig: s.TLS.ToConfig(),
 				Proxy:           proxy,
 				IdleConnTimeout: s.IdleConnTimeout,
 			},
 			Timeout: s.Timeout,
-		},
-		Encoder: encoder,
-		log:     logp.NewLogger("esclientleg"),
+		}
+		httpClient, err = kerberos.NewClient(s.Kerberos, c, s.URL)
+		if err != nil {
+			return nil, err
+		}
+		logp.Info("kerberos client created")
+	}
+
+	return &Connection{
+		ConnectionSettings: s,
+		HTTP:               httpClient,
+		Encoder:            encoder,
+		log:                logp.NewLogger("esclientleg"),
 	}, nil
 }
 
@@ -190,6 +216,7 @@ func NewClients(cfg *common.Config) ([]Connection, error) {
 			Proxy:            proxyURL,
 			ProxyDisable:     config.ProxyDisable,
 			TLS:              tlsConfig,
+			Kerberos:         config.Kerberos,
 			Username:         config.Username,
 			Password:         config.Password,
 			APIKey:           config.APIKey,

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -83,6 +83,7 @@ func NewClient(
 		APIKey:           base64.StdEncoding.EncodeToString([]byte(s.APIKey)),
 		Headers:          s.Headers,
 		TLS:              s.TLS,
+		Kerberos:         s.Kerberos,
 		Proxy:            s.Proxy,
 		ProxyDisable:     s.ProxyDisable,
 		Parameters:       s.Parameters,
@@ -149,12 +150,13 @@ func (client *Client) Clone() *Client {
 				// empty.
 				ProxyDisable:      client.conn.Proxy == nil,
 				TLS:               client.conn.TLS,
+				Kerberos:          client.conn.Kerberos,
 				Username:          client.conn.Username,
 				Password:          client.conn.Password,
 				APIKey:            client.conn.APIKey,
 				Parameters:        nil, // XXX: do not pass params?
 				Headers:           client.conn.Headers,
-				Timeout:           client.conn.HTTP.Timeout,
+				Timeout:           client.conn.Timeout,
 				CompressionLevel:  client.conn.CompressionLevel,
 				OnConnectCallback: nil,
 				Observer:          nil,

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
@@ -39,6 +40,7 @@ type elasticsearchConfig struct {
 	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
 	EscapeHTML       bool              `config:"escape_html"`
 	TLS              *tlscommon.Config `config:"ssl"`
+	Kerberos         *kerberos.Config  `config:"kerberos"`
 	BulkMaxSize      int               `config:"bulk_max_size"`
 	MaxRetries       int               `config:"max_retries"`
 	Timeout          time.Duration     `config:"timeout"`
@@ -69,6 +71,7 @@ var (
 		CompressionLevel: 0,
 		EscapeHTML:       false,
 		TLS:              nil,
+		Kerberos:         nil,
 		LoadBalance:      true,
 		Backoff: Backoff{
 			Init: 1 * time.Second,

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -676,3 +676,11 @@ for HTTPS-based connections. If the `ssl` section is missing, the host CAs are u
 Elasticsearch.
 
 See <<configuration-ssl>> for more information.
+
+===== `kebreros`
+
+Configuration options for Kerberos authentication.
+
+See <<configuration-kerberos>> for more information.
+
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -97,6 +97,7 @@ func makeES(
 				Proxy:            proxyURL,
 				ProxyDisable:     config.ProxyDisable,
 				TLS:              tlsConfig,
+				Kerberos:         config.Kerberos,
 				Username:         config.Username,
 				Password:         config.Password,
 				APIKey:           config.APIKey,

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -174,7 +174,7 @@ func newSaramaConfig(log *logp.Logger, config *kafkaConfig) (*sarama.Config, err
 		k.Net.TLS.Config = tls.BuildModuleConfig("")
 	}
 
-	if config.Kerberos != nil {
+	if config.Kerberos.IsEnabled() {
 		cfgwarn.Beta("Kerberos authentication for Kafka is beta.")
 
 		k.Net.SASL.Enable = true

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1279,6 +1279,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -1546,6 +1567,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -2132,6 +2156,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -953,6 +953,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -1220,6 +1241,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1806,6 +1830,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/.gitignore
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/LICENSE
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/README.md
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/README.md
@@ -1,0 +1,13 @@
+# goidentity
+
+Standard interface to holding authenticated identities and their attributes.
+
+To get the package, execute:
+```
+go get gopkg.in/jcmturner/goidentity.v3
+```
+To import this package, add the following line to your code:
+```go
+import "gopkg.in/jcmturner/goidentity.v3"
+
+```

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/authenticator.go
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/authenticator.go
@@ -1,0 +1,6 @@
+package goidentity
+
+type Authenticator interface {
+	Authenticate() (Identity, bool, error)
+	Mechanism() string // gives the name of the type of authentication mechanism
+}

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/identity.go
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/identity.go
@@ -1,0 +1,32 @@
+package goidentity
+
+import "time"
+
+const (
+	CTXKey = "jcmturner/goidentity"
+)
+
+type Identity interface {
+	UserName() string
+	SetUserName(s string)
+	Domain() string
+	SetDomain(s string)
+	DisplayName() string
+	SetDisplayName(s string)
+	Human() bool
+	SetHuman(b bool)
+	AuthTime() time.Time
+	SetAuthTime(t time.Time)
+	AuthzAttributes() []string
+	AddAuthzAttribute(a string)
+	RemoveAuthzAttribute(a string)
+	Authenticated() bool
+	SetAuthenticated(b bool)
+	Authorized(a string) bool
+	SessionID() string
+	Expired() bool
+	Attributes() map[string]interface{}
+	SetAttribute(k string, v interface{})
+	SetAttributes(map[string]interface{})
+	RemoveAttribute(k string)
+}

--- a/vendor/gopkg.in/jcmturner/goidentity.v3/user.go
+++ b/vendor/gopkg.in/jcmturner/goidentity.v3/user.go
@@ -1,0 +1,154 @@
+package goidentity
+
+import (
+	"github.com/hashicorp/go-uuid"
+	"time"
+)
+
+type User struct {
+	authenticated   bool
+	domain          string
+	userName        string
+	displayName     string
+	email           string
+	human           bool
+	groupMembership map[string]bool
+	authTime        time.Time
+	sessionID       string
+	expiry          time.Time
+	attributes      map[string]interface{}
+}
+
+func NewUser(username string) User {
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		uuid = "00unique-sess-ions-uuid-unavailable0"
+	}
+	return User{
+		userName:        username,
+		groupMembership: make(map[string]bool),
+		sessionID:       uuid,
+	}
+}
+
+func (u *User) UserName() string {
+	return u.userName
+}
+
+func (u *User) SetUserName(s string) {
+	u.userName = s
+}
+
+func (u *User) Domain() string {
+	return u.domain
+}
+
+func (u *User) SetDomain(s string) {
+	u.domain = s
+}
+
+func (u *User) DisplayName() string {
+	if u.displayName == "" {
+		return u.userName
+	}
+	return u.displayName
+}
+
+func (u *User) SetDisplayName(s string) {
+	u.displayName = s
+}
+
+func (u *User) Human() bool {
+	return u.human
+}
+
+func (u *User) SetHuman(b bool) {
+	u.human = b
+}
+
+func (u *User) AuthTime() time.Time {
+	return u.authTime
+}
+
+func (u *User) SetAuthTime(t time.Time) {
+	u.authTime = t
+}
+
+func (u *User) AuthzAttributes() []string {
+	s := make([]string, len(u.groupMembership))
+	i := 0
+	for a := range u.groupMembership {
+		s[i] = a
+		i++
+	}
+	return s
+}
+
+func (u *User) Authenticated() bool {
+	return u.authenticated
+}
+
+func (u *User) SetAuthenticated(b bool) {
+	u.authenticated = b
+}
+
+func (u *User) AddAuthzAttribute(a string) {
+	u.groupMembership[a] = true
+}
+
+func (u *User) RemoveAuthzAttribute(a string) {
+	if _, ok := u.groupMembership[a]; !ok {
+		return
+	}
+	delete(u.groupMembership, a)
+}
+
+func (u *User) EnableAuthzAttribute(a string) {
+	if enabled, ok := u.groupMembership[a]; ok && !enabled {
+		u.groupMembership[a] = true
+	}
+}
+
+func (u *User) DisableAuthzAttribute(a string) {
+	if enabled, ok := u.groupMembership[a]; ok && enabled {
+		u.groupMembership[a] = false
+	}
+}
+
+func (u *User) Authorized(a string) bool {
+	if enabled, ok := u.groupMembership[a]; ok && enabled {
+		return true
+	}
+	return false
+}
+
+func (u *User) SessionID() string {
+	return u.sessionID
+}
+
+func (u *User) SetExpiry(t time.Time) {
+	u.expiry = t
+}
+
+func (u *User) Expired() bool {
+	if !u.expiry.IsZero() && time.Now().UTC().After(u.expiry) {
+		return true
+	}
+	return false
+}
+
+func (u *User) Attributes() map[string]interface{} {
+	return u.attributes
+}
+
+func (u *User) SetAttribute(k string, v interface{}) {
+	u.attributes[k] = v
+}
+
+func (u *User) SetAttributes(a map[string]interface{}) {
+	u.attributes = a
+}
+
+func (u *User) RemoveAttribute(k string) {
+	delete(u.attributes, k)
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/service/APExchange.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/service/APExchange.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"time"
+
+	"gopkg.in/jcmturner/gokrb5.v7/credentials"
+	"gopkg.in/jcmturner/gokrb5.v7/iana/errorcode"
+	"gopkg.in/jcmturner/gokrb5.v7/messages"
+)
+
+// VerifyAPREQ verifies an AP_REQ sent to the service. Returns a boolean for if the AP_REQ is valid and the client's principal name and realm.
+func VerifyAPREQ(APReq messages.APReq, s *Settings) (bool, *credentials.Credentials, error) {
+	var creds *credentials.Credentials
+
+	ok, err := APReq.Verify(s.Keytab, s.MaxClockSkew(), s.ClientAddress())
+	if err != nil || !ok {
+		return false, creds, err
+	}
+
+	if s.RequireHostAddr() && len(APReq.Ticket.DecryptedEncPart.CAddr) < 1 {
+		return false, creds,
+			messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADADDR, "ticket does not contain HostAddress values required")
+	}
+
+	// Check for replay
+	rc := GetReplayCache(s.MaxClockSkew())
+	if rc.IsReplay(APReq.Ticket.SName, APReq.Authenticator) {
+		return false, creds,
+			messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_REPEAT, "replay detected")
+	}
+
+	c := credentials.NewFromPrincipalName(APReq.Authenticator.CName, APReq.Authenticator.CRealm)
+	creds = c
+	creds.SetAuthTime(time.Now().UTC())
+	creds.SetAuthenticated(true)
+	creds.SetValidUntil(APReq.Ticket.DecryptedEncPart.EndTime)
+
+	//PAC decoding
+	if !s.disablePACDecoding {
+		isPAC, pac, err := APReq.Ticket.GetPACType(s.Keytab, s.KeytabPrincipal(), s.Logger())
+		if isPAC && err != nil {
+			return false, creds, err
+		}
+		if isPAC {
+			// There is a valid PAC. Adding attributes to creds
+			creds.SetADCredentials(credentials.ADCredentials{
+				GroupMembershipSIDs: pac.KerbValidationInfo.GetGroupMembershipSIDs(),
+				LogOnTime:           pac.KerbValidationInfo.LogOnTime.Time(),
+				LogOffTime:          pac.KerbValidationInfo.LogOffTime.Time(),
+				PasswordLastSet:     pac.KerbValidationInfo.PasswordLastSet.Time(),
+				EffectiveName:       pac.KerbValidationInfo.EffectiveName.Value,
+				FullName:            pac.KerbValidationInfo.FullName.Value,
+				UserID:              int(pac.KerbValidationInfo.UserID),
+				PrimaryGroupID:      int(pac.KerbValidationInfo.PrimaryGroupID),
+				LogonServer:         pac.KerbValidationInfo.LogonServer.Value,
+				LogonDomainName:     pac.KerbValidationInfo.LogonDomainName.Value,
+				LogonDomainID:       pac.KerbValidationInfo.LogonDomainID.String(),
+			})
+		}
+	}
+	return true, creds, nil
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/service/authenticator.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/service/authenticator.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	goidentity "gopkg.in/jcmturner/goidentity.v3"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/config"
+	"gopkg.in/jcmturner/gokrb5.v7/credentials"
+)
+
+// NewKRB5BasicAuthenticator creates a new NewKRB5BasicAuthenticator
+func NewKRB5BasicAuthenticator(headerVal string, krb5conf *config.Config, serviceSettings *Settings, clientSettings *client.Settings) KRB5BasicAuthenticator {
+	return KRB5BasicAuthenticator{
+		BasicHeaderValue: headerVal,
+		clientConfig:     krb5conf,
+		serviceSettings:  serviceSettings,
+		clientSettings:   clientSettings,
+	}
+}
+
+// KRB5BasicAuthenticator implements gopkg.in/jcmturner/goidentity.v3.Authenticator interface.
+// It takes username and password so can be used for basic authentication.
+type KRB5BasicAuthenticator struct {
+	BasicHeaderValue string
+	serviceSettings  *Settings
+	clientSettings   *client.Settings
+	clientConfig     *config.Config
+	realm            string
+	username         string
+	password         string
+}
+
+// Authenticate and return the identity. The boolean indicates if the authentication was successful.
+func (a KRB5BasicAuthenticator) Authenticate() (i goidentity.Identity, ok bool, err error) {
+	a.realm, a.username, a.password, err = parseBasicHeaderValue(a.BasicHeaderValue)
+	if err != nil {
+		err = fmt.Errorf("could not parse basic authentication header: %v", err)
+		return
+	}
+	cl := client.NewClientWithPassword(a.username, a.realm, a.password, a.clientConfig)
+	err = cl.Login()
+	if err != nil {
+		// Username and/or password could be wrong
+		err = fmt.Errorf("error with user credentials during login: %v", err)
+		return
+	}
+	tkt, _, err := cl.GetServiceTicket(a.serviceSettings.SName())
+	if err != nil {
+		err = fmt.Errorf("could not get service ticket: %v", err)
+		return
+	}
+	err = tkt.DecryptEncPart(a.serviceSettings.Keytab, a.serviceSettings.KeytabPrincipal())
+	if err != nil {
+		err = fmt.Errorf("could not decrypt service ticket: %v", err)
+		return
+	}
+	cl.Credentials.SetAuthTime(time.Now().UTC())
+	cl.Credentials.SetAuthenticated(true)
+	isPAC, pac, err := tkt.GetPACType(a.serviceSettings.Keytab, a.serviceSettings.KeytabPrincipal(), a.serviceSettings.Logger())
+	if isPAC && err != nil {
+		err = fmt.Errorf("error processing PAC: %v", err)
+		return
+	}
+	if isPAC {
+		// There is a valid PAC. Adding attributes to creds
+		cl.Credentials.SetADCredentials(credentials.ADCredentials{
+			GroupMembershipSIDs: pac.KerbValidationInfo.GetGroupMembershipSIDs(),
+			LogOnTime:           pac.KerbValidationInfo.LogOnTime.Time(),
+			LogOffTime:          pac.KerbValidationInfo.LogOffTime.Time(),
+			PasswordLastSet:     pac.KerbValidationInfo.PasswordLastSet.Time(),
+			EffectiveName:       pac.KerbValidationInfo.EffectiveName.Value,
+			FullName:            pac.KerbValidationInfo.FullName.Value,
+			UserID:              int(pac.KerbValidationInfo.UserID),
+			PrimaryGroupID:      int(pac.KerbValidationInfo.PrimaryGroupID),
+			LogonServer:         pac.KerbValidationInfo.LogonServer.Value,
+			LogonDomainName:     pac.KerbValidationInfo.LogonDomainName.Value,
+			LogonDomainID:       pac.KerbValidationInfo.LogonDomainID.String(),
+		})
+	}
+	ok = true
+	i = cl.Credentials
+	return
+}
+
+// Mechanism returns the authentication mechanism.
+func (a KRB5BasicAuthenticator) Mechanism() string {
+	return "Kerberos Basic"
+}
+
+func parseBasicHeaderValue(s string) (domain, username, password string, err error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return
+	}
+	v := string(b)
+	vc := strings.SplitN(v, ":", 2)
+	password = vc[1]
+	// Domain and username can be specified in 2 formats:
+	// <Username> - no domain specified
+	// <Domain>\<Username>
+	// <Username>@<Domain>
+	if strings.Contains(vc[0], `\`) {
+		u := strings.SplitN(vc[0], `\`, 2)
+		domain = u[0]
+		username = u[1]
+	} else if strings.Contains(vc[0], `@`) {
+		u := strings.SplitN(vc[0], `@`, 2)
+		domain = u[1]
+		username = u[0]
+	} else {
+		username = vc[0]
+	}
+	return
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/service/cache.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/service/cache.go
@@ -1,0 +1,148 @@
+// Package service provides server side integrations for Kerberos authentication.
+package service
+
+import (
+	"gopkg.in/jcmturner/gokrb5.v7/types"
+	"sync"
+	"time"
+)
+
+/*The server MUST utilize a replay cache to remember any authenticator
+presented within the allowable clock skew.
+The replay cache will store at least the server name, along with the
+client name, time, and microsecond fields from the recently-seen
+authenticators, and if a matching tuple is found, the
+KRB_AP_ERR_REPEAT error is returned.  Note that the rejection here is
+restricted to authenticators from the same principal to the same
+server.  Other client principals communicating with the same server
+principal should not have their authenticators rejected if the time
+and microsecond fields happen to match some other client's
+authenticator.
+
+If a server loses track of authenticators presented within the
+allowable clock skew, it MUST reject all requests until the clock
+skew interval has passed, providing assurance that any lost or
+replayed authenticators will fall outside the allowable clock skew
+and can no longer be successfully replayed.  If this were not done,
+an attacker could subvert the authentication by recording the ticket
+and authenticator sent over the network to a server and replaying
+them following an event that caused the server to lose track of
+recently seen authenticators.*/
+
+// Cache for tickets received from clients keyed by fully qualified client name. Used to track replay of tickets.
+type Cache struct {
+	entries map[string]clientEntries
+	mux     sync.RWMutex
+}
+
+// clientEntries holds entries of client details sent to the service.
+type clientEntries struct {
+	replayMap map[time.Time]replayCacheEntry
+	seqNumber int64
+	subKey    types.EncryptionKey
+}
+
+// Cache entry tracking client time values of tickets sent to the service.
+type replayCacheEntry struct {
+	presentedTime time.Time
+	sName         types.PrincipalName
+	cTime         time.Time // This combines the ticket's CTime and Cusec
+}
+
+func (c *Cache) getClientEntries(cname types.PrincipalName) (clientEntries, bool) {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	ce, ok := c.entries[cname.PrincipalNameString()]
+	return ce, ok
+}
+
+func (c *Cache) getClientEntry(cname types.PrincipalName, t time.Time) (replayCacheEntry, bool) {
+	if ce, ok := c.getClientEntries(cname); ok {
+		c.mux.RLock()
+		defer c.mux.RUnlock()
+		if e, ok := ce.replayMap[t]; ok {
+			return e, true
+		}
+	}
+	return replayCacheEntry{}, false
+}
+
+// Instance of the ServiceCache. This needs to be a singleton.
+var replayCache Cache
+var once sync.Once
+
+// GetReplayCache returns a pointer to the Cache singleton.
+func GetReplayCache(d time.Duration) *Cache {
+	// Create a singleton of the ReplayCache and start a background thread to regularly clean out old entries
+	once.Do(func() {
+		replayCache = Cache{
+			entries: make(map[string]clientEntries),
+		}
+		go func() {
+			for {
+				// TODO consider using a context here.
+				time.Sleep(d)
+				replayCache.ClearOldEntries(d)
+			}
+		}()
+	})
+	return &replayCache
+}
+
+// AddEntry adds an entry to the Cache.
+func (c *Cache) AddEntry(sname types.PrincipalName, a types.Authenticator) {
+	ct := a.CTime.Add(time.Duration(a.Cusec) * time.Microsecond)
+	if ce, ok := c.getClientEntries(a.CName); ok {
+		c.mux.Lock()
+		defer c.mux.Unlock()
+		ce.replayMap[ct] = replayCacheEntry{
+			presentedTime: time.Now().UTC(),
+			sName:         sname,
+			cTime:         ct,
+		}
+		ce.seqNumber = a.SeqNumber
+		ce.subKey = a.SubKey
+	} else {
+		c.mux.Lock()
+		defer c.mux.Unlock()
+		c.entries[a.CName.PrincipalNameString()] = clientEntries{
+			replayMap: map[time.Time]replayCacheEntry{
+				ct: {
+					presentedTime: time.Now().UTC(),
+					sName:         sname,
+					cTime:         ct,
+				},
+			},
+			seqNumber: a.SeqNumber,
+			subKey:    a.SubKey,
+		}
+	}
+}
+
+// ClearOldEntries clears entries from the Cache that are older than the duration provided.
+func (c *Cache) ClearOldEntries(d time.Duration) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	for ke, ce := range c.entries {
+		for k, e := range ce.replayMap {
+			if time.Now().UTC().Sub(e.presentedTime) > d {
+				delete(ce.replayMap, k)
+			}
+		}
+		if len(ce.replayMap) == 0 {
+			delete(c.entries, ke)
+		}
+	}
+}
+
+// IsReplay tests if the Authenticator provided is a replay within the duration defined. If this is not a replay add the entry to the cache for tracking.
+func (c *Cache) IsReplay(sname types.PrincipalName, a types.Authenticator) bool {
+	ct := a.CTime.Add(time.Duration(a.Cusec) * time.Microsecond)
+	if e, ok := c.getClientEntry(a.CName, ct); ok {
+		if e.sName.Equal(sname) {
+			return true
+		}
+	}
+	c.AddEntry(sname, a)
+	return false
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/service/settings.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/service/settings.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"log"
+	"time"
+
+	"gopkg.in/jcmturner/gokrb5.v7/keytab"
+	"gopkg.in/jcmturner/gokrb5.v7/types"
+)
+
+// Settings defines service side configuration settings.
+type Settings struct {
+	Keytab             *keytab.Keytab
+	ktprinc            *types.PrincipalName
+	sname              string
+	requireHostAddr    bool
+	disablePACDecoding bool
+	cAddr              types.HostAddress
+	maxClockSkew       time.Duration
+	logger             *log.Logger
+}
+
+// NewSettings creates a new service Settings.
+func NewSettings(kt *keytab.Keytab, settings ...func(*Settings)) *Settings {
+	s := new(Settings)
+	s.Keytab = kt
+	for _, set := range settings {
+		set(s)
+	}
+	return s
+}
+
+// RequireHostAddr used to configure service side to required host addresses to be specified in Kerberos tickets.
+//
+// s := NewSettings(kt, RequireHostAddr(true))
+func RequireHostAddr(b bool) func(*Settings) {
+	return func(s *Settings) {
+		s.requireHostAddr = b
+	}
+}
+
+// RequireHostAddr indicates if the service should require the host address to be included in the ticket.
+func (s *Settings) RequireHostAddr() bool {
+	return s.requireHostAddr
+}
+
+// DecodePAC used to configure service side to enable/disable PAC decoding if the PAC is present.
+// Defaults to enabled if not specified.
+//
+// s := NewSettings(kt, DecodePAC(false))
+func DecodePAC(b bool) func(*Settings) {
+	return func(s *Settings) {
+		s.disablePACDecoding = !b
+	}
+}
+
+// DecodePAC indicates whether the service should decode any PAC information present in the ticket.
+func (s *Settings) DecodePAC() bool {
+	return !s.disablePACDecoding
+}
+
+// ClientAddress used to configure service side with the clients host address to be used during validation.
+//
+// s := NewSettings(kt, ClientAddress(h))
+func ClientAddress(h types.HostAddress) func(*Settings) {
+	return func(s *Settings) {
+		s.cAddr = h
+	}
+}
+
+// ClientAddress returns the client host address which has been provided to the service.
+func (s *Settings) ClientAddress() types.HostAddress {
+	return s.cAddr
+}
+
+// Logger used to configure service side with a logger.
+//
+// s := NewSettings(kt, Logger(l))
+func Logger(l *log.Logger) func(*Settings) {
+	return func(s *Settings) {
+		s.logger = l
+	}
+}
+
+// Logger returns the logger instances configured for the service. If none is configured nill will be returned.
+func (s *Settings) Logger() *log.Logger {
+	return s.logger
+}
+
+// KeytabPrincipal used to override the principal name used to find the key in the keytab.
+//
+// s := NewSettings(kt, KeytabPrincipal("someaccount"))
+func KeytabPrincipal(p string) func(*Settings) {
+	return func(s *Settings) {
+		pn, _ := types.ParseSPNString(p)
+		s.ktprinc = &pn
+	}
+}
+
+// KeytabPrincipal returns the principal name used to find the key in the keytab if it has been overridden.
+func (s *Settings) KeytabPrincipal() *types.PrincipalName {
+	return s.ktprinc
+}
+
+// MaxClockSkew used to configure service side with the maximum acceptable clock skew
+// between the service and the issue time of kerberos tickets
+//
+// s := NewSettings(kt, MaxClockSkew(d))
+func MaxClockSkew(d time.Duration) func(*Settings) {
+	return func(s *Settings) {
+		s.maxClockSkew = d
+	}
+}
+
+// MaxClockSkew returns the maximum acceptable clock skew between the service and the issue time of kerberos tickets.
+// If none is defined a duration of 5 minutes is returned.
+func (s *Settings) MaxClockSkew() time.Duration {
+	if s.maxClockSkew.Nanoseconds() == 0 {
+		return time.Duration(5) * time.Minute
+	}
+	return s.maxClockSkew
+}
+
+// SName used provide a specific service name to the service settings.
+//
+// s := NewSettings(kt, SName("HTTP/some.service.com"))
+func SName(sname string) func(*Settings) {
+	return func(s *Settings) {
+		s.sname = sname
+	}
+}
+
+// SName returns the specific service name to the service.
+func (s *Settings) SName() string {
+	return s.sname
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/http.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/http.go
@@ -1,0 +1,293 @@
+package spnego
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+
+	"gopkg.in/jcmturner/goidentity.v3"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
+	"gopkg.in/jcmturner/gokrb5.v7/keytab"
+	"gopkg.in/jcmturner/gokrb5.v7/krberror"
+	"gopkg.in/jcmturner/gokrb5.v7/service"
+	"gopkg.in/jcmturner/gokrb5.v7/types"
+)
+
+// Client side functionality //
+
+// Client will negotiate authentication with a server using SPNEGO.
+type Client struct {
+	*http.Client
+	krb5Client *client.Client
+	spn        string
+	reqs       []*http.Request
+}
+
+type redirectErr struct {
+	reqTarget *http.Request
+}
+
+func (e redirectErr) Error() string {
+	return fmt.Sprintf("redirect to %v", e.reqTarget.URL)
+}
+
+type teeReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// NewClient returns an SPNEGO enabled HTTP client.
+func NewClient(krb5Cl *client.Client, httpCl *http.Client, spn string) *Client {
+	if httpCl == nil {
+		httpCl = http.DefaultClient
+	}
+	// Add a cookie jar if there isn't one
+	if httpCl.Jar == nil {
+		httpCl.Jar, _ = cookiejar.New(nil)
+	}
+	// Add a CheckRedirect function that will execute any functional already defined and then error with a redirectErr
+	f := httpCl.CheckRedirect
+	httpCl.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if f != nil {
+			err := f(req, via)
+			if err != nil {
+				return err
+			}
+		}
+		return redirectErr{reqTarget: req}
+	}
+	return &Client{
+		Client:     httpCl,
+		krb5Client: krb5Cl,
+		spn:        spn,
+	}
+}
+
+// Do is the SPNEGO enabled HTTP client's equivalent of the http.Client's Do method.
+func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
+	var body bytes.Buffer
+	if req.Body != nil {
+		// Use a tee reader to capture any body sent in case we have to replay it again
+		teeR := io.TeeReader(req.Body, &body)
+		teeRC := teeReadCloser{teeR, req.Body}
+		req.Body = teeRC
+	}
+	resp, err = c.Client.Do(req)
+	if err != nil {
+		if ue, ok := err.(*url.Error); ok {
+			if e, ok := ue.Err.(redirectErr); ok {
+				// Picked up a redirect
+				e.reqTarget.Header.Del(HTTPHeaderAuthRequest)
+				c.reqs = append(c.reqs, e.reqTarget)
+				if len(c.reqs) >= 10 {
+					return resp, errors.New("stopped after 10 redirects")
+				}
+				if req.Body != nil {
+					// Refresh the body reader so the body can be sent again
+					e.reqTarget.Body = ioutil.NopCloser(&body)
+				}
+				return c.Do(e.reqTarget)
+			}
+		}
+		return resp, err
+	}
+	if respUnauthorizedNegotiate(resp) {
+		err := SetSPNEGOHeader(c.krb5Client, req, c.spn)
+		if err != nil {
+			return resp, err
+		}
+		if req.Body != nil {
+			// Refresh the body reader so the body can be sent again
+			req.Body = ioutil.NopCloser(&body)
+		}
+		return c.Do(req)
+	}
+	return resp, err
+}
+
+// Get is the SPNEGO enabled HTTP client's equivalent of the http.Client's Get method.
+func (c *Client) Get(url string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+// Post is the SPNEGO enabled HTTP client's equivalent of the http.Client's Post method.
+func (c *Client) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return c.Do(req)
+}
+
+// PostForm is the SPNEGO enabled HTTP client's equivalent of the http.Client's PostForm method.
+func (c *Client) PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	return c.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
+// Head is the SPNEGO enabled HTTP client's equivalent of the http.Client's Head method.
+func (c *Client) Head(url string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+func respUnauthorizedNegotiate(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusUnauthorized {
+		if resp.Header.Get(HTTPHeaderAuthResponse) == HTTPHeaderAuthResponseValueKey {
+			return true
+		}
+	}
+	return false
+}
+
+// SetSPNEGOHeader gets the service ticket and sets it as the SPNEGO authorization header on HTTP request object.
+// To auto generate the SPN from the request object pass a null string "".
+func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string) error {
+	if spn == "" {
+		h := strings.TrimSuffix(strings.SplitN(r.URL.Host, ":", 2)[0], ".")
+		name, err := net.LookupCNAME(h)
+		if err == nil {
+			// Underlyng canonical name should be used for SPN
+			h = strings.TrimSuffix(name, ".")
+		}
+		spn = "HTTP/" + h
+		r.Host = h
+	}
+	cl.Log("using SPN %s", spn)
+	s := SPNEGOClient(cl, spn)
+	err := s.AcquireCred()
+	if err != nil {
+		return fmt.Errorf("could not acquire client credential: %v", err)
+	}
+	st, err := s.InitSecContext()
+	if err != nil {
+		return fmt.Errorf("could not initialize context: %v", err)
+	}
+	nb, err := st.Marshal()
+	if err != nil {
+		return krberror.Errorf(err, krberror.EncodingError, "could not marshal SPNEGO")
+	}
+	hs := "Negotiate " + base64.StdEncoding.EncodeToString(nb)
+	r.Header.Set(HTTPHeaderAuthRequest, hs)
+	return nil
+}
+
+// Service side functionality //
+
+type ctxKey string
+
+const (
+	// spnegoNegTokenRespKRBAcceptCompleted - The response on successful authentication always has this header. Capturing as const so we don't have marshaling and encoding overhead.
+	spnegoNegTokenRespKRBAcceptCompleted = "Negotiate oRQwEqADCgEAoQsGCSqGSIb3EgECAg=="
+	// spnegoNegTokenRespReject - The response on a failed authentication always has this rejection header. Capturing as const so we don't have marshaling and encoding overhead.
+	spnegoNegTokenRespReject = "Negotiate oQcwBaADCgEC"
+	// spnegoNegTokenRespIncompleteKRB5 - Response token specifying incomplete context and KRB5 as the supported mechtype.
+	spnegoNegTokenRespIncompleteKRB5 = "Negotiate oRQwEqADCgEBoQsGCSqGSIb3EgECAg=="
+	// CTXKeyAuthenticated is the request context key holding a boolean indicating if the request has been authenticated.
+	CTXKeyAuthenticated ctxKey = "github.com/jcmturner/gokrb5/CTXKeyAuthenticated"
+	// CTXKeyCredentials is the request context key holding the credentials gopkg.in/jcmturner/goidentity.v2/Identity object.
+	CTXKeyCredentials ctxKey = "github.com/jcmturner/gokrb5/CTXKeyCredentials"
+	// HTTPHeaderAuthRequest is the header that will hold authn/z information.
+	HTTPHeaderAuthRequest = "Authorization"
+	// HTTPHeaderAuthResponse is the header that will hold SPNEGO data from the server.
+	HTTPHeaderAuthResponse = "WWW-Authenticate"
+	// HTTPHeaderAuthResponseValueKey is the key in the auth header for SPNEGO.
+	HTTPHeaderAuthResponseValueKey = "Negotiate"
+	// UnauthorizedMsg is the message returned in the body when authentication fails.
+	UnauthorizedMsg = "Unauthorised.\n"
+)
+
+// SPNEGOKRB5Authenticate is a Kerberos SPNEGO authentication HTTP handler wrapper.
+func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...func(*service.Settings)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Get the auth header
+		s := strings.SplitN(r.Header.Get(HTTPHeaderAuthRequest), " ", 2)
+		if len(s) != 2 || s[0] != HTTPHeaderAuthResponseValueKey {
+			// No Authorization header set so return 401 with WWW-Authenticate Negotiate header
+			w.Header().Set(HTTPHeaderAuthResponse, HTTPHeaderAuthResponseValueKey)
+			http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+			return
+		}
+
+		// Set up the SPNEGO GSS-API mechanism
+		var spnego *SPNEGO
+		h, err := types.GetHostAddress(r.RemoteAddr)
+		if err == nil {
+			// put in this order so that if the user provides a ClientAddress it will override the one here.
+			o := append([]func(*service.Settings){service.ClientAddress(h)}, settings...)
+			spnego = SPNEGOService(kt, o...)
+		} else {
+			spnego = SPNEGOService(kt, settings...)
+			spnego.Log("%s - SPNEGO could not parse client address: %v", r.RemoteAddr, err)
+		}
+
+		// Decode the header into an SPNEGO context token
+		b, err := base64.StdEncoding.DecodeString(s[1])
+		if err != nil {
+			spnegoNegotiateKRB5MechType(spnego, w, "%s - SPNEGO error in base64 decoding negotiation header: %v", r.RemoteAddr, err)
+			return
+		}
+		var st SPNEGOToken
+		err = st.Unmarshal(b)
+		if err != nil {
+			spnegoNegotiateKRB5MechType(spnego, w, "%s - SPNEGO error in unmarshaling SPNEGO token: %v", r.RemoteAddr, err)
+			return
+		}
+
+		// Validate the context token
+		authed, ctx, status := spnego.AcceptSecContext(&st)
+		if status.Code != gssapi.StatusComplete && status.Code != gssapi.StatusContinueNeeded {
+			spnegoResponseReject(spnego, w, "%s - SPNEGO validation error: %v", r.RemoteAddr, status)
+			return
+		}
+		if status.Code == gssapi.StatusContinueNeeded {
+			spnegoNegotiateKRB5MechType(spnego, w, "%s - SPNEGO GSS-API continue needed", r.RemoteAddr)
+			return
+		}
+		if authed {
+			id := ctx.Value(CTXKeyCredentials).(goidentity.Identity)
+			requestCtx := r.Context()
+			requestCtx = context.WithValue(requestCtx, CTXKeyCredentials, id)
+			requestCtx = context.WithValue(requestCtx, CTXKeyAuthenticated, ctx.Value(CTXKeyAuthenticated))
+			spnegoResponseAcceptCompleted(spnego, w, "%s %s@%s - SPNEGO authentication succeeded", r.RemoteAddr, id.UserName(), id.Domain())
+			inner.ServeHTTP(w, r.WithContext(requestCtx))
+		} else {
+			spnegoResponseReject(spnego, w, "%s - SPNEGO Kerberos authentication failed", r.RemoteAddr)
+			return
+		}
+	})
+}
+
+func spnegoNegotiateKRB5MechType(s *SPNEGO, w http.ResponseWriter, format string, v ...interface{}) {
+	s.Log(format, v...)
+	w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespIncompleteKRB5)
+	http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+}
+
+func spnegoResponseReject(s *SPNEGO, w http.ResponseWriter, format string, v ...interface{}) {
+	s.Log(format, v...)
+	w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespReject)
+	http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+}
+
+func spnegoResponseAcceptCompleted(s *SPNEGO, w http.ResponseWriter, format string, v ...interface{}) {
+	s.Log(format, v...)
+	w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespKRBAcceptCompleted)
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/krb5Token.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/krb5Token.go
@@ -1,0 +1,236 @@
+package spnego
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"gopkg.in/jcmturner/gokrb5.v7/asn1tools"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/credentials"
+	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
+	"gopkg.in/jcmturner/gokrb5.v7/iana/chksumtype"
+	"gopkg.in/jcmturner/gokrb5.v7/iana/msgtype"
+	"gopkg.in/jcmturner/gokrb5.v7/krberror"
+	"gopkg.in/jcmturner/gokrb5.v7/messages"
+	"gopkg.in/jcmturner/gokrb5.v7/service"
+	"gopkg.in/jcmturner/gokrb5.v7/types"
+)
+
+// GSSAPI KRB5 MechToken IDs.
+const (
+	TOK_ID_KRB_AP_REQ = "0100"
+	TOK_ID_KRB_AP_REP = "0200"
+	TOK_ID_KRB_ERROR  = "0300"
+)
+
+// KRB5Token context token implementation for GSSAPI.
+type KRB5Token struct {
+	OID      asn1.ObjectIdentifier
+	tokID    []byte
+	APReq    messages.APReq
+	APRep    messages.APRep
+	KRBError messages.KRBError
+	settings *service.Settings
+	context  context.Context
+}
+
+// Marshal a KRB5Token into a slice of bytes.
+func (m *KRB5Token) Marshal() ([]byte, error) {
+	// Create the header
+	b, _ := asn1.Marshal(m.OID)
+	b = append(b, m.tokID...)
+	var tb []byte
+	var err error
+	switch hex.EncodeToString(m.tokID) {
+	case TOK_ID_KRB_AP_REQ:
+		tb, err = m.APReq.Marshal()
+		if err != nil {
+			return []byte{}, fmt.Errorf("error marshalling AP_REQ for MechToken: %v", err)
+		}
+	case TOK_ID_KRB_AP_REP:
+		return []byte{}, errors.New("marshal of AP_REP GSSAPI MechToken not supported by gokrb5")
+	case TOK_ID_KRB_ERROR:
+		return []byte{}, errors.New("marshal of KRB_ERROR GSSAPI MechToken not supported by gokrb5")
+	}
+	if err != nil {
+		return []byte{}, fmt.Errorf("error mashalling kerberos message within mech token: %v", err)
+	}
+	b = append(b, tb...)
+	return asn1tools.AddASNAppTag(b, 0), nil
+}
+
+// Unmarshal a KRB5Token.
+func (m *KRB5Token) Unmarshal(b []byte) error {
+	var oid asn1.ObjectIdentifier
+	r, err := asn1.UnmarshalWithParams(b, &oid, fmt.Sprintf("application,explicit,tag:%v", 0))
+	if err != nil {
+		return fmt.Errorf("error unmarshalling KRB5Token OID: %v", err)
+	}
+	m.OID = oid
+	m.tokID = r[0:2]
+	switch hex.EncodeToString(m.tokID) {
+	case TOK_ID_KRB_AP_REQ:
+		var a messages.APReq
+		err = a.Unmarshal(r[2:])
+		if err != nil {
+			return fmt.Errorf("error unmarshalling KRB5Token AP_REQ: %v", err)
+		}
+		m.APReq = a
+	case TOK_ID_KRB_AP_REP:
+		var a messages.APRep
+		err = a.Unmarshal(r[2:])
+		if err != nil {
+			return fmt.Errorf("error unmarshalling KRB5Token AP_REP: %v", err)
+		}
+		m.APRep = a
+	case TOK_ID_KRB_ERROR:
+		var a messages.KRBError
+		err = a.Unmarshal(r[2:])
+		if err != nil {
+			return fmt.Errorf("error unmarshalling KRB5Token KRBError: %v", err)
+		}
+		m.KRBError = a
+	}
+	return nil
+}
+
+// Verify a KRB5Token.
+func (m *KRB5Token) Verify() (bool, gssapi.Status) {
+	switch hex.EncodeToString(m.tokID) {
+	case TOK_ID_KRB_AP_REQ:
+		ok, creds, err := service.VerifyAPREQ(m.APReq, m.settings)
+		if err != nil {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+		}
+		if !ok {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveCredential, Message: "KRB5_AP_REQ token not valid"}
+		}
+		m.context = context.Background()
+		m.context = context.WithValue(m.context, CTXKeyCredentials, creds)
+		m.context = context.WithValue(m.context, CTXKeyAuthenticated, ok)
+		return true, gssapi.Status{Code: gssapi.StatusComplete}
+	case TOK_ID_KRB_AP_REP:
+		// Client side
+		// TODO how to verify the AP_REP - not yet implemented
+		return false, gssapi.Status{Code: gssapi.StatusFailure, Message: "verifying an AP_REP is not currently supported by gokrb5"}
+	case TOK_ID_KRB_ERROR:
+		if m.KRBError.MsgType != msgtype.KRB_ERROR {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "KRB5_Error token not valid"}
+		}
+		return true, gssapi.Status{Code: gssapi.StatusUnavailable}
+	}
+	return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "unknown TOK_ID in KRB5 token"}
+}
+
+// IsAPReq tests if the MechToken contains an AP_REQ.
+func (m *KRB5Token) IsAPReq() bool {
+	if hex.EncodeToString(m.tokID) == TOK_ID_KRB_AP_REQ {
+		return true
+	}
+	return false
+}
+
+// IsAPRep tests if the MechToken contains an AP_REP.
+func (m *KRB5Token) IsAPRep() bool {
+	if hex.EncodeToString(m.tokID) == TOK_ID_KRB_AP_REP {
+		return true
+	}
+	return false
+}
+
+// IsKRBError tests if the MechToken contains an KRB_ERROR.
+func (m *KRB5Token) IsKRBError() bool {
+	if hex.EncodeToString(m.tokID) == TOK_ID_KRB_ERROR {
+		return true
+	}
+	return false
+}
+
+// Context returns the KRB5 token's context which will contain any verify user identity information.
+func (m *KRB5Token) Context() context.Context {
+	return m.context
+}
+
+// NewKRB5TokenAPREQ creates a new KRB5 token with AP_REQ
+func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, GSSAPIFlags []int, APOptions []int) (KRB5Token, error) {
+	// TODO consider providing the SPN rather than the specific tkt and key and get these from the krb client.
+	var m KRB5Token
+	m.OID = gssapi.OID(gssapi.OIDKRB5)
+	tb, _ := hex.DecodeString(TOK_ID_KRB_AP_REQ)
+	m.tokID = tb
+
+	auth, err := krb5TokenAuthenticator(cl.Credentials, GSSAPIFlags)
+	if err != nil {
+		return m, err
+	}
+	APReq, err := messages.NewAPReq(
+		tkt,
+		sessionKey,
+		auth,
+	)
+	if err != nil {
+		return m, err
+	}
+	for _, o := range APOptions {
+		types.SetFlag(&APReq.APOptions, o)
+	}
+	m.APReq = APReq
+	return m, nil
+}
+
+// krb5TokenAuthenticator creates a new kerberos authenticator for kerberos MechToken
+func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.Authenticator, error) {
+	//RFC 4121 Section 4.1.1
+	auth, err := types.NewAuthenticator(creds.Domain(), creds.CName())
+	if err != nil {
+		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
+	}
+	auth.Cksum = types.Checksum{
+		CksumType: chksumtype.GSSAPI,
+		Checksum:  newAuthenticatorChksum(flags),
+	}
+	return auth, nil
+}
+
+// Create new authenticator checksum for kerberos MechToken
+func newAuthenticatorChksum(flags []int) []byte {
+	a := make([]byte, 24)
+	binary.LittleEndian.PutUint32(a[:4], 16)
+	for _, i := range flags {
+		if i == gssapi.ContextFlagDeleg {
+			x := make([]byte, 28-len(a))
+			a = append(a, x...)
+		}
+		f := binary.LittleEndian.Uint32(a[20:24])
+		f |= uint32(i)
+		binary.LittleEndian.PutUint32(a[20:24], f)
+	}
+	return a
+}
+
+/*
+The authenticator checksum field SHALL have the following format:
+
+Octet        Name      Description
+-----------------------------------------------------------------
+0..3         Lgth    Number of octets in Bnd field;  Represented
+			in little-endian order;  Currently contains
+			hex value 10 00 00 00 (16).
+4..19        Bnd     Channel binding information, as described in
+			section 4.1.1.2.
+20..23       Flags   Four-octet context-establishment flags in
+			little-endian order as described in section
+			4.1.1.1.
+24..25       DlgOpt  The delegation option identifier (=1) in
+			little-endian order [optional].  This field
+			and the next two fields are present if and
+			only if GSS_C_DELEG_FLAG is set as described
+			in section 4.1.1.1.
+26..27       Dlgth   The length of the Deleg field in little-endian order [optional].
+28..(n-1)    Deleg   A KRB_CRED message (n = Dlgth + 28) [optional].
+n..last      Exts    Extensions [optional].
+*/

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/negotiationToken.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/negotiationToken.go
@@ -1,0 +1,338 @@
+package spnego
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
+	"gopkg.in/jcmturner/gokrb5.v7/messages"
+	"gopkg.in/jcmturner/gokrb5.v7/service"
+	"gopkg.in/jcmturner/gokrb5.v7/types"
+)
+
+/*
+https://msdn.microsoft.com/en-us/library/ms995330.aspx
+
+NegotiationToken ::= CHOICE {
+  negTokenInit    [0] NegTokenInit,  This is the Negotiation token sent from the client to the server.
+  negTokenResp    [1] NegTokenResp
+}
+
+NegTokenInit ::= SEQUENCE {
+  mechTypes       [0] MechTypeList,
+  reqFlags        [1] ContextFlags  OPTIONAL,
+  -- inherited from RFC 2478 for backward compatibility,
+  -- RECOMMENDED to be left out
+  mechToken       [2] OCTET STRING  OPTIONAL,
+  mechListMIC     [3] OCTET STRING  OPTIONAL,
+  ...
+}
+
+NegTokenResp ::= SEQUENCE {
+  negState       [0] ENUMERATED {
+    accept-completed    (0),
+    accept-incomplete   (1),
+    reject              (2),
+    request-mic         (3)
+  }                                 OPTIONAL,
+  -- REQUIRED in the first reply from the target
+  supportedMech   [1] MechType      OPTIONAL,
+  -- present only in the first reply from the target
+  responseToken   [2] OCTET STRING  OPTIONAL,
+  mechListMIC     [3] OCTET STRING  OPTIONAL,
+  ...
+}
+*/
+
+// Negotiation state values.
+const (
+	NegStateAcceptCompleted  NegState = 0
+	NegStateAcceptIncomplete NegState = 1
+	NegStateReject           NegState = 2
+	NegStateRequestMIC       NegState = 3
+)
+
+// NegState is a type to indicate the SPNEGO negotiation state.
+type NegState int
+
+// NegTokenInit implements Negotiation Token of type Init.
+type NegTokenInit struct {
+	MechTypes      []asn1.ObjectIdentifier
+	ReqFlags       gssapi.ContextFlags
+	MechTokenBytes []byte
+	MechListMIC    []byte
+	mechToken      gssapi.ContextToken
+	settings       *service.Settings
+}
+
+type marshalNegTokenInit struct {
+	MechTypes      []asn1.ObjectIdentifier `asn1:"explicit,tag:0"`
+	ReqFlags       gssapi.ContextFlags     `asn1:"explicit,optional,tag:1"`
+	MechTokenBytes []byte                  `asn1:"explicit,optional,omitempty,tag:2"`
+	MechListMIC    []byte                  `asn1:"explicit,optional,omitempty,tag:3"` // This field is not used when negotiating Kerberos tokens
+}
+
+// NegTokenResp implements Negotiation Token of type Resp/Targ
+type NegTokenResp struct {
+	NegState      asn1.Enumerated
+	SupportedMech asn1.ObjectIdentifier
+	ResponseToken []byte
+	MechListMIC   []byte
+	mechToken     gssapi.ContextToken
+	settings      *service.Settings
+}
+
+type marshalNegTokenResp struct {
+	NegState      asn1.Enumerated       `asn1:"explicit,tag:0"`
+	SupportedMech asn1.ObjectIdentifier `asn1:"explicit,optional,tag:1"`
+	ResponseToken []byte                `asn1:"explicit,optional,omitempty,tag:2"`
+	MechListMIC   []byte                `asn1:"explicit,optional,omitempty,tag:3"` // This field is not used when negotiating Kerberos tokens
+}
+
+// NegTokenTarg implements Negotiation Token of type Resp/Targ
+type NegTokenTarg NegTokenResp
+
+// Marshal an Init negotiation token
+func (n *NegTokenInit) Marshal() ([]byte, error) {
+	m := marshalNegTokenInit{
+		MechTypes:      n.MechTypes,
+		ReqFlags:       n.ReqFlags,
+		MechTokenBytes: n.MechTokenBytes,
+		MechListMIC:    n.MechListMIC,
+	}
+	b, err := asn1.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	nt := asn1.RawValue{
+		Tag:        0,
+		Class:      2,
+		IsCompound: true,
+		Bytes:      b,
+	}
+	nb, err := asn1.Marshal(nt)
+	if err != nil {
+		return nil, err
+	}
+	return nb, nil
+}
+
+// Unmarshal an Init negotiation token
+func (n *NegTokenInit) Unmarshal(b []byte) error {
+	init, nt, err := UnmarshalNegToken(b)
+	if err != nil {
+		return err
+	}
+	if !init {
+		return errors.New("bytes were not that of a NegTokenInit")
+	}
+	nInit := nt.(NegTokenInit)
+	n.MechTokenBytes = nInit.MechTokenBytes
+	n.MechListMIC = nInit.MechListMIC
+	n.MechTypes = nInit.MechTypes
+	n.ReqFlags = nInit.ReqFlags
+	return nil
+}
+
+// Verify an Init negotiation token
+func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
+	// Check if supported mechanisms are in the MechTypeList
+	var mtSupported bool
+	for _, m := range n.MechTypes {
+		if m.Equal(gssapi.OID(gssapi.OIDKRB5)) || m.Equal(gssapi.OID(gssapi.OIDMSLegacyKRB5)) {
+			if n.mechToken == nil && n.MechTokenBytes == nil {
+				return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
+			}
+			mtSupported = true
+			break
+		}
+	}
+	if !mtSupported {
+		return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
+	}
+	// There should be some mechtoken bytes for a KRB5Token (other mech types are not supported)
+	mt := new(KRB5Token)
+	mt.settings = n.settings
+	if n.mechToken == nil {
+		err := mt.Unmarshal(n.MechTokenBytes)
+		if err != nil {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+		}
+		n.mechToken = mt
+	} else {
+		var ok bool
+		mt, ok = n.mechToken.(*KRB5Token)
+		if !ok {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "MechToken is not a KRB5 token as expected"}
+		}
+	}
+	// RFC4178 states that the initial negotiation message can optionally contain the initial mechanism token for the preferred mechanism of the client.
+	if !mt.OID.Equal(n.MechTypes[0]) {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "OID of MechToken does not match the first in the MechTypeList"}
+	}
+	// Verify the mechtoken
+	return n.mechToken.Verify()
+}
+
+// Context returns the SPNEGO context which will contain any verify user identity information.
+func (n *NegTokenInit) Context() context.Context {
+	if n.mechToken != nil {
+		mt, ok := n.mechToken.(*KRB5Token)
+		if !ok {
+			return nil
+		}
+		return mt.Context()
+	}
+	return nil
+}
+
+// Marshal a Resp/Targ negotiation token
+func (n *NegTokenResp) Marshal() ([]byte, error) {
+	m := marshalNegTokenResp{
+		NegState:      n.NegState,
+		SupportedMech: n.SupportedMech,
+		ResponseToken: n.ResponseToken,
+		MechListMIC:   n.MechListMIC,
+	}
+	b, err := asn1.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	nt := asn1.RawValue{
+		Tag:        1,
+		Class:      2,
+		IsCompound: true,
+		Bytes:      b,
+	}
+	nb, err := asn1.Marshal(nt)
+	if err != nil {
+		return nil, err
+	}
+	return nb, nil
+}
+
+// Unmarshal a Resp/Targ negotiation token
+func (n *NegTokenResp) Unmarshal(b []byte) error {
+	init, nt, err := UnmarshalNegToken(b)
+	if err != nil {
+		return err
+	}
+	if init {
+		return errors.New("bytes were not that of a NegTokenResp")
+	}
+	nResp := nt.(NegTokenResp)
+	n.MechListMIC = nResp.MechListMIC
+	n.NegState = nResp.NegState
+	n.ResponseToken = nResp.ResponseToken
+	n.SupportedMech = nResp.SupportedMech
+	return nil
+}
+
+// Verify a Resp/Targ negotiation token
+func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
+	if n.SupportedMech.Equal(gssapi.OID(gssapi.OIDKRB5)) || n.SupportedMech.Equal(gssapi.OID(gssapi.OIDMSLegacyKRB5)) {
+		if n.mechToken == nil && n.ResponseToken == nil {
+			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
+		}
+		mt := new(KRB5Token)
+		mt.settings = n.settings
+		if n.mechToken == nil {
+			err := mt.Unmarshal(n.ResponseToken)
+			if err != nil {
+				return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+			}
+			n.mechToken = mt
+		} else {
+			var ok bool
+			mt, ok = n.mechToken.(*KRB5Token)
+			if !ok {
+				return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "MechToken is not a KRB5 token as expected"}
+			}
+		}
+		if mt == nil {
+			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
+		}
+		// Verify the mechtoken
+		return mt.Verify()
+	}
+	return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
+}
+
+// State returns the negotiation state of the negotiation response.
+func (n *NegTokenResp) State() NegState {
+	return NegState(n.NegState)
+}
+
+// Context returns the SPNEGO context which will contain any verify user identity information.
+func (n *NegTokenResp) Context() context.Context {
+	if n.mechToken != nil {
+		mt, ok := n.mechToken.(*KRB5Token)
+		if !ok {
+			return nil
+		}
+		return mt.Context()
+	}
+	return nil
+}
+
+// UnmarshalNegToken umarshals and returns either a NegTokenInit or a NegTokenResp.
+//
+// The boolean indicates if the response is a NegTokenInit.
+// If error is nil and the boolean is false the response is a NegTokenResp.
+func UnmarshalNegToken(b []byte) (bool, interface{}, error) {
+	var a asn1.RawValue
+	_, err := asn1.Unmarshal(b, &a)
+	if err != nil {
+		return false, nil, fmt.Errorf("error unmarshalling NegotiationToken: %v", err)
+	}
+	switch a.Tag {
+	case 0:
+		var n marshalNegTokenInit
+		_, err = asn1.Unmarshal(a.Bytes, &n)
+		if err != nil {
+			return false, nil, fmt.Errorf("error unmarshalling NegotiationToken type %d (Init): %v", a.Tag, err)
+		}
+		nt := NegTokenInit{
+			MechTypes:      n.MechTypes,
+			ReqFlags:       n.ReqFlags,
+			MechTokenBytes: n.MechTokenBytes,
+			MechListMIC:    n.MechListMIC,
+		}
+		return true, nt, nil
+	case 1:
+		var n marshalNegTokenResp
+		_, err = asn1.Unmarshal(a.Bytes, &n)
+		if err != nil {
+			return false, nil, fmt.Errorf("error unmarshalling NegotiationToken type %d (Resp/Targ): %v", a.Tag, err)
+		}
+		nt := NegTokenResp{
+			NegState:      n.NegState,
+			SupportedMech: n.SupportedMech,
+			ResponseToken: n.ResponseToken,
+			MechListMIC:   n.MechListMIC,
+		}
+		return false, nt, nil
+	default:
+		return false, nil, errors.New("unknown choice type for NegotiationToken")
+	}
+
+}
+
+// NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5
+func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey) (NegTokenInit, error) {
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
+	if err != nil {
+		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %v", err)
+	}
+	mtb, err := mt.Marshal()
+	if err != nil {
+		return NegTokenInit{}, fmt.Errorf("error marshalling KRB5 token; %v", err)
+	}
+	return NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{gssapi.OID(gssapi.OIDKRB5)},
+		MechTokenBytes: mtb,
+	}, nil
+}

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/spnego.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/spnego/spnego.go
@@ -1,0 +1,199 @@
+// Package spnego implements the Simple and Protected GSSAPI Negotiation Mechanism for Kerberos authentication.
+package spnego
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"gopkg.in/jcmturner/gokrb5.v7/asn1tools"
+	"gopkg.in/jcmturner/gokrb5.v7/client"
+	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
+	"gopkg.in/jcmturner/gokrb5.v7/keytab"
+	"gopkg.in/jcmturner/gokrb5.v7/service"
+)
+
+// SPNEGO implements the GSS-API mechanism for RFC 4178
+type SPNEGO struct {
+	serviceSettings *service.Settings
+	client          *client.Client
+	spn             string
+}
+
+// SPNEGOClient configures the SPNEGO mechanism suitable for client side use.
+func SPNEGOClient(cl *client.Client, spn string) *SPNEGO {
+	s := new(SPNEGO)
+	s.client = cl
+	s.spn = spn
+	s.serviceSettings = service.NewSettings(nil, service.SName(spn))
+	return s
+}
+
+// SPNEGOService configures the SPNEGO mechanism suitable for service side use.
+func SPNEGOService(kt *keytab.Keytab, options ...func(*service.Settings)) *SPNEGO {
+	s := new(SPNEGO)
+	s.serviceSettings = service.NewSettings(kt, options...)
+	return s
+}
+
+// OID returns the GSS-API assigned OID for SPNEGO.
+func (s *SPNEGO) OID() asn1.ObjectIdentifier {
+	return gssapi.OID(gssapi.OIDSPNEGO)
+}
+
+// AcquireCred is the GSS-API method to acquire a client credential via Kerberos for SPNEGO.
+func (s *SPNEGO) AcquireCred() error {
+	return s.client.Login()
+}
+
+// InitSecContext is the GSS-API method for the client to a generate a context token to the service via Kerberos.
+func (s *SPNEGO) InitSecContext() (gssapi.ContextToken, error) {
+	tkt, key, err := s.client.GetServiceTicket(s.spn)
+	if err != nil {
+		return &SPNEGOToken{}, err
+	}
+	negTokenInit, err := NewNegTokenInitKRB5(s.client, tkt, key)
+	if err != nil {
+		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %v", err)
+	}
+	return &SPNEGOToken{
+		Init:         true,
+		NegTokenInit: negTokenInit,
+		settings:     s.serviceSettings,
+	}, nil
+}
+
+// AcceptSecContext is the GSS-API method for the service to verify the context token provided by the client and
+// establish a context.
+func (s *SPNEGO) AcceptSecContext(ct gssapi.ContextToken) (bool, context.Context, gssapi.Status) {
+	var ctx context.Context
+	t, ok := ct.(*SPNEGOToken)
+	if !ok {
+		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "context token provided was not an SPNEGO token"}
+	}
+	t.settings = s.serviceSettings
+	var oid asn1.ObjectIdentifier
+	if t.Init {
+		oid = t.NegTokenInit.MechTypes[0]
+	}
+	if t.Resp {
+		oid = t.NegTokenResp.SupportedMech
+	}
+	if !(oid.Equal(gssapi.OID(gssapi.OIDKRB5)) || oid.Equal(gssapi.OID(gssapi.OIDMSLegacyKRB5))) {
+		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO OID of MechToken is not of type KRB5"}
+	}
+	// Flags in the NegInit must be used 	t.NegTokenInit.ReqFlags
+	ok, status := t.Verify()
+	ctx = t.Context()
+	return ok, ctx, status
+}
+
+// Log will write to the service's logger if it is configured.
+func (s *SPNEGO) Log(format string, v ...interface{}) {
+	if s.serviceSettings.Logger() != nil {
+		s.serviceSettings.Logger().Printf(format, v...)
+	}
+}
+
+// SPNEGOToken is a GSS-API context token
+type SPNEGOToken struct {
+	Init         bool
+	Resp         bool
+	NegTokenInit NegTokenInit
+	NegTokenResp NegTokenResp
+	settings     *service.Settings
+	context      context.Context
+}
+
+// Marshal SPNEGO context token
+func (s *SPNEGOToken) Marshal() ([]byte, error) {
+	var b []byte
+	if s.Init {
+		hb, _ := asn1.Marshal(gssapi.OID(gssapi.OIDSPNEGO))
+		tb, err := s.NegTokenInit.Marshal()
+		if err != nil {
+			return b, fmt.Errorf("could not marshal NegTokenInit: %v", err)
+		}
+		b = append(hb, tb...)
+		return asn1tools.AddASNAppTag(b, 0), nil
+	}
+	if s.Resp {
+		b, err := s.NegTokenResp.Marshal()
+		if err != nil {
+			return b, fmt.Errorf("could not marshal NegTokenResp: %v", err)
+		}
+		return b, nil
+	}
+	return b, errors.New("SPNEGO cannot be marshalled. It contains neither a NegTokenInit or NegTokenResp")
+}
+
+// Unmarshal SPNEGO context token
+func (s *SPNEGOToken) Unmarshal(b []byte) error {
+	var r []byte
+	var err error
+	if b[0] != byte(161) {
+		// Not a NegTokenResp/Targ could be a NegTokenInit
+		var oid asn1.ObjectIdentifier
+		r, err = asn1.UnmarshalWithParams(b, &oid, fmt.Sprintf("application,explicit,tag:%v", 0))
+		if err != nil {
+			return fmt.Errorf("not a valid SPNEGO token: %v", err)
+		}
+		// Check the OID is the SPNEGO OID value
+		SPNEGOOID := gssapi.OID(gssapi.OIDSPNEGO)
+		if !oid.Equal(SPNEGOOID) {
+			return fmt.Errorf("OID %s does not match SPNEGO OID %s", oid.String(), SPNEGOOID.String())
+		}
+	} else {
+		// Could be a NegTokenResp/Targ
+		r = b
+	}
+
+	_, nt, err := UnmarshalNegToken(r)
+	if err != nil {
+		return err
+	}
+	switch v := nt.(type) {
+	case NegTokenInit:
+		s.Init = true
+		s.NegTokenInit = v
+		s.NegTokenInit.settings = s.settings
+	case NegTokenResp:
+		s.Resp = true
+		s.NegTokenResp = v
+		s.NegTokenResp.settings = s.settings
+	default:
+		return errors.New("unknown choice type for NegotiationToken")
+	}
+	return nil
+}
+
+// Verify the SPNEGOToken
+func (s *SPNEGOToken) Verify() (bool, gssapi.Status) {
+	if (!s.Init && !s.Resp) || (s.Init && s.Resp) {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "invalid SPNEGO token, unclear if NegTokenInit or NegTokenResp"}
+	}
+	if s.Init {
+		s.NegTokenInit.settings = s.settings
+		ok, status := s.NegTokenInit.Verify()
+		if ok {
+			s.context = s.NegTokenInit.Context()
+		}
+		return ok, status
+	}
+	if s.Resp {
+		s.NegTokenResp.settings = s.settings
+		ok, status := s.NegTokenResp.Verify()
+		if ok {
+			s.context = s.NegTokenResp.Context()
+		}
+		return ok, status
+	}
+	// should not be possible to get here
+	return false, gssapi.Status{Code: gssapi.StatusFailure, Message: "unable to verify SPNEGO token"}
+}
+
+// Context returns the SPNEGO context which will contain any verify user identity information.
+func (s *SPNEGOToken) Context() context.Context {
+	return s.context
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1048,6 +1048,8 @@ gopkg.in/inf.v0
 gopkg.in/jcmturner/aescts.v1
 # gopkg.in/jcmturner/dnsutils.v1 v1.0.1
 gopkg.in/jcmturner/dnsutils.v1
+# gopkg.in/jcmturner/goidentity.v3 v3.0.0
+gopkg.in/jcmturner/goidentity.v3
 # gopkg.in/jcmturner/gokrb5.v7 v7.3.0
 gopkg.in/jcmturner/gokrb5.v7/asn1tools
 gopkg.in/jcmturner/gokrb5.v7/client
@@ -1078,6 +1080,8 @@ gopkg.in/jcmturner/gokrb5.v7/keytab
 gopkg.in/jcmturner/gokrb5.v7/krberror
 gopkg.in/jcmturner/gokrb5.v7/messages
 gopkg.in/jcmturner/gokrb5.v7/pac
+gopkg.in/jcmturner/gokrb5.v7/service
+gopkg.in/jcmturner/gokrb5.v7/spnego
 gopkg.in/jcmturner/gokrb5.v7/types
 # gopkg.in/jcmturner/rpc.v1 v1.1.0
 gopkg.in/jcmturner/rpc.v1/mstypes

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -449,6 +449,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -716,6 +737,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1302,6 +1326,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -582,6 +582,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -849,6 +870,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1435,6 +1459,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1970,6 +1970,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -2237,6 +2258,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -2823,6 +2847,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -792,6 +792,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -1304,6 +1325,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1705,6 +1705,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -1972,6 +1993,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -2558,6 +2582,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -452,6 +452,27 @@ output.elasticsearch:
   # The pin is a base64 encoded string of the SHA-256 fingerprint.
   #ssl.ca_sha256
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #----------------------------- Logstash output ---------------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
@@ -719,6 +740,9 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
 
   # Authentication type to use with Kerberos. Available options: keytab, password.
   #kerberos.auth_type: password
@@ -1305,6 +1329,27 @@ logging.files:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m


### PR DESCRIPTION
Cherry-pick of PR #17927 to 7.x branch. Original message: 

## What does this PR do?

This PR adds support for Kerberos authentication to Elasticsearch output.

### Configuration

Users can authenticate using either passwords or keytabs.

The option `service_name` is not exposed as in case of ES it has be `HTTP`. Thus, the [SPN](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html) of the output is always `HTTP/{output.elasticsearch.host}@{output.elasticsearch.kerberos.realm}`.

```yaml
# Authentication type to use with Kerberos. Available options: keytab, password.
#kerberos.auth_type: password

# Path to the keytab file. It is used when auth_type is set to keytab.
#kerberos.keytab: /etc/elastic.keytab

# Path to the Kerberos configuration.
#kerberos.config_path: /etc/krb5.conf

# Name of the Kerberos user.
#kerberos.username: elastic

# Password of the Kerberos user. It is used when auth_type is set to password.
#kerberos.password: changeme

# Kerberos realm.
#kerberos.realm: ELASTIC
```

### Architecture

Kerberos authentication is implemented by using the `spnego.Client` from `gopkg.in/jcmturner/gokrb5/v7.5`. It is an HTTP client which is able to authenticate to a Kerberos [KDC](https://en.wikipedia.org/wiki/Key_distribution_center) and get the required session key to authenticate to Elasticsearch.

In order to use the client when communicating with ES, I introduced a new interface named `esHTTPClient` with the following functions: 

```golang
type esHTTPClient interface {
	Do(req *http.Request) (resp *http.Response, err error)
	CloseIdleConnections()
}
```

So the newly created `kerberos.Client` and `http.Client` can be used in `Connection`.

The only drawback of this solution is that it is not compatible with `github.com/elastic/go-elasticsearch`. The main issue is the constructor of that package only lets us configure `http.Transport`. However, `http.Transport` should be used for authentication according to Golang documentation. For the record, it is possible to implement Kerberos authentication in a special `RoundTripper`, but I am not a huge fan of that approach as the Golang docs advise against it.

Reference:
- [SPNEGO client](https://pkg.go.dev/github.com/jcmturner/gokrb5@v7.5.0+incompatible/spnego?tab=doc#Client)
- [http.Transport](https://golang.org/pkg/net/http/#Transport)

### Testing

I am planning to add tests in a follow-up PR. I wanted to raise this first, so we can agree on the selected architecture.

## Why is it important?

Users now can authenticate to Kerberos-aware Elasticsearch instances.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.