### PR TITLE
Cherry-pick #18286 to 7.x: Fix version to 7.8 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@
 - Fix panic and flaky tests for the Agent. {pull}18135[18135]
 - Fix default configuration after enroll {pull}18232[18232]
 - Fix make sure the collected logs or metrics include streams information. {pull}18261[18261]
+- Fix version to 7.8 {pull}18286[18286]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/release/version.go
+++ b/x-pack/elastic-agent/pkg/release/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // version is the current version of the elastic-agent.
-var version = "8.0.0"
+var version = "7.8.0"
 
 // buildHash is the hash of the current build.
 var commit = "<unknown>"


### PR DESCRIPTION
Ideally this would be overridden during release, this is just a workaround for now

Cherry-pick of PR #18286 to 7.x branch. Original message:

## What does this PR do?

TO work with new release so agent downloads correct and existing beats

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
