### PR TITLE
Cherry-pick #18358 to 7.x: Move yum install of epel-release and jq to the docker file

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -5,6 +5,7 @@
 FROM {{ .from }}
 
 RUN yum -y --setopt=tsflags=nodocs update && \
+    yum install -y epel-release jq \
     yum clean all
 
 LABEL \

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -46,8 +46,6 @@ function enroll(){
 
     ./{{ .BeatName }} enroll ${KIBANA_HOST:-http://localhost:5601} $apikey -f
 }
-yum install -y epel-release
-yum install -y jq
 
 if [[ -n "${FLEET_SETUP}" ]] && [[ ${FLEET_SETUP} == 1 ]]; then setup; fi
 if [[ -n "${FLEET_ENROLL}" ]] && [[ ${FLEET_ENROLL} == 1 ]]; then enroll; fi


### PR DESCRIPTION
Cherry-pick of PR #18358 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Moves yum install of epel-release and jq to the docker file and not something that is done on first start of the docker container.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So on startup is faster and so it doesn't need access to the yum repo, in closed environment there might not be access to yum.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #18345
