### PR TITLE
[CI] cancel old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
-    disableConcurrentBuilds()
+    quietPeriod(10)
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
     stage('Checkout') {
       options { skipDefaultCheckout() }
       steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false


### PR DESCRIPTION
__NOTE__: Please the `Questions` section 

## What does this PR do?

Enable cancel old builds. If enabled then the GitHub PR comments will notify the build has been aborted (there is an open issue to disable the notifications for this particular case)

## Why is it important?

Avoid wasting build cycles for old commits

## How to test this PR locally

We can comment `Jenkins run the tests please` a few times to validate it works as expected

Build number 3 was caused with the comment: https://github.com/elastic/beats/pull/18317#issuecomment-624792738 and number 4 with the comment: https://github.com/elastic/beats/pull/18317#issuecomment-624800046

![image](https://user-images.githubusercontent.com/2871786/81685989-35da1280-9450-11ea-8b93-14c130abc088.png)

![image](https://user-images.githubusercontent.com/2871786/81686108-45595b80-9450-11ea-8d31-8ff4ee87f75c.png)

## Use cases

Sequential builds mean slow feedback while concurrent builds mean faster feedback but as a downside it means more resources, aka money. So this will help to align the quick feedback with less resources.

On the other hand, we will be working on the GitHub PR comments to avoid any kind of feedback if the build got aborted.

## Questions

- [x] How to delete the cloud scenarios that have been created?

![image](https://user-images.githubusercontent.com/2871786/81191788-5538f180-8fb1-11ea-960f-f3e37d9f6184.png)

They run as a specific post-cleanup stage:
- https://github.com/elastic/beats/blob/8f16020c135454080bca117701286e4d8a7099a2/Jenkinsfile#L384-L388

## Tasks
- [x] Categorise build status for `ABORTED` and `UNSTABLE`. _NOTE_: we are working on levelling the build status report with something like:

<details><summary>Expand to view screenshots</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/81405194-16c94100-912f-11ea-9a0f-a40f15566959.png)

![image](https://user-images.githubusercontent.com/2871786/81405220-23e63000-912f-11ea-8eca-039d05201cae.png)

![image](https://user-images.githubusercontent.com/2871786/81405240-2ba5d480-912f-11ea-8af8-9040f5d63862.png)

</p>
</details>


