### PR TITLE
Cherry-pick #17768 to 7.8: Fix dashboards export test

### DIFF
--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -1,12 +1,14 @@
-from base import BaseTest
 import os
 import os.path
-import subprocess
-from nose.plugins.attrib import attr
-import unittest
-from unittest import SkipTest
+import re
 import requests
 import semver
+import subprocess
+import unittest
+
+from base import BaseTest
+from nose.plugins.attrib import attr
+from unittest import SkipTest
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
@@ -188,7 +190,8 @@ class Test(BaseTest):
 
         beat.check_wait(exit_code=1)
 
-        assert self.log_contains("error exporting dashboard: Not found") is True
+        expected_error = re.compile("error exporting dashboard:.*not found", re.IGNORECASE)
+        assert self.log_contains(expected_error)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')


### PR DESCRIPTION
Cherry-pick of PR #17768 to 7.8 branch. Original message: 

Test is checking an error message from Kibana that has changed.

Fixes this issue currently affecting master:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.7/unittest/case.py", line 615, in run
    testMethod()
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_dashboard.py", line 191, in test_export_dashboard_cmd_export_dashboard_by_id_unknown_id
    assert self.log_contains("error exporting dashboard: Not found") is True
AssertionError
```

Co-Authored-By: Andrew Kroh <andrew.kroh@elastic.co>

Resolves #17827.