### PR TITLE
fix: Mark generator stages as unstable temporally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,14 +547,18 @@ pipeline {
           stages {
             stage('Generators Metricbeat Linux'){
               steps {
-                makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test")
-                makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test-package")
+                catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
+                  makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test")
+                  makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test-package")
+                }
               }
             }
             stage('Generators Beat Linux'){
               steps {
-                makeTarget("Generators Beat Linux", "-C generator/_templates/beat test")
-                makeTarget("Generators Beat Linux", "-C generator/_templates/beat test-package")
+                catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
+                  makeTarget("Generators Beat Linux", "-C generator/_templates/beat test")
+                  makeTarget("Generators Beat Linux", "-C generator/_templates/beat test-package")
+                }
               }
             }
             stage('Generators Metricbeat Mac OS X'){
@@ -567,7 +571,9 @@ pipeline {
                 }
               }
               steps {
-                makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
+                catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
+                  makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
+                }
               }
             }
             stage('Generators Beat Mac OS X'){
@@ -580,7 +586,9 @@ pipeline {
                 }
               }
               steps {
-                makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
+                catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
+                  makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,6 +547,7 @@ pipeline {
           stages {
             stage('Generators Metricbeat Linux'){
               steps {
+                // FIXME see https://github.com/elastic/beats/issues/18132
                 catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
                   makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test")
                   makeTarget("Generators Metricbeat Linux", "-C generator/_templates/metricbeat test-package")
@@ -555,6 +556,7 @@ pipeline {
             }
             stage('Generators Beat Linux'){
               steps {
+                // FIXME see https://github.com/elastic/beats/issues/18132
                 catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
                   makeTarget("Generators Beat Linux", "-C generator/_templates/beat test")
                   makeTarget("Generators Beat Linux", "-C generator/_templates/beat test-package")
@@ -571,6 +573,7 @@ pipeline {
                 }
               }
               steps {
+                // FIXME see https://github.com/elastic/beats/issues/18132
                 catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
                   makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
                 }
@@ -586,6 +589,7 @@ pipeline {
                 }
               }
               steps {
+                // FIXME see https://github.com/elastic/beats/issues/18132
                 catchError(buildResult: 'SUCCESS', message: 'Ignore error temporally', stageResult: 'UNSTABLE') {
                   makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
                 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

It ignores the errors on the generators' stages, and mark the stage as unstable.

## Why is it important?

It is a temporal workaround until we fix the tests.

Related to https://github.com/elastic/beats/issues/18132