### PR TITLE
Cherry-pick #16280 to 7.x: [Filebeat] Improve ECS field mapping for auditd module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -385,6 +385,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change the `json.*` input settings implementation to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
 - Improve ECS categorization field mappings in osquery module. {issue}16176[16176] {pull}17881[17881]
 - Add support for v10, v11 and v12 logs on Postgres {issue}13810[13810] {pull}17732[17732]
+- Add an SSL config example in config.yml for filebeat MISP module. {pull}16320[16320] 
+- Improve ECS categorization, container & process field mappings in auditd module. {issue}16153[16153] {pull}16280[16280]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #16280 to 7.x branch. Original message: 

- event.kind
- event.type
- event.category
- container.name
- container.runtime
- process.args_count
- process.exit_code
- process.working_directory

Closes #16153