### PR TITLE
Cherry-pick #18182 to 7.x: [Metricbeat] Remove requirement of connect as sysdba in Oracle

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -446,6 +446,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]
 - Add static mapping for metricsets under aws module. {pull}17614[17614] {pull}17650[17650]
 - Collect new `bulk` indexing metrics from Elasticsearch when `xpack.enabled:true` is set. {issue} {pull}17992[17992]
+- Remove requirement to connect as sysdba in Oracle module {issue}15846[15846] {pull}18182[18182]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -57,7 +57,7 @@ metricbeat.modules:
   metricsets: ["tablespace", "performance"]
   enabled: true
   period: 10s
-  hosts: ["oracle://user:pass@localhost:1521/ORCLPDB1.localdomain?sysdba=1"]
+  hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
 
   # username: ""
   # password: ""

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -993,7 +993,7 @@ metricbeat.modules:
   metricsets: ["tablespace", "performance"]
   enabled: true
   period: 10s
-  hosts: ["oracle://user:pass@localhost:1521/ORCLPDB1.localdomain?sysdba=1"]
+  hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
 
   # username: ""
   # password: ""

--- a/x-pack/metricbeat/module/oracle/_meta/config.yml
+++ b/x-pack/metricbeat/module/oracle/_meta/config.yml
@@ -2,7 +2,7 @@
   metricsets: ["tablespace", "performance"]
   enabled: true
   period: 10s
-  hosts: ["oracle://user:pass@localhost:1521/ORCLPDB1.localdomain?sysdba=1"]
+  hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
 
   # username: ""
   # password: ""

--- a/x-pack/metricbeat/module/oracle/connection.go
+++ b/x-pack/metricbeat/module/oracle/connection.go
@@ -50,10 +50,6 @@ func NewConnection(c *ConnectionDetails) (*sql.DB, error) {
 		params.Password = c.Password
 	}
 
-	if params.IsSysDBA == false {
-		return nil, errors.New("a user with DBA permissions are required, check your connection details on field `hosts`")
-	}
-
 	db, err := sql.Open("godror", params.StringWithPassword())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open database")

--- a/x-pack/metricbeat/module/oracle/testing.go
+++ b/x-pack/metricbeat/module/oracle/testing.go
@@ -28,7 +28,7 @@ func GetOracleEnvServiceName() string {
 	serviceName := os.Getenv("ORACLE_SERVICE_NAME")
 
 	if len(serviceName) == 0 {
-		serviceName = "ORCLPDB1.localdomain"
+		serviceName = "ORCLCDB.localdomain"
 	}
 	return serviceName
 }

--- a/x-pack/metricbeat/modules.d/oracle.yml.disabled
+++ b/x-pack/metricbeat/modules.d/oracle.yml.disabled
@@ -5,7 +5,7 @@
   metricsets: ["tablespace", "performance"]
   enabled: true
   period: 10s
-  hosts: ["oracle://user:pass@localhost:1521/ORCLPDB1.localdomain?sysdba=1"]
+  hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
 
   # username: ""
   # password: ""


### PR DESCRIPTION
Cherry-pick of PR #18182 to 7.x branch. Original message: 

Fixes https://github.com/elastic/beats/issues/15846