### PR TITLE
[7.7][docs] Backport: Fix typo in googlecloud examples (#18425)

### DIFF
--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -32,7 +32,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -77,7 +77,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -27,7 +27,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -72,7 +72,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id


### PR DESCRIPTION
Backports #18425  to 7.7 branch.