### PR TITLE
Cherry-pick #18127 to 7.x: Add Kerberos-aware Elasticsearch and integration test to ES output

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ES_MONITORING_HOST=elasticsearch_monitoring
       - ES_MONITORING_PORT=9200
       - ES_HOST_SSL=elasticsearchssl
+      - ES_KERBEROS_HOST=elasticsearch_kerberos.elastic
       - ES_PORT_SSL=9200
       - ES_SUPERUSER_USER=admin
       - ES_SUPERUSER_PASS=changeme
@@ -42,14 +43,15 @@ services:
   proxy_dep:
     image: busybox
     depends_on:
-      elasticsearch:            { condition: service_healthy }
-      elasticsearch_monitoring: { condition: service_healthy }
-      elasticsearchssl:         { condition: service_healthy }
-      logstash:                 { condition: service_healthy }
-      kafka:                    { condition: service_healthy }
-      redis:                    { condition: service_healthy }
-      sredis:                   { condition: service_healthy }
-      kibana:                   { condition: service_healthy }
+      elasticsearch:                  { condition: service_healthy }
+      elasticsearch_kerberos.elastic: { condition: service_healthy }
+      elasticsearch_monitoring:       { condition: service_healthy }
+      elasticsearchssl:               { condition: service_healthy }
+      logstash:                       { condition: service_healthy }
+      kafka:                          { condition: service_healthy }
+      redis:                          { condition: service_healthy }
+      sredis:                         { condition: service_healthy }
+      kibana:                         { condition: service_healthy }
     healthcheck:
       interval: 1s
       retries: 1200
@@ -127,6 +129,35 @@ services:
       - 2181
     environment:
       - ADVERTISED_HOST=kafka
+
+  elasticsearch_kerberos.elastic:
+    build: ${ES_BEATS}/testing/environments/docker/elasticsearch_kerberos
+    healthcheck:
+      test: bash -c "/healthcheck.sh"
+      retries: 1200
+      interval: 5s
+      start_period: 60s
+    environment:
+      - "TERM=linux"
+      - "ELASTIC_PASSWORD=changeme"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.krb5.conf=/etc/krb5.conf"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=true"
+      - "indices.id_field_data.enabled=true"
+      - "xpack.license.self_generated.type=trial"
+      - "xpack.security.authc.realms.kerberos.ELASTIC.order=1"
+      - "xpack.security.authc.realms.kerberos.ELASTIC.keytab.path=/usr/share/elasticsearch/config/HTTP_elasticsearch_kerberos.elastic.keytab"
+    hostname: elasticsearch_kerberos.elastic
+    volumes:
+      # This is needed otherwise there won't be enough entropy to generate a new kerberos realm
+      - /dev/urandom:/dev/random
+    ports:
+      - 1088
+      - 1749
+      - 9200
+    command: bash -c "/start.sh"
 
   kibana:
     extends:

--- a/libbeat/esleg/eslegtest/util.go
+++ b/libbeat/esleg/eslegtest/util.go
@@ -64,6 +64,11 @@ func GetEsHost() string {
 	return getEnv("ES_HOST", ElasticsearchDefaultHost)
 }
 
