### PR TITLE
Cherry-pick #13808 to 6.8: Fix renaming cloud metadata processor fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,6 +34,8 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -348,7 +348,7 @@ func (p *addCloudMetadata) init() {
 
 func (p *addCloudMetadata) getMeta() common.MapStr {
 	p.initOnce.Do(p.init)
-	return p.metadata
+	return p.metadata.Clone()
 }
 
 func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {


### PR DESCRIPTION
Cherry-pick of PR #13808 to 6.8 branch. Original message: 

Clone the underlying metadata to allow renaming sub-fields under cloud
that are injected by the cloud metadata processor.

Without cloning the injected metadata, `rename` and possibly other processors fail to operate on the sub-fields of the injected `cloud` field.

Further details can be found in the community post: https://discuss.elastic.co/t/cannot-rename-sub-fields-of-cloud-metadata-added-via-add-cloud-metadata/201157.