### PR TITLE
Cherry-pick #13808 to 7.6: Fix renaming cloud metadata processor fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Fix bug with `monitoring.cluster_uuid` setting not always being exposed via GET /state Beats API. {issue}16732[16732] {pull}17420[17420]
+- Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -97,7 +97,7 @@ func (p *addCloudMetadata) init() {
 
 func (p *addCloudMetadata) getMeta() common.MapStr {
 	p.init()
-	return p.metadata
+	return p.metadata.Clone()
 }
 
 func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {


### PR DESCRIPTION
Cherry-pick of PR #13808 to 7.6 branch. Original message: 

Clone the underlying metadata to allow renaming sub-fields under cloud
that are injected by the cloud metadata processor.

Without cloning the injected metadata, `rename` and possibly other processors fail to operate on the sub-fields of the injected `cloud` field.

Further details can be found in the community post: https://discuss.elastic.co/t/cannot-rename-sub-fields-of-cloud-metadata-added-via-add-cloud-metadata/201157.