### PR TITLE
[7.7] Give precedence to monitoring reporter hosts over output hosts (#17991)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,7 +80,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
-- Fix panic when assigning a key to a `nil` value in an event. {pull}18143[18143]
 - Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
+- Fix panic when assigning a key to a `nil` value in an event. {pull}18143[18143]
+- Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/report_test.go
+++ b/libbeat/monitoring/report/report_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestMergeHosts(t *testing.T) {
+	tests := map[string]struct {
+		outCfg      *common.Config
+		reporterCfg *common.Config
+		expectedCfg *common.Config
+	}{
+		"no_hosts": {
+			expectedCfg: newConfigWithHosts(),
+		},
+		"only_reporter_hosts": {
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
+		},
+		"only_output_hosts": {
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			expectedCfg: newConfigWithHosts("o1", "o2"),
+		},
+		"equal_hosts": {
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
+		},
+		"more_output_hosts": {
+			outCfg:      newConfigWithHosts("o1", "o2"),
+			reporterCfg: newConfigWithHosts("r1"),
+			expectedCfg: newConfigWithHosts("r1"),
+		},
+		"more_reporter_hosts": {
+			outCfg:      newConfigWithHosts("o1"),
+			reporterCfg: newConfigWithHosts("r1", "r2"),
+			expectedCfg: newConfigWithHosts("r1", "r2"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mergedCfg := common.MustNewConfigFrom(map[string]interface{}{})
+			err := mergeHosts(mergedCfg, test.outCfg, test.reporterCfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expectedCfg, mergedCfg)
+		})
+	}
+}
+
+func newConfigWithHosts(hosts ...string) *common.Config {
+	if len(hosts) == 0 {
+		return common.MustNewConfigFrom(map[string][]string{})
+	}
+	return common.MustNewConfigFrom(map[string][]string{"hosts": hosts})
+}


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Give precedence to monitoring reporter hosts over output hosts  (#17991)