### PR TITLE
[Elastic Agent] Left out fleet injection for x-pack management

### DIFF
--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -11,6 +11,9 @@ import (
 	"github.com/elastic/beats/v7/x-pack/libbeat/licenser"
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/management"
 
+	// Register fleet
+	_ "github.com/elastic/beats/v7/x-pack/libbeat/management/fleet"
+
 	// register processors
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/processors/add_cloudfoundry_metadata"
 


### PR DESCRIPTION
## What does this PR do?

During initial backport this was probably left out. Without this beats are not able to be managed by agent.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
