### PR TITLE
Add simple HTTP output, for another log API integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/josephspurrier/goversioninfo v0.0.0-20190209210621-63e6d1acd3dd
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.7
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/klauspost/compress v1.9.3-0.20191122130757-c099ac9f21dd // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/libbeat/outputs/http/config.go
+++ b/libbeat/outputs/http/config.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package http
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/elastic/beats/v7/libbeat/outputs/codec"
+)
+
+type config struct {
+	URL                   string       `config:"url"`
+	Codec                 codec.Config `config:"codec"`
+	OnlyFields            bool         `config:"only_fields"`
+	MaxRetries            int          `config:"max_retries"`
+	Compression           bool         `config:"compression"`
+	KeepAlive             bool         `config:"keep_alive"`
+	MaxIdleConns          int          `config:"max_idle_conns"`
+	IdleConnTimeout       int          `config:"idle_conn_timeout"`
+	ResponseHeaderTimeout int          `config:"response_header_timeout"`
+	Username              string       `config:"username"`
+	Password              string       `config:"password"`
+}
+
+var (
+	defaultConfig = config{
+		URL:                   "http://127.0.0.1:8090/message",
+		OnlyFields:            false,
+		MaxRetries:            -1,
+		Compression:           false,
+		KeepAlive:             true,
+		MaxIdleConns:          1,
+		IdleConnTimeout:       0,
+		ResponseHeaderTimeout: 100,
+		Username:              "",
+		Password:              "",
+	}
+)
+
+func (c *config) Validate() error {
+	_, err := http.NewRequest("POST", c.URL, nil)
+	if err != nil {
+		return err
+	}
+	if c.MaxIdleConns < 1 {
+		return errors.New("max_idle_conns can't be <1")
+	}
+	if c.IdleConnTimeout < 0 {
+		return errors.New("idle_conn_timeout can't be <0")
+	}
+	if c.ResponseHeaderTimeout < 1 {
+		return errors.New("response_header_timeout can't be <1")
+	}
+	if c.Username != "" && c.Password == "" {
+		return errors.New("password can't be empty")
+	}
+	return nil
+}

--- a/libbeat/outputs/http/docs/http.asciidoc
+++ b/libbeat/outputs/http/docs/http.asciidoc
@@ -1,0 +1,110 @@
+[[http-output]]
+=== Configure the HTTP output
+
+++++
+<titleabbrev>HTTP</titleabbrev>
+++++
+
+The HTTP output dumps the transactions into HTTP api by POST request where each transaction is in a JSON format.
+Currently, this output is used for custom http log api integration.
+
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the file output by adding `output.http`.
+
+Example configuration:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.http:
+  only_fields: true
+  # only fields set force json codec for body and send
+  # only Fields content, no @metadata
+  # default=false
+  url: 'http://some.example.com:80/foo'
+  # URL for sending POST request
+  max_retries: -1
+  # How many retry fail send: -1=infinite, 0=no retry, default=-1
+  compression: false
+  # Use HTTP client compression? default=false
+  keep_alive: true
+  # HTTP KeepAlive using default=true
+  max_idle_conns: 1
+  # Controls the maximum number of idle (keep-alive) must be 1 and greater
+  # Default=1
+  idle_conn_timeout: 0
+  # Is the maximum amount of time in seconds an idle (keep-alive)
+  # connection will remain idle before closing itself.
+  # Zero means no limit
+  # Default=0
+  response_header_timeout: 100
+  # Specifies the amount of time in milliseconds to wait for a server's response
+  # headers after fully writing the request (including its body, if any).
+  # This time does not include the time to read the response body.
+  # default=100ms
+  username: 'test'
+  # Basic Auth username if empty or none Authorization header not set
+  password: 'password'
+  # Basic Auth password if auth set. If auth set, can't be empty!
+------------------------------------------------------------------------------
+
+==== Configuration options
+
+You can specify the following `output.http` options in the +{beatname_lc}.yml+ config file:
+
+[[url]]
+===== `url`
+
+The URL of HTTP api where POST request sending.
+This option is mandatory.
+
+===== `only_fields`
+
+Set sending only Fields content, no @metadata.Default false.
+
+===== `max_retries`
+
+How many retry for fail send:
+  -1 is infinite
+  0 is no retry
+
+Default -1
+
+===== `compression`
+
+HTTP using gzip compression. Default false.
+
+===== `keep_alive`
+
+HTTP using KeepAlive. Default=true.
+
+===== `max_idle_conns`
+
+Controls the maximum number of idle (keep-alive)
+must be 1 and greater. Default=1
+
+==== `idle_conn_timeout`
+
+Is the maximum amount of time in seconds an idle (keep-alive)
+connection will remain idle before closing itself.
+Zero means no limit. Default=0
+
+==== `response_header_timeout`
+
+Specifies the amount of time in milliseconds to wait for a server's response
+headers after fully writing the request (including its body, if any).
+This time does not include the time to read the response body.
+Default=100ms
+
+==== `username`
+
+Basic Auth username if empty Authorization header not set.
+
+==== `password`
+
+Basic Auth password if auth set. If auth set, can't be empty!
+
+===== `codec`
+
+Output codec configuration. If the `codec` section is missing, events will be json encoded.
+
+See <<configuration-output-codec>> for more information.

