### PR TITLE
[Elastic-Agent] Follow home path for all config files

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -45,3 +45,4 @@
 - Enable Filebeat input: S3, Azureeventhub, cloudfoundry, httpjson, netflow, o365audit. {pull}17909[17909]
 - Use data subfolder as default for process logs {pull}17960[17960]
 - Enable debug log level for Metricbeat and Filebeat when run under the Elastic Agent. {pull}17935[17935]
+- Follow home path for all config files {pull}18161[18161]

--- a/x-pack/elastic-agent/pkg/agent/application/config.go
+++ b/x-pack/elastic-agent/pkg/agent/application/config.go
@@ -8,23 +8,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/kibana"
 	fleetreporter "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/reporter/fleet"
 	logreporter "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/reporter/log"
 )
-
-// TODO(ph) correctly setup global path.
-func fleetAgentConfigPath() string {
-	return info.AgentConfigFile()
-}
-
-// TODO(ph) correctly setup with global path.
-func fleetActionStoreFile() string {
-	return info.AgentActionStoreFile
-}
 
 // Config define the configuration of the Agent.
 type Config struct {

--- a/x-pack/elastic-agent/pkg/agent/application/config.go
+++ b/x-pack/elastic-agent/pkg/agent/application/config.go
@@ -18,7 +18,7 @@ import (
 
 // TODO(ph) correctly setup global path.
 func fleetAgentConfigPath() string {
-	return info.AgentConfigFile
+	return info.AgentConfigFile()
 }
 
 // TODO(ph) correctly setup with global path.

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -91,7 +91,7 @@ func NewEnrollCmd(
 	store := storage.NewReplaceOnSuccessStore(
 		configPath,
 		DefaultAgentFleetConfig,
-		storage.NewEncryptedDiskStore(fleetAgentConfigPath(), []byte("")),
+		storage.NewEncryptedDiskStore(info.AgentConfigFile(), []byte("")),
 	)
 
 	return NewEnrollCmdWithStore(

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
@@ -19,12 +19,12 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 )
 
-// AgentConfigFile is a name of file used to store agent information
+// defaultAgentConfigFile is a name of file used to store agent information
 const defaultAgentConfigFile = "fleet.yml"
 const agentInfoKey = "agent_info"
 
-// AgentActionStoreFile is the file that will contains the action that can be replayed after restart.
-const AgentActionStoreFile = "action_store.yml"
+// defaultAgentActionStoreFile is the file that will contains the action that can be replayed after restart.
+const defaultAgentActionStoreFile = "action_store.yml"
 
 type persistentAgentInfo struct {
 	ID string `json:"ID" yaml:"ID" config:"ID"`
@@ -35,8 +35,14 @@ type ioStore interface {
 	Load() (io.ReadCloser, error)
 }
 
+// AgentConfigFile is a name of file used to store agent information
 func AgentConfigFile() string {
 	return filepath.Join(paths.Home(), defaultAgentConfigFile)
+}
+
+// AgentActionStoreFile is the file that will contains the action that can be replayed after restart.
+func AgentActionStoreFile() string {
+	return filepath.Join(paths.Home(), defaultAgentActionStoreFile)
 }
 
 func generateAgentID() (string, error) {

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -61,7 +61,7 @@ func newManaged(
 		return nil, err
 	}
 
-	path := fleetAgentConfigPath()
+	path := info.AgentConfigFile()
 
 	// TODO(ph): Define the encryption password.
 	store := storage.NewEncryptedDiskStore(path, []byte(""))
@@ -149,9 +149,9 @@ func newManaged(
 	batchedAcker := newLazyAcker(acker)
 
 	// Create the action store that will persist the last good policy change on disk.
-	actionStore, err := newActionStore(log, storage.NewDiskStore(fleetActionStoreFile()))
+	actionStore, err := newActionStore(log, storage.NewDiskStore(info.AgentActionStoreFile()))
 	if err != nil {
-		return nil, errors.New(err, fmt.Sprintf("fail to read action store '%s'", fleetActionStoreFile()))
+		return nil, errors.New(err, fmt.Sprintf("fail to read action store '%s'", info.AgentActionStoreFile()))
 	}
 	actionAcker := newActionStoreAcker(batchedAcker, actionStore)
 


### PR DESCRIPTION
## What does this PR do?

Currently even if specified fleet.yml and action_store.yml files are generated next to binary (which is default home). This PR makes it so these files are generated in actual home (path.home) spcified by user.

## Why is it important?

To have a the same behavior across config files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #17967 