### PR TITLE
[Elastic-Agent] Use nested objects so fleet can handle metadata correctly

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -50,3 +50,4 @@
 - Enable debug log level for Metricbeat and Filebeat when run under the Elastic Agent. {pull}17935[17935]
 - Enable introspecting configuration {pull}18124[18124]
 - Follow home path for all config files {pull}18161[18161]
+- Use nested objects so fleet can handle metadata correctly {pull}18234[18234]

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
@@ -17,9 +17,14 @@ import (
 
 // ECSMeta is a collection of agent related metadata in ECS compliant object form.
 type ECSMeta struct {
-	Agent *AgentECSMeta  `json:"elastic.agent"`
-	Host  *HostECSMeta   `json:"host"`
-	OS    *SystemECSMeta `json:"os"`
+	Elastic *ElasticECSMeta `json:"elastic"`
+	Host    *HostECSMeta    `json:"host"`
+	OS      *SystemECSMeta  `json:"os"`
+}
+
+// ElasticECSMeta is a collection of elastic vendor metadata in ECS compliant object form.
+type ElasticECSMeta struct {
+	Agent *AgentECSMeta `json:"agent"`
 }
 
 // AgentECSMeta is a collection of agent metadata in ECS compliant object form.
@@ -119,9 +124,11 @@ func (i *AgentInfo) ECSMetadata() (*ECSMeta, error) {
 	info := sysInfo.Info()
 
 	return &ECSMeta{
-		Agent: &AgentECSMeta{
-			ID:      i.agentID,
-			Version: release.Version(),
+		Elastic: &ElasticECSMeta{
+			Agent: &AgentECSMeta{
+				ID:      i.agentID,
+				Version: release.Version(),
+			},
 		},
 		Host: &HostECSMeta{
 			Arch:     info.Architecture,


### PR DESCRIPTION
## What does this PR do?
 
moves agent metadata to elastic object, if not nested object is constructed in a weird way on fleet side

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