--- a/libbeat/outputs/http/http.go
+++ b/libbeat/outputs/http/http.go
@@ -1,0 +1,286 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/outputs/codec"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+)
+
+func init() {
+	outputs.RegisterType("http", makeHTTP)
+}
+
+type httpOutput struct {
+	log       *logp.Logger
+	beat      beat.Info
+	observer  outputs.Observer
+	codec     codec.Codec
+	client    *http.Client
+	serialize func(event *publisher.Event) ([]byte, error)
+	reqPool   sync.Pool
+	conf      config
+}
+
+// makeHTTP instantiates a new http output instance.
+func makeHTTP(
+	_ outputs.IndexManager,
+	beat beat.Info,
+	observer outputs.Observer,
+	cfg *common.Config,
+) (outputs.Group, error) {
+
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return outputs.Fail(err)
+	}
+
+	ho := &httpOutput{
+		log:      logp.NewLogger("http"),
+		beat:     beat,
+		observer: observer,
+		conf:     config,
+	}
+
+	// disable bulk support in publisher pipeline
+	if err := cfg.SetInt("bulk_max_size", -1, -1); err != nil {
+		ho.log.Error("Disable bulk error: ", err)
+	}
+
+	//select serializer
+	ho.serialize = ho.serializeAll
+
+	if config.OnlyFields {
+		ho.serialize = ho.serializeOnlyFields
+	}
+
+	// init output
+	if err := ho.init(beat, config); err != nil {
+		return outputs.Fail(err)
+	}
+
+	return outputs.Success(-1, config.MaxRetries, ho)
+}
+
+func (out *httpOutput) init(beat beat.Info, c config) error {
+	var err error
+
+	out.codec, err = codec.CreateEncoder(beat, c.Codec)
+	if err != nil {
+		return err
+	}
+
+	tr := &http.Transport{
+		MaxIdleConns:          out.conf.MaxIdleConns,
+		ResponseHeaderTimeout: time.Duration(out.conf.ResponseHeaderTimeout) * time.Millisecond,
+		IdleConnTimeout:       time.Duration(out.conf.IdleConnTimeout) * time.Second,
+		DisableCompression:    !out.conf.Compression,
+		DisableKeepAlives:     !out.conf.KeepAlive,
+	}
+
+	out.client = &http.Client{
+		Transport: tr,
+	}
+
+	out.reqPool = sync.Pool{
+		New: func() interface{} {
+			req, err := http.NewRequest("POST", out.conf.URL, nil)
+			if err != nil {
+				return err
+			}
+			return req
+		},
+	}
+
+	out.log.Infof("Initialized http output:\n"+
+		"url=%v\n"+
+		"codec=%v\n"+
+		"only_fields=%v\n"+
+		"max_retries=%v\n"+
+		"compression=%v\n"+
+		"keep_alive=%v\n"+
+		"max_idle_conns=%v\n"+
+		"idle_conn_timeout=%vs\n"+
+		"response_header_timeout=%vms\n"+
+		"username=%v\n"+
+		"password=%v\n",
+		c.URL, c.Codec, c.OnlyFields, c.MaxRetries, c.Compression,
+		c.KeepAlive, c.MaxIdleConns, c.IdleConnTimeout, c.ResponseHeaderTimeout,
+		c.Username, maskPass(c.Password))
+	return nil
+}
+
+func maskPass(password string) string {
+	result := ""
+	if len(password) <= 8 {
+		for i := 0; i < len(password); i++ {
+			result += "*"
+		}
+		return result
+	}
+
+	for i, char := range password {
+		if i > 1 && i < len(password)-2 {
+			result += "*"
+		} else {
+			result += string(char)
+		}
+	}
+
+	return result
+}
+
+// Implement Client
+func (out *httpOutput) Close() error {
+	out.client.CloseIdleConnections()
+	return nil
+}
+
+func (out *httpOutput) serializeOnlyFields(event *publisher.Event) ([]byte, error) {
+	serializedEvent, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(&event.Content.Fields)
+	if err != nil {
+		out.log.Error("Serialization error: ", err)
+		return make([]byte, 0), err
+	}
+	return serializedEvent, nil
+}
+
+func (out *httpOutput) serializeAll(event *publisher.Event) ([]byte, error) {
+	serializedEvent, err := out.codec.Encode(out.beat.Beat, &event.Content)
+	if err != nil {
+		out.log.Error("Serialization error: ", err)
+		return make([]byte, 0), err
+	}
+	return serializedEvent, nil
+}
+
+func (out *httpOutput) Publish(_ context.Context, batch publisher.Batch) error {
+	st := out.observer
+	events := batch.Events()
+	st.NewBatch(len(events))
+
+	if len(events) == 0 {
+		batch.ACK()
+		return nil
+	}
+
+	for i := range events {
+		event := events[i]
+
+		serializedEvent, err := out.serialize(&event)
+
+		if err != nil {
+			if event.Guaranteed() {
+				out.log.Errorf("Failed to serialize the event: %+v", err)
+			} else {
+				out.log.Warnf("Failed to serialize the event: %+v", err)
+			}
+			out.log.Debugf("Failed event: %v", event)
+
+			batch.RetryEvents(events)
+			st.Failed(len(events))
+			return nil
+		}
+
+		if err = out.send(serializedEvent); err != nil {
+			if event.Guaranteed() {
+				out.log.Errorf("Writing event to http failed with: %+v", err)
+			} else {
+				out.log.Warnf("Writing event to http failed with: %+v", err)
+			}
+
+			batch.RetryEvents(events)
+			st.Failed(len(events))
+			return nil
+		}
+	}
+
+	batch.ACK()
+	st.Acked(len(events))
+	return nil
+}
+
+func (out *httpOutput) String() string {
+	return "http(" + out.conf.URL + ")"
+}
+
+func (out *httpOutput) send(data []byte) error {
+
+	req, err := out.getReq(data)
+	if err != nil {
+		return err
+	}
+	defer out.putReq(req)
+
+	resp, err := out.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		out.log.Warn("Close response body error:", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad response code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (out *httpOutput) getReq(data []byte) (*http.Request, error) {
+	tmp := out.reqPool.Get()
+
+	req, ok := tmp.(*http.Request)
+	if ok {
+		buf := bytes.NewBuffer(data)
+		req.Body = ioutil.NopCloser(buf)
+		req.Header.Set("User-Agent", "beat "+out.beat.Version)
+		if out.conf.Username != "" {
+			req.SetBasicAuth(out.conf.Username, out.conf.Password)
+		}
+		return req, nil
+	}
+
+	err, ok := tmp.(error)
+	if ok {
+		return nil, err
+	}
+
+	return nil, errors.New("pool assertion error")
+}
+
+func (out *httpOutput) putReq(req *http.Request) {
+	out.reqPool.Put(req)
+}

--- a/libbeat/outputs/http/http_test.go
+++ b/libbeat/outputs/http/http_test.go
@@ -14,20 +14,34 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+// +build !integration
 
-package includes
+package http
 
-import (
-	// import queue types
-	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/format"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/console"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/fileout"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/http"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/kafka"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/logstash"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/redis"
-	_ "github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
-	_ "github.com/elastic/beats/v7/libbeat/publisher/queue/spool"
-)
+import "testing"
+
+func Test_maskPass(t *testing.T) {
+	if maskPass("r") != "*" {
+		t.Fail()
+	}
+
+	if maskPass("er") != "**" {
+		t.Fail()
+	}
+
+	if maskPass("ert") != "***" {
+		t.Fail()
+	}
+
+	if maskPass("hgfd") != "****" {
+		t.Fail()
+	}
+
+	if maskPass("password") != "********" {
+		t.Fail()
+	}
+
+	if maskPass("password1") != "pa*****d1" {
+		t.Fail()
+	}
+}

--- a/libbeat/scripts/cmd/stress_pipeline/main.go
+++ b/libbeat/scripts/cmd/stress_pipeline/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/outputs/console"
 	_ "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	_ "github.com/elastic/beats/v7/libbeat/outputs/fileout"
+	_ "github.com/elastic/beats/v7/libbeat/outputs/http"
 	_ "github.com/elastic/beats/v7/libbeat/outputs/logstash"
 	"github.com/elastic/beats/v7/libbeat/paths"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline/stress"


### PR DESCRIPTION
<!-- Type of change
- Enhancement
-->

## What does this PR do?

This PR add simple HTTP output . It's necessary for integration for another logs API. With non-elastic stack, for example.

## Why is it important?

It's important because users requested simple http output.
For request example https://discuss.elastic.co/t/output-beat-events-as-plain-http-post/57923

## Checklist

- [X] My code follows the style guidelines of this project (At least - trying)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ]  ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ]  ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ 

