### PR TITLE
Cherry-pick #17960 to 7.x: Allow CLI paths override

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,4 +37,5 @@
 - Display the stability of the agent at enroll and start.  {pull}17336[17336]
 - Expose stream.* variables in events {pull}17468[17468]
 - Monitoring configuration reloadable {pull}17855[17855]
+- Allow CLI overrides of paths {pull}17781[17781]
 - Enable Filebeat input: S3, Azureeventhub, cloudfoundry, httpjson, netflow, o365audit. {pull}17909[17909]

--- a/x-pack/elastic-agent/main_test.go
+++ b/x-pack/elastic-agent/main_test.go
@@ -8,17 +8,21 @@ import (
 	"flag"
 	"testing"
 
-	// Just using this a place holder.
-	"github.com/elastic/beats/v7/x-pack/filebeat/cmd"
+	"github.com/spf13/cobra"
 )
 
 var systemTest *bool
 
 func init() {
 	testing.Init()
+
+	cmd := &cobra.Command{
+		Use: "elastic-agent [subcommand]",
+	}
+
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
-	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -5,30 +5,30 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/basecmd"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-var defaultConfig = "elastic-agent.yml"
+const defaultConfig = "elastic-agent.yml"
 
 type globalFlags struct {
-	PathConfigFile  string
 	PathConfig      string
-	PathData        string
-	PathHome        string
-	PathLogs        string
+	PathConfigFile  string
 	FlagStrictPerms bool
 }
 
+// Config returns path which identifies configuration file.
 func (f *globalFlags) Config() string {
 	if len(f.PathConfigFile) == 0 {
-		return filepath.Join(f.PathHome, defaultConfig)
+		return filepath.Join(application.HomePath(), defaultConfig)
 	}
 	return f.PathConfigFile
 }
@@ -50,11 +50,11 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 
 	flags := &globalFlags{}
 
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.home"))
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.data"))
+
 	cmd.PersistentFlags().StringVarP(&flags.PathConfigFile, "", "c", defaultConfig, fmt.Sprintf(`Configuration file, relative to path.config (default "%s")`, defaultConfig))
-	cmd.PersistentFlags().StringVarP(&flags.PathHome, "path.home", "", "", "Home path")
 	cmd.PersistentFlags().StringVarP(&flags.PathConfig, "path.config", "", "${path.home}", "Configuration path")
-	cmd.PersistentFlags().StringVarP(&flags.PathData, "path.data", "", "${path.home}/data", "Data path")
-	cmd.PersistentFlags().StringVarP(&flags.PathLogs, "path.logs", "", "${path.home}/logs", "Logs path")
 	cmd.PersistentFlags().BoolVarP(&flags.FlagStrictPerms, "strict.perms", "", true, "Strict permission checking on config files")
 
 	// Add version.

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -46,13 +46,13 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 
 func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
 	warn.PrintNotGA(streams.Out)
-
-	config, err := config.LoadYAML(flags.PathConfigFile)
+	pathConfigFile := flags.Config()
+	config, err := config.LoadYAML(pathConfigFile)
 	if err != nil {
 		return errors.New(err,
-			fmt.Sprintf("could not read configuration file %s", flags.PathConfigFile),
+			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
 			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, flags.PathConfigFile))
+			errors.M(errors.MetaKeyPath, pathConfigFile))
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
@@ -95,7 +95,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 	c, err := application.NewEnrollCmd(
 		logger,
 		&options,
-		flags.PathConfigFile,
+		pathConfigFile,
 	)
 
 	if err != nil {

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -33,12 +33,13 @@ func newRunCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStream
 }
 
 func run(flags *globalFlags, streams *cli.IOStreams) error {
-	config, err := config.LoadYAML(flags.PathConfigFile)
+	pathConfigFile := flags.Config()
+	config, err := config.LoadYAML(pathConfigFile)
 	if err != nil {
 		return errors.New(err,
-			fmt.Sprintf("could not read configuration file %s", flags.PathConfigFile),
+			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
 			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, flags.PathConfigFile))
+			errors.M(errors.MetaKeyPath, pathConfigFile))
 	}
 
 	logger, err := logger.NewFromConfig(config)
@@ -46,7 +47,7 @@ func run(flags *globalFlags, streams *cli.IOStreams) error {
 		return err
 	}
 
-	app, err := application.New(logger, flags.PathConfigFile)
+	app, err := application.New(logger, pathConfigFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry-pick of PR #17781 to 7.x branch. Original message:

## What does this PR do?

Allowing override of configuration using `-E` flag of two specific cases `--path.data`  `--path.home` 

## Why is it important?

Allows having data (download, install) outside of agent directory without manually changing configuration file

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
