### PR TITLE
[Elastic-Agent] Use /tmp for default monitoring endpoint location for libbeat

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@
 - Moved stream.* fields to top of event {pull}17858[17858]
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
 - Use default output by default {pull}18091[18091]
+- Use tmp for default metricbeat endpoint location {pull}18131[18131]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -27,7 +27,7 @@
 - Moved stream.* fields to top of event {pull}17858[17858]
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
 - Use default output by default {pull}18091[18091]
-- Use tmp for default metricbeat endpoint location {pull}18131[18131]
+- Use /tmp for default monitoring endpoint location for libbeat {pull}18131[18131]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/monitoring.go
@@ -17,7 +17,7 @@ const (
 	logFileFormatWin = "%s\\logs\\%s\\%s"
 
 	// args: pipeline name, application name
-	mbEndpointFileFormat = "unix://%s/run/%s/%s/%s.sock"
+	mbEndpointFileFormat = "unix:///tmp/elastic-agent/%s/%s/%s.sock"
 	// args: pipeline name, application name
 	mbEndpointFileFormatWin = `npipe:///%s-%s`
 )
@@ -27,7 +27,7 @@ func getMonitoringEndpoint(program, operatingSystem, pipelineID string) string {
 		return fmt.Sprintf(mbEndpointFileFormatWin, pipelineID, program)
 	}
 
-	return fmt.Sprintf(mbEndpointFileFormat, paths.Data(), pipelineID, program, program)
+	return fmt.Sprintf(mbEndpointFileFormat, pipelineID, program, program)
 }
 
 func getLoggingFile(program, operatingSystem, installPath, pipelineID string) string {


### PR DESCRIPTION
## What does this PR do?

This PR moves default location feeded to metricbeat for exposing metrics endpoint to /tmp/ to cope with #18118 

This way only risk is the length of the output name which needs to be handled in a followup

## Why is it important?

To enable running agent deeper in a filesystem

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
