### PR TITLE
Cherry-pick #18408 to 7.x: Fix jq: command not found

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -4,8 +4,10 @@
 
 FROM {{ .from }}
 
+# Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
 RUN yum -y --setopt=tsflags=nodocs update && \
-    yum install -y epel-release jq \
+    yum install epel-release -y && \
+    yum install jq -y && \
     yum clean all
 
 LABEL \

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@
 - Fix version to 7.8 {pull}18286[18286]
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
 - Stop monitoring on config change {pull}18284[18284]
+- Fix jq: command not found {pull}18408[18408]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #18408 to 7.x branch. Original message:

## What does this PR do?

Fixes jq command not found issue with generated dockerfile by splitting installation in two steps.

## Why is it important?

to have jq present so entrypoint script is able to parse fleet responses

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test it
build Dockerfiles out of templates using 
```
cd x-pack/elastic-agent
PLATFORMS=`+all linux/amd64 mage package
````

you will find it inside `x-pack/elastic-agent/build/package/elastic-agent/elastic-agent-linux-amd64.docker/docker-build`

from ^^ directory build docker image and run it

```
docker build -t agent .
docker run -it --entrypoint /bin/bash agent
```

verify that `jq` is present

Fixes: #18406