### PR TITLE
[Elastic-Agent] Use default output by default

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@
 - Make sure that the Elastic Agent connect over TLS in cloud. {pull}17843[17843]
 - Moved stream.* fields to top of event {pull}17858[17858]
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
+- Use default output by default {pull}18091[18091]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/monitoring_decorator.go
+++ b/x-pack/elastic-agent/pkg/agent/application/monitoring_decorator.go
@@ -19,10 +19,11 @@ const (
 	monitoringOutputFormatKey = "outputs.%s"
 	outputKey                 = "output"
 
-	enabledKey       = "settings.monitoring.enabled"
-	outputsKey       = "outputs"
-	elasticsearchKey = "elasticsearch"
-	typeKey          = "type"
+	enabledKey        = "settings.monitoring.enabled"
+	outputsKey        = "outputs"
+	elasticsearchKey  = "elasticsearch"
+	typeKey           = "type"
+	defaultOutputName = "default"
 )
 
 func injectMonitoring(outputGroup string, rootAst *transpiler.AST, programsToRun []program.Program) ([]program.Program, error) {
@@ -40,17 +41,17 @@ func injectMonitoring(outputGroup string, rootAst *transpiler.AST, programsToRun
 		config[enabledKey] = false
 	} else {
 		// get monitoring output name to be used
+		monitoringOutputName := defaultOutputName
 		useOutputNode, found := transpiler.Lookup(rootAst, monitoringUseOutputKey)
-		if !found {
-			return programsToRun, nil
-		}
+		if found {
 
-		monitoringOutputNameKey, ok := useOutputNode.Value().(*transpiler.StrVal)
-		if !ok {
-			return programsToRun, nil
-		}
+			monitoringOutputNameKey, ok := useOutputNode.Value().(*transpiler.StrVal)
+			if !ok {
+				return programsToRun, nil
+			}
 
-		monitoringOutputName := monitoringOutputNameKey.String()
+			monitoringOutputName = monitoringOutputNameKey.String()
+		}
 
 		ast := rootAst.Clone()
 		if err := getMonitoringRule(monitoringOutputName).Apply(ast); err != nil {


### PR DESCRIPTION
## What does this PR do?

Releases neccesity of having `use_output` specified with monitoring settings. 
if not output is specified the one called `default` is used

## Why is it important?

Default configurations does not state use output settings so this might be confusing

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
