### PR TITLE
Cherry-pick #17480 to 7.x: Add AWS tests to Jenkinsfile

### DIFF
--- a/.ci/scripts/install-terraform.sh
+++ b/.ci/scripts/install-terraform.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+MSG="parameter missing."
+TERRAFORM_VERSION=${TERRAFORM_VERSION:?$MSG}
+HOME=${HOME:?$MSG}
+TERRAFORM_CMD="${HOME}/bin/terraform"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+mkdir -p "${HOME}/bin"
+
+curl -sSLo - "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_amd64.zip" > ${TERRAFORM_CMD}.zip
+unzip -o ${TERRAFORM_CMD}.zip -d $(dirname ${TERRAFORM_CMD})
+rm ${TERRAFORM_CMD}.zip
+
+chmod +x "${TERRAFORM_CMD}"

--- a/.ci/scripts/terraform-cleanup.sh
+++ b/.ci/scripts/terraform-cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+DIRECTORY=${1:-.}
+
+FAILED=0
+for tfstate in $(find $DIRECTORY -name terraform.tfstate); do
+  cd $(dirname $tfstate)
+  if ! terraform destroy -auto-approve; then
+    FAILED=1
+  fi
+  cd -
+done
+
+exit $FAILED

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ x-pack/dockerlogbeat/temproot.tar
 *.test
 *.prof
 *.pyc
+
+# Terraform
+*.terraform
+*.tfstate*

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -833,3 +833,28 @@ func ListMatchingEnvVars(prefixes ...string) []string {
 	}
 	return vars
 }
