### PR TITLE
[7.8][docs] Backport: Fix typo in googlecloud examples (#18425)

### DIFF
--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -35,7 +35,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   audit:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -80,7 +80,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -125,7 +125,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -30,7 +30,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   audit:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -75,7 +75,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -120,7 +120,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id


### PR DESCRIPTION
Backports #18425  to 7.8 branch.