### PR TITLE
[7.8] Allow delete and index actions with a document ID (#12606)

### DIFF
--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -54,6 +54,19 @@ func (e *Event) SetID(id string) {
 	e.Meta["_id"] = id
 }
 
+func (e *Event) GetMetaStringValue(key string) (string, error) {
+	tmp, err := e.Meta.GetValue(key)
+	if err != nil {
+		return "", err
+	}
+
+	if s, ok := tmp.(string); ok {
+		return s, nil
+	}
+
+	return "", nil
+}
+
 func (e *Event) GetValue(key string) (interface{}, error) {
 	if key == "@timestamp" {
 		return e.Timestamp, nil

--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -46,6 +46,10 @@ type BulkCreateAction struct {
 	Create BulkMeta `json:"create" struct:"create"`
 }
 
+type BulkDeleteAction struct {
+	Delete BulkMeta `json:"delete" struct:"delete"`
+}
+
 type BulkMeta struct {
 	Index    string `json:"_index" struct:"_index"`
 	DocType  string `json:"_type,omitempty" struct:"_type,omitempty"`

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -319,6 +319,68 @@ func TestBulkEncodeEvents(t *testing.T) {
 	}
 }
 
+func TestBulkEncodeEventsWithOpType(t *testing.T) {
+	cases := []common.MapStr{
+		{"_id": "111", "op_type": "index", "message": "test 1", "bulkIndex": 0},
+		{"_id": "112", "op_type": "", "message": "test 2", "bulkIndex": 2},
+		{"_id": "", "op_type": "delete", "message": "test 6", "bulkIndex": -1}, // this won't get encoded due to missing _id
+		{"_id": "", "op_type": "", "message": "test 3", "bulkIndex": 4},
+		{"_id": "114", "op_type": "delete", "message": "test 4", "bulkIndex": 6},
+		{"_id": "115", "op_type": "index", "message": "test 5", "bulkIndex": 7},
+	}
+
+	cfg := common.MustNewConfigFrom(common.MapStr{})
+	info := beat.Info{
+		IndexPrefix: "test",
+		Version:     version.GetDefaultVersion(),
+	}
+
+	im, err := idxmgmt.DefaultSupport(nil, info, common.NewConfig())
+	require.NoError(t, err)
+
+	index, pipeline, err := buildSelectors(im, info, cfg)
+	require.NoError(t, err)
+
+	events := make([]publisher.Event, len(cases))
+	for i, fields := range cases {
+		events[i] = publisher.Event{
+			Content: beat.Event{
+				Meta: common.MapStr{
+					"_id":     fields["_id"],
+					"op_type": fields["op_type"],
+				},
+				Fields: common.MapStr{
+					"message": fields["message"],
+				},
+			}}
+	}
+
+	encoded, bulkItems := bulkEncodePublishRequest(logp.L(), *common.MustNewVersion(version.GetDefaultVersion()), index, pipeline, events)
+	require.Equal(t, len(events)-1, len(encoded), "all events should have been encoded")
+	require.Equal(t, 9, len(bulkItems), "incomplete bulk")
+
+	for i := 0; i < len(cases); i++ {
+		bulkEventIndex, _ := cases[i]["bulkIndex"].(int)
+		if bulkEventIndex == -1 {
+			continue
+		}
+		caseOpType, _ := cases[i]["op_type"].(string)
+		caseMessage, _ := cases[i]["message"].(string)
+		switch bulkItems[bulkEventIndex].(type) {
+		case eslegclient.BulkCreateAction:
+			validOpTypes := []string{opTypeCreate, ""}
+			require.Contains(t, validOpTypes, caseOpType, caseMessage)
+		case eslegclient.BulkIndexAction:
+			require.Equal(t, opTypeIndex, caseOpType, caseMessage)
+		case eslegclient.BulkDeleteAction:
+			require.Equal(t, opTypeDelete, caseOpType, caseMessage)
+		default:
+			require.FailNow(t, "unknown type")
+		}
+	}
+
+}
+
 func TestClientWithAPIKey(t *testing.T) {
 	var headers http.Header
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Allow delete and index actions with a document ID  (#12606)