## Author's Checklist
## How to test this PR locally

Build filebeat project with this PR and test all new output functionality.
Test branch 7.8 and master all working as expected.
## Related issues
## Use cases
Integration with not elastic stack log API
## Logs
```
2020-05-09T21:50:09.338+0300	INFO	[http]	http/http.go:108	Initialized http output:
url=http://127.0.0.1:8090/headers
codec={{ <nil>}}
only_fields=true
max_retries=-1
compression=true
keep_alive=true
max_idle_conns=1
idle_conn_timeout=0s
response_header_timeout=100ms
username=test
password=pa************et
2020-05-09T21:50:09.340+0300	INFO	[publisher]
```
Retry example
```
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:221	retryer: send unwait signal to consumer
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:225	  done
2020-05-09T21:44:38.091+0300	ERROR	[http]	http/http.go:200	Writing event to http failed with: Post "http://127.0.0.1:8090/headers": dial tcp 127.0.0.1:8090: connect: connection refused
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:221	retryer: send unwait signal to consumer
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:225	  done
2020-05-09T21:44:38.091+0300	ERROR	[http]	http/http.go:200	Writing event to http failed with: Post "http://127.0.0.1:8090/headers": dial tcp 127.0.0.1:8090: connect: connection refused
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:221	retryer: send unwait signal to consumer
2020-05-09T21:44:38.091+0300	INFO	[publisher]	pipeline/retry.go:225	  done
```