### PR TITLE
Cherry-pick #18339 to 7.x: Disable tracer by default

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -124,8 +124,7 @@ var debugf = logp.MakeDebug("beat")
 
 func init() {
 	initRand()
-	// we need to close the default tracer to prevent the beat sending events to localhost:8200
-	apm.DefaultTracer.Close()
+	preventDefaultTracing()
 }
 
 // initRand initializes the runtime random number generator seed using
@@ -143,6 +142,16 @@ func initRand() {
 		seed = n.Int64()
 	}
 	rand.Seed(seed)
+}
+
+func preventDefaultTracing() {
+	// By default, the APM tracer is active. We switch behaviour to not require users to have
+	// an APM Server running, making it opt-in
+	if os.Getenv("ELASTIC_APM_ACTIVE") == "" {
+		os.Setenv("ELASTIC_APM_ACTIVE", "false")
+	}
+	// we need to close the default tracer to prevent the beat sending events to localhost:8200
+	apm.DefaultTracer.Close()
 }
 
 // Run initializes and runs a Beater implementation. name is the name of the

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -24,6 +24,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 
 	"github.com/gofrs/uuid"
@@ -114,4 +118,11 @@ func TestEmptyMetaJson(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Unable to load meta file properly")
 	assert.NotEqual(t, uuid.Nil, b.Info.ID, "Beats UUID is not set")
+}
+
+func TestAPMTracerDisabledByDefault(t *testing.T) {
+	tracer, err := apm.NewTracer("", "")
+	require.NoError(t, err)
+	defer tracer.Close()
+	assert.False(t, tracer.Active())
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable tracer by default (#18339)