### PR TITLE
Fix metricbeat generator test to use mage test

### DIFF
--- a/generator/_templates/metricbeat/{beat}/magefile.go
+++ b/generator/_templates/metricbeat/{beat}/magefile.go
@@ -46,6 +46,7 @@ func Package() {
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
 	devtools.UseCommunityBeatPackaging()
+	devtools.PackageKibanaDashboardsFromBuildDir()
 
 	mg.Deps(Update)
 	mg.Deps(build.CrossBuild, build.CrossBuildGoDaemon)

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -16,7 +16,7 @@ test: prepare-test
 	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
-	$(MAKE) unit
+	mage unit-test
 
 .PHONY: test-package
 test-package: test

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -16,7 +16,7 @@ test: prepare-test
 	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
-	mage unit-test
+	$(MAKE) unit-test
 
 .PHONY: test-package
 test-package: test

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -16,7 +16,7 @@ test: prepare-test
 	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \
-	$(MAKE) unit-test
+	mage test
 
 .PHONY: test-package
 test-package: test


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Updates the generated custom metricbeat to use `mage test` instead of `make unit`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So the generator tests pass.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
