### PR TITLE
Cherry-pick #18370 to 7.8: [Filebeat] Unescape characters in s3 file names

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -158,6 +158,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed `cloudfoundry.access` to have the correct `cloudfoundry.app.id` contents. {pull}17847[17847]
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
+- Fix Cisco ASA ASA 3020** and 106023 messages {pull}17964[17964]
+- Unescape file name from SQS message. {pull}18370[18370]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -158,7 +158,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed `cloudfoundry.access` to have the correct `cloudfoundry.app.id` contents. {pull}17847[17847]
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
-- Fix Cisco ASA ASA 3020** and 106023 messages {pull}17964[17964]
 - Unescape file name from SQS message. {pull}18370[18370]
 
 *Heartbeat*

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -360,10 +361,16 @@ func handleSQSMessage(m sqs.Message) ([]s3Info, error) {
 	var s3Infos []s3Info
 	for _, record := range msg.Records {
 		if record.EventSource == "aws:s3" && strings.HasPrefix(record.EventName, "ObjectCreated:") {
+			// Unescape substrings from s3 log name. For example, convert "%3D" back to "="
+			filename, err := url.QueryUnescape(record.S3.object.Key)
+			if err != nil {
+				return nil, errors.Wrapf(err, "url.QueryUnescape failed")
+			}
+
 			s3Infos = append(s3Infos, s3Info{
 				region: record.AwsRegion,
 				name:   record.S3.bucket.Name,
-				key:    record.S3.object.Key,
+				key:    filename,
 				arn:    record.S3.bucket.Arn,
 			})
 		} else {
@@ -381,6 +388,7 @@ func (p *s3Input) handleS3Objects(svc s3iface.ClientAPI, s3Infos []s3Info, errC 
 	defer s3Ctx.done()
 
 	for _, info := range s3Infos {
+		p.logger.Debugf("Processing file from s3 bucket \"%s\" with name \"%s\"", info.name, info.key)
 		err := p.createEventsFromS3Info(svc, info, s3Ctx)
 		if err != nil {
 			err = errors.Wrapf(err, "createEventsFromS3Info failed for %v", info.key)

--- a/x-pack/filebeat/input/s3/input_test.go
+++ b/x-pack/filebeat/input/s3/input_test.go
@@ -89,6 +89,30 @@ func TestHandleMessage(t *testing.T) {
 				},
 			},
 		},
+		{
+			"sqs message with event source aws:s3, event name ObjectCreated:Put and encoded filename",
+			sqs.Message{
+				Body: awssdk.String("{\"Records\":[{\"eventSource\":\"aws:s3\",\"awsRegion\":\"ap-southeast-1\",\"eventTime\":\"2019-06-21T16:16:54.629Z\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"configurationId\":\"object-created-event\",\"bucket\":{\"name\":\"test-s3-ks-2\",\"arn\":\"arn:aws:s3:::test-s3-ks-2\"},\"object\":{\"key\":\"year%3D2020/month%3D05/test1.txt\"}}}]}"),
+			},
+			[]s3Info{
+				{
+					name: "test-s3-ks-2",
+					key:  "year=2020/month=05/test1.txt",
+				},
+			},
+		},
+		{
+			"sqs message with event source aws:s3, event name ObjectCreated:Put and gzip filename",
+			sqs.Message{
+				Body: awssdk.String("{\"Records\":[{\"eventSource\":\"aws:s3\",\"awsRegion\":\"ap-southeast-1\",\"eventTime\":\"2019-06-21T16:16:54.629Z\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"configurationId\":\"object-created-event\",\"bucket\":{\"name\":\"test-s3-ks-2\",\"arn\":\"arn:aws:s3:::test-s3-ks-2\"},\"object\":{\"key\":\"428152502467_CloudTrail_us-east-2_20191219T1655Z_WXCas1PVnOaTpABD.json.gz\"}}}]}"),
+			},
+			[]s3Info{
+				{
+					name: "test-s3-ks-2",
+					key:  "428152502467_CloudTrail_us-east-2_20191219T1655Z_WXCas1PVnOaTpABD.json.gz",
+				},
+			},
+		},
 	}
 
 	for _, c := range casesPositive {


### PR DESCRIPTION
Cherry-pick of PR #18370 to 7.8 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR unescape 3-byte encoded substring to regular string. For example: "%3D" to "=".

## Why is it important?
When user uses folders in S3 bucket to organize log files, SQS notification actually encode the log file path like below:
```
{"Records":[{"eventVersion":"2.1","eventSource":"aws:s3","awsRegion":"us-east-1","eventTime":"2020-05-07T21:02:38.676Z","eventName":"ObjectCreated:Put","userIdentity":{"principalId":"AWS:AIDAWHL7AXDB2IME26NB3"},"requestParameters":{"sourceIPAddress":"174.29.210.150"},"responseElements":{"x-amz-request-id":"B86806D8E85F4A5F","x-amz-id-2":"yw1VtzJIcckqIpEjmp/oeesJj3yplnGR48PDCX0/nS8Qj5VXWGdzCrjSzAv0cRio/oAXihdDwscZE7pm32CHQH8gbjM60Qu6"},"s3":{"s3SchemaVersion":"1.0","configurationId":"ObjectCreated","bucket":{"name":"test-fb-ks","ownerIdentity":{"principalId":"A2EOMKP5A4DS45"},"arn":"arn:aws:s3:::test-fb-ks"},"object":{"key":"year%3D2020/month%3D05/test1.txt","size":6,"eTag":"3e7705498e8be60520841409ebc69bc1","sequencer":"005EB47773C10D8A81"}}}]}
```

File in S3 is `year=2020/month=05/test1.txt` but in SQS is converted to `year%3D2020/month%3D05/test1.txt`.

This conversion needs to be undo when Filebeat tries to read the S3 file pointed by SQS message. Otherwise, this file will not be found.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
https://discuss.elastic.co/t/filebeat-s3-issue/230441
