### PR TITLE
Cherry-pick #18083 to 7.x: Configurable log level

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -41,5 +41,6 @@
 - Pack ECS metadata to request payload send to fleet {pull}17894[17894]
 - Allow CLI overrides of paths {pull}17781[17781]
 - Enable Filebeat input: S3, Azureeventhub, cloudfoundry, httpjson, netflow, o365audit. {pull}17909[17909]
+- Configurable log level {pull}18083[18083]
 - Use data subfolder as default for process logs {pull}17960[17960]
 - Do not require unnecessary configuration {pull}18003[18003]

--- a/x-pack/elastic-agent/_meta/common.p2.yml
+++ b/x-pack/elastic-agent/_meta/common.p2.yml
@@ -119,3 +119,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/_meta/common.reference.p2.yml
+++ b/x-pack/elastic-agent/_meta/common.reference.p2.yml
@@ -119,3 +119,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/_meta/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.docker.yml
@@ -119,3 +119,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/_meta/elastic-agent.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.yml
@@ -119,3 +119,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/docs/elastic-agent_configuration_example.yml
+++ b/x-pack/elastic-agent/docs/elastic-agent_configuration_example.yml
@@ -25,6 +25,10 @@ outputs:
 settings.monitoring:
   use_output: monitoring
 
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace
+
 datasources:
   # use the nginx package
   - id?: nginx-x1

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -119,3 +119,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -124,3 +124,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -124,3 +124,7 @@ datasources:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -55,7 +55,7 @@ func newLocal(
 ) (*Local, error) {
 	var err error
 	if log == nil {
-		log, err = logger.New()
+		log, err = logger.NewFromConfig(rawConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/agent/operation/config/config.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/retry"
 )
@@ -16,6 +17,7 @@ type Config struct {
 	RetryConfig   *retry.Config   `yaml:"retry" config:"retry"`
 
 	DownloadConfig *artifact.Config `yaml:"download" config:"download"`
+	LoggingConfig  *logger.Config   `yaml:"logging,omitempty" config:"logging,omitempty"`
 }
 
 // DefaultConfig creates a config with pre-set default values.
@@ -24,5 +26,6 @@ func DefaultConfig() *Config {
 		ProcessConfig:  process.DefaultConfig(),
 		RetryConfig:    retry.DefaultConfig(),
 		DownloadConfig: artifact.DefaultConfig(),
+		LoggingConfig:  logger.DefaultLoggingConfig(),
 	}
 }

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -239,7 +239,20 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 		return nil, fmt.Errorf("descriptor is not an app.Specifier")
 	}
 
-	a, err := app.NewApplication(o.bgContext, p.ID(), p.BinaryName(), o.pipelineID, specifier, factory, o.config, o.logger, o.eventProcessor.OnFailing, o.monitor)
+	// TODO: (michal) join args into more compact options version
+	a, err := app.NewApplication(
+		o.bgContext,
+		p.ID(),
+		p.BinaryName(),
+		o.pipelineID,
+		o.config.LoggingConfig.Level.String(),
+		specifier,
+		factory,
+		o.config,
+		o.logger,
+		o.eventProcessor.OnFailing,
+		o.monitor)
+
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -5,6 +5,8 @@
 package logger
 
 import (
+	"fmt"
+
 	"github.com/urso/ecslog"
 	"github.com/urso/ecslog/backend"
 	"github.com/urso/ecslog/backend/appender"
@@ -16,21 +18,78 @@ import (
 // Logger alias ecslog.Logger with Logger.
 type Logger = ecslog.Logger
 
+// Config is a configuration of logging.
+type Config struct {
+	Level loggingLevel `config:"level"`
+}
+
+// DefaultLoggingConfig creates a default logging configuration.
+func DefaultLoggingConfig() *Config {
+	return &Config{
+		Level: loggingLevel(backend.Trace),
+	}
+}
+
 // New returns a configured ECS Logger
 func New() (*Logger, error) {
-	backend, err := createJSONBackend()
+	return new(backend.Trace)
+}
+
+func createJSONBackend(lvl backend.Level) (backend.Backend, error) {
+	return appender.Console(lvl, layout.Text(true))
+}
+
+//NewFromConfig takes the user configuration and generate the right logger.
+// TODO: Finish implementation, need support on the library that we use.
+func NewFromConfig(cfg *config.Config) (*Logger, error) {
+	wrappedConfig := &struct {
+		Logging *Config `config:"logging"`
+	}{
+		Logging: DefaultLoggingConfig(),
+	}
+
+	if err := cfg.Unpack(&wrappedConfig); err != nil {
+		return nil, err
+	}
+
+	return new(backend.Level(wrappedConfig.Logging.Level))
+}
+
+func new(lvl backend.Level) (*Logger, error) {
+	backend, err := createJSONBackend(lvl)
 	if err != nil {
 		return nil, err
 	}
 	return ecslog.New(backend), nil
 }
 
-func createJSONBackend() (backend.Backend, error) {
-	return appender.Console(backend.Trace, layout.Text(true))
+type loggingLevel backend.Level
+
+var loggingLevelMap = map[string]loggingLevel{
+	"trace": loggingLevel(backend.Trace),
+	"debug": loggingLevel(backend.Debug),
+	"info":  loggingLevel(backend.Info),
+	"error": loggingLevel(backend.Error),
 }
 
-//NewFromConfig takes the user configuration and generate the right logger.
-// TODO: Finish implementation, need support on the library that we use.
-func NewFromConfig(_ *config.Config) (*Logger, error) {
-	return New()
+func (m *loggingLevel) Unpack(v string) error {
+	mgt, ok := loggingLevelMap[v]
+	if !ok {
+		return fmt.Errorf(
+			"unknown logging level mode, received '%s' and valid values are 'trace', 'debug', 'info' or 'error'",
+			v,
+		)
+	}
+	*m = mgt
+	return nil
+}
+
+func (m *loggingLevel) String() string {
+	for s, v := range loggingLevelMap {
+		if v == *m {
+			return s
+		}
+	}
+
+	return "unknown"
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/app.go
@@ -42,6 +42,7 @@ type Application struct {
 	id              string
 	name            string
 	pipelineID      string
+	logLevel        string
 	spec            Specifier
 	state           state.State
 	grpcClient      remoteconfig.Client
@@ -70,7 +71,7 @@ type ArgsDecorator func([]string) []string
 // the application.
 func NewApplication(
 	ctx context.Context,
-	id, appName, pipelineID string,
+	id, appName, pipelineID, logLevel string,
 	spec Specifier,
 	factory remoteconfig.ConnectionCreator,
 	cfg *config.Config,
@@ -90,6 +91,7 @@ func NewApplication(
 		id:              id,
 		name:            appName,
 		pipelineID:      pipelineID,
+		logLevel:        logLevel,
 		spec:            spec,
 		clientFactory:   factory,
 		processConfig:   cfg.ProcessConfig,


### PR DESCRIPTION
Cherry-pick of PR #18083 to 7.x branch. Original message:

## What does this PR do?

This PR enables log level to be configurable. It even brings configuration level of agent and managed processes even. 


## Why is it important?

This is important for troubleshooting.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
