### PR TITLE
Cherry-pick #18284 to 7.x: Stop monitoring on config change

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@
 - Fix make sure the collected logs or metrics include streams information. {pull}18261[18261]
 - Fix version to 7.8 {pull}18286[18286]
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
+- Stop monitoring on config change {pull}18284[18284]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -43,7 +43,7 @@ func TestGenerateSteps(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := &testMonitor{monitorLogs: tc.Config.MonitorLogs, monitorMetrics: tc.Config.MonitorMetrics}
 			operator, _ := getMonitorableTestOperator(t, "tests/scripts", m)
-			steps := operator.generateMonitoringSteps("8.0", sampleOutput)
+			steps := operator.generateMonitoringSteps("8.0", sampleOutput, tc.Config.MonitorLogs, tc.Config.MonitorMetrics)
 			if actualSteps := len(steps); actualSteps != tc.ExpectedSteps {
 				t.Fatalf("invalid number of steps, expected %v, got %v", tc.ExpectedSteps, actualSteps)
 			}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -228,6 +228,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 
 	id := p.ID()
 
+	o.logger.Debugf("operator is looking for %s in app collection: %v", p.ID(), o.apps)
 	if a, ok := o.apps[id]; ok {
 		return a, nil
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator_handlers.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_handlers.go
@@ -42,6 +42,7 @@ func (o *Operator) handleRun(step configrequest.Step) error {
 }
 
 func (o *Operator) handleRemove(step configrequest.Step) error {
+	o.logger.Debugf("stopping process %s: %s", step.Process, step.ID)
 	if step.Process == monitoringName {
 		return o.handleStopSidecar(step)
 	}

--- a/x-pack/elastic-agent/pkg/core/plugin/app/configure.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/configure.go
@@ -68,6 +68,7 @@ func (a *Application) Configure(ctx context.Context, config map[string]interface
 			return errors.New(ErrClientNotConfigurable, errors.TypeApplication)
 		}
 
+		a.logger.Debugf("configuring application %s: %s", a.Name(), string(rawYaml))
 		err = configClient.Config(ctx, string(rawYaml))
 
 		if netErr, ok := err.(net.Error); ok && (netErr.Timeout() || netErr.Temporary()) {


### PR DESCRIPTION
Cherry-pick of PR #18284 to 7.x branch. Original message:

## What does this PR do?

This PR fixes a behavior of stopping monitoring.

When agent start with monitoring enabled and then configuration changes to disable monitoring or part of it (metrics/logs) agent need to stop respective beats.

Atm agent wont stop them and keeps them running


## Why is it important?

Enable stopping of monitoring 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
