### PR TITLE
[docs] Add troubleshooting topic for failed to parse private key error

### DIFF
--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -105,10 +105,23 @@ TIP: For testing purposes only, you can set `verification_mode: none` to disable
 
 Here are some common errors and ways to fix them:
 
+* <<failed-to-parse-private-key,tls: failed to parse private key>>
 * <<cannot-validate-certificate,x509: cannot validate certificate>>
 * <<getsockopt-no-route-to-host,getsockopt: no route to host>>
 * <<getsockopt-connection-refused,getsockopt: connection refused>>
 * <<target-machine-refused-connection,No connection could be made because the target machine actively refused it>>
+
+[[failed-to-parse-private-key]]
+===== tls: failed to parse private key
+
+This might occur for a few reasons:
+
+* The encrypted file is not recognized as an encrypted PEM block. {beatname_uc}
+tries to use the encrypted content as the final key, which fails.
+* The file is correctly encrypted in a PEM block, but the decrypted content is
+not a key in a format that {beatname_uc} recognizes. The key must be encoded as
+PEM format.
+* The passphrase is missing or has an error.
 
 [[cannot-validate-certificate]]
 ===== x509: cannot validate certificate for <IP address> because it doesn't contain any IP SANs


### PR DESCRIPTION
# What does this PR do?

Adds troubleshooting section.

## Why is it important?

Customers are running into this issue. 

## Checklist

- [x ] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


## Related issues


