### PR TITLE
[Filebeat] Explicitly set ECS version

### DIFF
--- a/filebeat/module/apache/access/config/access.yml
+++ b/filebeat/module/apache/access/config/access.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/apache/error/config/error.yml
+++ b/filebeat/module/apache/error/config/error.yml
@@ -6,4 +6,8 @@ paths:
 exclude_files: [".gz$"]
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/auditd/log/config/log.yml
+++ b/filebeat/module/auditd/log/config/log.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/elasticsearch/audit/config/audit.yml
+++ b/filebeat/module/elasticsearch/audit/config/audit.yml
@@ -6,4 +6,8 @@ paths:
 exclude_files: [".gz$"]
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/elasticsearch/deprecation/config/log.yml
+++ b/filebeat/module/elasticsearch/deprecation/config/log.yml
@@ -12,3 +12,7 @@ multiline:
 processors:
 # Locale for time zone is only needed in non-json logs
 - add_locale.when.not.regexp.message: "^{"
+- add_fields:
+    target: ''
+    fields:
+      ecs.version: 1.5.0

--- a/filebeat/module/elasticsearch/gc/config/gc.yml
+++ b/filebeat/module/elasticsearch/gc/config/gc.yml
@@ -9,3 +9,8 @@ multiline:
   pattern: '^(\[?[0-9]{4}-[0-9]{2}-[0-9]{2}|{)'
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/elasticsearch/server/config/log.yml
+++ b/filebeat/module/elasticsearch/server/config/log.yml
@@ -12,3 +12,7 @@ multiline:
 processors:
 # Locale for time zone is only needed in non-json logs
 - add_locale.when.not.regexp.message: "^{"
+- add_fields:
+    target: ''
+    fields:
+      ecs.version: 1.5.0

--- a/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
+++ b/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
@@ -13,3 +13,7 @@ multiline:
 processors:
 # Locale for time zone is only needed in non-json logs
 - add_locale.when.not.regexp.message: "^{"
+- add_fields:
+    target: ''
+    fields:
+      ecs.version: 1.5.0

