### PR TITLE
[Filebeat] Improve ECS categorization field mappings for netflow module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -281,6 +281,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings in rabbitmq module. {issue}16178[16178] {pull}17916[17916]
 - Improve ECS categorization field mappings in redis module. {issue}16179[16179] {pull}17918[17918]
 - Improve ECS categorization field mappings for zeek module. {issue}16029[16029] {pull}17738[17738]
+- Improve ECS categorization field mappings for netflow module. {issue}16135[16135] {pull}18108[18108]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -320,9 +320,7 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 		event.Fields["network"] = ecsNetwork
 	}
 	if len(relatedIP) > 0 {
-		ecsRelated := common.MapStr{}
-		ecsRelated["ip"] = relatedIP
-		event.Fields["related"] = ecsRelated
+		event.Fields["related"] = common.MapStr{"ip": relatedIP}
 	}
 	return
 }

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -66,8 +66,11 @@ func toBeatEventCommon(flow record.Record) (event beat.Event) {
 	ecsEvent := common.MapStr{
 		"created":  flow.Timestamp,
 		"kind":     "event",
-		"category": "network_traffic",
+		"category": []string{"network_traffic", "network"},
 		"action":   flow.Fields["type"],
+	}
+	if ecsEvent["action"] == "netflow_flow" {
+		ecsEvent["type"] = []string{"connection"}
 	}
 	// ECS Fields -- device
 	ecsDevice := common.MapStr{}
@@ -155,9 +158,10 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 	}
 
 	flowDirection, hasFlowDirection := getKeyUint64(flow.Fields, "flowDirection")
-	// ECS Fields -- source and destination
+	// ECS Fields -- source, destination & related.ip
 	ecsSource := common.MapStr{}
 	ecsDest := common.MapStr{}
+	var relatedIP []net.IP
 
 	// Populate first with WLAN fields
 	if hasFlowDirection {
@@ -189,6 +193,7 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 	// Regular IPv4 fields
 	if ip, found := getKeyIP(flow.Fields, "sourceIPv4Address"); found {
 		ecsSource["ip"] = ip
+		relatedIP = append(relatedIP, ip)
 		ecsSource["locality"] = getIPLocality(ip).String()
 	}
 	if sourcePort, found := getKeyUint64(flow.Fields, "sourceTransportPort"); found {
@@ -201,6 +206,7 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 	// ECS Fields -- destination
 	if ip, found := getKeyIP(flow.Fields, "destinationIPv4Address"); found {
 		ecsDest["ip"] = ip
+		relatedIP = append(relatedIP, ip)
 		ecsDest["locality"] = getIPLocality(ip).String()
 	}
 	if destPort, found := getKeyUint64(flow.Fields, "destinationTransportPort"); found {
@@ -312,6 +318,11 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 	}
 	if len(ecsNetwork) > 0 {
 		event.Fields["network"] = ecsNetwork
+	}
+	if len(relatedIP) > 0 {
+		ecsRelated := common.MapStr{}
+		ecsRelated["ip"] = relatedIP
+		event.Fields["related"] = ecsRelated
 	}
 	return
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -12,10 +12,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-18T08:16:47Z",
           "duration": 0,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "kSpZ1WuBhjc",
@@ -70,6 +76,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.236.5.4",
+            "64.235.151.76"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "10.236.5.4",
@@ -93,10 +105,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-18T08:16:47Z",
           "duration": 0,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "kSpZ1WuBhjc",
@@ -150,6 +168,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "64.235.151.76",
+            "10.236.5.4"
+          ]
         },
         "source": {
           "bytes": 0,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -12,10 +12,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20269000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2vFIarATx_4",
@@ -58,6 +64,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.99.130.239",
+            "10.99.252.50"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "10.99.130.239",
@@ -81,10 +93,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20269000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2vFIarATx_4",
@@ -127,6 +145,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.99.252.50",
+            "10.99.130.239"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "10.99.252.50",
@@ -150,10 +174,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20306000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wU3G8idsscw",
@@ -196,6 +226,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.99.130.239",
+            "10.98.243.20"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "10.99.130.239",
@@ -219,10 +255,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20306000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wU3G8idsscw",
@@ -265,6 +307,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.98.243.20",
+            "10.99.130.239"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "10.98.243.20",
@@ -288,10 +336,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20317000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rOmj8EdZ2dc",
@@ -334,6 +388,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.99.168.140",
+            "10.98.243.20"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "10.99.168.140",
@@ -357,10 +417,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20317000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rOmj8EdZ2dc",
@@ -403,6 +469,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.98.243.20",
+            "10.99.168.140"
+          ]
+        },
         "source": {
           "bytes": 113,
           "ip": "10.98.243.20",
@@ -426,10 +498,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20368000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "JE7pThaMwJY",
@@ -472,6 +550,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.99.168.140",
+            "10.98.243.20"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "10.99.168.140",
@@ -495,10 +579,16 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-29T13:58:28Z",
           "duration": 20368000000,
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "JE7pThaMwJY",
@@ -540,6 +630,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.98.243.20",
+            "10.99.168.140"
+          ]
         },
         "source": {
           "bytes": 113,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1SREAwMSn_Y",
@@ -57,6 +63,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.197",
+            "192.168.128.17"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "10.10.8.197",
@@ -79,9 +91,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-1ecQ0Y-YzY",
@@ -124,6 +142,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.35.143",
+            "192.168.230.216"
+          ]
+        },
         "source": {
           "bytes": 502,
           "ip": "192.168.35.143",
@@ -146,9 +170,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_ztnBsqvzw4",
@@ -191,6 +221,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.6.11",
+            "192.168.35.143"
+          ]
+        },
         "source": {
           "bytes": 2233,
           "ip": "10.10.6.11",
@@ -213,9 +249,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "83jerlRbQig",
@@ -258,6 +300,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.128.17",
+            "192.168.230.216"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "192.168.128.17",
@@ -280,9 +328,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "r6DcuKSlKG8",
@@ -325,6 +379,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.220",
+            "172.20.5.191"
+          ]
+        },
         "source": {
           "bytes": 79724,
           "ip": "10.10.8.220",
@@ -347,9 +407,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MJV4se1d1EY",
@@ -392,6 +458,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.199",
+            "172.20.4.1"
+          ]
+        },
         "source": {
           "bytes": 161,
           "ip": "172.20.4.199",
@@ -414,9 +486,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MJV4se1d1EY",
@@ -459,6 +537,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.1",
+            "172.20.4.199"
+          ]
+        },
         "source": {
           "bytes": 245,
           "ip": "172.20.4.1",
@@ -481,9 +565,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Md4y9RxWsu0",
@@ -526,6 +616,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.30",
+            "10.10.8.34"
+          ]
+        },
         "source": {
           "bytes": 504,
           "ip": "172.20.4.30",
@@ -548,9 +644,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_XZysP4InTc",
@@ -593,6 +695,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.105",
+            "172.20.4.30"
+          ]
+        },
         "source": {
           "bytes": 784,
           "ip": "10.10.8.105",
@@ -615,9 +723,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_XZysP4InTc",
@@ -660,6 +774,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.30",
+            "10.10.8.105"
+          ]
+        },
         "source": {
           "bytes": 433,
           "ip": "172.20.4.30",
@@ -682,9 +802,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "5stvUzTWY8c",
@@ -727,6 +853,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.7.11",
+            "192.168.183.199"
+          ]
+        },
         "source": {
           "bytes": 196,
           "ip": "10.10.7.11",
@@ -749,9 +881,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "VdPCBSYnnS0",
@@ -794,6 +932,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.183.199",
+            "192.168.230.216"
+          ]
+        },
         "source": {
           "bytes": 206,
           "ip": "192.168.183.199",
@@ -816,9 +960,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "asoP1PL3Pao",
@@ -861,6 +1011,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.34",
+            "172.20.4.30"
+          ]
+        },
         "source": {
           "bytes": 504,
           "ip": "10.10.8.34",
@@ -883,9 +1039,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "r6DcuKSlKG8",
@@ -928,6 +1090,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.5.191",
+            "10.10.8.220"
+          ]
+        },
         "source": {
           "bytes": 3539,
           "ip": "172.20.5.191",
@@ -950,9 +1118,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "4AA5ETLDkm0",
@@ -995,6 +1169,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "172.20.4.1",
@@ -1017,9 +1197,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "4AA5ETLDkm0",
@@ -1062,6 +1248,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.20.4.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "172.20.4.1",
@@ -1084,9 +1276,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "BaTGW6h8V9s",
@@ -1129,6 +1327,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.30.0.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 435,
           "ip": "172.30.0.1",
@@ -1151,9 +1355,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "BaTGW6h8V9s",
@@ -1196,6 +1406,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.30.0.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 290,
           "ip": "172.30.0.1",
@@ -1218,9 +1434,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "a0peNOTOYXA",
@@ -1263,6 +1485,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.6.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "10.10.6.1",
@@ -1285,9 +1513,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "a0peNOTOYXA",
@@ -1330,6 +1564,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.6.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "10.10.6.1",
@@ -1352,9 +1592,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rX81_0wnl4c",
@@ -1397,6 +1643,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.7.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "10.10.7.1",
@@ -1419,9 +1671,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rX81_0wnl4c",
@@ -1464,6 +1722,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.7.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "10.10.7.1",
@@ -1486,9 +1750,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "7EW3D8kjT4Q",
@@ -1531,6 +1801,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "10.10.8.1",
@@ -1553,9 +1829,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "7EW3D8kjT4Q",
@@ -1598,6 +1880,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.8.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "10.10.8.1",
@@ -1620,9 +1908,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "JacJ1_FgpYg",
@@ -1665,6 +1959,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.20.0.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "10.20.0.1",
@@ -1687,9 +1987,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "JacJ1_FgpYg",
@@ -1732,6 +2038,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.20.0.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "10.20.0.1",
@@ -1754,9 +2066,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "38frmBtEgfI",
@@ -1799,6 +2117,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.10.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 495,
           "ip": "10.10.10.1",
@@ -1821,9 +2145,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "38frmBtEgfI",
@@ -1866,6 +2196,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.10.1",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 330,
           "ip": "10.10.10.1",
@@ -1886,9 +2222,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1947,9 +2289,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2008,9 +2356,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2069,9 +2423,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2130,9 +2490,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2191,9 +2557,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2252,9 +2624,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2313,9 +2691,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2374,9 +2758,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2435,9 +2825,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2496,9 +2892,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2557,9 +2959,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2618,9 +3026,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2679,9 +3093,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2740,9 +3160,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2801,9 +3227,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2862,9 +3294,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2923,9 +3361,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-19T16:18:08Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RlrAo_U1Y14",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -80,6 +86,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "10.0.0.1"
+          ]
+        },
         "source": {
           "bytes": 40,
           "ip": "192.168.0.1",
@@ -102,9 +114,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -158,6 +176,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.0.1",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 1525,
           "ip": "10.0.0.1",
@@ -180,9 +204,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -247,6 +277,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "10.0.0.1"
+          ]
         },
         "source": {
           "bytes": 1541,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-12-14T07:23:45Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "aVnWxMM8qxI",
@@ -49,6 +55,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.0.1.228",
+            "10.0.0.34"
+          ]
         },
         "source": {
           "ip": "10.0.1.228",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_dzJqQAoWYk",
@@ -53,6 +59,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -75,9 +87,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_dzJqQAoWYk",
@@ -116,6 +134,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 6634,
           "ip": "192.168.0.1",
@@ -138,9 +162,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iSYE82PBcbQ",
@@ -179,6 +209,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
@@ -201,9 +237,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iSYE82PBcbQ",
@@ -242,6 +284,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 10893,
           "ip": "192.168.0.1",
@@ -264,9 +312,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iSYE82PBcbQ",
@@ -305,6 +359,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
@@ -327,9 +387,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iSYE82PBcbQ",
@@ -368,6 +434,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 10893,
           "ip": "192.168.0.1",
@@ -390,9 +462,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "L_N7tNeOZwc",
@@ -431,6 +509,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -453,9 +537,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "L_N7tNeOZwc",
@@ -494,6 +584,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 6780,
           "ip": "192.168.0.1",
@@ -516,9 +612,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "L_N7tNeOZwc",
@@ -557,6 +659,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -579,9 +687,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "L_N7tNeOZwc",
@@ -620,6 +734,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 6780,
           "ip": "192.168.0.1",
@@ -642,9 +762,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
@@ -683,6 +809,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -705,9 +837,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
@@ -746,6 +884,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 7319,
           "ip": "192.168.0.1",
@@ -768,9 +912,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
@@ -809,6 +959,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -831,9 +987,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
@@ -872,6 +1034,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 7319,
           "ip": "192.168.0.1",
@@ -894,9 +1062,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B9Jsqhany8Q",
@@ -935,6 +1109,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 333,
           "ip": "192.168.0.17",
@@ -957,9 +1137,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B9Jsqhany8Q",
@@ -998,6 +1184,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 1833,
           "ip": "192.168.0.1",
@@ -1020,9 +1212,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B9Jsqhany8Q",
@@ -1061,6 +1259,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 333,
           "ip": "192.168.0.17",
@@ -1083,9 +1287,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B9Jsqhany8Q",
@@ -1124,6 +1334,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 1833,
           "ip": "192.168.0.1",
@@ -1146,9 +1362,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O7k79Py4ef0",
@@ -1187,6 +1409,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
@@ -1209,9 +1437,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O7k79Py4ef0",
@@ -1250,6 +1484,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 10550,
           "ip": "192.168.0.1",
@@ -1272,9 +1512,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O7k79Py4ef0",
@@ -1313,6 +1559,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
@@ -1335,9 +1587,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O7k79Py4ef0",
@@ -1376,6 +1634,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 10550,
           "ip": "192.168.0.1",
@@ -1398,9 +1662,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "T1etbJ4WSI0",
@@ -1439,6 +1709,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -1461,9 +1737,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "T1etbJ4WSI0",
@@ -1502,6 +1784,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 6425,
           "ip": "192.168.0.1",
@@ -1524,9 +1812,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "T1etbJ4WSI0",
@@ -1565,6 +1859,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.17",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
@@ -1587,9 +1887,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:30:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "T1etbJ4WSI0",
@@ -1627,6 +1933,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
         },
         "source": {
           "bytes": 6425,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "gEodlN50y4w",
@@ -62,6 +68,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "181.214.87.71",
+            "138.44.161.14"
+          ]
+        },
         "source": {
           "ip": "181.214.87.71",
           "locality": "public",
@@ -82,9 +94,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "GYmhjYyvaAI",
@@ -132,6 +150,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "0.0.0.0",
+            "0.0.0.0"
+          ]
+        },
         "source": {
           "ip": "0.0.0.0",
           "locality": "private",
@@ -152,9 +176,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "qSSNfC38l0c",
@@ -202,6 +232,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "5.188.11.35",
+            "138.44.161.14"
+          ]
+        },
         "source": {
           "ip": "5.188.11.35",
           "locality": "public",
@@ -222,9 +258,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Tv1jmZy2vn4",
@@ -272,6 +314,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "206.117.25.89",
+            "138.44.161.14"
+          ]
+        },
         "source": {
           "ip": "206.117.25.89",
           "locality": "public",
@@ -292,9 +340,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "GYmhjYyvaAI",
@@ -342,6 +396,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "0.0.0.0",
+            "0.0.0.0"
+          ]
+        },
         "source": {
           "ip": "0.0.0.0",
           "locality": "private",
@@ -362,9 +422,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "JhEHWMX5XwI",
@@ -412,6 +478,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "185.232.29.199",
+            "138.44.161.14"
+          ]
+        },
         "source": {
           "ip": "185.232.29.199",
           "locality": "public",
@@ -432,9 +504,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q_zyIhDZuIo",
@@ -482,6 +560,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "177.188.228.137",
+            "138.44.161.14"
+          ]
+        },
         "source": {
           "ip": "177.188.228.137",
           "locality": "public",
@@ -502,9 +586,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-04-15T03:30:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "pNMKY7O9aVc",
@@ -551,6 +641,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "138.44.161.14",
+            "138.44.161.13"
+          ]
         },
         "source": {
           "ip": "138.44.161.14",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-22T12:17:52Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-Sv1di8xiKE",
@@ -62,6 +68,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.18.65.21",
+            "172.18.65.211"
+          ]
+        },
         "source": {
           "bytes": 100,
           "ip": "172.18.65.21",
@@ -84,9 +96,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-22T12:17:56Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "OQCLJ5IN83c",
@@ -134,6 +152,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.18.65.91",
+            "172.18.65.255"
+          ]
+        },
         "source": {
           "bytes": 229,
           "ip": "172.18.65.91",
@@ -156,9 +180,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-22T12:17:56Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "OQCLJ5IN83c",
@@ -206,6 +236,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.18.65.91",
+            "172.18.65.255"
+          ]
+        },
         "source": {
           "bytes": 229,
           "ip": "172.18.65.91",
@@ -228,9 +264,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-22T12:26:04Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "xcyYrM-QBl0",
@@ -278,6 +320,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.18.65.21",
+            "224.0.0.252"
+          ]
+        },
         "source": {
           "bytes": 104,
           "ip": "172.18.65.21",
@@ -298,9 +346,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-22T12:26:04Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "y_Vml2vPNtw",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -14,9 +14,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-25T13:03:38Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "QMH_S2K9KdI",
@@ -63,6 +69,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 132,
           "ip": "172.16.32.201",
@@ -87,9 +99,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-25T12:58:38Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "YlvEOsG0NHc",
@@ -142,6 +160,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.215"
+          ]
+        },
         "source": {
           "bytes": 172,
           "ip": "172.16.32.100",
@@ -159,7 +183,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-25T13:03:33Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -80,6 +86,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "10.0.0.1"
+          ]
+        },
         "source": {
           "bytes": 40,
           "ip": "192.168.0.1",
@@ -102,9 +114,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -158,6 +176,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.0.1",
+            "192.168.0.1"
+          ]
+        },
         "source": {
           "bytes": 1525,
           "ip": "10.0.0.1",
@@ -180,9 +204,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-11T12:09:19Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8wXIKNz6u_8",
@@ -247,6 +277,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "10.0.0.1"
+          ]
         },
         "source": {
           "bytes": 1541,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-06-01T15:11:53Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-21T14:32:15Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "dO-Anbp9xpw",
@@ -64,6 +70,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.113.7.54",
+            "172.16.21.27"
+          ]
         },
         "source": {
           "bytes": 775,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
           "kind": "event"
         },
