### PR TITLE
Cherry-pick #17823 to 7.x: Add process.command_line to Sysmon module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -455,6 +455,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add more DNS error codes to the Sysmon module. {issue}15685[15685]
 - Add Audit and Log Management, Computer Object Management, and Distribution Group related events to the Security module. {pull}15217[15217]
 - Add experimental event log reader implementation that should be faster in most cases. {issue}6585[6585] {pull}16849[16849]
+- Set process.command_line and process.parent.command_line from Sysmon Event ID 1. {pull}17327[17327]
 - Add support for event IDs 4673,4674,4697,4698,4699,4700,4701,4702,4768,4769,4770,4771,4776,4778,4779,4964 to the Security module {pull}17517[17517]
 
 ==== Deprecated

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -301,20 +301,20 @@ var sysmon = (function () {
         evt.Put(nameField, path.basename(exe));
     };
 
-    var splitCommandLine = function(evt, field) {
-        var commandLine = evt.Get(field);
+    var splitCommandLine = function(evt, source, target) {
+        var commandLine = evt.Get(source);
         if (!commandLine) {
             return;
         }
-        evt.Put(field, winlogbeat.splitCommandLine(commandLine));
+        evt.Put(target, winlogbeat.splitCommandLine(commandLine));
     };
 
     var splitProcessArgs = function(evt) {
-        splitCommandLine(evt, "process.args");
+        splitCommandLine(evt, "process.command_line", "process.args");
     };
 
     var splitParentProcessArgs = function(evt) {
-        splitCommandLine(evt, "process.parent.args");
+        splitCommandLine(evt, "process.parent.command_line", "process.parent.args");
     };
 
     var addUser = function(evt) {
@@ -468,12 +468,12 @@ var sysmon = (function () {
                 {from: "winlog.event_data.ProcessGuid", to: "process.entity_id"},
                 {from: "winlog.event_data.ProcessId", to: "process.pid", type: "long"},
                 {from: "winlog.event_data.Image", to: "process.executable"},
-                {from: "winlog.event_data.CommandLine", to: "process.args"},
+                {from: "winlog.event_data.CommandLine", to: "process.command_line"},
                 {from: "winlog.event_data.CurrentDirectory", to: "process.working_directory"},
                 {from: "winlog.event_data.ParentProcessGuid", to: "process.parent.entity_id"},
                 {from: "winlog.event_data.ParentProcessId", to: "process.parent.pid", type: "long"},
                 {from: "winlog.event_data.ParentImage", to: "process.parent.executable"},
-                {from: "winlog.event_data.ParentCommandLine", to: "process.parent.args"},
+                {from: "winlog.event_data.ParentCommandLine", to: "process.parent.command_line"},
             ],
             mode: "rename",
             ignore_missing: true,

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -101,6 +101,7 @@
       "args": [
         "C:\\Windows\\Sysmon.exe"
       ],
+      "command_line": "C:\\Windows\\Sysmon.exe",
       "entity_id": "{42f11c3b-ce01-5c8f-0000-0010c73e2a00}",
       "executable": "C:\\Windows\\Sysmon.exe",
       "name": "Sysmon.exe",
@@ -108,6 +109,7 @@
         "args": [
           "C:\\Windows\\system32\\services.exe"
         ],
+        "command_line": "C:\\Windows\\system32\\services.exe",
         "entity_id": "{42f11c3b-6e1a-5c8c-0000-0010f14d0000}",
         "executable": "C:\\Windows\\System32\\services.exe",
         "name": "services.exe",
@@ -177,6 +179,7 @@
         "C:\\Windows\\system32\\wbem\\unsecapp.exe",
         "-Embedding"
       ],
+      "command_line": "C:\\Windows\\system32\\wbem\\unsecapp.exe -Embedding",
       "entity_id": "{42f11c3b-ce01-5c8f-0000-00102c412a00}",
       "executable": "C:\\Windows\\System32\\wbem\\unsecapp.exe",
       "name": "unsecapp.exe",
@@ -186,6 +189,7 @@
           "-k",
           "DcomLaunch"
         ],
+        "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
         "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
@@ -345,6 +349,7 @@
         "C:\\Windows\\system32\\wbem\\wmiprvse.exe",
         "-Embedding"
       ],
+      "command_line": "C:\\Windows\\system32\\wbem\\wmiprvse.exe -Embedding",
       "entity_id": "{42f11c3b-ce03-5c8f-0000-0010e9462a00}",
       "executable": "C:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
       "name": "WmiPrvSE.exe",
@@ -354,6 +359,7 @@
           "-k",
           "DcomLaunch"
         ],
+        "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
         "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",


### PR DESCRIPTION
Cherry-pick of PR #17823 to 7.x branch. Original message: 

## What does this PR do?

This is a continuation of #17327. The source fork no longer exists.

This add `process.command_line` and `process.parent.command_line` to Sysmon Event ID 1.

## Why is it important?

The command_line is an ECS field.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

