### PR TITLE
[7.6][docs] Backport: Fix typo in googlecloud examples

### DIFF
--- a/filebeat/docs/modules/googlecloud.asciidoc
+++ b/filebeat/docs/modules/googlecloud.asciidoc
@@ -33,7 +33,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -78,7 +78,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id

--- a/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/googlecloud/_meta/docs.asciidoc
@@ -28,7 +28,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   vpcflow:
     enabled: true
     var.project_id: my-gcp-project-id
@@ -73,7 +73,7 @@ Example config:
 
 [source,yaml]
 ----
-- module: googleclcoud
+- module: googlecloud
   firewall:
     enabled: true
     var.project_id: my-gcp-project-id


### PR DESCRIPTION
Backports #18425 to 7.6 branch.