@@ -48,9 +51,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ofdVXz7_x6E",
@@ -93,6 +102,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.1",
+            "192.168.253.128"
+          ]
+        },
         "source": {
           "bytes": 260,
           "ip": "192.168.253.1",
@@ -115,9 +130,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ofdVXz7_x6E",
@@ -160,6 +181,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.128",
+            "192.168.253.1"
+          ]
+        },
         "source": {
           "bytes": 1000,
           "ip": "192.168.253.128",
@@ -182,9 +209,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ztL93_3GZNs",
@@ -227,6 +260,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.2",
+            "192.168.253.132"
+          ]
+        },
         "source": {
           "bytes": 601,
           "ip": "192.168.253.2",
@@ -249,9 +288,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ztL93_3GZNs",
@@ -294,6 +339,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.132",
+            "192.168.253.2"
+          ]
+        },
         "source": {
           "bytes": 148,
           "ip": "192.168.253.132",
@@ -316,9 +367,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "VANFUe1rklc",
@@ -361,6 +418,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "54.214.9.161",
+            "192.168.253.132"
+          ]
+        },
         "source": {
           "bytes": 5946,
           "ip": "54.214.9.161",
@@ -383,9 +446,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "VANFUe1rklc",
@@ -428,6 +497,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.132",
+            "54.214.9.161"
+          ]
+        },
         "source": {
           "bytes": 2608,
           "ip": "192.168.253.132",
@@ -450,9 +525,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:26Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iDHwMSG6faQ",
@@ -495,6 +576,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.130",
+            "10.4.36.64"
+          ]
+        },
         "source": {
           "bytes": 60,
           "ip": "192.168.253.130",
@@ -517,9 +604,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:28Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ofdVXz7_x6E",
@@ -562,6 +655,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.1",
+            "192.168.253.128"
+          ]
+        },
         "source": {
           "bytes": 256,
           "ip": "192.168.253.1",
@@ -584,9 +683,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:28Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ofdVXz7_x6E",
@@ -629,6 +734,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.128",
+            "192.168.253.1"
+          ]
+        },
         "source": {
           "bytes": 1916,
           "ip": "192.168.253.128",
@@ -651,9 +762,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:28Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WgPN9s2D0jg",
@@ -696,6 +813,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.1",
+            "192.168.253.128"
+          ]
+        },
         "source": {
           "bytes": 168,
           "ip": "192.168.253.1",
@@ -718,9 +841,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:28Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WgPN9s2D0jg",
@@ -763,6 +892,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.253.128",
+            "192.168.253.1"
+          ]
+        },
         "source": {
           "bytes": 84,
           "ip": "192.168.253.128",
@@ -785,9 +920,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-05-13T11:20:28Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "PSMPOofjjVU",
@@ -829,6 +970,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.253.1",
+            "224.0.0.251"
+          ]
         },
         "source": {
           "bytes": 232,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "BPlkuHwo9sU",
@@ -56,6 +62,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.111",
+            "62.217.193.1"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
@@ -79,9 +91,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-PhJhHv5gvE",
@@ -123,6 +141,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.111",
+            "62.217.193.65"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
@@ -146,9 +170,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "zTrEnrxMnjo",
@@ -190,6 +220,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.111",
+            "62.217.193.1"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
@@ -213,9 +249,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "G4AVpSxBAVo",
@@ -257,6 +299,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.111",
+            "62.217.193.65"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
@@ -280,9 +328,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2nQmjOOzSH0",
@@ -324,6 +378,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "158.85.58.115",
+            "192.168.3.142"
+          ]
+        },
         "source": {
           "bytes": 964,
           "ip": "158.85.58.115",
@@ -347,9 +407,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "z7uHiA5SrD0",
@@ -391,6 +457,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.88",
+            "216.58.212.195"
+          ]
+        },
         "source": {
           "bytes": 2748,
           "ip": "192.168.0.88",
@@ -414,9 +486,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "z7uHiA5SrD0",
@@ -458,6 +536,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "216.58.212.195",
+            "192.168.0.88"
+          ]
+        },
         "source": {
           "bytes": 2023,
           "ip": "216.58.212.195",
@@ -481,9 +565,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "eyNcUtWu34I",
@@ -525,6 +615,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.201",
+            "216.58.201.106"
+          ]
+        },
         "source": {
           "bytes": 2180,
           "ip": "192.168.1.201",
@@ -548,9 +644,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "eyNcUtWu34I",
@@ -592,6 +694,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "216.58.201.106",
+            "192.168.1.201"
+          ]
+        },
         "source": {
           "bytes": 700,
           "ip": "216.58.201.106",
@@ -615,9 +723,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "i7e4W23LBGg",
@@ -659,6 +773,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "52.236.33.163",
+            "192.168.2.118"
+          ]
+        },
         "source": {
           "bytes": 161,
           "ip": "52.236.33.163",
@@ -682,9 +802,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ALOJ32qLh_s",
@@ -726,6 +852,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.3.34",
+            "52.216.130.237"
+          ]
+        },
         "source": {
           "bytes": 1764,
           "ip": "192.168.3.34",
@@ -749,9 +881,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "h9s7TXaoMZw",
@@ -793,6 +931,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "209.197.3.19",
+            "192.168.3.34"
+          ]
+        },
         "source": {
           "bytes": 13811,
           "ip": "209.197.3.19",
@@ -816,9 +960,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ALOJ32qLh_s",
@@ -860,6 +1010,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "52.216.130.237",
+            "192.168.3.34"
+          ]
+        },
         "source": {
           "bytes": 4717,
           "ip": "52.216.130.237",
@@ -883,9 +1039,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2GPS5gJiF8g",
@@ -927,6 +1089,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.157",
+            "172.217.23.232"
+          ]
+        },
         "source": {
           "bytes": 2419,
           "ip": "192.168.0.157",
@@ -950,9 +1118,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2GPS5gJiF8g",
@@ -994,6 +1168,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.217.23.232",
+            "192.168.0.157"
+          ]
+        },
         "source": {
           "bytes": 5551,
           "ip": "172.217.23.232",
@@ -1017,9 +1197,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ughO0a0lrBw",
@@ -1061,6 +1247,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "107.21.232.174",
+            "192.168.3.178"
+          ]
+        },
         "source": {
           "bytes": 187,
           "ip": "107.21.232.174",
@@ -1084,9 +1276,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ughO0a0lrBw",
@@ -1128,6 +1326,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.3.178",
+            "107.21.232.174"
+          ]
+        },
         "source": {
           "bytes": 104,
           "ip": "192.168.3.178",
@@ -1151,9 +1355,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Ie4W_7Snl8w",
@@ -1195,6 +1405,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.2.118",
+            "95.0.145.242"
+          ]
+        },
         "source": {
           "bytes": 4050,
           "ip": "192.168.2.118",
@@ -1218,9 +1434,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Ie4W_7Snl8w",
@@ -1262,6 +1484,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "95.0.145.242",
+            "192.168.2.118"
+          ]
+        },
         "source": {
           "bytes": 3719,
           "ip": "95.0.145.242",
@@ -1285,9 +1513,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "yokq763qB0U",
@@ -1329,6 +1563,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.79",
+            "23.5.100.66"
+          ]
+        },
         "source": {
           "bytes": 1402,
           "ip": "192.168.0.79",
@@ -1352,9 +1592,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "DCY-5ocv9ik",
@@ -1396,6 +1642,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.79",
+            "23.5.100.66"
+          ]
+        },
         "source": {
           "bytes": 1538,
           "ip": "192.168.0.79",
@@ -1419,9 +1671,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "DCY-5ocv9ik",
@@ -1463,6 +1721,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "23.5.100.66",
+            "192.168.0.79"
+          ]
+        },
         "source": {
           "bytes": 13002,
           "ip": "23.5.100.66",
@@ -1486,9 +1750,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B7rjR_940zU",
@@ -1530,6 +1800,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "170.251.180.15",
+            "192.168.0.61"
+          ]
+        },
         "source": {
           "bytes": 1194,
           "ip": "170.251.180.15",
@@ -1553,9 +1829,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B7rjR_940zU",
@@ -1597,6 +1879,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.61",
+            "170.251.180.15"
+          ]
+        },
         "source": {
           "bytes": 682,
           "ip": "192.168.0.61",
@@ -1620,9 +1908,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "0RrmR_QtH34",
@@ -1664,6 +1958,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.3.34",
+            "74.119.119.84"
+          ]
+        },
         "source": {
           "bytes": 1804,
           "ip": "192.168.3.34",
@@ -1687,9 +1987,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O1-Y9rjVH2A",
@@ -1731,6 +2037,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "185.60.218.19",
+            "192.168.3.142"
+          ]
+        },
         "source": {
           "bytes": 4774,
           "ip": "185.60.218.19",
@@ -1754,9 +2066,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "CtFBGbTcLpg",
@@ -1798,6 +2116,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.3.200",
+            "185.60.218.15"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "192.168.3.200",
@@ -1821,9 +2145,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "CtFBGbTcLpg",
@@ -1865,6 +2195,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "185.60.218.15",
+            "192.168.3.200"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "185.60.218.15",
@@ -1888,9 +2224,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-03T17:03:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lT_guTKc7y4",
@@ -1931,6 +2273,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.95",
+            "169.45.214.246"
+          ]
         },
         "source": {
           "bytes": 194,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -13,9 +13,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "UTkRrDbrhnI",
@@ -61,6 +67,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
@@ -83,9 +95,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WQVc0v7217I",
@@ -130,6 +148,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
         },
         "source": {
           "bytes": 81,
@@ -153,9 +177,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WQVc0v7217I",
@@ -201,6 +231,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
@@ -223,9 +259,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Nle5z0FLBjA",
@@ -270,6 +312,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
         },
         "source": {
           "bytes": 81,
@@ -293,9 +341,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Nle5z0FLBjA",
@@ -341,6 +395,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "192.168.0.1",
@@ -363,9 +423,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lfYzCmoZgqo",
@@ -411,6 +477,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
@@ -433,9 +505,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lfYzCmoZgqo",
@@ -481,6 +559,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
@@ -502,9 +586,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_9ahEyFsD94",
@@ -550,6 +640,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "ip": "192.168.0.1",
           "locality": "private",
@@ -571,9 +667,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_9ahEyFsD94",
@@ -619,6 +721,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
@@ -641,9 +749,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_9ahEyFsD94",
@@ -689,6 +803,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
@@ -710,9 +830,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bnG6S7DUlEE",
@@ -758,6 +884,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "ip": "192.168.0.2",
           "locality": "private",
@@ -779,9 +911,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bnG6S7DUlEE",
@@ -827,6 +965,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 69,
           "ip": "192.168.0.2",
@@ -849,9 +993,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bnG6S7DUlEE",
@@ -897,6 +1047,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.2",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 69,
           "ip": "192.168.0.2",
@@ -918,9 +1074,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wuMbsS0oTj4",
@@ -966,6 +1128,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "ip": "192.168.0.1",
           "locality": "private",
@@ -987,9 +1155,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wuMbsS0oTj4",
@@ -1035,6 +1209,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.1",
@@ -1057,9 +1237,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wuMbsS0oTj4",
@@ -1105,6 +1291,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.17"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "192.168.0.1",
@@ -1126,9 +1318,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "geQD5O-NWw8",
@@ -1174,6 +1372,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "ip": "192.168.0.1",
           "locality": "private",
@@ -1195,9 +1399,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "geQD5O-NWw8",
@@ -1243,6 +1453,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
+        },
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
@@ -1265,9 +1481,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-07-21T13:50:37Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "geQD5O-NWw8",
@@ -1312,6 +1534,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.1",
+            "192.168.0.18"
+          ]
         },
         "source": {
           "bytes": 69,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "5JpExP8VeSU",
@@ -62,6 +68,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.14.1",
+            "2.2.2.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.14.1",
@@ -83,9 +95,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MSQgezzAYh0",
@@ -133,6 +151,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.23.22",
+            "164.164.37.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.23.22",
@@ -154,9 +178,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MSQgezzAYh0",
@@ -204,6 +234,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "164.164.37.11",
+            "192.168.23.22"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
@@ -225,9 +261,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ioGVEAJtaEQ",
@@ -275,6 +317,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.23.20",
+            "164.164.37.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.23.20",
@@ -296,9 +344,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ioGVEAJtaEQ",
@@ -346,6 +400,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "164.164.37.11",
+            "192.168.23.20"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
@@ -367,9 +427,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "0xqELVtMeog",
@@ -417,6 +483,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.14.11",
+            "2.2.2.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.14.11",
@@ -438,9 +510,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "0xqELVtMeog",
@@ -488,6 +566,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "2.2.2.11",
+            "192.168.14.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "2.2.2.11",
@@ -509,9 +593,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "LA3WpK17LAw",
@@ -559,6 +649,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "2.2.2.11",
+            "192.168.14.1"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "2.2.2.11",
@@ -580,9 +676,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "LA3WpK17LAw",
@@ -630,6 +732,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.14.1",
+            "2.2.2.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.14.1",
@@ -651,9 +759,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tBFZO1WrQyk",
@@ -701,6 +815,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "164.164.37.11",
+            "192.168.23.1"
+          ]
+        },
         "source": {
           "bytes": 160,
           "ip": "164.164.37.11",
@@ -722,9 +842,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "oil2JqFPSyE",
@@ -772,6 +898,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.23.22",
+            "164.164.37.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.23.22",
@@ -793,9 +925,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "oil2JqFPSyE",
@@ -843,6 +981,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "164.164.37.11",
+            "192.168.23.22"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
@@ -864,9 +1008,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Pbk_o-xetL4",
@@ -914,6 +1064,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.23.20",
+            "164.164.37.11"
+          ]
+        },
         "source": {
           "bytes": 56,
           "ip": "192.168.23.20",
@@ -935,9 +1091,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-09T09:47:51Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Pbk_o-xetL4",
@@ -984,6 +1146,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "164.164.37.11",
+            "192.168.23.20"
+          ]
         },
         "source": {
           "bytes": 56,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -41,7 +44,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -75,7 +81,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -109,7 +118,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -143,7 +155,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -177,7 +192,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -211,7 +229,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -245,7 +266,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -279,7 +303,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -313,7 +340,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -347,7 +377,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -381,7 +414,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -415,7 +451,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -449,7 +488,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -483,7 +525,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -517,7 +562,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -551,7 +599,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -585,7 +636,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
@@ -619,7 +673,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.94Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.94Z"
+          "start": "2016-12-06T10:08:53.94Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "kkhtKjgAywQ",
@@ -66,6 +72,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.9.146",
+            "10.0.31.81"
+          ]
+        },
         "source": {
           "bytes": 40,
           "ip": "10.0.9.146",
@@ -88,12 +100,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 641000000,
           "end": "2016-12-06T10:08:54.583Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.942Z"
+          "start": "2016-12-06T10:08:53.942Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "4su7p2nlyno",
@@ -142,6 +160,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.17.42",
+            "10.0.35.4"
+          ]
+        },
         "source": {
           "bytes": 104,
           "ip": "10.0.17.42",
@@ -164,12 +188,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.945Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.945Z"
+          "start": "2016-12-06T10:08:53.945Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "mfb1_zWayo4",
@@ -218,6 +248,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.22.111",
+            "10.0.34.141"
+          ]
+        },
         "source": {
           "bytes": 52,
           "ip": "10.0.22.111",
@@ -240,12 +276,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.947Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.947Z"
+          "start": "2016-12-06T10:08:53.947Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "jKhffDbQq0o",
@@ -294,6 +336,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.23.59",
+            "10.0.36.170"
+          ]
+        },
         "source": {
           "bytes": 435,
           "ip": "10.0.23.59",
@@ -316,12 +364,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.948Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.948Z"
+          "start": "2016-12-06T10:08:53.948Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "5siGD7iCzo4",
@@ -370,6 +424,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.34.71",
+            "10.0.20.242"
+          ]
+        },
         "source": {
           "bytes": 969,
           "ip": "10.0.34.71",
@@ -392,12 +452,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 83000000,
           "end": "2016-12-06T10:08:53.948Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.865Z"
+          "start": "2016-12-06T10:08:53.865Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "IyuegsSri_U",
@@ -446,6 +512,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.10.133",
+            "10.0.30.102"
+          ]
+        },
         "source": {
           "bytes": 104,
           "ip": "10.0.10.133",
@@ -468,12 +540,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.951Z"
+          "start": "2016-12-06T10:08:53.951Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "9JGzjsOdNi4",
@@ -522,6 +600,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.37.29",
+            "10.0.6.24"
+          ]
+        },
         "source": {
           "bytes": 52,
           "ip": "10.0.37.29",
@@ -544,12 +628,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.951Z"
+          "start": "2016-12-06T10:08:53.951Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Y3aiAEAjjys",
@@ -598,6 +688,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.32.176",
+            "10.0.11.113"
+          ]
+        },
         "source": {
           "bytes": 614,
           "ip": "10.0.32.176",
@@ -620,12 +716,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 5418000000,
           "end": "2016-12-06T10:08:53.952Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:48.534Z"
+          "start": "2016-12-06T10:08:48.534Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "sC3kzwxISec",
@@ -674,6 +776,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.12.21",
+            "10.0.15.38"
+          ]
+        },
         "source": {
           "bytes": 4350,
           "ip": "10.0.12.21",
@@ -696,12 +804,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 3317000000,
           "end": "2016-12-06T10:08:57.27Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.953Z"
+          "start": "2016-12-06T10:08:53.953Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "dTmlxL48EoA",
@@ -750,6 +864,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.4.212",
+            "10.0.3.110"
+          ]
+        },
         "source": {
           "bytes": 533,
           "ip": "10.0.4.212",
@@ -772,12 +892,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 19894000000,
           "end": "2016-12-06T10:09:04.383Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:44.489Z"
+          "start": "2016-12-06T10:08:44.489Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "oMLDxCSgNuA",
@@ -826,6 +952,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.33.122",
+            "10.0.1.136"
+          ]
+        },
         "source": {
           "bytes": 13660,
           "ip": "10.0.33.122",
@@ -848,12 +980,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.955Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.955Z"
+          "start": "2016-12-06T10:08:53.955Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "5siGD7iCzo4",
@@ -902,6 +1040,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.20.242",
+            "10.0.34.71"
+          ]
+        },
         "source": {
           "bytes": 89,
           "ip": "10.0.20.242",
@@ -924,12 +1068,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.957Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.957Z"
+          "start": "2016-12-06T10:08:53.957Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-IcTJfcRi8w",
@@ -978,6 +1128,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.13.25",
+            "10.0.15.38"
+          ]
+        },
         "source": {
           "bytes": 833,
           "ip": "10.0.13.25",
@@ -1000,12 +1156,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 89000000,
           "end": "2016-12-06T10:08:53.959Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.87Z"
+          "start": "2016-12-06T10:08:53.87Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tyf0jfEIDwM",
@@ -1054,6 +1216,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.25.59",
+            "10.0.2.18"
+          ]
+        },
         "source": {
           "bytes": 1625,
           "ip": "10.0.25.59",
@@ -1076,12 +1244,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 17325000000,
           "end": "2016-12-06T10:09:05.882Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:48.557Z"
+          "start": "2016-12-06T10:08:48.557Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "OYKOBQNKdF4",
@@ -1130,6 +1304,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.7.73",
+            "10.0.27.168"
+          ]
+        },
         "source": {
           "bytes": 142184,
           "ip": "10.0.7.73",
@@ -1152,12 +1332,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 2705000000,
           "end": "2016-12-06T10:08:56.186Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.481Z"
+          "start": "2016-12-06T10:08:53.481Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "fC6tFjsdK54",
@@ -1206,6 +1392,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.19.50",
+            "10.0.27.169"
+          ]
+        },
         "source": {
           "bytes": 3016,
           "ip": "10.0.19.50",
@@ -1228,12 +1420,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 361000000,
           "end": "2016-12-06T10:08:54.28Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.919Z"
+          "start": "2016-12-06T10:08:53.919Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Kk4bVU4hDRk",
@@ -1282,6 +1480,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.28.150",
+            "10.0.24.13"
+          ]
+        },
         "source": {
           "bytes": 31500,
           "ip": "10.0.28.150",
@@ -1304,12 +1508,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 378000000,
           "end": "2016-12-06T10:08:54.037Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.659Z"
+          "start": "2016-12-06T10:08:53.659Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_Fk2ywvptGE",
@@ -1358,6 +1568,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.26.188",
+            "10.0.21.200"
+          ]
+        },
         "source": {
           "bytes": 2919,
           "ip": "10.0.26.188",
@@ -1380,12 +1596,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 11106000000,
           "end": "2016-12-06T10:09:03.759Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:52.653Z"
+          "start": "2016-12-06T10:08:52.653Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MrTF7IZhOrg",
@@ -1434,6 +1656,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.29.34",
+            "10.0.15.38"
+          ]
+        },
         "source": {
           "bytes": 4514,
           "ip": "10.0.29.34",
@@ -1456,12 +1684,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.964Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:53.964Z"
+          "start": "2016-12-06T10:08:53.964Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "hUKUTbBVmIY",
@@ -1510,6 +1744,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.0.8.200",
+            "10.0.5.224"
+          ]
+        },
         "source": {
           "bytes": 326,
           "ip": "10.0.8.200",
@@ -1532,12 +1772,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-06T10:09:24Z",
           "duration": 1587000000,
           "end": "2016-12-06T10:08:53.964Z",
           "kind": "event",
-          "start": "2016-12-06T10:08:52.377Z"
+          "start": "2016-12-06T10:08:52.377Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "IoEUbnBqGXE",
@@ -1585,6 +1831,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.0.29.46",
+            "10.0.15.38"
+          ]
         },
         "source": {
           "bytes": 112,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_qSyv-Xe8IM",
@@ -56,6 +62,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.111.111.242",
+            "10.12.100.13"
+          ]
+        },
         "source": {
           "bytes": 965,
           "ip": "10.111.111.242",
@@ -78,9 +90,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "7s_4xBb69Y0",
@@ -122,6 +140,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.4.29",
+            "10.100.105.85"
+          ]
+        },
         "source": {
           "bytes": 284,
           "ip": "10.10.4.29",
@@ -144,9 +168,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_qSyv-Xe8IM",
@@ -188,6 +218,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.100.13",
+            "10.111.111.242"
+          ]
+        },
         "source": {
           "bytes": 670,
           "ip": "10.12.100.13",
@@ -210,9 +246,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "jk1T8-P2OHM",
@@ -254,6 +296,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.104.239",
+            "10.10.11.21"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.12.104.239",
@@ -276,9 +324,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "jk1T8-P2OHM",
@@ -320,6 +374,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.11.21",
+            "10.12.104.239"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
@@ -342,9 +402,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6AEj_wlzQm4",
@@ -386,6 +452,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.100.101.45",
+            "10.15.131.98"
+          ]
+        },
         "source": {
           "bytes": 101,
           "ip": "10.100.101.45",
@@ -408,9 +480,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MtCuD-nvBTY",
@@ -452,6 +530,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.100.101.43",
+            "10.12.105.23"
+          ]
+        },
         "source": {
           "bytes": 1134,
           "ip": "10.100.101.43",
@@ -474,9 +558,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8zAXung0YbA",
@@ -518,6 +608,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "31.13.71.7",
+            "10.11.31.108"
+          ]
+        },
         "source": {
           "bytes": 237,
           "ip": "31.13.71.7",
@@ -540,9 +636,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "5LxKkXX5FfM",
@@ -584,6 +686,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.11.21.60",
+            "10.100.105.86"
+          ]
+        },
         "source": {
           "bytes": 91,
           "ip": "10.11.21.60",
@@ -606,9 +714,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MnDMft-qZjs",
@@ -650,6 +764,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.92.102",
+            "172.217.11.5"
+          ]
+        },
         "source": {
           "bytes": 41,
           "ip": "10.12.92.102",
@@ -672,9 +792,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Ddy-Ii-ZDDI",
@@ -716,6 +842,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.100.105.86",
+            "10.11.21.60"
+          ]
+        },
         "source": {
           "bytes": 111,
           "ip": "10.100.105.86",
@@ -738,9 +870,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Hiy-Ti0eVlY",
@@ -782,6 +920,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.4.234",
+            "10.100.105.85"
+          ]
+        },
         "source": {
           "bytes": 1164,
           "ip": "10.10.4.234",
@@ -804,9 +948,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "7iMintjCsaw",
@@ -848,6 +998,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.106.83",
+            "10.10.11.21"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.12.106.83",
@@ -870,9 +1026,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MnDMft-qZjs",
@@ -914,6 +1076,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.217.11.5",
+            "10.12.92.102"
+          ]
+        },
         "source": {
           "bytes": 52,
           "ip": "172.217.11.5",
@@ -936,9 +1104,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "7iMintjCsaw",
@@ -980,6 +1154,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.11.21",
+            "10.12.106.83"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
@@ -1002,9 +1182,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "hphBugBrKPY",
@@ -1046,6 +1232,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.81.86",
+            "74.201.129.29"
+          ]
+        },
         "source": {
           "bytes": 3088,
           "ip": "10.12.81.86",
@@ -1068,9 +1260,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "gJ7Z20zGGk8",
@@ -1112,6 +1310,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.14.121.98",
+            "10.12.100.13"
+          ]
+        },
         "source": {
           "bytes": 5306,
           "ip": "10.14.121.98",
@@ -1134,9 +1338,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Ddy-Ii-ZDDI",
@@ -1178,6 +1388,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.11.21.60",
+            "10.100.105.86"
+          ]
+        },
         "source": {
           "bytes": 116,
           "ip": "10.11.21.60",
@@ -1200,9 +1416,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "gJ7Z20zGGk8",
@@ -1244,6 +1466,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.100.13",
+            "10.14.121.98"
+          ]
+        },
         "source": {
           "bytes": 22764,
           "ip": "10.12.100.13",
@@ -1266,9 +1494,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "LZaFrMI9jg0",
@@ -1310,6 +1544,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.12.102.125",
+            "10.10.11.21"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.12.102.125",
@@ -1332,9 +1572,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "f6pXcQQIzpU",
@@ -1376,6 +1622,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.100.105.86",
+            "10.11.21.60"
+          ]
+        },
         "source": {
           "bytes": 75,
           "ip": "10.100.105.86",
@@ -1398,9 +1650,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "LZaFrMI9jg0",
@@ -1442,6 +1700,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.11.21",
+            "10.12.102.125"
+          ]
+        },
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
@@ -1464,9 +1728,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "gQGJtHjUcB8",
@@ -1508,6 +1778,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.100.105.85",
+            "10.10.4.151"
+          ]
+        },
         "source": {
           "bytes": 160,
           "ip": "10.100.105.85",
@@ -1530,9 +1806,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "UHiF_w4I6zM",
@@ -1574,6 +1856,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.14.25.80",
+            "17.253.24.253"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "10.14.25.80",
@@ -1596,9 +1884,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-10-09T20:22:35Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "czsFrOKrayM",
@@ -1639,6 +1933,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.12.150.13",
+            "10.100.101.43"
+          ]
         },
         "source": {
           "bytes": 1340,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -13,12 +13,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
           "kind": "event",
-          "start": "2017-02-14T11:10:19.368Z"
+          "start": "2017-02-14T11:10:19.368Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Bk-2FcuOyCU",
@@ -70,6 +76,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.30.18.62",
+            "10.30.19.180"
+          ]
+        },
         "source": {
           "bytes": 44,
           "ip": "10.30.18.62",
@@ -94,12 +106,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
           "kind": "event",
-          "start": "2017-02-14T11:10:19.368Z"
+          "start": "2017-02-14T11:10:19.368Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "4Xk8GtQfUAo",
@@ -151,6 +169,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.30.18.62",
+            "10.30.19.180"
+          ]
+        },
         "source": {
           "bytes": 106,
           "ip": "10.30.18.62",
@@ -175,12 +199,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.924Z",
           "kind": "event",
-          "start": "2017-02-14T11:10:19.924Z"
+          "start": "2017-02-14T11:10:19.924Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tfLRXnB6AOA",
@@ -232,6 +262,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.172.60",
+            "10.30.19.180"
+          ]
+        },
         "source": {
           "bytes": 44,
           "ip": "10.10.172.60",
@@ -256,12 +292,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.996Z",
           "kind": "event",
-          "start": "2017-02-14T11:10:19.996Z"
+          "start": "2017-02-14T11:10:19.996Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1mfP23NPuB8",
@@ -313,6 +355,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.10.172.60",
+            "10.30.19.180"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "10.10.172.60",
@@ -337,12 +385,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:10:36Z",
           "duration": 72000000,
           "end": "2017-02-14T11:10:20.008Z",
           "kind": "event",
-          "start": "2017-02-14T11:10:19.936Z"
+          "start": "2017-02-14T11:10:19.936Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "g6a7KlISbtM",
@@ -393,6 +447,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.10.172.60",
+            "10.30.19.180"
+          ]
         },
         "source": {
           "bytes": 2794,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -42,7 +45,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -77,7 +83,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -112,7 +121,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -147,7 +159,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -182,7 +197,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -217,7 +235,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -252,7 +273,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -287,7 +311,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -322,7 +349,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -357,7 +387,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -392,7 +425,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -427,7 +463,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -462,7 +501,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
@@ -497,7 +539,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
@@ -10,9 +10,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -70,9 +76,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -126,9 +138,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -186,9 +204,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -242,9 +266,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -300,9 +330,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -360,9 +396,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -416,9 +458,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -476,9 +524,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -532,9 +586,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -592,9 +652,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -648,9 +714,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -708,9 +780,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -764,9 +842,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -824,9 +908,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -880,9 +970,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -940,9 +1036,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -996,9 +1098,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -1056,9 +1164,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-06-22T06:31:14Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Q1JIGzkHw0I",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-18T05:42:14Z",
           "kind": "event"
         },