+
+// IntegrationTestEnvVars returns the names of environment variables needed to configure
+// connections to integration test environments.
+func IntegrationTestEnvVars() []string {
+	// Environment variables that can be configured with paths to files
+	// with authentication information.
+	vars := []string{
+		"AWS_SHARED_CREDENTIAL_FILE",
+		"AZURE_AUTH_LOCATION",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+	}
+	// Environment variables with authentication information.
+	prefixes := []string{
+		"AWS_",
+		"AZURE_",
+
+		// Accepted by terraform, but not by many clients, including Beats
+		"GOOGLE_",
+		"GCLOUD_",
+	}
+	for _, prefix := range prefixes {
+		vars = append(vars, ListMatchingEnvVars(prefix)...)
+	}
+	return vars
+}

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -156,7 +156,9 @@ func GoTestIntegrationForModule(ctx context.Context) error {
 		foundModule = true
 
 		// Set MODULE because only want that modules tests to run inside the testing environment.
-		runners, err := NewIntegrationRunners(path.Join("./module", fi.Name()), map[string]string{"MODULE": fi.Name()})
+		env := map[string]string{"MODULE": fi.Name()}
+		passThroughEnvs(env, IntegrationTestEnvVars()...)
+		runners, err := NewIntegrationRunners(path.Join("./module", fi.Name()), env)
 		if err != nil {
 			return errors.Wrapf(err, "test setup failed for module %s", fi.Name())
 		}

--- a/docs/devguide/terraform.asciidoc
+++ b/docs/devguide/terraform.asciidoc
@@ -1,0 +1,101 @@
+[[terraform-beats]]
+== Terraform in Beats
+
+Terraform is used to provision scenarios for integration testing of some cloud
+features. Features implementing integration tests that require the presence of
+cloud resources should have their own Terraform configuration, this configuration
+can be used when developing locally to create (and destroy) resources that allow
+to test these features.
+
+Tests requiring access to cloud providers should be disabled by default with the
+use of build tags.
+
+[[installing-terraform]]
+=== Installing Terraform
+
+Terraform is available in https://www.terraform.io/downloads.html
+
+Download it and place it in some directory in your PATH.
+
+`terraform` is the main command for Terraform and the only one that is usually
+needed to manage configurations. Terraform will also download other plugins that
+implement the specific functionality for each provider. These plugins are
+automatically managed and stored in the working copy, if you want to share the
+plugins between multiple working copies you can manually install them in the
+user the user plugins directory located at `~/.terraform.d/plugins`,
+or `%APPDATA%\terraform.d\plugins on Windows`.
+
+Plugins are available in https://registry.terraform.io/
+
+[[using-terraform]]
+=== Using Terraform
+
+The most important commands when using Terraform are:
+* `terraform init` to do some initial checks and install the required plugins.
+* `terraform apply` to create the resources defined in the configuration.
+* `terraform destroy` to destroy resources previously created.
+
+Cloud providers use to require credentials, they can be provided with the usual
+methods supported by these providers, using environment variables and/or
+credential files.
+
+Terraform stores the last known state of the resources managed by a
+configuration in a `terraform.tfstate` file. It is important to keep this file
+as it is used as input by `terraform destroy`. This file is created in the same
+directory where `terraform apply` is executed.
+
+Please take a look to Terraform documentation for more details: https://www.terraform.io/intro/index.html
+
+[[terraform-configurations]]
+=== Terraform configuration guidelines
+
+The main purpouse of Terraform in Beats is to create and destroy cloud resources
+required by integration tests. For these configurations there are some things to
+take into account:
+* Apply should work without additional inputs or files. Only input will be the
+  required for specific providers, using environment variables or credential
+  files.
+* You must be able to apply the same configuration multiple times in the same
+  account. This will allow to have multiple builds using the same configuration
+  but with different instances of the resources. Some resources are already
+  created with unique identifiers (as EC2 instances), some others have to be
+  explicitly created with unique names (e.g. S3 buckets). For these cases random
+  suffixes can be added to identifiers.
+* Destroy must work without additional input, and should be able to destroy all
+  the resources created by the configuration. There are some resources that need
+  specific flags to be destroyed by `terraform destroy`. For example S3 buckets
+  need a flag to force to empty the bucket before deleting it, or RDS instances
+  need a flag to disable snapshots on deletion.
+
+[[terraform-in-ci]]
+=== Terraform in CI
+
+Integration tests that need the presence of certain resources to work can be
+executed in CI if they provide a Terraform configuration to start these
+resources. These tests are disabled by default in CI.
+
+Terraform states are archived as artifacrs of builds, this allows to manually
+destroy resources created by builds that were not able to do a proper cleanup.
+
+Here is a checklist to add support for a cloud feature in Jenkins:
+* In the feature code:
+  * Tests have a build tag so they are disabled by default. When run from mage,
+    its execution can be selected using the `TEST_TAGS` environment variable, e.g:
+    `TEST_TAGS=aws` for AWS tests.
+  * There is some Terraform configuration that defines a cloud scenario where
+    tests pass. This configuration should be in the directory of the feature.
+* In the Jenkinsfile:
+  * Add a boolean parameter to run the tests on this environment, e.g.
+    `awsCloudTests`. This parameter should be set to false by default.
+  * Add a conditional block in `withCloudTestEnv` that:
+     * Will be executed if the previously added boolean parameter, or `allCloudTests`
+       are set to true.
+     * Adds the tag to `TEST_TAGS` (as comma separated values), so tests are
+       selected.
+     * Defines how to obtain the credentials and provide them to the tests.
+  * In the stage of the specific beat:
+    * Add a stage that calls to `startCloudTestEnv`, if there isn't anyone.
+    * Add a post cleanup step that calls to `terraformCleanup`, if there isn't anyone.
+    * Add a environment to the list of environments started by `startCloudEnv`,
+      with the condition to start the scenario, and the path to the directory
+      with its definition, e.g. `[cond: params.awsCloudTests, dir: 'x-pack/metricbeat/module/aws']`

--- a/x-pack/metricbeat/module/aws/terraform.tf
+++ b/x-pack/metricbeat/module/aws/terraform.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  version = "~> 2.58"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "random_password" "db" {
+  length  = 16
+  special = false
+}
+
+resource "aws_db_instance" "test" {
+  identifier          = "metricbeat-test-${random_id.suffix.hex}"
+  allocated_storage   = 20 // Gigabytes
+  engine              = "mysql"
+  instance_class      = "db.t2.micro"
+  name                = "metricbeattest"
+  username            = "foo"
+  password            = random_password.db.result
+  skip_final_snapshot = true // Required for cleanup
+}
+
+resource "aws_sqs_queue" "test" {
+  name                      = "metricbeat-test-${random_id.suffix.hex}"
+  receive_wait_time_seconds = 10
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = "metricbeat-test-${random_id.suffix.hex}"
+  force_destroy = true // Required for cleanup
+}
+
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_bucket.test.id
+  name   = "EntireBucket"
+}
+
+resource "aws_s3_bucket_object" "test" {
+  key     = "someobject"
+  bucket  = aws_s3_bucket.test.id
+  content = "something"
+}


