### PR TITLE
Cherry-pick #16701 to 7.x: Decouple fileset from inputs

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/autodiscover"
 	"github.com/elastic/beats/v7/libbeat/autodiscover/builder"
 	"github.com/elastic/beats/v7/libbeat/autodiscover/template"
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/bus"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -60,7 +61,7 @@ func NewLogHints(cfg *common.Config) (autodiscover.Builder, error) {
 		return nil, fmt.Errorf("unable to unpack hints config due to error: %v", err)
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry([]*common.Config{}, "", false)
+	moduleRegistry, err := fileset.NewModuleRegistry(nil, beat.Info{}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -84,7 +84,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info.Version, true)
+	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info, true)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 		// When running the subcommand setup, configuration from modules.d directories
 		// have to be loaded using cfg.Reloader. Otherwise those configurations are skipped.
 		pipelineLoaderFactory := newPipelineLoaderFactory(b.Config.Output.Config())
-		modulesFactory := fileset.NewSetupFactory(b.Info.Version, pipelineLoaderFactory)
+		modulesFactory := fileset.NewSetupFactory(b.Info, pipelineLoaderFactory)
 		if fb.config.ConfigModules.Enabled() {
 			modulesLoader := cfgfile.NewReloader(b.Publisher, fb.config.ConfigModules)
 			modulesLoader.Load(modulesFactory)
@@ -336,13 +336,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	inputLoader := input.NewRunnerFactory(pipelineConnector, registrar, fb.done)
-	moduleLoader := fileset.NewFactory(pipelineConnector,
-		registrar,
-		b.Info.Version,
-		pipelineLoaderFactory,
-		config.OverwritePipelines,
-		fb.done,
-	)
+	moduleLoader := fileset.NewFactory(inputLoader, b.Info, pipelineLoaderFactory, config.OverwritePipelines)
 
 	crawler, err := newCrawler(inputLoader, moduleLoader, config.Inputs, fb.done, *once)
 	if err != nil {

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -255,7 +255,7 @@ func (fb *Filebeat) loadModulesML(b *beat.Beat, kibanaConfig *common.Config) err
 				errs = append(errs, errors.Wrap(err, "error loading config file"))
 				continue
 			}
-			set, err := fileset.NewModuleRegistry(confs, "", false)
+			set, err := fileset.NewModuleRegistry(confs, b.Info, false)
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -20,9 +20,6 @@ package fileset
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/elastic/beats/v7/filebeat/channel"
-	"github.com/elastic/beats/v7/filebeat/input"
-	"github.com/elastic/beats/v7/filebeat/registrar"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -44,33 +41,33 @@ func init() {
 
 // Factory for modules
 type Factory struct {
-	outlet                channel.Factory
-	registrar             *registrar.Registrar
-	beatVersion           string
+	beatInfo              beat.Info
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
 	pipelineCallbackID    uuid.UUID
-	beatDone              chan struct{}
+	inputFactory          cfgfile.RunnerFactory
 }
 
 // Wrap an array of inputs and implements cfgfile.Runner interface
 type inputsRunner struct {
 	id                    uint64
 	moduleRegistry        *ModuleRegistry
-	inputs                []*input.Runner
+	inputs                []cfgfile.Runner
 	pipelineLoaderFactory PipelineLoaderFactory
 	pipelineCallbackID    uuid.UUID
 	overwritePipelines    bool
 }
 
 // NewFactory instantiates a new Factory
-func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVersion string,
-	pipelineLoaderFactory PipelineLoaderFactory, overwritePipelines bool, beatDone chan struct{}) *Factory {
+func NewFactory(
+	inputFactory cfgfile.RunnerFactory,
+	beatInfo beat.Info,
+	pipelineLoaderFactory PipelineLoaderFactory,
+	overwritePipelines bool,
+) *Factory {
 	return &Factory{
-		outlet:                outlet,
-		registrar:             registrar,
-		beatVersion:           beatVersion,
-		beatDone:              beatDone,
+		inputFactory:          inputFactory,
+		beatInfo:              beatInfo,
 		pipelineLoaderFactory: pipelineLoaderFactory,
 		pipelineCallbackID:    uuid.Nil,
 		overwritePipelines:    overwritePipelines,
@@ -80,7 +77,7 @@ func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVers
 // Create creates a module based on a config
 func (f *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
 	// Start a registry of one module:
-	m, err := NewModuleRegistry([]*common.Config{c}, f.beatVersion, false)
+	m, err := NewModuleRegistry([]*common.Config{c}, f.beatInfo, false)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +95,9 @@ func (f *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrP
 		return nil, err
 	}
 
-	inputs := make([]*input.Runner, len(pConfigs))
-	connector := f.outlet(p)
+	inputs := make([]cfgfile.Runner, len(pConfigs))
 	for i, pConfig := range pConfigs {
-		inputs[i], err = input.New(pConfig, connector, f.beatDone, f.registrar.GetStates(), meta)
+		inputs[i], err = f.inputFactory.Create(p, pConfig, meta)
 		if err != nil {
 			logp.Err("Error creating input: %s", err)
 			return nil, err

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -15,11 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/*
-Package fileset contains the code that loads Filebeat modules (which are
-composed of filesets).
-*/
-
+// Package fileset contains the code that loads Filebeat modules (which are
+// composed of filesets).
 package fileset
 
 import (
@@ -39,6 +36,7 @@ import (
 	errw "github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -70,7 +68,7 @@ func New(
 
 	modulePath := filepath.Join(modulesPath, mcfg.Module)
 	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("Module %s (%s) doesn't exist.", mcfg.Module, modulePath)
+		return nil, fmt.Errorf("module %s (%s) doesn't exist", mcfg.Module, modulePath)
 	}
 
 	return &Fileset{
@@ -87,19 +85,19 @@ func (fs *Fileset) String() string {
 }
 
 // Read reads the manifest file and evaluates the variables.
-func (fs *Fileset) Read(beatVersion string) error {
+func (fs *Fileset) Read(info beat.Info) error {
 	var err error
 	fs.manifest, err = fs.readManifest()
 	if err != nil {
 		return err
 	}
 
-	fs.vars, err = fs.evaluateVars(beatVersion)
+	fs.vars, err = fs.evaluateVars(info)
 	if err != nil {
 		return err
 	}
 
-	fs.pipelineIDs, err = fs.getPipelineIDs(beatVersion)
+	fs.pipelineIDs, err = fs.getPipelineIDs(info)
 	if err != nil {
 		return err
 	}
@@ -160,10 +158,10 @@ func (fs *Fileset) readManifest() (*manifest, error) {
 }
 
 // evaluateVars resolves the fileset variables.
-func (fs *Fileset) evaluateVars(beatVersion string) (map[string]interface{}, error) {
+func (fs *Fileset) evaluateVars(info beat.Info) (map[string]interface{}, error) {
 	var err error
 	vars := map[string]interface{}{}
-	vars["builtin"], err = fs.getBuiltinVars(beatVersion)
+	vars["builtin"], err = fs.getBuiltinVars(info)
 	if err != nil {
 		return nil, err
 	}
@@ -301,6 +299,7 @@ func getTemplateFunctions(vars map[string]interface{}) (template.FuncMap, error)
 	return template.FuncMap{
 		"IngestPipeline": func(shortID string) string {
 			return formatPipelineID(
+				builtinVars["prefix"].(string),
 				builtinVars["module"].(string),
 				builtinVars["fileset"].(string),
 				shortID,
@@ -312,7 +311,7 @@ func getTemplateFunctions(vars map[string]interface{}) (template.FuncMap, error)
 
 // getBuiltinVars computes the supported built in variables and groups them
 // in a dictionary
-func (fs *Fileset) getBuiltinVars(beatVersion string) (map[string]interface{}, error) {
+func (fs *Fileset) getBuiltinVars(info beat.Info) (map[string]interface{}, error) {
 	host, err := os.Hostname()
 	if err != nil || len(host) == 0 {
 		return nil, fmt.Errorf("Error getting the hostname: %v", err)
@@ -325,11 +324,12 @@ func (fs *Fileset) getBuiltinVars(beatVersion string) (map[string]interface{}, e
 	}
 
 	return map[string]interface{}{
+		"prefix":      info.IndexPrefix,
 		"hostname":    hostname,
 		"domain":      domain,
 		"module":      fs.mcfg.Module,
 		"fileset":     fs.name,
-		"beatVersion": beatVersion,
+		"beatVersion": info.Version,
 	}, nil
 }
 
@@ -397,7 +397,7 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 }
 
 // getPipelineIDs returns the Ingest Node pipeline IDs
-func (fs *Fileset) getPipelineIDs(beatVersion string) ([]string, error) {
+func (fs *Fileset) getPipelineIDs(info beat.Info) ([]string, error) {
 	var pipelineIDs []string
 	for _, ingestPipeline := range fs.manifest.IngestPipeline {
 		path, err := applyTemplate(fs.vars, ingestPipeline, false)
@@ -405,7 +405,7 @@ func (fs *Fileset) getPipelineIDs(beatVersion string) ([]string, error) {
 			return nil, fmt.Errorf("Error expanding vars on the ingest pipeline path: %v", err)
 		}
 
-		pipelineIDs = append(pipelineIDs, formatPipelineID(fs.mcfg.Module, fs.name, path, beatVersion))
+		pipelineIDs = append(pipelineIDs, formatPipelineID(info.IndexPrefix, fs.mcfg.Module, fs.name, path, info.Version))
 	}
 
 	return pipelineIDs, nil
@@ -500,8 +500,8 @@ func fixYAMLMaps(elem interface{}) (_ interface{}, err error) {
 }
 
 // formatPipelineID generates the ID to be used for the pipeline ID in Elasticsearch
-func formatPipelineID(module, fileset, path, beatVersion string) string {
-	return fmt.Sprintf("filebeat-%s-%s-%s-%s", beatVersion, module, fileset, removeExt(filepath.Base(path)))
+func formatPipelineID(prefix, module, fileset, path, version string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s", prefix, version, module, fileset, removeExt(filepath.Base(path)))
 }
 
 // removeExt returns the file name without the extension. If no dot is found,

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -30,8 +30,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
+
+func makeTestInfo(version string) beat.Info {
+	return beat.Info{
+		IndexPrefix: "filebeat",
+		Version:     version,
+	}
+}
 
 func getModuleForTesting(t *testing.T, module, fileset string) *Fileset {
 	modulesPath, err := filepath.Abs("../module")
@@ -60,7 +68,7 @@ func TestLoadManifestNginx(t *testing.T) {
 func TestGetBuiltinVars(t *testing.T) {
 	fs := getModuleForTesting(t, "nginx", "access")
 
-	vars, err := fs.getBuiltinVars("6.6.0")
+	vars, err := fs.getBuiltinVars(makeTestInfo("6.6.0"))
 	assert.NoError(t, err)
 
 	assert.IsType(t, vars["hostname"], "a-mac-with-esc-key")
@@ -77,7 +85,7 @@ func TestEvaluateVarsNginx(t *testing.T) {
 	fs.manifest, err = fs.readManifest()
 	assert.NoError(t, err)
 
-	vars, err := fs.evaluateVars("6.6.0")
+	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
 	assert.NoError(t, err)
 
 	builtin := vars["builtin"].(map[string]interface{})
@@ -100,7 +108,7 @@ func TestEvaluateVarsNginxOverride(t *testing.T) {
 	fs.manifest, err = fs.readManifest()
 	assert.NoError(t, err)
 
-	vars, err := fs.evaluateVars("6.6.0")
+	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "no_plugins", vars["pipeline"])
@@ -113,7 +121,7 @@ func TestEvaluateVarsMySQL(t *testing.T) {
 	fs.manifest, err = fs.readManifest()
 	assert.NoError(t, err)
 
-	vars, err := fs.evaluateVars("6.6.0")
+	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
 	assert.NoError(t, err)
 
 	builtin := vars["builtin"].(map[string]interface{})
@@ -171,7 +179,7 @@ func TestResolveVariable(t *testing.T) {
 
 func TestGetInputConfigNginx(t *testing.T) {
 	fs := getModuleForTesting(t, "nginx", "access")
-	assert.NoError(t, fs.Read("5.2.0"))
+	assert.NoError(t, fs.Read(makeTestInfo("5.2.0")))
 
 	cfg, err := fs.getInputConfig()
 	assert.NoError(t, err)
@@ -236,7 +244,7 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.NoError(t, fs.Read("5.2.0"))
+			assert.NoError(t, fs.Read(makeTestInfo("5.2.0")))
 
 			cfg, err := fs.getInputConfig()
 			assert.NoError(t, err)
@@ -260,7 +268,7 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 
 func TestGetPipelineNginx(t *testing.T) {
 	fs := getModuleForTesting(t, "nginx", "access")
-	assert.NoError(t, fs.Read("5.2.0"))
+	assert.NoError(t, fs.Read(makeTestInfo("5.2.0")))
 
 	version := common.MustNewVersion("5.2.0")
 	pipelines, err := fs.GetPipelines(*version)

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/kibana"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -48,7 +49,8 @@ type ModuleRegistry struct {
 func newModuleRegistry(modulesPath string,
 	moduleConfigs []*ModuleConfig,
 	overrides *ModuleOverrides,
-	beatVersion string) (*ModuleRegistry, error) {
+	beatInfo beat.Info,
+) (*ModuleRegistry, error) {
 
 	var reg ModuleRegistry
 	reg.registry = map[string]map[string]*Fileset{}
@@ -89,7 +91,7 @@ func newModuleRegistry(modulesPath string,
 			if err != nil {
 				return nil, err
 			}
-			err = fileset.Read(beatVersion)
+			err = fileset.Read(beatInfo)
 			if err != nil {
 				return nil, fmt.Errorf("Error reading fileset %s/%s: %v", mcfg.Module, filesetName, err)
 			}
@@ -108,7 +110,7 @@ func newModuleRegistry(modulesPath string,
 				}
 			}
 			if !found {
-				return nil, fmt.Errorf("Fileset %s/%s is configured but doesn't exist", mcfg.Module, filesetName)
+				return nil, fmt.Errorf("fileset %s/%s is configured but doesn't exist", mcfg.Module, filesetName)
 			}
 		}
 	}
@@ -117,7 +119,7 @@ func newModuleRegistry(modulesPath string,
 }
 
 // NewModuleRegistry reads and loads the configured module into the registry.
-func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string, init bool) (*ModuleRegistry, error) {
+func NewModuleRegistry(moduleConfigs []*common.Config, beatInfo beat.Info, init bool) (*ModuleRegistry, error) {
 	modulesPath := paths.Resolve(paths.Home, "module")
 
 	stat, err := os.Stat(modulesPath)
@@ -153,7 +155,7 @@ func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string, init 
 		return nil, err
 	}
 
-	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides, beatVersion)
+	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides, beatInfo)
 }
 
 func mcfgFromConfig(cfg *common.Config) (*ModuleConfig, error) {

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -26,9 +26,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegtest"
 )
+
+func makeTestInfo(version string) beat.Info {
+	return beat.Info{
+		IndexPrefix: "filebeat",
+		Version:     version,
+	}
+}
 
 func TestLoadPipeline(t *testing.T) {
 	client := getTestingElasticsearch(t)
@@ -97,7 +105,7 @@ func TestSetupNginx(t *testing.T) {
 		&ModuleConfig{Module: "nginx"},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("5.2.0"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +184,7 @@ func TestLoadMultiplePipelines(t *testing.T) {
 		&ModuleConfig{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "6.6.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +229,7 @@ func TestLoadMultiplePipelinesWithRollback(t *testing.T) {
 		&ModuleConfig{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "6.6.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/paths"
 )
@@ -50,7 +51,7 @@ func TestNewModuleRegistry(t *testing.T) {
 		&ModuleConfig{Module: "auditd"},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -115,7 +116,7 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -139,7 +140,7 @@ func TestMovedModule(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 }
@@ -395,7 +396,7 @@ func TestMissingModuleFolder(t *testing.T) {
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
-	reg, err := NewModuleRegistry(configs, "5.2.0", true)
+	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0"}, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -26,15 +26,15 @@ import (
 
 // SetupFactory is for loading module assets when running setup subcommand.
 type SetupFactory struct {
-	beatVersion           string
+	beatInfo              beat.Info
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
 }
 
 // NewSetupFactory creates a SetupFactory
-func NewSetupFactory(beatVersion string, pipelineLoaderFactory PipelineLoaderFactory) *SetupFactory {
+func NewSetupFactory(beatInfo beat.Info, pipelineLoaderFactory PipelineLoaderFactory) *SetupFactory {
 	return &SetupFactory{
-		beatVersion:           beatVersion,
+		beatInfo:              beatInfo,
 		pipelineLoaderFactory: pipelineLoaderFactory,
 		overwritePipelines:    true,
 	}
@@ -42,7 +42,7 @@ func NewSetupFactory(beatVersion string, pipelineLoaderFactory PipelineLoaderFac
 
 // Create creates a new SetupCfgRunner to setup module configuration.
 func (sf *SetupFactory) Create(_ beat.Pipeline, c *common.Config, _ *common.MapStrPointer) (cfgfile.Runner, error) {
-	m, err := NewModuleRegistry([]*common.Config{c}, sf.beatVersion, false)
+	m, err := NewModuleRegistry([]*common.Config{c}, sf.beatInfo, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick of PR #16701 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

The fileset package used to depend on the filebeat.input package
to generate and load actual inputs. This change removes the dependency,
by passing a cfgfile.RunnerFactory instance to the fileset factory
constructor.

Besides fileset only being used by filebeat, this makes the package independent of any Beats and might become a reusable component we can move to libbeat.

The change only changes how the factory is intialized. This should not result in any breaking or user facing changes.

## Why is it important?

As part of the input refactoring we will have different RunnerFactory instance for the different input types. These will be combined into one single RunnerFactory and passed to the Fileset factory. For this to work we need the fileset package to be independent from the internal filebeat.input package.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Testplan

The change replaces an hard coded string with a variable. If the variable is not correctly set when initializing the beat we might end up with wrong pipeline names.

1. configure filebeat with some module enabled
2. index data using the module
3. check the `filebeat-*` pipelines do exist
4. verify the indexed data have been parsed (did use correct pipeline).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->

- Requires elastic/beats#16700 