### PR TITLE
Cherry-pick #18398 to 7.8: [Metricbeat] Remove checking region/zone and service name from googlecloud

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -479,6 +479,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Collect new `bulk` indexing metrics from Elasticsearch when `xpack.enabled:true` is set. {issue} {pull}17992[17992]
 - Remove requirement to connect as sysdba in Oracle module {issue}15846[15846] {pull}18182[18182]
 - Update MSSQL module to fix some SSPI authentication and add brackets to USE statements {pull}17862[17862]]
+- Remove required for region/zone and make stackdriver a metricset in googlecloud. {issue}16785[16785] {pull}18398[18398]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/googlecloud.asciidoc
+++ b/metricbeat/docs/modules/googlecloud.asciidoc
@@ -29,7 +29,8 @@ a partial region name like `us-east` or `us-east*`, which will monitor all regio
 `us-east`: `us-east1` and `us-east4`. If both region and zone are configured,
 only region will be used.
 Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP regions]
-for regions that are available in GCP.
+for regions that are available in GCP. If both `region` and `zone` are not
+specified, metrics will be collected from all regions/zones.
 
 * *project_id*: A single string with your GCP Project ID
 
@@ -236,6 +237,23 @@ metricbeat.modules:
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 5m
+
+- module: googlecloud
+  metricsets:
+    - stackdriver
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  stackdriver:
+    service: compute
+    metrics:
+      - aligner: ALIGN_NONE
+        metric_types:
+          - "compute.googleapis.com/instance/cpu/reserved_cores"
+          - "compute.googleapis.com/instance/cpu/usage_time"
+          - "compute.googleapis.com/instance/cpu/utilization"
+          - "compute.googleapis.com/instance/uptime"
 ----
 
 [float]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -524,6 +524,23 @@ metricbeat.modules:
   exclude_labels: false
   period: 5m
 
+- module: googlecloud
+  metricsets:
+    - stackdriver
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  stackdriver:
+    service: compute
+    metrics:
+      - aligner: ALIGN_NONE
+        metric_types:
+          - "compute.googleapis.com/instance/cpu/reserved_cores"
+          - "compute.googleapis.com/instance/cpu/usage_time"
+          - "compute.googleapis.com/instance/cpu/utilization"
+          - "compute.googleapis.com/instance/uptime"
+
 #------------------------------- Graphite Module -------------------------------
 - module: graphite
   metricsets: ["server"]

--- a/x-pack/metricbeat/module/googlecloud/_meta/config.yml
+++ b/x-pack/metricbeat/module/googlecloud/_meta/config.yml
@@ -25,3 +25,20 @@
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 5m
+
+- module: googlecloud
+  metricsets:
+    - stackdriver
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  stackdriver:
+    service: compute
+    metrics:
+      - aligner: ALIGN_NONE
+        metric_types:
+          - "compute.googleapis.com/instance/cpu/reserved_cores"
+          - "compute.googleapis.com/instance/cpu/usage_time"
+          - "compute.googleapis.com/instance/cpu/utilization"
+          - "compute.googleapis.com/instance/uptime"

--- a/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/googlecloud/_meta/docs.asciidoc
@@ -19,7 +19,8 @@ a partial region name like `us-east` or `us-east*`, which will monitor all regio
 `us-east`: `us-east1` and `us-east4`. If both region and zone are configured,
 only region will be used.
 Please see https://cloud.google.com/compute/docs/regions-zones#available[GCP regions]
-for regions that are available in GCP.
+for regions that are available in GCP. If both `region` and `zone` are not
+specified, metrics will be collected from all regions/zones.
 
 * *project_id*: A single string with your GCP Project ID
 

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metadata_services.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metadata_services.go
@@ -5,8 +5,6 @@
 package stackdriver
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/googlecloud"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/googlecloud/stackdriver/compute"
 )
