### PR TITLE
[Elastic Agent] Fix jq: command not found 

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -5,6 +5,8 @@
 FROM {{ .from }}
 
 RUN yum -y --setopt=tsflags=nodocs update && \
+    yum install epel-release -y
+RUN yum install jq -y \
     yum clean all
 
 LABEL \
@@ -50,9 +52,6 @@ USER {{ .user }}
 {{- range $i, $port := .ExposePorts }}
 EXPOSE {{ $port }}
 {{- end }}
-
-RUN yum install epel-release -y
-RUN yum install jq -y
 
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -5,7 +5,6 @@
 FROM {{ .from }}
 
 RUN yum -y --setopt=tsflags=nodocs update && \
-    yum install -y epel-release jq \
     yum clean all
 
 LABEL \
@@ -51,6 +50,9 @@ USER {{ .user }}
 {{- range $i, $port := .ExposePorts }}
 EXPOSE {{ $port }}
 {{- end }}
+
+RUN yum install epel-release -y
+RUN yum install jq -y
 
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -4,7 +4,7 @@
 
 FROM {{ .from }}
 
-# Installing jq needs to be on a separate layer to be installed correctly
+# Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
 RUN yum -y --setopt=tsflags=nodocs update && \
     yum install epel-release -y && \
     yum install jq -y && \

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -4,6 +4,7 @@
 
 FROM {{ .from }}
 
+# Installing jq needs to be on a separate layer to be installed correctly
 RUN yum -y --setopt=tsflags=nodocs update && \
     yum install epel-release -y
 RUN yum install jq -y \

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -6,8 +6,8 @@ FROM {{ .from }}
 
 # Installing jq needs to be on a separate layer to be installed correctly
 RUN yum -y --setopt=tsflags=nodocs update && \
-    yum install epel-release -y
-RUN yum install jq -y \
+    yum install epel-release -y && \
+    yum install jq -y && \
     yum clean all
 
 LABEL \

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2 h1:DW6WrARxK5J+o8uAKCiACi5wy9EK1UzrsCpGBPsKHAA=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
+github.com/elastic/beats v7.6.2+incompatible h1:jHdLv83KURaqWUC6f55iMyVP6LYZrgElfeqxKWcskVE=
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqrj3lotWinO9+jFmeDXIC4gvIQs=
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/ecs v1.5.0 h1:/VEIBsRU4ecq2+U3RPfKNc6bFyomP6qnthYEcQZu8GU=

--- a/go.sum
+++ b/go.sum
@@ -221,7 +221,6 @@ github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2 h1:DW6WrARxK5J+o8uAKCiACi5wy9EK1UzrsCpGBPsKHAA=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
-github.com/elastic/beats v7.6.2+incompatible h1:jHdLv83KURaqWUC6f55iMyVP6LYZrgElfeqxKWcskVE=
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqrj3lotWinO9+jFmeDXIC4gvIQs=
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/ecs v1.5.0 h1:/VEIBsRU4ecq2+U3RPfKNc6bFyomP6qnthYEcQZu8GU=

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@
 - Fix default configuration after enroll {pull}18232[18232]
 - Fix make sure the collected logs or metrics include streams information. {pull}18261[18261]
 - Stop monitoring on config change {pull}18284[18284]
+- Fix jq: command not found {pull}18408[18408]
 
 ==== New features
 


### PR DESCRIPTION
## What does this PR do?

Fixes jq command not found issue with generated dockerfile by splitting installation in two steps.

## Why is it important?

to have jq present so entrypoint script is able to parse fleet responses

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test it
build Dockerfiles out of templates using 
```
cd x-pack/elastic-agent
PLATFORMS='+all linux/amd64' mage package
````

you will find it inside `x-pack/elastic-agent/build/package/elastic-agent/elastic-agent-linux-amd64.docker/docker-build`

from ^^ directory build docker image and run it

```
docker build -t agent .
docker run -it --entrypoint /bin/bash agent
```

verify that `jq` is present

Fixes: #18406