### PR TITLE
Cherry-pick #18204 to 7.x:  Enable monitoring by default

### DIFF
--- a/x-pack/elastic-agent/_meta/common.p2.yml
+++ b/x-pack/elastic-agent/_meta/common.p2.yml
@@ -23,6 +23,14 @@ datasources:
           - metricset: filesystem
             dataset: system.filesystem
 
+settings.monitoring:
+  # enabled turns on monitoring of running processes
+  enabled: true
+  # enables log monitoring
+  logs: true
+  # enables metrics monitoring
+  metrics: true
+
 # management:
 #   # Mode of management, the Elastic Agent support two modes of operation:
 #   #
@@ -111,14 +119,6 @@ datasources:
 #   # With 30s delay and 3 retries: 30, 60, 120s
 #   # Default is false
 #   exponential: false
-
-# settings.monitoring:
-#   # enabled turns on monitoring of running processes
-#   enabled: false
-#   # enables log monitoring
-#   logs: false
-#   # enables metrics monitoring
-#   metrics: false
 
 # Sets log level. The default log level is info.
 # Available log levels are: error, warning, info, debug

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -28,6 +28,14 @@ datasources:
           - metricset: filesystem
             dataset: system.filesystem
 
+settings.monitoring:
+  # enabled turns on monitoring of running processes
+  enabled: true
+  # enables log monitoring
+  logs: true
+  # enables metrics monitoring
+  metrics: true
+
 # management:
 #   # Mode of management, the Elastic Agent support two modes of operation:
 #   #
@@ -116,14 +124,6 @@ datasources:
 #   # With 30s delay and 3 retries: 30, 60, 120s
 #   # Default is false
 #   exponential: false
-
-# settings.monitoring:
-#   # enabled turns on monitoring of running processes
-#   enabled: false
-#   # enables log monitoring
-#   logs: false
-#   # enables metrics monitoring
-#   metrics: false
 
 # Sets log level. The default log level is info.
 # Available log levels are: error, warning, info, debug


### PR DESCRIPTION
Cherry-pick of PR #18204 to 7.x branch. Original message:

This enables monitoring of the agent by default. This PR only changes it in the configuration file. If we decide to move forward with this default, it should also be changed in the code.

The reason I think monitoring should be enabled out of the box as it will make debugging agents easier as all the data is directly avaiable in Elasticsearch and enhances the out of the box experience.

(cherry picked from commit ea39b3ccd529d7329306d2a26821be568a281bb5)