@@ -17,9 +15,7 @@ func NewMetadataServiceForConfig(c config) (googlecloud.MetadataService, error) 
 	switch c.ServiceName {
 	case googlecloud.ServiceCompute:
 		return compute.NewMetadataService(c.ProjectID, c.Zone, c.Region, c.opt...)
-	case googlecloud.ServicePubsub, googlecloud.ServiceLoadBalancing, googlecloud.ServiceStorage:
-		return nil, nil
 	default:
-		return nil, errors.Errorf("service '%s' not supported", c.ServiceName)
+		return nil, nil
 	}
 }

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
@@ -105,6 +105,9 @@ var serviceRegexp = regexp.MustCompile(`^(?P<service>[a-z]+)\.googleapis.com.*`)
 // if they have a region specified.
 func (r *stackdriverMetricsRequester) getFilterForMetric(m string) (f string) {
 	f = fmt.Sprintf(`metric.type="%s"`, m)
+	if r.config.Zone == "" && r.config.Region == "" {
+		return
+	}
 
 	service := serviceRegexp.ReplaceAllString(m, "${service}")
 

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester_test.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester_test.go
@@ -88,6 +88,12 @@ func TestGetFilterForMetric(t *testing.T) {
 			stackdriverMetricsRequester{config: config{Zone: "us-west1-*"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west1-\")",
 		},
+		{
+			"compute service with no region/zone in config",
+			"compute.googleapis.com/firewall/dropped_bytes_count",
+			stackdriverMetricsRequester{config: config{}},
+			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\"",
+		},
 	}
 
 	for _, c := range cases {

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metricset.go
@@ -106,7 +106,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, errors.Wrap(err, "error creating Stackdriver client")
 	}
 
-	m.metricsMeta, err = metricDescriptor(ctx, client, m.config.ProjectID, m.stackDriverConfig)
+	m.metricsMeta, err = m.metricDescriptor(ctx, client)
 	if err != nil {
 		return nil, errors.Wrap(err, "error calling metricDescriptor function")
 	}
@@ -188,19 +188,6 @@ func validatePeriodForGCP(d time.Duration) (err error) {
 	return nil
 }
 
-// Validate googlecloud module config
-func (c *config) Validate() error {
-	// storage metricset does not require region or zone config parameter.
-	if c.ServiceName == "storage" {
-		return nil
-	}
-
-	if c.Region == "" && c.Zone == "" {
-		return errors.New("region and zone in Google Cloud config file cannot both be empty")
-	}
-	return nil
-}
-
 // Validate stackdriver related config
 func (mc *stackDriverConfig) Validate() error {
 	gcpAlignerNames := make([]string, 0)
@@ -218,13 +205,13 @@ func (mc *stackDriverConfig) Validate() error {
 
 // metricDescriptor calls ListMetricDescriptorsRequest API to get metric metadata
 // (sample period and ingest delay) of each given metric type
-func metricDescriptor(ctx context.Context, client *monitoring.MetricClient, projectID string, stackDriverConfigs []stackDriverConfig) (map[string]metricMeta, error) {
+func (m *MetricSet) metricDescriptor(ctx context.Context, client *monitoring.MetricClient) (map[string]metricMeta, error) {
 	metricsWithMeta := make(map[string]metricMeta, 0)
 
-	for _, sdc := range stackDriverConfigs {
+	for _, sdc := range m.stackDriverConfig {
 		for _, mt := range sdc.MetricTypes {
 			req := &monitoringpb.ListMetricDescriptorsRequest{
-				Name:   "projects/" + projectID,
+				Name:   "projects/" + m.config.ProjectID,
 				Filter: fmt.Sprintf(`metric.type = "%s"`, mt),
 			}
 
@@ -234,10 +221,23 @@ func metricDescriptor(ctx context.Context, client *monitoring.MetricClient, proj
 				return metricsWithMeta, errors.Errorf("Could not make ListMetricDescriptors request: %s: %v", mt, err)
 			}
 
-			metricsWithMeta[mt] = metricMeta{
-				samplePeriod: time.Duration(out.Metadata.SamplePeriod.Seconds) * time.Second,
-				ingestDelay:  time.Duration(out.Metadata.IngestDelay.Seconds) * time.Second,
+			// Set samplePeriod default to 60 seconds and ingestDelay default to 0.
+			meta := metricMeta{
+				samplePeriod: 60 * time.Second,
+				ingestDelay:  0 * time.Second,
 			}
+
+			if out.Metadata.SamplePeriod != nil {
+				m.Logger().Debugf("For metric type %s: sample period = %s", mt, out.Metadata.SamplePeriod)
+				meta.samplePeriod = time.Duration(out.Metadata.SamplePeriod.Seconds) * time.Second
+			}
+
+			if out.Metadata.IngestDelay != nil {
+				m.Logger().Debugf("For metric type %s: ingest delay = %s", mt, out.Metadata.IngestDelay)
+				meta.ingestDelay = time.Duration(out.Metadata.IngestDelay.Seconds) * time.Second
+			}
+
+			metricsWithMeta[mt] = meta
 		}
 	}
 

--- a/x-pack/metricbeat/modules.d/googlecloud.yml.disabled
+++ b/x-pack/metricbeat/modules.d/googlecloud.yml.disabled
@@ -28,3 +28,20 @@
   credentials_file_path: "your JSON credentials file path"
   exclude_labels: false
   period: 5m
+
+- module: googlecloud
+  metricsets:
+    - stackdriver
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  stackdriver:
+    service: compute
+    metrics:
+      - aligner: ALIGN_NONE
+        metric_types:
+          - "compute.googleapis.com/instance/cpu/reserved_cores"
+          - "compute.googleapis.com/instance/cpu/usage_time"
+          - "compute.googleapis.com/instance/cpu/utilization"
+          - "compute.googleapis.com/instance/uptime"


### PR DESCRIPTION
Cherry-pick of PR #18398 to 7.8 branch. Original message: 

## What does this PR do?

This PR is to remove validations for region/zone/service name in order for `stackdriver` metricset to work for wider services.

## Why is it important?

`service` is only used to check when adding metadata and this is only available for `compute` metricset right now.

`region/zone` is not required for making `ListTimeSeriesRequest` API. 

## Checklist 

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Enable googlecloud in Metricbeat
`./metricbeat modules enable googlecloud`

2. Modify modules.d/googlecloud.yml to use stackdriver metricset to collect logging metrics:
```
- module: googlecloud
  metricsets:
    - stackdriver
  project_id: elastic-observability
  credentials_file_path: "/Users/kaiyansheng/Downloads/elastic-observability-d17781618202.json"
  exclude_labels: false
  period: 1m
  stackdriver:
    service: billing
    metrics:
      - aligner: ALIGN_NONE
        metric_types:
          - "logging.googleapis.com/billing/bytes_ingested"
          - "logging.googleapis.com/byte_count"
```

3. Start metricbeat:
```
./metricbeat -e
```

4. You should see metrics in Kibana like:
`googlecloud.stackdriver.byte_count.value` and `googlecloud.stackdriver.billing.bytes_ingested.value`

5. Change modules.d/googlecloud.yml to collect compute metrics and also should work:
```
- module: googlecloud
  metricsets:
    - stackdriver
  project_id: "your project id"
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 1m
  period: 1m
  stackdriver:
    service: compute
    metrics:
      - aligner: ALIGN_NONE
        metric_types:
          - "compute.googleapis.com/instance/cpu/reserved_cores"
          - "compute.googleapis.com/instance/cpu/usage_time"
          - "compute.googleapis.com/instance/cpu/utilization"
          - "compute.googleapis.com/instance/uptime"
```

## Related issues

- Closes https://github.com/elastic/beats/issues/16785