+// GetEsKerberosHost returns the Elasticsearch testing host.
+func GetEsKerberosHost() string {
+	return getEnv("ES_KERBEROS_HOST", ElasticsearchDefaultHost)
+}
+
 // getEsPort returns the Elasticsearch testing port.
 func getEsPort() string {
 	return getEnv("ES_PORT", ElasticsearchDefaultPort)

--- a/libbeat/outputs/elasticsearch/testdata/krb5.conf
+++ b/libbeat/outputs/elasticsearch/testdata/krb5.conf
@@ -1,0 +1,43 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[libdefaults]
+    default_realm = ELASTIC
+    dns_canonicalize_hostname = false
+    dns_lookup_kdc = false
+    dns_lookup_realm = false
+    dns_uri_lookup = false
+    forwardable = true
+    ignore_acceptor_hostname = true
+    rdns = false
+    default_tgs_enctypes = aes128-cts-hmac-sha1-96
+    default_tkt_enctypes = aes128-cts-hmac-sha1-96
+    permitted_enctypes = aes128-cts-hmac-sha1-96
+    udp_preference_limit = 1
+    kdc_timeout = 3000
+
+[realms]
+    ELASTIC = {
+        kdc = elasticsearch_kerberos.elastic:1088
+        admin_server = elasticsearch_kerberos.elastic:1749
+        default_domain = elastic
+    }
+
+[domain_realm]
+    .elastic = ELASTIC
+    elastic = ELASTIC
+

--- a/testing/environments/docker/elasticsearch/kerberos/init.sh
+++ b/testing/environments/docker/elasticsearch/kerberos/init.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# setup Keberos
+echo elasticsearch_kerberos.elastic > /etc/hostname && echo "127.0.0.1 elasticsearch_kerberos.elastic" >> /etc/hosts
+
+/scripts/installkdc.sh
+/scripts/addprincs.sh
+
+# add test user
+bin/elasticsearch-users useradd beats -r superuser -p testing | /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/testing/environments/docker/elasticsearch/kerberos/installkdc.sh
+++ b/testing/environments/docker/elasticsearch/kerberos/installkdc.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# KDC installation steps and considerations based on https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html
+# and helpful input from https://help.ubuntu.com/community/Kerberos
+
+LOCALSTATEDIR=/etc
+LOGDIR=/var/log/krb5
+
+#MARKER_FILE=/etc/marker
+
+# Transfer and interpolate krb5.conf
+cp /config/krb5.conf.template $LOCALSTATEDIR/krb5.conf
+sed -i 's/${REALM_NAME}/'$REALM_NAME'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${KDC_NAME}/'$KDC_NAME'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${BUILD_ZONE}/'$BUILD_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${ELASTIC_ZONE}/'$ELASTIC_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+
+
+# Transfer and interpolate the kdc.conf
+mkdir -p $LOCALSTATEDIR/krb5kdc
+cp /config/kdc.conf.template $LOCALSTATEDIR/krb5kdc/kdc.conf
+sed -i 's/${REALM_NAME}/'$REALM_NAME'/g' $LOCALSTATEDIR/krb5kdc/kdc.conf
+sed -i 's/${KDC_NAME}/'$KDC_NAME'/g' $LOCALSTATEDIR/krb5kdc/kdc.conf
+sed -i 's/${BUILD_ZONE}/'$BUILD_ZONE'/g' $LOCALSTATEDIR/krb5kdc/kdc.conf
+sed -i 's/${ELASTIC_ZONE}/'$ELASTIC_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+
+# Touch logging locations
+mkdir -p $LOGDIR
+touch $LOGDIR/kadmin.log
+touch $LOGDIR/krb5kdc.log
+touch $LOGDIR/krb5lib.log
+
+# Update package manager
+yum update -qqy
+
+# Install krb5 packages
+yum install -qqy krb5-{server,libs,workstation}
+
+# Create kerberos database with stash file and garbage password
+kdb5_util create -s -r $REALM_NAME -P zyxwvutsrpqonmlk9876
+
+# Set up admin acls
+cat << EOF > /etc/krb5kdc/kadm5.acl
+*/admin@$REALM_NAME	*
+*@$REALM_NAME   	*
+*/*@$REALM_NAME		i
+EOF
+
+# Create admin principal
+kadmin.local -q "addprinc -pw elastic admin/admin@$REALM_NAME"
+kadmin.local -q "ktadd -k /etc/admin.keytab admin/admin@$REALM_NAME"
+
+# Create a link so addprinc.sh is on path
+ln -s /scripts/addprinc.sh /usr/bin/

--- a/testing/environments/docker/elasticsearch_kerberos/Dockerfile
+++ b/testing/environments/docker/elasticsearch_kerberos/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+
+ADD scripts /scripts
+ADD config /config
+ADD healthcheck.sh /healthcheck.sh
+ADD start.sh /start.sh
+
+ENV REALM_NAME ELASTIC
+ENV KDC_NAME elasticsearch_kerberos.elastic
+ENV BUILD_ZONE elastic
+ENV ELASTIC_ZONE $BUILD_ZONE
+
+USER root
+RUN /scripts/installkdc.sh && /scripts/addprincs.sh
+USER elasticsearch

--- a/testing/environments/docker/elasticsearch_kerberos/Dockerfile
+++ b/testing/environments/docker/elasticsearch_kerberos/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.7.0-SNAPSHOT
 
 ADD scripts /scripts
 ADD config /config

--- a/testing/environments/docker/elasticsearch_kerberos/config/kdc.conf.template
+++ b/testing/environments/docker/elasticsearch_kerberos/config/kdc.conf.template
@@ -1,0 +1,34 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[kdcdefaults]
+    kdc_listen = 1088
+    kdc_tcp_listen = 1088
+
+[realms]
+    ${REALM_NAME} = {
+        kadmind_port = 1749
+        max_life = 12h 0m 0s
+        max_renewable_life = 7d 0h 0m 0s
+        master_key_type = aes256-cts
+        supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+    }
+
+[logging]
+    kdc = FILE:/var/log/krb5/krb5kdc.log
+    admin_server = FILE:/var/log/krb5/kadmin.log
+    default = FILE:/var/log/krb5/krb5lib.log

--- a/testing/environments/docker/elasticsearch_kerberos/config/krb5.conf
+++ b/testing/environments/docker/elasticsearch_kerberos/config/krb5.conf
@@ -1,0 +1,25 @@
+[libdefaults]
+    default_realm = ELASTIC
+    dns_canonicalize_hostname = false
+    dns_lookup_kdc = false
+    dns_lookup_realm = false
+    dns_uri_lookup = false
+    forwardable = true
+    ignore_acceptor_hostname = true
+    rdns = false
+    default_tgs_enctypes = aes128-cts-hmac-sha1-96
+    default_tkt_enctypes = aes128-cts-hmac-sha1-96
+    permitted_enctypes = aes128-cts-hmac-sha1-96
+    kdc_timeout = 3000
+
+[realms]
+    ELASTIC = {
+        kdc = elasticsearch_kerberos.elastic:88
+        admin_server = elasticsearch_kerberos.elastic:749
+        default_domain = elastic
+    }
+
+[domain_realm]
+    .elastic = ELASTIC
+    elastic = ELASTIC
+

--- a/testing/environments/docker/elasticsearch_kerberos/config/krb5.conf.template
+++ b/testing/environments/docker/elasticsearch_kerberos/config/krb5.conf.template
@@ -1,0 +1,43 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[libdefaults]
+    default_realm = ${REALM_NAME}
+    dns_canonicalize_hostname = false
+    dns_lookup_kdc = false
+    dns_lookup_realm = false
+    dns_uri_lookup = false
+    forwardable = true
+    ignore_acceptor_hostname = true
+    rdns = false
+    default_tgs_enctypes = aes128-cts-hmac-sha1-96
+    default_tkt_enctypes = aes128-cts-hmac-sha1-96
+    permitted_enctypes = aes128-cts-hmac-sha1-96
+    udp_preference_limit = 1
+    kdc_timeout = 3000
+
+[realms]
+    ${REALM_NAME} = {
+        kdc = localhost:1088
+        admin_server = localhost:1749
+        default_domain = ${BUILD_ZONE}
+    }
+
+[domain_realm]
+    .${ELASTIC_ZONE} = ${REALM_NAME}
+    ${ELASTIC_ZONE} = ${REALM_NAME}
+

--- a/testing/environments/docker/elasticsearch_kerberos/healthcheck.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# check if service principal is OK
+KRB5_CONFIG=/etc/krb5.conf \
+    kinit -k -t /etc/HTTP_elasticsearch_kerberos.elastic.keytab HTTP/elasticsearch_kerberos.elastic@ELASTIC
+
+
+# check if beats user can connect
+echo testing | KRB5_CONFIG=/etc/krb5.conf kinit beats@ELASTIC
+klist
+curl --negotiate -u : -XGET http://elasticsearch_kerberos.elastic:9200/

--- a/testing/environments/docker/elasticsearch_kerberos/scripts/addprinc.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/scripts/addprinc.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+  echo 'Usage: addprinc.sh principalName [password]'
+  echo '  principalName    user principal name without realm'
+  echo '  password         If provided then will set password for user else it will provision user with keytab'
+  exit 1
+fi
+
+PRINC="$1"
+PASSWD="$2"
+USER=$(echo $PRINC | tr "/" "_")
+REALM=ELASTIC
+
+VDIR=/usr/share/kerberos
+BUILD_DIR=/var/build
+LOCALSTATEDIR=/etc
+LOGDIR=/var/log/krb5
+
+ADMIN_PRIN=admin/admin@$REALM
+ADMIN_KTAB=$LOCALSTATEDIR/admin.keytab
+
+USER_PRIN=$PRINC@$REALM
+USER_KTAB=$LOCALSTATEDIR/$USER.keytab
+
+if [ -f $USER_KTAB ] && [ -z "$PASSWD" ]; then
+  echo "Principal '${PRINC}@${REALM}' already exists. Re-copying keytab..."
+  sudo cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
+else
+  if [ -z "$PASSWD" ]; then
+    echo "Provisioning '${PRINC}@${REALM}' principal and keytab..."
+    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -randkey $USER_PRIN"
+    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "ktadd -k $USER_KTAB $USER_PRIN"
+    sudo chmod 777 $USER_KTAB
+    sudo cp $USER_KTAB /usr/share/elasticsearch/config
+    sudo chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/$USER.keytab
+  else
+    echo "Provisioning '${PRINC}@${REALM}' principal with password..."
+    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -pw $PASSWD $PRINC"
+  fi
+fi
+
+echo "Done provisioning $USER"

--- a/testing/environments/docker/elasticsearch_kerberos/scripts/addprincs.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/scripts/addprincs.sh
@@ -1,0 +1,7 @@
+set -e
+
+krb5kdc
+kadmind
+
+addprinc.sh HTTP/elasticsearch_kerberos.elastic
+addprinc.sh beats testing

--- a/testing/environments/docker/elasticsearch_kerberos/scripts/installkdc.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/scripts/installkdc.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+LOCALSTATEDIR=/etc
+KDC_CONFIG=/var/kerberos
+LOGDIR=/var/log/krb5
+
+#MARKER_FILE=/etc/marker
+
+# Transfer and interpolate krb5.conf
+cp /config/krb5.conf.template $LOCALSTATEDIR/krb5.conf
+sed -i 's/${REALM_NAME}/'$REALM_NAME'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${KDC_NAME}/'$KDC_NAME'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${BUILD_ZONE}/'$BUILD_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+sed -i 's/${ELASTIC_ZONE}/'$ELASTIC_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+
+
+# Transfer and interpolate the kdc.conf
+mkdir -p $KDC_CONFIG/krb5kdc
+cp /config/kdc.conf.template $KDC_CONFIG/krb5kdc/kdc.conf
+sed -i 's/${REALM_NAME}/'$REALM_NAME'/g' $KDC_CONFIG/krb5kdc/kdc.conf
+sed -i 's/${KDC_NAME}/'$KDC_NAME'/g' $KDC_CONFIG/krb5kdc/kdc.conf
+sed -i 's/${BUILD_ZONE}/'$BUILD_ZONE'/g' $KDC_CONFIG/krb5kdc/kdc.conf
+sed -i 's/${ELASTIC_ZONE}/'$ELASTIC_ZONE'/g' $LOCALSTATEDIR/krb5.conf
+
+# Touch logging locations
+mkdir -p $LOGDIR
+touch $LOGDIR/kadmin.log
+touch $LOGDIR/krb5kdc.log
+touch $LOGDIR/krb5lib.log
+
+# Update package manager
+yum update -qqy
+
+# Install krb5 packages
+yum install -qqy krb5-{server,libs,workstation} sudo
+
+# Create kerberos database with stash file and garbage password
+kdb5_util create -s -r $REALM_NAME -P zyxwvutsrpqonmlk9876
+
+# Set up admin acls
+cat << EOF > /var/kerberos/krb5kdc/kadm5.acl
+*/admin@$REALM_NAME	*
+*@$REALM_NAME   	*
+*/*@$REALM_NAME	    i
+EOF
+
+# Create admin principal
+kadmin.local -q "addprinc -pw elastic admin/admin@$REALM_NAME"
+kadmin.local -q "ktadd -k /etc/admin.keytab admin/admin@$REALM_NAME"
+
+# set ownership for ES
+chown -R elasticsearch:elasticsearch $LOGDIR
+chown -R elasticsearch:elasticsearch $KDC_CONFIG
+chown -R elasticsearch:elasticsearch $LOCALSTATEDIR/krb5.conf
+chown -R elasticsearch:elasticsearch $LOCALSTATEDIR/admin.keytab
+
+
+# Create a link so addprinc.sh is on path
+ln -s /scripts/addprinc.sh /usr/bin/

--- a/testing/environments/docker/elasticsearch_kerberos/start.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# start Kerberos services
+krb5kdc
+kadmind
+
+# start ES
+/usr/local/bin/docker-entrypoint.sh eswrapper

--- a/testing/environments/docker/kerberos_kdc/Dockerfile
+++ b/testing/environments/docker/kerberos_kdc/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:14.04
+ADD scripts /scripts
+
+ENV REALM_NAME ELASTIC
+ENV KDC_NAME kerberos_kdc
+ENV BUILD_ZONE elastic
+ENV ELASTIC_ZONE $BUILD_ZONE
+
+RUN echo kerberos_kdc.elastic > /etc/hostname && echo "127.0.0.1 kerberos_kdc.elastic" >> /etc/hosts
+RUN bash /scripts/installkdc.sh
+
+EXPOSE 88
+EXPOSE 749
+
+CMD sleep infinity


### PR DESCRIPTION
Cherry-pick of PR #18127 to 7.x branch. Original message: 

## What does this PR do?

This PR adds an integration test to the Elasticsearch output to check Kerberos authentication.

Furthermore, it adds a new element to our testing environment, a Kerberos-aware Elasticsearch instance named `elasticsearch_kerberos.elastic`.

## Why is it important?

To make sure Kerberos authentication is working.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