@@ -51,9 +54,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-07-18T05:41:59Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "SKsZNpZob60",
@@ -92,6 +101,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.99.7",
+            "31.13.87.36"
+          ]
         },
         "source": {
           "bytes": 152,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.99Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:09.58Z"
+          "start": "2018-05-11T00:54:09.58Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "FfT-8jRRvok",
@@ -64,6 +70,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.151",
+            "182.50.136.239"
+          ]
+        },
         "source": {
           "bytes": 748,
           "ip": "192.168.100.151",
@@ -86,12 +98,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.61Z"
+          "start": "2018-05-11T00:54:08.61Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bZjTG4EkhLs",
@@ -138,6 +156,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "208.100.17.187",
+            "192.168.100.151"
+          ]
+        },
         "source": {
           "bytes": 6948,
           "ip": "208.100.17.187",
@@ -160,12 +184,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.61Z"
+          "start": "2018-05-11T00:54:08.61Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bZjTG4EkhLs",
@@ -212,6 +242,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.151",
+            "208.100.17.187"
+          ]
+        },
         "source": {
           "bytes": 1584,
           "ip": "192.168.100.151",
@@ -234,12 +270,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.7Z"
+          "start": "2018-05-11T00:54:08.7Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "kZjCeMUhjqE",
@@ -286,6 +328,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "208.100.17.189",
+            "192.168.100.151"
+          ]
+        },
         "source": {
           "bytes": 8201,
           "ip": "208.100.17.189",
@@ -308,12 +356,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.7Z"
+          "start": "2018-05-11T00:54:08.7Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "kZjCeMUhjqE",
@@ -360,6 +414,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.151",
+            "208.100.17.189"
+          ]
+        },
         "source": {
           "bytes": 1729,
           "ip": "192.168.100.151",
@@ -382,12 +442,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.7Z"
+          "start": "2018-05-11T00:54:08.7Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8PR91KFjFKw",
@@ -434,6 +500,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "178.255.83.1",
+            "192.168.100.151"
+          ]
+        },
         "source": {
           "bytes": 1122,
           "ip": "178.255.83.1",
@@ -456,12 +528,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.7Z"
+          "start": "2018-05-11T00:54:08.7Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "8PR91KFjFKw",
@@ -508,6 +586,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.151",
+            "178.255.83.1"
+          ]
+        },
         "source": {
           "bytes": 705,
           "ip": "192.168.100.151",
@@ -530,12 +614,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.16Z"
+          "start": "2018-05-11T00:54:08.16Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O5vacJG8mLQ",
@@ -582,6 +672,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "178.255.83.1",
+            "192.168.100.151"
+          ]
+        },
         "source": {
           "bytes": 1123,
           "ip": "178.255.83.1",
@@ -604,12 +700,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:08.16Z"
+          "start": "2018-05-11T00:54:08.16Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "O5vacJG8mLQ",
@@ -656,6 +758,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.151",
+            "178.255.83.1"
+          ]
+        },
         "source": {
           "bytes": 706,
           "ip": "192.168.100.151",
@@ -678,12 +786,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
-          "start": "2018-05-11T00:51:08.55Z"
+          "start": "2018-05-11T00:51:08.55Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wdz94oax40U",
@@ -726,6 +840,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.111",
+            "192.168.100.150"
+          ]
+        },
         "source": {
           "bytes": 74,
           "ip": "192.168.100.111",
@@ -748,12 +868,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
-          "start": "2018-05-11T00:51:08.55Z"
+          "start": "2018-05-11T00:51:08.55Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wdz94oax40U",
@@ -796,6 +922,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.150",
+            "192.168.100.111"
+          ]
+        },
         "source": {
           "bytes": 58,
           "ip": "192.168.100.150",
@@ -818,12 +950,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
-          "start": "2018-05-11T00:51:08.55Z"
+          "start": "2018-05-11T00:51:08.55Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "KvZZ7LW-Qdc",
@@ -866,6 +1004,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.111",
+            "192.168.100.150"
+          ]
+        },
         "source": {
           "bytes": 74,
           "ip": "192.168.100.111",
@@ -888,12 +1032,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
-          "start": "2018-05-11T00:51:08.55Z"
+          "start": "2018-05-11T00:51:08.55Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "KvZZ7LW-Qdc",
@@ -936,6 +1086,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.150",
+            "192.168.100.111"
+          ]
+        },
         "source": {
           "bytes": 58,
           "ip": "192.168.100.150",
@@ -958,12 +1114,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:04.19Z"
+          "start": "2018-05-11T00:54:04.19Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "PC3a5T13Dpw",
@@ -1006,6 +1168,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.111",
+            "192.168.100.150"
+          ]
+        },
         "source": {
           "bytes": 1071,
           "ip": "192.168.100.111",
@@ -1028,12 +1196,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
           "kind": "event",
-          "start": "2018-05-11T00:54:04.19Z"
+          "start": "2018-05-11T00:54:04.19Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "PC3a5T13Dpw",
@@ -1076,6 +1250,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.150",
+            "192.168.100.111"
+          ]
+        },
         "source": {
           "bytes": 1147,
           "ip": "192.168.100.150",
@@ -1098,12 +1278,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
           "kind": "event",
-          "start": "2018-05-11T00:53:56.19Z"
+          "start": "2018-05-11T00:53:56.19Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "zdGWMwGlfsg",
@@ -1146,6 +1332,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.100.111",
+            "192.168.100.150"
+          ]
+        },
         "source": {
           "bytes": 1980,
           "ip": "192.168.100.111",
@@ -1168,12 +1360,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
           "kind": "event",
-          "start": "2018-05-11T00:53:56.19Z"
+          "start": "2018-05-11T00:53:56.19Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "zdGWMwGlfsg",
@@ -1215,6 +1413,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.100.150",
+            "192.168.100.111"
+          ]
         },
         "source": {
           "bytes": 2164,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-07-18T01:35:35Z",
           "duration": 29695000000,
           "end": "2018-07-18T01:35:02.969Z",
           "kind": "event",
-          "start": "2018-07-18T01:34:33.274Z"
+          "start": "2018-07-18T01:34:33.274Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "dK1E5m-O-ns",
@@ -69,6 +75,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "20.20.20.20",
+            "20.20.255.255"
+          ]
         },
         "source": {
           "bytes": 702,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 89519000000,
           "end": "2018-05-21T09:25:03.677Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.158Z"
+          "start": "2018-05-21T09:23:34.158Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6gDDasxO-4o",
@@ -69,6 +75,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.30",
+            "10.22.163.21"
+          ]
+        },
         "source": {
           "bytes": 1027087,
           "ip": "10.22.166.30",
@@ -91,12 +103,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.662Z",
           "kind": "event",
-          "start": "2018-05-21T09:24:03.657Z"
+          "start": "2018-05-21T09:24:03.657Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "RJbWY0zxttI",
@@ -148,6 +166,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.12",
+            "10.21.3.172"
+          ]
+        },
         "source": {
           "bytes": 6200,
           "ip": "10.22.166.12",
@@ -170,12 +194,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 60016000000,
           "end": "2018-05-21T09:25:03.656Z",
           "kind": "event",
-          "start": "2018-05-21T09:24:03.64Z"
+          "start": "2018-05-21T09:24:03.64Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MfdYhUDA3Y4",
@@ -227,6 +257,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.33",
+            "10.22.178.37"
+          ]
+        },
         "source": {
           "bytes": 11896,
           "ip": "10.22.166.33",
@@ -249,12 +285,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 90011000000,
           "end": "2018-05-21T09:25:03.643Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:33.632Z"
+          "start": "2018-05-21T09:23:33.632Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_QFogYw9xiY",
@@ -306,6 +348,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.35",
+            "10.20.100.253"
+          ]
+        },
         "source": {
           "bytes": 1041,
           "ip": "10.22.166.35",
@@ -328,12 +376,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.629Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:33.629Z"
+          "start": "2018-05-21T09:23:33.629Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-O7eEnuq5LI",
@@ -385,6 +439,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.36",
+            "10.20.136.36"
+          ]
+        },
         "source": {
           "bytes": 1740,
           "ip": "10.22.166.36",
@@ -407,12 +467,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 29467000000,
           "end": "2018-05-21T09:24:03.669Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.202Z"
+          "start": "2018-05-21T09:23:34.202Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "pcgnaJ3iCvI",
@@ -464,6 +530,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.36",
+            "10.20.147.28"
+          ]
+        },
         "source": {
           "bytes": 2998,
           "ip": "10.22.166.36",
@@ -486,12 +558,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 29452000000,
           "end": "2018-05-21T09:24:03.67Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.218Z"
+          "start": "2018-05-21T09:23:34.218Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "_gbuwRW4AVE",
@@ -543,6 +621,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.28",
+            "10.20.141.16"
+          ]
+        },
         "source": {
           "bytes": 55773,
           "ip": "10.22.166.28",
@@ -565,12 +649,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 29449000000,
           "end": "2018-05-21T09:24:03.684Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.235Z"
+          "start": "2018-05-21T09:23:34.235Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "VOe0rUor-cg",
@@ -622,6 +712,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.35",
+            "10.20.162.17"
+          ]
+        },
         "source": {
           "bytes": 3239438,
           "ip": "10.22.166.35",
@@ -644,12 +740,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.685Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:33.685Z"
+          "start": "2018-05-21T09:23:33.685Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "nkp7tr2MVcs",
@@ -701,6 +803,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.15",
+            "10.20.171.36"
+          ]
+        },
         "source": {
           "bytes": 5701,
           "ip": "10.22.166.15",
@@ -723,12 +831,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 29391000000,
           "end": "2018-05-21T09:24:03.691Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.3Z"
+          "start": "2018-05-21T09:23:34.3Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WxCFEmsTIh0",
@@ -780,6 +894,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.2",
+            "10.22.208.12"
+          ]
+        },
         "source": {
           "bytes": 4255012,
           "ip": "10.22.166.2",
@@ -802,12 +922,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 29196000000,
           "end": "2018-05-21T09:24:03.699Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.503Z"
+          "start": "2018-05-21T09:23:34.503Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rAIv2psXy74",
@@ -859,6 +985,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.28",
+            "10.22.196.21"
+          ]
+        },
         "source": {
           "bytes": 37557,
           "ip": "10.22.166.28",
@@ -881,12 +1013,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.753Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:33.753Z"
+          "start": "2018-05-21T09:23:33.753Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lR18K-eSVNM",
@@ -938,6 +1076,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.25",
+            "10.22.202.15"
+          ]
+        },
         "source": {
           "bytes": 23676,
           "ip": "10.22.166.25",
@@ -960,12 +1104,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 89282000000,
           "end": "2018-05-21T09:25:03.971Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:34.689Z"
+          "start": "2018-05-21T09:23:34.689Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1XCFo-Jv19g",
@@ -1017,6 +1167,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.25",
+            "10.20.166.26"
+          ]
+        },
         "source": {
           "bytes": 22821,
           "ip": "10.22.166.25",
@@ -1039,12 +1195,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 90012000000,
           "end": "2018-05-21T09:25:03.95Z",
           "kind": "event",
-          "start": "2018-05-21T09:23:33.938Z"
+          "start": "2018-05-21T09:23:33.938Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "DkV-9Meb8W8",
@@ -1096,6 +1258,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.12",
+            "10.21.3.117"
+          ]
+        },
         "source": {
           "bytes": 526,
           "ip": "10.22.166.12",
@@ -1118,12 +1286,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.938Z",
           "kind": "event",
-          "start": "2018-05-21T09:24:03.933Z"
+          "start": "2018-05-21T09:24:03.933Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "v1m_MeAqdL4",
@@ -1175,6 +1349,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.22.166.17",
+            "10.22.145.26"
+          ]
+        },
         "source": {
           "bytes": 33129,
           "ip": "10.22.166.17",
@@ -1197,12 +1377,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-05-21T09:25:04Z",
           "duration": 60006000000,
           "end": "2018-05-21T09:25:03.928Z",
           "kind": "event",
-          "start": "2018-05-21T09:24:03.922Z"
+          "start": "2018-05-21T09:24:03.922Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ru0mPvG-tKw",
@@ -1253,6 +1439,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.22.166.36",
+            "10.21.75.38"
+          ]
         },
         "source": {
           "bytes": 5092,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -13,12 +13,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-01-29T03:02:20Z",
           "duration": 327060000000,
           "end": "2018-01-29T03:02:19Z",
           "kind": "event",
-          "start": "2018-01-29T02:56:51.94Z"
+          "start": "2018-01-29T02:56:51.94Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "d-FUjj8eKi8",
@@ -69,6 +75,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.108.219.53",
+            "10.111.112.204"
+          ]
         },
         "source": {
           "bytes": 200,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-12-01T17:04:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "X6k2SQeAX5c",
@@ -56,6 +62,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.0.3",
+            "192.168.0.2"
+          ]
+        },
         "source": {
           "bytes": 78,
           "ip": "192.168.0.3",
@@ -78,9 +90,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-12-01T17:04:39Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "XEzNKvE_H1k",
@@ -121,6 +139,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.0.4",
+            "192.168.0.5"
+          ]
         },
         "source": {
           "bytes": 232,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-06-06T13:20:17Z",
           "duration": 0,
           "end": "2018-06-06T13:20:02Z",
           "kind": "event",
-          "start": "2018-06-06T13:20:02Z"
+          "start": "2018-06-06T13:20:02Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "A-NpGXd6eh4",
@@ -61,6 +67,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "134.220.2.6",
+            "134.220.1.156"
+          ]
         },
         "source": {
           "bytes": 363,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "0HZ2F4aNlps",
@@ -62,6 +68,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "23.35.171.27",
+            "10.32.91.205"
+          ]
+        },
         "source": {
           "bytes": 70,
           "ip": "23.35.171.27",
@@ -84,12 +96,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 339000000000,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:33:52Z"
+          "start": "2017-11-13T14:33:52Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "GTu1zsDt3yw",
@@ -134,6 +152,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.32.105.103",
+            "162.115.24.30"
+          ]
+        },
         "source": {
           "bytes": 111,
           "ip": "10.32.105.103",
@@ -156,12 +180,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "nUCuFEB8z_c",
@@ -206,6 +236,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.32.144.145",
+            "34.202.173.126"
+          ]
+        },
         "source": {
           "bytes": 70,
           "ip": "10.32.144.145",
@@ -228,12 +264,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "inYZm0Y9EVM",
@@ -278,6 +320,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "23.209.52.99",
+            "10.130.145.44"
+          ]
+        },
         "source": {
           "bytes": 70,
           "ip": "23.209.52.99",
@@ -300,12 +348,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6vds_sLxXqE",
@@ -350,6 +404,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.50.97.57",
+            "10.50.96.20"
+          ]
+        },
         "source": {
           "bytes": 78,
           "ip": "10.50.97.57",
@@ -372,12 +432,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6vds_sLxXqE",
@@ -422,6 +488,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.50.96.20",
+            "10.50.97.57"
+          ]
+        },
         "source": {
           "bytes": 78,
           "ip": "10.50.96.20",
@@ -444,12 +516,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "v3XVGdLaIe4",
@@ -494,6 +572,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "34.234.173.147",
+            "10.48.208.209"
+          ]
+        },
         "source": {
           "bytes": 70,
           "ip": "34.234.173.147",
@@ -516,12 +600,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
-          "start": "2017-11-13T14:39:31Z"
+          "start": "2017-11-13T14:39:31Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "aenMB9Z5Tzc",
@@ -565,6 +655,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.130.167.43",
+            "65.52.108.254"
+          ]
         },
         "source": {
           "bytes": 70,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-01-11T11:48:15Z",
           "duration": 6012000000,
           "end": "2017-01-11T11:47:28.879Z",
           "kind": "event",
-          "start": "2017-01-11T11:47:22.867Z"
+          "start": "2017-01-11T11:47:22.867Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wdxUeEaOBho",
@@ -57,6 +63,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "100.78.40.201",
+            "10.231.128.150"
+          ]
+        },
         "source": {
           "bytes": 128,
           "ip": "100.78.40.201",
@@ -79,12 +91,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-01-11T11:48:15Z",
           "duration": 6020000000,
           "end": "2017-01-11T11:47:28.886Z",
           "kind": "event",
-          "start": "2017-01-11T11:47:22.866Z"
+          "start": "2017-01-11T11:47:22.866Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wdxUeEaOBho",
@@ -124,6 +142,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.231.128.150",
+            "100.78.40.201"
+          ]
+        },
         "source": {
           "bytes": 172,
           "ip": "10.231.128.150",
@@ -146,12 +170,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-01-11T11:23:51Z",
           "duration": 50997000000,
           "end": "2017-01-11T11:23:34.936Z",
           "kind": "event",
-          "start": "2017-01-11T11:22:43.939Z"
+          "start": "2017-01-11T11:22:43.939Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6_Ia6lqx2cg",
@@ -191,6 +221,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "100.78.40.201",
+            "10.27.8.20"
+          ]
+        },
         "source": {
           "bytes": 3943,
           "ip": "100.78.40.201",
@@ -213,12 +249,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2017-01-11T11:23:51Z",
           "duration": 51015000000,
           "end": "2017-01-11T11:23:34.954Z",
           "kind": "event",
-          "start": "2017-01-11T11:22:43.939Z"
+          "start": "2017-01-11T11:22:43.939Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "6_Ia6lqx2cg",
@@ -257,6 +299,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "10.27.8.20",
+            "100.78.40.201"
+          ]
         },
         "source": {
           "bytes": 3052,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -13,12 +13,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
           "kind": "event",
-          "start": "2016-09-10T16:17:25.825Z"
+          "start": "2016-09-10T16:17:25.825Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "KYJ6RiyA5YM",
@@ -65,6 +71,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.135",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 174,
           "ip": "10.1.0.135",
@@ -89,12 +101,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
           "kind": "event",
-          "start": "2016-09-10T16:17:25.825Z"
+          "start": "2016-09-10T16:17:25.825Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "4GHcyowN7sg",
@@ -141,6 +159,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.136",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 87,
           "ip": "10.1.0.136",
@@ -165,12 +189,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
           "kind": "event",
-          "start": "2016-09-10T15:20:10.664Z"
+          "start": "2016-09-10T15:20:10.664Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "GRn2z1Rao3c",
@@ -217,6 +247,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.232",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 1920,
           "ip": "10.1.0.232",
@@ -241,12 +277,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
           "kind": "event",
-          "start": "2016-09-10T15:20:10.664Z"
+          "start": "2016-09-10T15:20:10.664Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iHA6jdIkqjA",
@@ -293,6 +335,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.232",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 610,
           "ip": "10.1.0.232",
@@ -317,12 +365,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 177102000000,
           "end": "2016-09-10T16:20:32.763Z",
           "kind": "event",
-          "start": "2016-09-10T16:17:35.661Z"
+          "start": "2016-09-10T16:17:35.661Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "cBjtKefzGos",
@@ -369,6 +423,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.5.0.91",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 2420,
           "ip": "10.5.0.91",
@@ -393,12 +453,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 176903000000,
           "end": "2016-09-10T16:20:32.666Z",
           "kind": "event",
-          "start": "2016-09-10T16:17:35.763Z"
+          "start": "2016-09-10T16:17:35.763Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "EzT0lQWYBRw",
@@ -445,6 +511,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.30",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 10204,
           "ip": "10.1.0.30",
@@ -469,12 +541,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T15:22:36.207Z",
           "kind": "event",
-          "start": "2016-09-10T15:22:36.207Z"
+          "start": "2016-09-10T15:22:36.207Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "TROGwofkmJA",
@@ -521,6 +599,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.3.0.100",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 216,
           "ip": "10.3.0.100",
@@ -545,12 +629,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:35.661Z",
           "kind": "event",
-          "start": "2016-09-10T16:17:35.661Z"
+          "start": "2016-09-10T16:17:35.661Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wLclDbADA9s",
@@ -597,6 +687,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.1.0.135",
+            "10.4.0.251"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "10.1.0.135",
@@ -620,12 +716,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 116000000,
           "end": "2016-09-10T15:23:38.951Z",
           "kind": "event",
-          "start": "2016-09-10T15:23:38.835Z"
+          "start": "2016-09-10T15:23:38.835Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "LpdyE0SSB-o",
@@ -672,6 +774,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.98",
+            "10.0.0.73"
+          ]
+        },
         "source": {
           "bytes": 260,
           "ip": "192.168.1.98",
@@ -694,12 +802,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "32P6av-L8P0",
@@ -746,6 +860,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 32,
           "ip": "10.4.0.251",
@@ -768,12 +888,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ft_m5C7Hgpo",
@@ -820,6 +946,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
@@ -842,12 +974,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bVX88Ii80AQ",
@@ -894,6 +1032,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
@@ -916,12 +1060,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bA4nBN4veuI",
@@ -968,6 +1118,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
@@ -990,12 +1146,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lY5yfRKXE3s",
@@ -1042,6 +1204,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
@@ -1064,12 +1232,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
-          "start": "2016-09-10T16:18:39.443Z"
+          "start": "2016-09-10T16:18:39.443Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "x3GfEtY3zCQ",
@@ -1116,6 +1290,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.4.0.251",
+            "255.255.255.255"
+          ]
+        },
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
@@ -1138,12 +1318,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-09-10T16:24:08Z",
           "duration": 1250988000000,
           "end": "2016-09-10T15:23:44.363Z",
           "kind": "event",
