### PR TITLE
Cherry-pick #17949 to 7.8: Fleet issues with configuring the Gateway

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@
 - Fix default configuration after enroll {pull}18232[18232]
 - Fix make sure the collected logs or metrics include streams information. {pull}18261[18261]
 - Fix version to 7.8 {pull}18286[18286]
+- Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #17949 to 7.8 branch. Original message:
This pull request ensure that the values configuration locally in the
elastic-agent.yml are correctly applied to the fleet gateway.

This also ensure that we have appropriate default sets on the Gateway.

The following options are now supported on the Gateway.

```yaml
  # Check in frequency configure the time between calls to fleet to retrieve the new configuration.
  #
  # Default is 30s
  #checkin_frequency: 30s

  # Add variance between API calls to better distribute the calls.
  #jitter: 5s

  # The Elastic Agent does Exponential backoff when an error happen.
  #
  #backoff:
  #
  # Initial time to wait before retrying the call.
  #init: 1s
  #
  # Maximum time to wait before retrying the call.
  #max: 10s
```

Fixes: #17900

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
