### PR TITLE
Cherry-pick #18143 to 7.x: Regression: Fix assigning to nil map in DeepMerge

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,6 +101,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix goroutine leak and Elasticsearch output file descriptor leak when output reloading is in use. {issue}10491[10491] {pull}17381[17381]
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
+- Fix panic when assigning a key to a `nil` value in an event. {pull}18143[18143]
 
 *Auditbeat*
 

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -96,20 +96,26 @@ func (m MapStr) deepUpdateMap(d MapStr, overwrite bool) {
 }
 
 func deepUpdateValue(old interface{}, val MapStr, overwrite bool) interface{} {
-	if old == nil {
-		return val
-	}
-
 	switch sub := old.(type) {
 	case MapStr:
+		if sub == nil {
+			return val
+		}
+
 		sub.deepUpdateMap(val, overwrite)
 		return sub
 	case map[string]interface{}:
+		if sub == nil {
+			return val
+		}
+
 		tmp := MapStr(sub)
 		tmp.deepUpdateMap(val, overwrite)
 		return tmp
 	default:
-		// This should never happen
+		// We reach the default branch if old is no map or if old == nil.
+		// In either case we return `val`, such that the old value is completely
+		// replaced when merging.
 		return val
 	}
 }

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -87,6 +87,11 @@ func TestMapStrDeepUpdate(t *testing.T) {
 			MapStr{"a.b": 1},
 			MapStr{"a": 1, "a.b": 1},
 		},
+		{
+			MapStr{"a": (MapStr)(nil)},
+			MapStr{"a": MapStr{"b": 1}},
+			MapStr{"a": MapStr{"b": 1}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Cherry-pick of PR #18143 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

If a Value in a MapStr itself has the type MapStr but is nil, we will
have a panic in DeepUpdate. This change fixes the Update functionality
to handle typed nil values.

## Why is it important?

Do not panic the Beat if we have an event with `nil` values.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123


- Relates #123


- Requires #123


- Superseds elastic/beats#123
-->
- 