-          "start": "2016-09-10T15:02:53.375Z"
+          "start": "2016-09-10T15:02:53.375Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "bfT831bq5AI",
@@ -1189,6 +1375,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.1.102",
+            "10.2.0.95"
+          ]
         },
         "source": {
           "bytes": 3668,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-01-16T09:45:02Z",
           "duration": 0,
           "end": "2018-01-16T09:44:47Z",
           "kind": "event",
-          "start": "2018-01-16T09:44:47Z"
+          "start": "2018-01-16T09:44:47Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tS3zN7t_rFg",
@@ -60,6 +66,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.200.136",
+            "80.82.237.40"
+          ]
         },
         "source": {
           "bytes": 52,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -13,12 +13,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 8996000000,
           "end": "2018-02-18T05:46:53.996Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:45Z"
+          "start": "2018-02-18T05:46:45Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "XLC-7u3wi0U",
@@ -65,6 +71,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "37.122.1.226",
+            "193.151.198.166"
+          ]
+        },
         "source": {
           "bytes": 156,
           "ip": "37.122.1.226",
@@ -89,12 +101,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 0,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.992Z"
+          "start": "2018-02-18T05:46:53.992Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2mdiEm9z6pA",
@@ -141,6 +159,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "5.141.231.166",
+            "193.151.199.69"
+          ]
+        },
         "source": {
           "bytes": 48,
           "ip": "5.141.231.166",
@@ -165,12 +189,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 7652000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:46.336Z"
+          "start": "2018-02-18T05:46:46.336Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "IKsDJxZK5UA",
@@ -217,6 +247,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.233.128.4",
+            "212.224.113.74"
+          ]
+        },
         "source": {
           "bytes": 584,
           "ip": "10.233.128.4",
@@ -241,12 +277,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 16000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.976Z"
+          "start": "2018-02-18T05:46:53.976Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lfpS1KL7LwI",
@@ -293,6 +335,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "193.151.192.46",
+            "10.236.8.4"
+          ]
+        },
         "source": {
           "bytes": 577,
           "ip": "193.151.192.46",
@@ -317,12 +365,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 1168000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:52.82Z"
+          "start": "2018-02-18T05:46:52.82Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "HRyho8QOr5M",
@@ -369,6 +423,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.235.197.6",
+            "62.221.115.205"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "10.235.197.6",
@@ -393,12 +453,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 8992000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:45Z"
+          "start": "2018-02-18T05:46:45Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "jbL3H_oK7ok",
@@ -445,6 +511,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.236.31.7",
+            "37.146.125.64"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "10.236.31.7",
@@ -469,12 +541,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 4432000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:49.56Z"
+          "start": "2018-02-18T05:46:49.56Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "ayKjfr1z0QU",
@@ -521,6 +599,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.233.151.8",
+            "52.198.214.72"
+          ]
+        },
         "source": {
           "bytes": 1809,
           "ip": "10.233.151.8",
@@ -545,12 +629,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 80000000,
           "end": "2018-02-18T05:46:53.996Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.916Z"
+          "start": "2018-02-18T05:46:53.916Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B15R8wv_tVI",
@@ -597,6 +687,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.234.22.4",
+            "64.233.161.188"
+          ]
+        },
         "source": {
           "bytes": 234,
           "ip": "10.234.22.4",
@@ -621,12 +717,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 400000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.592Z"
+          "start": "2018-02-18T05:46:53.592Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "oYN-uwp504w",
@@ -673,6 +775,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.233.36.7",
+            "185.209.20.240"
+          ]
+        },
         "source": {
           "bytes": 1681,
           "ip": "10.233.36.7",
@@ -697,12 +805,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 9024000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:44.964Z"
+          "start": "2018-02-18T05:46:44.964Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "MUPum_LUoxk",
@@ -749,6 +863,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "10.233.200.7",
+            "84.39.245.175"
+          ]
+        },
         "source": {
           "bytes": 152,
           "ip": "10.233.200.7",
@@ -773,12 +893,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 60000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.932Z"
+          "start": "2018-02-18T05:46:53.932Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "YStkNP0pV1E",
@@ -825,6 +951,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "23.43.139.27",
+            "10.232.8.45"
+          ]
+        },
         "source": {
           "bytes": 1866,
           "ip": "23.43.139.27",
@@ -849,12 +981,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-02-18T05:47:09Z",
           "duration": 192000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
-          "start": "2018-02-18T05:46:53.8Z"
+          "start": "2018-02-18T05:46:53.8Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "nkastJ_vPI4",
@@ -900,6 +1038,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "2.17.140.47",
+            "10.233.150.21"
+          ]
         },
         "source": {
           "bytes": 187,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:46:56Z",
           "kind": "event"
         },
