### PR TITLE
Cherry-pick #18259 to 7.8: [Metricbeat] Revert unskipping of mssql tests

### DIFF
--- a/x-pack/metricbeat/module/mssql/performance/data_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/performance/data_integration_test.go
@@ -8,9 +8,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/tests/compose"
-
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -20,10 +17,9 @@ import (
 )
 
 func TestData(t *testing.T) {
-	logp.TestingSetup()
-	service := compose.EnsureUp(t, "mssql")
+	t.Skip("Skipping `data.json` generation test")
 
-	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig(service.Host(), "performance"))
+	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("performance"))
 
 	err := mbtest.WriteEventsReporterV2(f, t, "")
 	assert.NoError(t, err)

--- a/x-pack/metricbeat/module/mssql/transaction_log/data_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/transaction_log/data_integration_test.go
@@ -7,18 +7,14 @@ package transaction_log
 import (
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/tests/compose"
-
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	mtest "github.com/elastic/beats/v7/x-pack/metricbeat/module/mssql/testing"
 )
 
 func TestData(t *testing.T) {
-	logp.TestingSetup()
-	service := compose.EnsureUp(t, "mssql")
+	t.Skip("Skipping `data.json` generation test")
 
-	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig(service.Host(), "transaction_log"))
+	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("transaction_log"))
 
 	err := mbtest.WriteEventsReporterV2(f, t, "")
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #18259 to 7.8 branch. Original message: 

Travis tests got broken. Skips those of `-data` on mssql manually.

Changelog omitted as it's a minor fix in tests