### PR TITLE
Pin version of python ordered-set to 3.1.1

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -31,5 +31,6 @@ parameterized==0.7.0
 jsondiff==1.1.2
 semver==2.8.1
 stomp.py==4.1.22
+ordered-set==3.1.1
 deepdiff==4.2.0
 kafka-python==1.4.3


### PR DESCRIPTION
##  What does this PR do?

A new version of ordered-set was released on April 29, 2020 and builds
under Python 3.5 on Jenkins started failing. So this pins the version of
ordered-set to the previous version that it was using and working under.

Fixes #18150

## Why is it important?

The nose tests are failing on Jenkins under linux with python 3.5.

