### PR TITLE
Cherry-pick #18035 to 7.x: [Auditbeat] Add system module user dataset ECS categorization fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -283,6 +283,11 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix syscall kprobe arguments for 32-bit systems in socket module. {pull}17500[17500]
 - Fix memory leak on when we miss socket close kprobe events. {pull}17500[17500]
 - Add system module process dataset ECS categorization fields. {pull}18032[18032]
+- Add system module socket dataset ECS categorization fields. {pull}18036[18036]
+- Add ECS categories for system module host dataset. {pull}18031[18031]
+- Add system module package dataset ECS categorization fields. {pull}18033[18033]
+- Add system module login dataset ECS categorization fields. {pull}18034[18034]
+- Add system module user dataset ECS categorization fields. {pull}18035[18035]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -283,10 +283,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix syscall kprobe arguments for 32-bit systems in socket module. {pull}17500[17500]
 - Fix memory leak on when we miss socket close kprobe events. {pull}17500[17500]
 - Add system module process dataset ECS categorization fields. {pull}18032[18032]
-- Add system module socket dataset ECS categorization fields. {pull}18036[18036]
-- Add ECS categories for system module host dataset. {pull}18031[18031]
-- Add system module package dataset ECS categorization fields. {pull}18033[18033]
-- Add system module login dataset ECS categorization fields. {pull}18034[18034]
 - Add system module user dataset ECS categorization fields. {pull}18035[18035]
 
 *Filebeat*

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/auditbeat/core"
 	abtest "github.com/elastic/beats/v7/auditbeat/testing"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
@@ -36,7 +38,16 @@ func TestData(t *testing.T) {
 	}
 
 	for _, e := range events {
-		if name, _ := e.RootFields.GetValue("user.name"); name == "elastic" {
+		if name, _ := e.RootFields.GetValue("user.name"); name == "__elastic" {
+			relatedNames, err := e.RootFields.GetValue("related.user")
+			require.NoError(t, err)
+			require.Equal(t, []string{"__elastic"}, relatedNames)
+			groupName, err := e.RootFields.GetValue("user.group.name")
+			require.NoError(t, err)
+			require.Equal(t, "__elastic", groupName)
+			groupID, err := e.RootFields.GetValue("user.group.id")
+			require.NoError(t, err)
+			require.Equal(t, "1001", groupID)
 			fullEvent := mbtest.StandardizeEvent(f, e, core.AddDatasetToEvent)
 			mbtest.WriteEventToDataJSON(t, fullEvent, "")
 			return
@@ -48,13 +59,13 @@ func TestData(t *testing.T) {
 
 func testUser() *User {
 	return &User{
-		Name: "elastic",
+		Name: "__elastic",
 		UID:  "9999",
 		GID:  "1001",
 		Groups: []*user.Group{
 			&user.Group{
 				Gid:  "1001",
-				Name: "elastic",
+				Name: "__elastic",
 			},
 			&user.Group{
 				Gid:  "1002",


### PR DESCRIPTION
Cherry-pick of PR #18035 to 7.x branch. Original message: 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/17527
