### PR TITLE
Cherry-pick #18032 to 7.x: [Auditbeat] Add system module process dataset ECS categorization fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -277,6 +277,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Log to stderr when running using reference kubernetes manifests. {pull}17443[174443]
 - Fix syscall kprobe arguments for 32-bit systems in socket module. {pull}17500[17500]
 - Fix memory leak on when we miss socket close kprobe events. {pull}17500[17500]
+- Add system module process dataset ECS categorization fields. {pull}18032[18032]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -66,6 +66,21 @@ func (action eventAction) String() string {
 	}
 }
 
+func (action eventAction) Type() string {
+	switch action {
+	case eventActionExistingProcess:
+		return "info"
+	case eventActionProcessStarted:
+		return "start"
+	case eventActionProcessStopped:
+		return "end"
+	case eventActionProcessError:
+		return "info"
+	default:
+		return "info"
+	}
+}
+
 func init() {
 	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
 		mb.DefaultMetricSet(),
@@ -319,8 +334,10 @@ func (ms *MetricSet) processEvent(process *Process, eventType string, action eve
 	event := mb.Event{
 		RootFields: common.MapStr{
 			"event": common.MapStr{
-				"kind":   eventType,
-				"action": action.String(),
+				"kind":     eventType,
+				"category": []string{"process"},
+				"type":     []string{action.Type()},
+				"action":   action.String(),
 			},
 			"process": process.toMapStr(),
 			"message": processMessage(process, action),

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -66,9 +66,11 @@ func TestProcessEvent(t *testing.T) {
 	}
 
 	expectedRootFields := map[string]interface{}{
-		"event.kind":   "event",
-		"event.action": "process_started",
-		"message":      "Process zsh (PID: 9086) by user elastic STARTED",
+		"event.kind":     "event",
+		"event.category": []string{"process"},
+		"event.type":     []string{"start"},
+		"event.action":   "process_started",
+		"message":        "Process zsh (PID: 9086) by user elastic STARTED",
 
 		"process.pid":        9086,
 		"process.ppid":       9085,


### PR DESCRIPTION
Cherry-pick of PR #18032 to 7.x branch. Original message: 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/17525