### PR TITLE
Add client address to events from http server module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -392,6 +392,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Collect new `bulk` indexing metrics from Elasticsearch when `xpack.enabled:true` is set. {issue} {pull}17992[17992]
 - Remove requirement to connect as sysdba in Oracle module {issue}15846[15846] {pull}18182[18182]
 - Update MSSQL module to fix some SSPI authentication and add brackets to USE statements {pull}17862[17862]]
+- Add client address to events from http server module {pull}18336[18336]
 
 *Packetbeat*
 

--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -138,7 +138,8 @@ func (h *HttpServer) handleFunc(writer http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "POST":
 		meta := server.Meta{
-			"path": req.URL.String(),
+			"path":    req.URL.String(),
+			"address": req.RemoteAddr,
 		}
 
 		contentType := req.Header.Get("Content-Type")

--- a/metricbeat/module/http/server/server.go
+++ b/metricbeat/module/http/server/server.go
@@ -80,7 +80,10 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 			if err != nil {
 				reporter.Error(err)
 			} else {
-				event := mb.Event{}
+				meta := msg.GetMeta()
+				event := mb.Event{
+					Host: meta["address"].(string),
+				}
 				ns, ok := fields[mb.NamespaceKey].(string)
 				if ok {
 					ns = fmt.Sprintf("http.%s", ns)


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Adds client address as `service.address` as part of events coming in from http server module

## Why is it important?

It seems to be a gap in the module while things were moved to ECS

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

