### PR TITLE
Pin version of ordered-set python package

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -33,3 +33,4 @@ semver==2.8.1
 stomp.py==4.1.22
 deepdiff==4.2.0
 kafka-python==1.4.3
+ordered-set==3.1.1


### PR DESCRIPTION
X-pack filebeat tests are failing in CI with a weird message that
comes from the ordered-dict Python library, that was recently
[updated](https://pypi.org/project/ordered-set/#history). Pin it to an older version to see if it fixes the issues.

Thanks @blakerouse for the idea!

This is the full error trace:
```
[2020-04-29T21:30:50.548Z] ======================================================================
[2020-04-29T21:30:50.548Z] ERROR: Failure: TypeError (Cannot subscript an existing Union. Use Union[u, t] instead.)
[2020-04-29T21:30:50.548Z] ----------------------------------------------------------------------
[2020-04-29T21:30:50.548Z] Traceback (most recent call last):
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/nose/failure.py", line 39, in runTest
[2020-04-29T21:30:50.548Z]     raise self.exc_val.with_traceback(self.tb)
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/nose/loader.py", line 418, in loadTestsFromName
[2020-04-29T21:30:50.548Z]     addr.filename, addr.module)
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/nose/importer.py", line 47, in importFromPath
[2020-04-29T21:30:50.548Z]     return self.importFromDir(dir_path, fqname)
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/nose/importer.py", line 94, in importFromDir
[2020-04-29T21:30:50.548Z]     mod = load_module(part_fqname, fh, filename, desc)
[2020-04-29T21:30:50.548Z]   File "/usr/lib/python3.5/imp.py", line 234, in load_module
[2020-04-29T21:30:50.548Z]     return load_source(name, filename, file)
[2020-04-29T21:30:50.548Z]   File "/usr/lib/python3.5/imp.py", line 172, in load_source
[2020-04-29T21:30:50.548Z]     module = _load(spec)
[2020-04-29T21:30:50.548Z]   File "<frozen importlib._bootstrap>", line 693, in _load
[2020-04-29T21:30:50.548Z]   File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
[2020-04-29T21:30:50.548Z]   File "<frozen importlib._bootstrap_external>", line 665, in exec_module
[2020-04-29T21:30:50.548Z]   File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/src/github.com/elastic/beats/x-pack/filebeat/tests/system/test_xpack_modules.py", line 6, in <module>
[2020-04-29T21:30:50.548Z]     import test_modules
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/src/github.com/elastic/beats/x-pack/filebeat/tests/system/../../../../filebeat/tests/system/test_modules.py", line 12, in <module>
[2020-04-29T21:30:50.548Z]     from deepdiff import DeepDiff
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/deepdiff/__init__.py", line 10, in <module>
[2020-04-29T21:30:50.548Z]     from .diff import DeepDiff
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/deepdiff/diff.py", line 17, in <module>
[2020-04-29T21:30:50.548Z]     from ordered_set import OrderedSet
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/ordered_set.py", line 51, in <module>
[2020-04-29T21:30:50.548Z]     class OrderedSet(MutableSet[T], Sequence[T]):
[2020-04-29T21:30:50.548Z]   File "/var/lib/jenkins/workspace/Beats_beats-beats-mbp_master/python-env/build/ve/linux/lib/python3.5/site-packages/ordered_set.py", line 186, in OrderedSet
[2020-04-29T21:30:50.548Z]     def update(self, sequence: SetLike[T]) -> int:
[2020-04-29T21:30:50.548Z]   File "/usr/lib/python3.5/typing.py", line 546, in __getitem__
[2020-04-29T21:30:50.548Z]     "Cannot subscript an existing Union. Use Union[u, t] instead.")
[2020-04-29T21:30:50.549Z] TypeError: Cannot subscript an existing Union. Use Union[u, t] instead.
[2020-04-29T21:30:50.549Z] 
[2020-04-29T21:30:50.549Z] [error] 100.00% nose.failure.Failure.runTest: 0.0027s
[2020-04-29T21:30:50.549Z] ----------------------------------------------------------------------
[2020-04-29T21:30:50.549Z] Ran 1 test in 0.003s
[2020-04-29T21:30:50.549Z] 
[2020-04-29T21:30:50.549Z] FAILED (errors=1)
```