### PR TITLE
Prettify processors section in docker yml files

### DIFF
--- a/auditbeat/auditbeat.docker.yml
+++ b/auditbeat/auditbeat.docker.yml
@@ -14,8 +14,8 @@ auditbeat.modules:
     - /etc
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/filebeat/filebeat.docker.yml
+++ b/filebeat/filebeat.docker.yml
@@ -4,8 +4,8 @@ filebeat.config:
     reload.enabled: false
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/heartbeat/heartbeat.docker.yml
+++ b/heartbeat/heartbeat.docker.yml
@@ -23,8 +23,8 @@ heartbeat.monitors:
     - kibana
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/journalbeat/journalbeat.docker.yml
+++ b/journalbeat/journalbeat.docker.yml
@@ -3,8 +3,8 @@ journalbeat.inputs:
   seek: cursor
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/libbeat/_meta/config/default.docker.yml.tmpl
+++ b/libbeat/_meta/config/default.docker.yml.tmpl
@@ -1,7 +1,7 @@
 {{block "beat.docker.yml.tmpl" .}}{{end}}
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/metricbeat/metricbeat.docker.yml
+++ b/metricbeat/metricbeat.docker.yml
@@ -3,8 +3,8 @@ metricbeat.config.modules:
   reload.enabled: false
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/packetbeat/packetbeat.docker.yml
+++ b/packetbeat/packetbeat.docker.yml
@@ -38,8 +38,8 @@ packetbeat.protocols.tls:
   ports: [443, 993, 995, 5223, 8443, 8883, 9243]
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/auditbeat/auditbeat.docker.yml
+++ b/x-pack/auditbeat/auditbeat.docker.yml
@@ -14,8 +14,8 @@ auditbeat.modules:
     - /etc
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/filebeat/filebeat.docker.yml
+++ b/x-pack/filebeat/filebeat.docker.yml
@@ -4,8 +4,8 @@ filebeat.config:
     reload.enabled: false
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/metricbeat/metricbeat.docker.yml
+++ b/x-pack/metricbeat/metricbeat.docker.yml
@@ -3,8 +3,8 @@ metricbeat.config.modules:
   reload.enabled: false
 
 processors:
-- add_cloud_metadata: ~
-- add_docker_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'


### PR DESCRIPTION
## What does this PR do?

Indents processor definitions for consistency with other yaml files. 

## Why is it important?

We just cleaned up the Beats docs and reference.yml files to make the indentation for processors consistent with our beat yml files (for example, [filebeat.yml](https://github.com/elastic/beats/blob/master/filebeat/filebeat.yml#L178)).

The docker yml files are the only outliers, so they should be updated for consistency.

## Checklist

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


## Related issues

- Relates to https://github.com/elastic/beats/pull/18115.