@@ -47,9 +50,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "zQfsdfKgh-o",
@@ -81,6 +90,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -103,9 +118,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
@@ -137,6 +158,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -159,9 +186,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "NF1W3jyrHAA",
@@ -193,6 +226,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.100",
           "locality": "private",
@@ -215,9 +254,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B-_-kE8PEgA",
@@ -249,6 +294,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -271,9 +322,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "B-_-kE8PEgA",
@@ -305,6 +362,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -327,9 +390,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "q6jss8DvXWE",
@@ -361,6 +430,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -383,9 +458,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "q6jss8DvXWE",
@@ -417,6 +498,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -439,9 +526,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "3TmuMjQR8Mk",
@@ -473,6 +566,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -495,9 +594,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "3TmuMjQR8Mk",
@@ -529,6 +634,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -551,9 +662,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2KDgFVtVKGg",
@@ -585,6 +702,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -607,9 +730,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2KDgFVtVKGg",
@@ -641,6 +770,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -663,9 +798,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "vwr6dNcr6FE",
@@ -697,6 +838,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -719,9 +866,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "vwr6dNcr6FE",
@@ -753,6 +906,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -775,9 +934,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tmgCubSF_CU",
@@ -809,6 +974,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -831,9 +1002,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tmgCubSF_CU",
@@ -865,6 +1042,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -887,9 +1070,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Agzgga7RAr0",
@@ -921,6 +1110,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -943,9 +1138,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Agzgga7RAr0",
@@ -977,6 +1178,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -999,9 +1206,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-cqFlm16mLc",
@@ -1033,6 +1246,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1055,9 +1274,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-cqFlm16mLc",
@@ -1089,6 +1314,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -1111,9 +1342,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Txfldw7-948",
@@ -1145,6 +1382,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1167,9 +1410,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Txfldw7-948",
@@ -1201,6 +1450,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -1223,9 +1478,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iaXg6w051Ho",
@@ -1257,6 +1518,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1279,9 +1546,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "iaXg6w051Ho",
@@ -1313,6 +1586,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -1335,9 +1614,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "cEvEMCFhKJk",
@@ -1369,6 +1654,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1391,9 +1682,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "cEvEMCFhKJk",
@@ -1425,6 +1722,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -1447,9 +1750,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "DnN0kX-gR3Q",
@@ -1481,6 +1790,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1503,9 +1818,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "DnN0kX-gR3Q",
@@ -1537,6 +1858,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
+        },
         "source": {
           "ip": "172.16.32.201",
           "locality": "private",
@@ -1559,9 +1886,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-kLcuxmRzgk",
@@ -1593,6 +1926,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.1",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "ip": "172.16.32.1",
           "locality": "private",
@@ -1615,9 +1954,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-10T08:47:01Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "-kLcuxmRzgk",
@@ -1648,6 +1993,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
         },
         "source": {
           "ip": "172.16.32.201",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:06:29Z",
           "kind": "event"
         },
