### PR TITLE
Disable tracer by default

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -123,6 +123,12 @@ var debugf = logp.MakeDebug("beat")
 
 func init() {
 	initRand()
+
+	// By default, the APM tracer is active. We switch behaviour to not require users to have
+	// an APM Server running, making it opt-in
+	if os.Getenv("ELASTIC_APM_ACTIVE") == "" {
+		os.Setenv("ELASTIC_APM_ACTIVE", "false")
+	}
 	// we need to close the default tracer to prevent the beat sending events to localhost:8200
 	apm.DefaultTracer.Close()
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -123,14 +123,7 @@ var debugf = logp.MakeDebug("beat")
 
 func init() {
 	initRand()
-
-	// By default, the APM tracer is active. We switch behaviour to not require users to have
-	// an APM Server running, making it opt-in
-	if os.Getenv("ELASTIC_APM_ACTIVE") == "" {
-		os.Setenv("ELASTIC_APM_ACTIVE", "false")
-	}
-	// we need to close the default tracer to prevent the beat sending events to localhost:8200
-	apm.DefaultTracer.Close()
+	preventDefaultTracing()
 }
 
 // initRand initializes the runtime random number generator seed using
@@ -148,6 +141,16 @@ func initRand() {
 		seed = n.Int64()
 	}
 	rand.Seed(seed)
+}
+
+func preventDefaultTracing() {
+	// By default, the APM tracer is active. We switch behaviour to not require users to have
+	// an APM Server running, making it opt-in
+	if os.Getenv("ELASTIC_APM_ACTIVE") == "" {
+		os.Setenv("ELASTIC_APM_ACTIVE", "false")
+	}
+	// we need to close the default tracer to prevent the beat sending events to localhost:8200
+	apm.DefaultTracer.Close()
 }
 
 // Run initializes and runs a Beater implementation. name is the name of the

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -24,6 +24,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 
 	"github.com/gofrs/uuid"
@@ -114,4 +118,11 @@ func TestEmptyMetaJson(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Unable to load meta file properly")
 	assert.NotEqual(t, uuid.Nil, b.Info.ID, "Beats UUID is not set")
+}
+
+func TestAPMTracerDisabledByDefault(t *testing.T) {
+	tracer, err := apm.NewTracer("", "")
+	require.NoError(t, err)
+	defer tracer.Close()
+	assert.False(t, tracer.Active())
 }


### PR DESCRIPTION
## What does this PR do?

This is a follow up of https://github.com/elastic/beats/pull/17938

I made a wrong assumption there: If there is no `ELASTIC_APM_ACTIVE` env var, then the tracer is active. 

This PR reverts that behaviour to make it opt-in, instead opt-out.

This needs backport to 7.x and 7.8

## Why is it important?

Because otherwise users will be required to have an APM Server running locally on a minor upgrade.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run any beat and check there are not outgoing connections to localhost:8200

