### PR TITLE
Cherry-pick #17944 to 7.x: corrected module decode_cef documentation from Beta to GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -350,6 +350,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added Unix stream socket support as an input source and a syslog input source. {pull}17492[17492]
 - Improve ECS categorization field mappings in misp module. {issue}16026[16026] {pull}17344[17344]
 - Enhance `elasticsearch/deprecation` fileset to handle ECS-compatible logs emitted by Elasticsearch. {issue}17715[17715] {pull}17728[17728]
+- Make `decode_cef` processor GA. {pull}17944[17944]
 - Improve ECS categorization field mappings in redis module. {issue}16179[16179] {pull}17918[17918]
 - Improve ECS categorization field mappings in rabbitmq module. {issue}16178[16178] {pull}17916[17916]
 - Improve ECS categorization field mappings in postgresql module. {issue}16177[16177] {pull}17914[17914]

--- a/x-pack/filebeat/processors/decode_cef/decode_cef.go
+++ b/x-pack/filebeat/processors/decode_cef/decode_cef.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/x-pack/filebeat/processors/decode_cef/cef"
@@ -45,8 +44,6 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 func newDecodeCEF(c config) (*processor, error) {
-	cfgwarn.Beta("The " + procName + " processor is a beta feature.")
-
 	log := logp.NewLogger(logName)
 	if c.ID != "" {
 		log = log.With("instance_id", c.ID)

--- a/x-pack/filebeat/processors/decode_cef/docs/decode_cef.asciidoc
+++ b/x-pack/filebeat/processors/decode_cef/docs/decode_cef.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>decode_cef</titleabbrev>
 ++++
 
-beta[]
-
 The `decode_cef` processor decodes Common Event Format (CEF) messages. This
 processor is available in Filebeat.
 


### PR DESCRIPTION
Cherry-pick of PR #17944 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
decode_cef codec is not beta any more.
For the moment this is not consistent with https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-cef.html

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
https://www.elastic.co/guide/en/beats/filebeat/current/processor-decode-cef.html and https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-cef.html have differences regarding documentation. This should be fixed after this PR is merged.