### PR TITLE
Cherry-pick #18124 to 7.x: Enable introspecting configuration 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -42,5 +42,6 @@
 - Allow CLI overrides of paths {pull}17781[17781]
 - Enable Filebeat input: S3, Azureeventhub, cloudfoundry, httpjson, netflow, o365audit. {pull}17909[17909]
 - Use data subfolder as default for process logs {pull}17960[17960]
+- Enable introspecting configuration {pull}18124[18124]
 - Follow home path for all config files {pull}18161[18161]
 - Do not require unnecessary configuration {pull}18003[18003]

--- a/x-pack/elastic-agent/pkg/agent/application/emitter.go
+++ b/x-pack/elastic-agent/pkg/agent/application/emitter.go
@@ -26,7 +26,11 @@ type configModifiers struct {
 	Decorators []decoratorFunc
 }
 
-func emitter(log *logger.Logger, router *router, modifiers *configModifiers, reloadables ...reloadable) emitterFunc {
+type programsDispatcher interface {
+	Dispatch(id string, grpProg map[routingKey][]program.Program) error
+}
+
+func emitter(log *logger.Logger, router programsDispatcher, modifiers *configModifiers, reloadables ...reloadable) emitterFunc {
 	return func(c *config.Config) error {
 		if err := InjectAgentConfig(c); err != nil {
 			return err

--- a/x-pack/elastic-agent/pkg/agent/application/introspect_config_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/introspect_config_cmd.go
@@ -1,0 +1,131 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
+)
+
+// IntrospectConfigCmd is an introspect subcommand that shows configurations of the agent.
+type IntrospectConfigCmd struct {
+	cfgPath string
+}
+
+// NewIntrospectConfigCmd creates a new introspect command.
+func NewIntrospectConfigCmd(configPath string,
+) (*IntrospectConfigCmd, error) {
+	return &IntrospectConfigCmd{
+		cfgPath: configPath,
+	}, nil
+}
+
+// Execute introspects agent configuration.
+func (c *IntrospectConfigCmd) Execute() error {
+	return c.introspectConfig()
+}
+
+func (c *IntrospectConfigCmd) introspectConfig() error {
+	cfg, err := loadConfig(c.cfgPath)
+	if err != nil {
+		return err
+	}
+
+	isLocal, err := isLocalMode(cfg)
+	if err != nil {
+		return err
+	}
+
+	if isLocal {
+		return printConfig(cfg)
+	}
+
+	fleetConfig, err := loadFleetConfig(cfg)
+	if err != nil {
+		return err
+	} else if fleetConfig == nil {
+		return errors.New("no fleet config retrieved yet")
+	}
+
+	return printMapStringConfig(fleetConfig)
+}
+
+func loadConfig(configPath string) (*config.Config, error) {
+	rawConfig, err := config.LoadYAML(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := InjectAgentConfig(rawConfig); err != nil {
+		return nil, err
+	}
+
+	return rawConfig, nil
+}
+
+func loadFleetConfig(cfg *config.Config) (map[string]interface{}, error) {
+	log, err := newErrorLogger()
+	if err != nil {
+		return nil, err
+	}
+
+	as, err := newActionStore(log, storage.NewDiskStore(info.AgentActionStoreFile()))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range as.Actions() {
+		cfgChange, ok := c.(*fleetapi.ActionConfigChange)
+		if !ok {
+			continue
+		}
+
+		fmt.Println("Action ID:", cfgChange.ID())
+		return cfgChange.Config, nil
+	}
+	return nil, nil
+}
+
+func isLocalMode(rawConfig *config.Config) (bool, error) {
+	c := localDefaultConfig()
+	if err := rawConfig.Unpack(&c); err != nil {
+		return false, errors.New(err, "initiating application")
+	}
+
+	managementConfig := struct {
+		Mode string `config:"mode" yaml:"mode"`
+	}{}
+
+	if err := c.Management.Unpack(&managementConfig); err != nil {
+		return false, errors.New(err, "initiating application")
+	}
+	return managementConfig.Mode == "local", nil
+}
+
+func printMapStringConfig(mapStr map[string]interface{}) error {
+	data, err := yaml.Marshal(mapStr)
+	if err != nil {
+		return errors.New(err, "could not marshal to YAML")
+	}
+
+	fmt.Println(string(data))
+	return nil
+}
+
+func printConfig(cfg *config.Config) error {
+	mapStr, err := cfg.ToMapStr()
+	if err != nil {
+		return err
+	}
+
+	return printMapStringConfig(mapStr)
+}

--- a/x-pack/elastic-agent/pkg/agent/application/introspect_output_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/introspect_output_cmd.go
@@ -1,0 +1,211 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"fmt"
+
+	"github.com/urso/ecslog"
+	"github.com/urso/ecslog/backend"
+	"github.com/urso/ecslog/backend/appender"
+	"github.com/urso/ecslog/backend/layout"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filters"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop"
+)
+
+// IntrospectOutputCmd is an introspect subcommand that shows configurations of the agent.
+type IntrospectOutputCmd struct {
+	cfgPath string
+	output  string
+	program string
+}
+
+// NewIntrospectOutputCmd creates a new introspect command.
+func NewIntrospectOutputCmd(configPath, output, program string) (*IntrospectOutputCmd, error) {
+	return &IntrospectOutputCmd{
+		cfgPath: configPath,
+		output:  output,
+		program: program,
+	}, nil
+}
+
+// Execute tries to enroll the agent into Fleet.
+func (c *IntrospectOutputCmd) Execute() error {
+	if c.output == "" {
+		return c.introspectOutputs()
+	}
+
+	return c.introspectOutput()
+}
+
+func (c *IntrospectOutputCmd) introspectOutputs() error {
+	cfg, err := loadConfig(c.cfgPath)
+	if err != nil {
+		return err
+	}
+
+	isLocal, err := isLocalMode(cfg)
+	if err != nil {
+		return err
+	}
+
+	l, err := newErrorLogger()
+	if err != nil {
+		return err
+	}
+
+	if isLocal {
+		return listOutputsFromConfig(l, cfg)
+	}
+
+	fleetConfig, err := loadFleetConfig(cfg)
+	if err != nil {
+		return err
+	} else if fleetConfig == nil {
+		return errors.New("no fleet config retrieved yet")
+	}
+
+	return listOutputsFromMap(l, fleetConfig)
+}
+
+func listOutputsFromConfig(log *logger.Logger, cfg *config.Config) error {
+	programsGroup, err := getProgramsFromConfig(log, cfg)
+	if err != nil {
+		return err
+
+	}
+
+	for k := range programsGroup {
+		fmt.Println(k)
+	}
+
+	return nil
+}
+
+func listOutputsFromMap(log *logger.Logger, cfg map[string]interface{}) error {
+	c, err := config.NewConfigFrom(cfg)
+	if err != nil {
+		return err
+	}
+
+	return listOutputsFromConfig(log, c)
+}
+
+func (c *IntrospectOutputCmd) introspectOutput() error {
+	cfg, err := loadConfig(c.cfgPath)
+	if err != nil {
+		return err
+	}
+
+	l, err := newErrorLogger()
+	if err != nil {
+		return err
+	}
+
+	isLocal, err := isLocalMode(cfg)
+	if err != nil {
+		return err
+	}
+
+	if isLocal {
+		return printOutputFromConfig(l, c.output, c.program, cfg)
+	}
+
+	fleetConfig, err := loadFleetConfig(cfg)
+	if err != nil {
+		return err
+	} else if fleetConfig == nil {
+		return errors.New("no fleet config retrieved yet")
+	}
+
+	return printOutputFromMap(l, c.output, c.program, fleetConfig)
+}
+
+func printOutputFromConfig(log *logger.Logger, output, programName string, cfg *config.Config) error {
+	programsGroup, err := getProgramsFromConfig(log, cfg)
+	if err != nil {
+		return err
+
+	}
+
+	for k, programs := range programsGroup {
+		if k != output {
+			continue
+		}
+
+		var programFound bool
+		for _, p := range programs {
+			if programName != "" && programName != p.Spec.Cmd {
+				continue
+			}
+
+			programFound = true
+			fmt.Printf("[%s] %s:\n", k, p.Spec.Cmd)
+			printMapStringConfig(p.Configuration())
+			fmt.Println("---")
+		}
+
+		if !programFound {
+			fmt.Printf("program '%s' is not recognized within output '%s', try running `elastic-agent introspect output` to find available outputs.\n",
+				programName,
+				output)
+		}
+		return nil
+	}
+
+	fmt.Printf("output '%s' is not recognized, try running `elastic-agent introspect output` to find available outputs.\n", output)
+
+	return nil
+}
+
+func printOutputFromMap(log *logger.Logger, output, programName string, cfg map[string]interface{}) error {
+	c, err := config.NewConfigFrom(cfg)
+	if err != nil {
+		return err
+	}
+
+	return printOutputFromConfig(log, output, programName, c)
+}
+
+func getProgramsFromConfig(log *logger.Logger, cfg *config.Config) (map[string][]program.Program, error) {
+	monitor := noop.NewMonitor()
+	router := &inmemRouter{}
+	emit := emitter(
+		log,
+		router,
+		&configModifiers{
+			Decorators: []decoratorFunc{injectMonitoring},
+			Filters:    []filterFunc{filters.ConstraintFilter},
+		},
+		monitor,
+	)
+
+	if err := emit(cfg); err != nil {
+		return nil, err
+	}
+	return router.programs, nil
+}
+
+type inmemRouter struct {
+	programs map[string][]program.Program
+}
+
+func (r *inmemRouter) Dispatch(id string, grpProg map[routingKey][]program.Program) error {
+	r.programs = grpProg
+	return nil
+}
+
+func newErrorLogger() (*logger.Logger, error) {
+	backend, err := appender.Console(backend.Error, layout.Text(true))
+	if err != nil {
+		return nil, err
+	}
+	return ecslog.New(backend), nil
+}

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -61,6 +61,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(basecmd.NewDefaultCommandsWithArgs(args, streams)...)
 	cmd.AddCommand(newRunCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newEnrollCommandWithArgs(flags, args, streams))
+	cmd.AddCommand(newIntrospectCommandWithArgs(flags, args, streams))
 
 	return cmd
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/introspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/introspect.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
+)
+
+func newIntrospectCommandWithArgs(flags *globalFlags, s []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Shows configuration of the agent",
+		Long:  "Shows current configuration of the agent",
+		Args:  cobra.ExactArgs(0),
+		Run: func(c *cobra.Command, args []string) {
+			command, err := application.NewIntrospectConfigCmd(flags.Config())
+			if err != nil {
+				fmt.Fprintf(streams.Err, "%v\n", err)
+				os.Exit(1)
+			}
+
+			if err := command.Execute(); err != nil {
+				fmt.Fprintf(streams.Err, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.AddCommand(newIntrospectOutputCommandWithArgs(flags, s, streams))
+
+	return cmd
+}
+
+func newIntrospectOutputCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "output",
+		Short: "Displays configuration generated for output",
+		Long:  "Displays configuration generated for output.\nIf no output is specified list of output is displayed",
+		Args:  cobra.MaximumNArgs(2),
+		Run: func(c *cobra.Command, args []string) {
+			outName, _ := c.Flags().GetString("output")
+			program, _ := c.Flags().GetString("program")
+
+			command, err := application.NewIntrospectOutputCmd(flags.Config(), outName, program)
+			if err != nil {
+				fmt.Fprintf(streams.Err, "%v\n", err)
+				os.Exit(1)
+			}
+
+			if err := command.Execute(); err != nil {
+				fmt.Fprintf(streams.Err, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringP("output", "o", "", "name of the output to be introspected")
+	cmd.Flags().StringP("program", "p", "", "type of program to introspect, needs to be combined with output. e.g filebeat")
+
+	return cmd
+}


### PR DESCRIPTION
Cherry-pick of PR #18124 to 7.x branch. Original message:

## What does this PR do?

This PR adds 3 options to our agents CLI

### Option 1 - Introspecting current config
Usage `./elastic-agent inspect`
This will print out current configuration either from fleet or from yml. 
Sample output:
```
datasources:
- inputs:
  - streams:
    - dataset: system.cpu
      metricset: cpu
    - dataset: system.memory
      metricset: memory
    - dataset: system.network
      metricset: network
    - dataset: system.filesystem
      metricset: filesystem
    type: system/metrics
  namespace: default
  use_output: default
download:
  install_path: /Users/michalpristas/agent/data/install
  pgpfile: /Users/michalpristas/agent/data/elastic.pgp
  sourceURI: https://artifacts.elastic.co/downloads/beats/
  target_directory: /Users/michalpristas/agent/data/downloads
  timeout: 30s
...
```

### Option 2 - Introspecting used outputs
Usage `./elastic-agent inspect output`
This will print out outputs which are actually used . If config contains definition for output but output is not used in any datastream it will not be present in the printout
Sample output:
```
default
monitoring
```

### Option 3: Introspecting specific output
Usage: ` ./elastic-agent inspect output -o default`
This will print out actual configuration of the beats, this helps you understand how configuration retrieved from fleet translates to configuration which is sent out to the process itself.
Sample output:
```
[default] metricbeat:
metricbeat:
  modules:
  - index: metrics-system.filesystem-default
    metricsets:
    - filesystem
    module: system
    processors:
    - add_fields:
        fields:
          dataset: system.filesystem
          namespace: default
          type: metrics
        target: stream
output:
  elasticsearch:
    hosts:
    - 127.0.0.1:9200
    password: changeme
    username: elastic
```


## Why is it important?

To improve debugging experience

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