--- a/filebeat/module/haproxy/log/config/file.yml
+++ b/filebeat/module/haproxy/log/config/file.yml
@@ -5,4 +5,8 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/haproxy/log/config/syslog.yml
+++ b/filebeat/module/haproxy/log/config/syslog.yml
@@ -2,4 +2,8 @@ type: syslog
 protocol.udp:
   host: "{{.syslog_host}}:{{.syslog_port}}"
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/icinga/debug/config/debug.yml
+++ b/filebeat/module/icinga/debug/config/debug.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: '^\['
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/icinga/main/config/main.yml
+++ b/filebeat/module/icinga/main/config/main.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: '^\['
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/icinga/startup/config/startup.yml
+++ b/filebeat/module/icinga/startup/config/startup.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: '^[a-z]*\/[a-zA-Z]*:'
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/iis/access/config/iis-access.yml
+++ b/filebeat/module/iis/access/config/iis-access.yml
@@ -5,3 +5,8 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 exclude_lines: ["^#"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/iis/error/config/iis-error.yml
+++ b/filebeat/module/iis/error/config/iis-error.yml
@@ -5,3 +5,8 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 exclude_lines: ["^#"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/kafka/log/config/log.yml
+++ b/filebeat/module/kafka/log/config/log.yml
@@ -9,4 +9,8 @@ multiline:
   negate: true
   match: after
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/kibana/log/config/log.yml
+++ b/filebeat/module/kibana/log/config/log.yml
@@ -7,3 +7,8 @@ exclude_files: [".gz$"]
 
 json.keys_under_root: false
 json.add_error_key: true
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/logstash/log/config/log.yml
+++ b/filebeat/module/logstash/log/config/log.yml
@@ -15,3 +15,7 @@ multiline:
 processors:
 # Locale for time zone is only needed in non-json logs
 - add_locale.when.not.regexp.message: "^{"
+- add_fields:
+    target: ''
+    fields:
+      ecs.version: 1.5.0

--- a/filebeat/module/logstash/slowlog/config/slowlog.yml
+++ b/filebeat/module/logstash/slowlog/config/slowlog.yml
@@ -8,3 +8,7 @@ exclude_files: [".gz$"]
 processors:
 # Locale for time zone is only needed in non-json logs
 - add_locale.when.not.regexp.message: "^{"
+- add_fields:
+    target: ''
+    fields:
+      ecs.version: 1.5.0

--- a/filebeat/module/mongodb/log/config/log.yml
+++ b/filebeat/module/mongodb/log/config/log.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -12,4 +12,8 @@ multiline:
   match: after
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -9,3 +9,8 @@ multiline:
   negate: true
   match: after
 exclude_lines: ['^[\/\w\.]+, Version: .* started with:.*', '^# Time:.*']   # Exclude the header and time
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/nats/log/config/log.yml
+++ b/filebeat/module/nats/log/config/log.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -6,4 +6,8 @@ paths:
 exclude_files: [".gz$"]
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -10,4 +10,8 @@ multiline:
   match: after
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/nginx/ingress_controller/config/ingress_controller.yml
+++ b/filebeat/module/nginx/ingress_controller/config/ingress_controller.yml
@@ -7,3 +7,7 @@ exclude_files: [".gz$"]
 
 processors:
   - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/postgresql/log/config/log.yml
+++ b/filebeat/module/postgresql/log/config/log.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: '^\d{4}-\d{2}-\d{2} '
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/redis/log/config/log.yml
+++ b/filebeat/module/redis/log/config/log.yml
@@ -5,3 +5,8 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines\n
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/santa/log/config/file.yml
+++ b/filebeat/module/santa/log/config/file.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -8,4 +8,8 @@ multiline:
   pattern: "^\\s"
   match: after
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/filebeat/module/system/syslog/config/syslog.yml
+++ b/filebeat/module/system/syslog/config/syslog.yml
@@ -8,4 +8,8 @@ multiline:
   pattern: "^\\s"
   match: after
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/activemq/audit/config/audit.yml
+++ b/x-pack/filebeat/module/activemq/audit/config/audit.yml
@@ -4,3 +4,9 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/activemq/log/config/log.yml
+++ b/x-pack/filebeat/module/activemq/log/config/log.yml
@@ -10,3 +10,7 @@ multiline:
   match: after
 processors:
   - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/cloudtrail/config/file.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/file.yml
@@ -4,3 +4,8 @@ paths:
   - {{$path}}
     {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -37,3 +37,9 @@ session_token: {{ .session_token }}
 {{ if .role_arn }}
 role_arn: {{ .role_arn }}
 {{ end }}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/cloudwatch/config/file.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/file.yml
@@ -4,3 +4,8 @@ paths:
   - {{$path}}
     {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
@@ -36,3 +36,9 @@ session_token: {{ .session_token }}
 {{ if .role_arn }}
 role_arn: {{ .role_arn }}
 {{ end }}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/ec2/config/file.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/file.yml
@@ -4,3 +4,8 @@ paths:
   - {{$path}}
     {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/ec2/config/s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/s3.yml
@@ -36,3 +36,9 @@ session_token: {{ .session_token }}
 {{ if .role_arn }}
 role_arn: {{ .role_arn }}
 {{ end }}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/elb/config/file.yml
+++ b/x-pack/filebeat/module/aws/elb/config/file.yml
@@ -4,3 +4,8 @@ paths:
 - {{$path}}
   {{ end }}
 exclude_files: [".gz$"]
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/elb/config/s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/s3.yml
@@ -36,3 +36,9 @@ session_token: {{ .session_token }}
 {{ if .role_arn }}
 role_arn: {{ .role_arn }}
 {{ end }}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/s3access/config/file.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/file.yml
@@ -4,3 +4,9 @@ paths:
 - {{$path}}
   {{ end }}
 exclude_files: [".gz$"]
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/s3access/config/s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/s3.yml
@@ -36,3 +36,9 @@ session_token: {{ .session_token }}
 {{ if .role_arn }}
 role_arn: {{ .role_arn }}
 {{ end }}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -167,3 +167,8 @@ processors:
       - add_fields:
           target: network
           fields: {transport: udp}
+
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/cef/log/config/input.yml
+++ b/x-pack/filebeat/module/cef/log/config/input.yml
@@ -24,3 +24,7 @@ processors:
   - decode_cef:
       field: event.original
   - community_id:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/googlecloud/audit/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/audit/config/input.yml
@@ -29,3 +29,7 @@ processors:
       file: ${path.home}/module/googlecloud/audit/config/pipeline.js
       params:
         keep_original_message: {{ .keep_original_message }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/googlecloud/firewall/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/firewall/config/input.yml
@@ -30,3 +30,7 @@ processors:
         debug: {{ .debug }}
         keep_original_message: {{ .keep_original_message }}
       file: ${path.home}/module/googlecloud/firewall/config/pipeline.js
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
@@ -29,3 +29,7 @@ processors:
       file: ${path.home}/module/googlecloud/vpcflow/config/pipeline.js
       params:
         keep_original_message: {{ .keep_original_message }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/ibmmq/errorlog/config/errorlog.yml
+++ b/x-pack/filebeat/module/ibmmq/errorlog/config/errorlog.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: "^[\\-]{5}.*[\\-]{10,}$"
   negate: true
   match: after
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/iptables/log/config/input.yml
+++ b/x-pack/filebeat/module/iptables/log/config/input.yml
@@ -51,3 +51,7 @@ processors:
         icmp_type: iptables.icmp.type
         icmp_code: iptables.icmp.code
 {{ end}}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/misp/threat/config/input.yml
+++ b/x-pack/filebeat/module/misp/threat/config/input.yml
@@ -34,3 +34,7 @@ processors:
         - UNIX
   - drop_fields:
       fields: [json]
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/mssql/log/config/config.yml
+++ b/x-pack/filebeat/module/mssql/log/config/config.yml
@@ -10,4 +10,8 @@ multiline.negate: true
 multiline.match: after
 
 processors:
-- add_locale: ~
+  - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -23,3 +23,9 @@ custom_definitions:
 {{ if .detect_sequence_reset}}
 detect_sequence_reset: {{.detect_sequence_reset}}
 {{end}}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/o365/audit/config/input.yml
+++ b/x-pack/filebeat/module/o365/audit/config/input.yml
@@ -59,4 +59,7 @@ processors:
           - id: "{{ .id }}"
             name: "{{ .name }}"
           {{ end }}
-
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/okta/system/config/input.yml
+++ b/x-pack/filebeat/module/okta/system/config/input.yml
@@ -33,3 +33,7 @@ processors:
       file: ${path.home}/module/okta/system/config/pipeline.js
       params:
         keep_original_message: {{ .keep_original_message }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -166,3 +166,7 @@ processors:
         - {from: destination.nat.ip, to: panw.panos.destination.nat.ip, type: ip}
         - {from: source.nat.port, to: panw.panos.source.nat.port, type: long}
         - {from: destination.nat.port, to: panw.panos.destination.nat.port, type: long}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/rabbitmq/log/config/log.yml
+++ b/x-pack/filebeat/module/rabbitmq/log/config/log.yml
@@ -15,3 +15,7 @@ multiline:
 
 processors:
   - add_locale: ~
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/suricata/eve/config/eve.yml
+++ b/x-pack/filebeat/module/suricata/eve/config/eve.yml
@@ -403,3 +403,7 @@ processors:
         - suricata.eve.dns.version
         - suricata.eve.dns.flags
         - suricata.eve.dns.grouped
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
+++ b/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
@@ -18,3 +18,7 @@ processors:
 
       ignore_missing: true
       fail_on_error: false
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/connection/config/connection.yml
+++ b/x-pack/filebeat/module/zeek/connection/config/connection.yml
@@ -99,3 +99,7 @@ processors:
     else:
       community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
@@ -56,3 +56,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
@@ -118,3 +118,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
@@ -66,3 +66,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/dns/config/dns.yml
+++ b/x-pack/filebeat/module/zeek/dns/config/dns.yml
@@ -208,3 +208,7 @@ processors:
         - zeek.dns.auth
         - zeek.dns.addl
         - zeek.dns.ts
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
+++ b/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
@@ -55,3 +55,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/files/config/files.yml
+++ b/x-pack/filebeat/module/zeek/files/config/files.yml
@@ -37,3 +37,7 @@ processors:
           - file
         type:
           - info
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
+++ b/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
@@ -84,3 +84,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/http/config/http.yml
+++ b/x-pack/filebeat/module/zeek/http/config/http.yml
@@ -91,3 +91,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/intel/config/intel.yml
+++ b/x-pack/filebeat/module/zeek/intel/config/intel.yml
@@ -70,3 +70,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/irc/config/irc.yml
+++ b/x-pack/filebeat/module/zeek/irc/config/irc.yml
@@ -70,3 +70,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
@@ -102,3 +102,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
+++ b/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
@@ -71,3 +71,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
+++ b/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
@@ -70,3 +70,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -100,3 +100,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
@@ -84,3 +84,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
+++ b/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
@@ -60,3 +60,7 @@ processors:
       target: event
       fields:
         kind: event
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/pe/config/pe.yml
+++ b/x-pack/filebeat/module/zeek/pe/config/pe.yml
@@ -29,3 +29,7 @@ processors:
           - file
         type:
           - info
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/radius/config/radius.yml
+++ b/x-pack/filebeat/module/zeek/radius/config/radius.yml
@@ -56,3 +56,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
+++ b/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
@@ -86,3 +86,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
+++ b/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
@@ -71,3 +71,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/sip/config/sip.yml
+++ b/x-pack/filebeat/module/zeek/sip/config/sip.yml
@@ -93,3 +93,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
@@ -99,3 +99,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
@@ -59,3 +59,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
@@ -55,3 +55,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
+++ b/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
@@ -65,3 +65,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
+++ b/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
@@ -67,3 +67,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/socks/config/socks.yml
+++ b/x-pack/filebeat/module/zeek/socks/config/socks.yml
@@ -65,3 +65,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
+++ b/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
@@ -74,3 +74,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
+++ b/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
@@ -77,3 +77,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/stats/config/stats.yml
+++ b/x-pack/filebeat/module/zeek/stats/config/stats.yml
@@ -93,3 +93,7 @@ processors:
 
       ignore_missing: true
       fail_on_error: false
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
+++ b/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
@@ -55,3 +55,7 @@ processors:
 {{ if .community_id }}
   - community_id:
 {{ end }}
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
+++ b/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
@@ -41,3 +41,7 @@ processors:
           - network
         type:
           - info
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
+++ b/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
@@ -52,3 +52,7 @@ processors:
           - network
         type:
           - connection
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/weird/config/weird.yml
+++ b/x-pack/filebeat/module/zeek/weird/config/weird.yml
@@ -52,3 +52,7 @@ processors:
           - network
         type:
           - info
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0

--- a/x-pack/filebeat/module/zeek/x509/config/x509.yml
+++ b/x-pack/filebeat/module/zeek/x509/config/x509.yml
@@ -63,3 +63,7 @@ processors:
         kind: event
         type:
           - info
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.5.0


### PR DESCRIPTION
## What does this PR do?
Explicitly set the ecs version field in filesets that have
been upgraded to ECS 1.5.  Specifically:

- activemq
- apache
- auditd
- aws
- cef
- elasticsearch
- googlecloud
- haproxy
- ibmmq
- icinga
- iis
- iptables
- kafka
- kibana
- logstash
- misp
- mongodb
- mssql
- mysql
- nats
- netflow
- nginx
- panw
- postgresql
- rabbitmq
- redis
- santa
- suricata
- system
- zeek

## Why is it important?
For maintenace reasonse we need to know what version of ECS each pipeline was written against.
This makes the reported ECS version consistent regardless of what version of ECS libbeat
is at.

## Checklist
- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally
```
mage -v pythonIntegTest
```

## Related issues
- Relates #16089