### PR DESCRIPTION
Cherry-pick of PR #17480 to 7.x branch. Original message: 

## What does this PR do?

Add execution of AWS integration tests for Metricbeat to Jenkinsfile. For that, a simple terraform scenario is created that seems to be enough to pass the AWS module tests, this scenario is started by Jenkins, and destroyed as a cleanup step. With this approach terraform scenarios are defined per module, this is consequent with other efforts we are doing with other integrations, where integration test scenarios are defined at the module level. Similar approach will be followed for input integration tests.

Most of the logic is added in the Jenkinsfile and as scripts. Some things could be moved to mage when we modify our targets to start scenarios depending on the type of provisioner. Some parts are going to continue being needed in Jenkinsfile in my opinion, as the archive of Terraform states for manual cleanups.

Summary of changes:

* In Jenkinsfile:
  * Add a parameter to select provisioning and run all cloud tests, and another one specific for AWS tests.
  * Add a stage to x-pack metricbeat to provision scenarios, and a post cleanup stage to clean them up.
  * Terraform state is stashed so it can be used in other stages (this is required for cleanup). It is also archived to ease manual cleanups.
* In mage, environment variables for cloud clients setup are passed through to integration tests scenarios for testing.
* A simple terraform scenario is provided for AWS metricbeat module, seems enough to make current tests pass (except for `s3_request`, see note below).

## Why is it important?

To be able to run AWS-related Metricbeat integration tests in Jenkins.

## Pending for the future

* The test for `s3_request` metricset doesn't pass only by creating S3 buckets, we may need to make some requests to this bucket? I am skipping it by now.
* Allow to access to the Terraform state outputs in the tests. This is not possible at the moment because `mageTarget` cleans up the environment and only has a clean working copy of the code. This can be needed if we want to check for the metrics of an specific resource, or we want to collect logs from an specific endpoint. There are two approaches for that:
  * Refactor `mageTarget` so it is possible to unstash more things apart of the source.
  * Move environments provisioning to a mage target, so it can be run as part of `mageTarget`. We may still need to stash/archive the terraform state for cleanups or sharing the environment between stages.
* Add framework for testing filebeat inputs, previous point will be probably needed.
* Consider passing the credentials using files, instead of environment variables. This seems to be needed for Google Cloud, but can be tricky with current management of workspaces.
* When terraform scenario grows, start using modules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- [x] Load credentials.
- [x] Actually do the provisioning of the scenario.
- [x] Double check that everything works with or without cloud tests.
- [x] Add somewhere some guidelines about terraform, and a checklist to add a new environment:
  ```
  - Execution of tests with mage can be selected using the `TEST_TAGS` environment variable, e.g: TEST_TAGS=aws.
  - There is some terraform configuration that defines a cloud scenario where tests pass.
  - In the Jenkinsfile:
    - Add a boolean parameter to run the tests on this environment, e.g. `awsCloudTests`.
    - Add a conditional block in `withCloudTestEnv` that:
       - Will be executed if the previoysly added boolean parameter, or `allCloudTests` are set to true.
       - Adds the tag to `TEST_TAGS` (as comma separated values).
       - Defines how to obtain the credentials and provide them to the tests.
    - In the stage of the specific beat:
      - Add a stage that calls to `startCloudTestEnv`, if there isn't anyone.
      - Add a post cleanup step that calls to `terraformCleanup`, if there isn't anyone.
      - Add a environment to the list of environments started by `startCloudEnv`, with the condition to start the scenario, and the path to the directory with its definition, e.g. `[cond: params.awsCloudTests, dir: 'x-pack/metricbeat/module/aws']`
  ```

## Related issues

- Closes https://github.com/elastic/beats/issues/15891
