### PR TITLE
Cherry-pick #18026 to 7.x: Document recent changes to nginx fileset as breaking changes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix parsing of Elasticsearch node name by `elasticsearch/slowlog` fileset. {pull}14547[14547]
 - CEF extensions are now mapped to the data types defined in the CEF guide. {pull}14342[14342]
 - Improve ECS field mappings in panw module.  event.outcome now only contains success/failure per ECS specification. {issue}16025[16025] {pull}17910[17910]
+- Improve ECS categorization field mappings for nginx module. http.request.referrer is now lowercase & http.request.referrer only populated when nginx sets a value {issue}16174[16174] {pull}17844[17844]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #18026 to 7.x branch. Original message: 

## What does this PR do?
PR #17844   introduced the following changes:

- http.request.method is now lowercase
- http.request.referrer is only set when nginx provides a value

This PR updates the CHANGELOG to report this as a breaking change.

## Why is it important?
Notifies our users of a breaking change in behavior


## Checklist
~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related Issues
Relates elastic/beats#17844