### PR TITLE
Fixing typo in serialized JSON property name

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -125,7 +125,7 @@ type bulkStats struct {
 	TotalOperations   int `json:"total_operations"`
 	TotalTimeInMillis int `json:"total_time_in_millis"`
 	TotalSizeInBytes  int `json:"total_size_in_bytes"`
-	AvgTimeInMillis   int `json:"throttle_time_in_millis"`
+	AvgTimeInMillis   int `json:"avg_time_in_millis"`
 	AvgSizeInBytes    int `json:"avg_size_in_bytes"`
 }
 


### PR DESCRIPTION
Fixes a typo in a field name introduced in #17992. See https://github.com/elastic/beats/pull/17992/files#r423112702.