@@ -46,12 +49,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:46.14Z"
+          "start": "2015-10-08T19:03:46.14Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1E-M5OJg_go",
@@ -92,6 +101,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.248"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -114,12 +129,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:46.14Z"
+          "start": "2015-10-08T19:03:46.14Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "yMxFd8CW_Ok",
@@ -160,6 +181,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.248",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.248",
@@ -182,12 +209,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:51.813Z"
+          "start": "2015-10-08T19:03:51.813Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "NF1W3jyrHAA",
@@ -228,6 +261,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -250,12 +289,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:51.813Z"
+          "start": "2015-10-08T19:03:51.813Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
@@ -296,6 +341,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.201",
@@ -318,12 +369,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:55.958Z"
+          "start": "2015-10-08T19:03:55.958Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "sNF38-obC7k",
@@ -364,6 +421,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.202"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -386,12 +449,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:55.958Z"
+          "start": "2015-10-08T19:03:55.958Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "458D6voFu3E",
@@ -432,6 +501,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.202",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.202",
@@ -452,12 +527,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:47.819Z"
+          "start": "2015-10-08T19:03:47.819Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tYpw8DU5u10",
@@ -518,12 +599,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:06:29Z",
           "duration": 5000000,
           "end": "2015-10-08T19:05:55.015Z",
           "kind": "event",
-          "start": "2015-10-08T19:05:55.01Z"
+          "start": "2015-10-08T19:05:55.01Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "zQfsdfKgh-o",
@@ -567,6 +654,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.1"
+          ]
         },
         "source": {
           "bytes": 200,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
@@ -12,9 +12,15 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "1970-01-01T00:08:22Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "oFN7CMNpOLQ",
@@ -51,6 +57,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "0.0.0.0",
+            "0.0.0.0"
+          ]
         },
         "source": {
           "bytes": 82,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:06:29Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:48.299Z"
+          "start": "2016-12-23T01:34:48.299Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "BSsjrf_TZnk",
@@ -62,6 +68,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "239.255.255.250",
+            "192.168.1.80"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
@@ -84,12 +96,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:48.299Z"
+          "start": "2016-12-23T01:34:48.299Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "R1Sjz_ITbgo",
@@ -134,6 +152,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.80",
+            "239.255.255.250"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "192.168.1.80",
@@ -156,12 +180,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.469Z"
+          "start": "2016-12-23T01:34:51.469Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "FpUgB2PIhjQ",
@@ -206,6 +236,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "239.255.255.250",
+            "192.168.1.95"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
@@ -228,12 +264,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.469Z"
+          "start": "2016-12-23T01:34:51.469Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "qN8iQExOvkc",
@@ -278,6 +320,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.95",
+            "239.255.255.250"
+          ]
+        },
         "source": {
           "bytes": 32,
           "ip": "192.168.1.95",
@@ -300,12 +348,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.469Z"
+          "start": "2016-12-23T01:34:51.469Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "FpUgB2PIhjQ",
@@ -350,6 +404,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "239.255.255.250",
+            "192.168.1.95"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
@@ -372,12 +432,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.469Z"
+          "start": "2016-12-23T01:34:51.469Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "qN8iQExOvkc",
@@ -422,6 +488,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.95",
+            "239.255.255.250"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "192.168.1.95",
@@ -444,12 +516,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.569Z"
+          "start": "2016-12-23T01:34:51.569Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WuFpyBG1Gt0",
@@ -494,6 +572,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "239.255.255.250",
+            "192.168.1.33"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
@@ -516,12 +600,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.569Z"
+          "start": "2016-12-23T01:34:51.569Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1aysHUs7BpA",
@@ -566,6 +656,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "192.168.1.33",
+            "239.255.255.250"
+          ]
+        },
         "source": {
           "bytes": 32,
           "ip": "192.168.1.33",
@@ -588,12 +684,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.569Z"
+          "start": "2016-12-23T01:34:51.569Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "WuFpyBG1Gt0",
@@ -638,6 +740,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "239.255.255.250",
+            "192.168.1.33"
+          ]
+        },
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
@@ -660,12 +768,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
-          "start": "2016-12-23T01:34:51.569Z"
+          "start": "2016-12-23T01:34:51.569Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1aysHUs7BpA",
@@ -709,6 +823,12 @@
         },
         "observer": {
           "ip": "192.0.2.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.1.33",
+            "239.255.255.250"
+          ]
         },
         "source": {
           "bytes": 0,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:46.14Z"
+          "start": "2015-10-08T19:03:46.14Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "1E-M5OJg_go",
@@ -58,6 +64,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.248"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -80,12 +92,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:46.14Z"
+          "start": "2015-10-08T19:03:46.14Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "yMxFd8CW_Ok",
@@ -126,6 +144,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.248",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.248",
@@ -148,12 +172,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:51.813Z"
+          "start": "2015-10-08T19:03:51.813Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "NF1W3jyrHAA",
@@ -194,6 +224,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.201"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -216,12 +252,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:51.813Z"
+          "start": "2015-10-08T19:03:51.813Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
@@ -262,6 +304,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.201",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.201",
@@ -284,12 +332,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:55.958Z"
+          "start": "2015-10-08T19:03:55.958Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "sNF38-obC7k",
@@ -330,6 +384,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.100",
+            "172.16.32.202"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
@@ -352,12 +412,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:55.958Z"
+          "start": "2015-10-08T19:03:55.958Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "458D6voFu3E",
@@ -398,6 +464,12 @@
         "observer": {
           "ip": "192.0.2.1"
         },
+        "related": {
+          "ip": [
+            "172.16.32.202",
+            "172.16.32.100"
+          ]
+        },
         "source": {
           "bytes": 76,
           "ip": "172.16.32.202",
@@ -418,12 +490,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
           "kind": "event",
-          "start": "2015-10-08T19:03:47.819Z"
+          "start": "2015-10-08T19:03:47.819Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "tYpw8DU5u10",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
@@ -7,7 +7,10 @@
       "Fields": {
         "event": {
           "action": "netflow_options",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2016-11-29T00:21:56Z",
           "kind": "event"
         },

--- a/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
@@ -17,7 +17,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -102,7 +105,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -187,7 +193,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -272,7 +281,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -357,7 +369,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -442,7 +457,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -527,7 +545,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -612,7 +633,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -697,7 +721,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -782,7 +809,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -867,7 +897,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -952,7 +985,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1037,7 +1073,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1122,7 +1161,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1207,7 +1249,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1292,7 +1337,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1377,7 +1425,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1462,7 +1513,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1547,7 +1601,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1632,7 +1689,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1717,7 +1777,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1802,7 +1865,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1887,7 +1953,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1972,7 +2041,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -2057,7 +2129,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -2142,7 +2217,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -2227,7 +2305,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -2312,7 +2393,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -2397,7 +2481,10 @@
           "action": "netflow_flow",
           "category": "network_session",
           "created": "2018-07-03T10:47:00Z",
-          "kind": "event"
+          "kind": "event",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "Vhs9T5k296w",

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -12,12 +12,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 287000000,
           "end": "2018-08-09T16:43:00.307Z",
           "kind": "event",
-          "start": "2018-08-09T16:43:00.02Z"
+          "start": "2018-08-09T16:43:00.02Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "NPZRWU1oZKQ",
@@ -64,6 +70,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.5.2",
+            "159.65.125.168"
+          ]
+        },
         "source": {
           "bytes": 421,
           "ip": "10.100.5.2",
@@ -86,12 +98,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 30209000000,
           "end": "2018-08-09T16:43:01.317Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:31.108Z"
+          "start": "2018-08-09T16:42:31.108Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "wMmxEUF-2Sk",
@@ -138,6 +156,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.125"
+          ]
+        },
         "source": {
           "bytes": 7621,
           "ip": "10.100.6.93",
@@ -160,12 +184,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:01.41Z",
           "kind": "event",
-          "start": "2018-08-09T16:43:01.41Z"
+          "start": "2018-08-09T16:43:01.41Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "2NG48p7EGpw",
@@ -212,6 +242,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.4.1",
+            "10.100.6.80"
+          ]
+        },
         "source": {
           "bytes": 95,
           "ip": "10.100.4.1",
@@ -234,12 +270,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 59651000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:02.683Z"
+          "start": "2018-08-09T16:42:02.683Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "f0LYEiUntL0",
@@ -286,6 +328,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.8"
+          ]
+        },
         "source": {
           "bytes": 3162,
           "ip": "10.100.6.93",
@@ -308,12 +356,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 40015000000,
           "end": "2018-08-09T16:43:02.876Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:22.861Z"
+          "start": "2018-08-09T16:42:22.861Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "9ATz0HlBbIQ",
@@ -360,6 +414,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.80",
+            "52.22.76.61"
+          ]
+        },
         "source": {
           "bytes": 2711,
           "ip": "10.100.6.80",
@@ -382,12 +442,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 37121000000,
           "end": "2018-08-09T16:43:02.43Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:25.309Z"
+          "start": "2018-08-09T16:42:25.309Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "vueGG5QVS_M",
@@ -434,6 +500,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.125"
+          ]
+        },
         "source": {
           "bytes": 20855,
           "ip": "10.100.6.93",
@@ -456,12 +528,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 31322000000,
           "end": "2018-08-09T16:43:02.43Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:31.108Z"
+          "start": "2018-08-09T16:42:31.108Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "rJySLUBW94Y",
@@ -508,6 +586,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.125"
+          ]
+        },
         "source": {
           "bytes": 7495,
           "ip": "10.100.6.93",
@@ -530,12 +614,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 31226000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:31.108Z"
+          "start": "2018-08-09T16:42:31.108Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "pWQ3ZWUMRfU",
@@ -582,6 +672,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.125"
+          ]
+        },
         "source": {
           "bytes": 7049,
           "ip": "10.100.6.93",
@@ -604,12 +700,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 30976000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
-          "start": "2018-08-09T16:42:31.358Z"
+          "start": "2018-08-09T16:42:31.358Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "M0l00u11bWc",
@@ -656,6 +758,12 @@
         "observer": {
           "ip": "10.100.4.1"
         },
+        "related": {
+          "ip": [
+            "10.100.6.93",
+            "13.32.251.126"
+          ]
+        },
         "source": {
           "bytes": 1348,
           "ip": "10.100.6.93",
@@ -678,12 +786,18 @@
         },
         "event": {
           "action": "netflow_flow",
-          "category": "network_traffic",
+          "category": [
+            "network_traffic",
+            "network"
+          ],
           "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:06.28Z",
           "kind": "event",
-          "start": "2018-08-09T16:43:06.28Z"
+          "start": "2018-08-09T16:43:06.28Z",
+          "type": [
+            "connection"
+          ]
         },
         "flow": {
           "id": "lzKTutEyrKA",
@@ -729,6 +843,12 @@
         },
         "observer": {
           "ip": "10.100.4.1"
+        },
+        "related": {
+          "ip": [
+            "192.168.1.4",
+            "10.100.0.1"
+          ]
         },
         "source": {
           "bytes": 82,


### PR DESCRIPTION
## What does this PR do?
Adds ECS categorization fields to netflow input.  Specifically:

- event.category : make array and add network
- event.type
- related.ip

## Why is it important?
ECS categorization fields improves usability of the data in the SIEM app and improves cross correlation between data sources.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```
cd x-pack/filebeat/input/netflow && go test
```

## Related issues
Closes #16135
