### PR TITLE
Cherry-pick #18361 to 7.x: perfmon - remove negative counter value errors from the event output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -222,6 +222,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix storage metricset to allow config without region/zone. {issue}17623[17623] {pull}17624[17624]
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
+- Remove specific win32 api errors from events in perfmon. {issue}18292[18292] {pull}18361[18361]
 
 *Packetbeat*
 

--- a/metricbeat/helper/windows/pdh/pdh_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_windows.go
@@ -161,7 +161,7 @@ func PdhGetFormattedCounterValueDouble(counter PdhCounterHandle) (uint32, *PdhCo
 	var counterType uint32
 	var value PdhCounterValueDouble
 	if err := _PdhGetFormattedCounterValueDouble(counter, PdhFmtDouble|PdhFmtNoCap100, &counterType, &value); err != nil {
-		return 0, nil, PdhErrno(err.(syscall.Errno))
+		return 0, &value, PdhErrno(err.(syscall.Errno))
 	}
 
 	return counterType, &value, nil
@@ -172,7 +172,7 @@ func PdhGetFormattedCounterValueLarge(counter PdhCounterHandle) (uint32, *PdhCou
 	var counterType uint32
 	var value PdhCounterValueLarge
 	if err := _PdhGetFormattedCounterValueLarge(counter, PdhFmtLarge|PdhFmtNoCap100, &counterType, &value); err != nil {
-		return 0, nil, PdhErrno(err.(syscall.Errno))
+		return 0, &value, PdhErrno(err.(syscall.Errno))
 	}
 
 	return counterType, &value, nil
@@ -183,7 +183,7 @@ func PdhGetFormattedCounterValueLong(counter PdhCounterHandle) (uint32, *PdhCoun
 	var counterType uint32
 	var value PdhCounterValueLong
 	if err := _PdhGetFormattedCounterValueLong(counter, PdhFmtLong|PdhFmtNoCap100, &counterType, &value); err != nil {
-		return 0, nil, PdhErrno(err.(syscall.Errno))
+		return 0, &value, PdhErrno(err.(syscall.Errno))
 	}
 
 	return counterType, &value, nil

--- a/metricbeat/helper/windows/pdh/pdh_windows_test.go
+++ b/metricbeat/helper/windows/pdh/pdh_windows_test.go
@@ -51,7 +51,8 @@ func TestPdhAddCounterInvalidCounter(t *testing.T) {
 func TestPdhGetFormattedCounterValueInvalidCounter(t *testing.T) {
 	counterType, counterValue, err := PdhGetFormattedCounterValueDouble(InvalidCounterHandle)
 	assert.EqualValues(t, counterType, 0)
-	assert.EqualValues(t, counterValue, (*PdhCounterValueDouble)(nil))
+	assert.NotNil(t, counterValue)
+	assert.Equal(t, counterValue.Value, float64(0))
 	assert.EqualValues(t, err, PDH_INVALID_HANDLE)
 }
 

--- a/metricbeat/module/windows/perfmon/data_test.go
+++ b/metricbeat/module/windows/perfmon/data_test.go
@@ -49,7 +49,7 @@ func TestGroupToEvents(t *testing.T) {
 			{
 				Instance:    "",
 				Measurement: 23,
-				Err:         nil,
+				Err:         pdh.CounterValueError{},
 			},
 		},
 	}

--- a/metricbeat/module/windows/perfmon/perfmon_test.go
+++ b/metricbeat/module/windows/perfmon/perfmon_test.go
@@ -175,7 +175,7 @@ func TestQuery(t *testing.T) {
 		t.Fatal(path[0], "not found")
 	}
 
-	assert.NoError(t, value[0].Err)
+	assert.NoError(t, value[0].Err.Error)
 	assert.Equal(t, "TestInstanceName", value[0].Instance)
 }
 
@@ -444,6 +444,7 @@ func TestWildcardQuery(t *testing.T) {
 	}
 	config.Queries[0].Name = "Processor Information"
 	config.Queries[0].Instance = []string{"*"}
+	config.Queries[0].Namespace = "metrics"
 	config.Queries[0].Counters = []QueryCounter{
 		{
 			Name: "% Processor Time",
@@ -478,6 +479,7 @@ func TestWildcardQueryNoInstanceName(t *testing.T) {
 	}
 	config.Queries[0].Name = "Process"
 	config.Queries[0].Instance = []string{"*"}
+	config.Queries[0].Namespace = "metrics"
 	config.Queries[0].Counters = []QueryCounter{
 		{
 			Name: "Private Bytes",
@@ -523,6 +525,7 @@ func TestGroupByInstance(t *testing.T) {
 	}
 	config.Queries[0].Name = "Processor Information"
 	config.Queries[0].Instance = []string{"_Total"}
+	config.Queries[0].Namespace = "metrics"
 	config.Queries[0].Counters = []QueryCounter{
 		{
 			Name: "% Processor Time",

--- a/metricbeat/module/windows/perfmon/reader_integration_test.go
+++ b/metricbeat/module/windows/perfmon/reader_integration_test.go
@@ -77,7 +77,7 @@ func TestReadSuccessfully(t *testing.T) {
 	// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).
 	events, err := reader.Read()
 	assert.Nil(t, err)
-	assert.NotNil(t, events)
+	assert.Nil(t, events)
 	assert.Zero(t, len(events))
 	events, err = reader.Read()
 	assert.Nil(t, err)


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#18361 to 7.x branch. Original message:

## What does this PR do?

- ignores `PDH_CALC_NEGATIVE_VALUE` and `PDH_INVALID_DATA` type errors from the event output
- adds `cstatus` value in the debug information 

## Why is it important?

When collecting a high number of counters values seems that for specific processes the counter values retrieved are negative and the win32 api returns the error:

`0x800007D8 (PDH_CALC_NEGATIVE_VALUE) | A counter with a negative value was detected.`

or 

`0xC0000BC6 (PDH_INVALID_DATA) | The data is not valid.` with cstatus ` 0xC0000BBA (PDH_CSTATUS_INVALID_DATA) | The returned data is not valid.`

Which means the counter was successfully found, but the data returned is not valid. This error can occur if the counter value is less than the previous value. (Because counter values always increment, the counter value rolls over to zero when it reaches its maximum value.) Another possible cause is a system timer that is not correct.

These errors do not cause the application to run unsuccessfully and the following calls return a positive value.
These types of errors are still logged as debug messages.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Create a perfmon configuration with a high number of perfmon counters including `Process` object counters since the errors are encountered only at that level and run the perfmon metricset with a small interval.

## Related issues

- Closes https://github.com/elastic/beats/issues/18292

## Logs

```
	Line 236493: 2020-05-07T18:18:27.118+0200	DEBUG	[perfmon]	perfmon/data.go:51	Counter value retrieval returned	{"error": "A counter with a negative value was detected.", "cstatus": "A counter with a negative value was detected.", "perfmon": {"query": "\\\\DESKTOP-RFOOE09\\Process(SearchFilterHost)\\IO Other Bytes/sec"}}
	Line 236494: 2020-05-07T18:18:27.144+0200	DEBUG	[perfmon]	perfmon/data.go:51	Counter value retrieval returned	{"error": "A counter with a negative value was detected.", "cstatus": "A counter with a negative value was detected.", "perfmon": {"query": "\\\\DESKTOP-RFOOE09\\Process(SearchFilterHost)\\% Processor Time"}}
	Line 273453: 2020-05-07T18:18:42.141+0200	DEBUG	[perfmon]	perfmon/data.go:51	Counter value retrieval returned	{"error": "The data is not valid.", "cstatus": "The returned data is not valid.", "perfmon": {"query": "\\\\DESKTOP-RFOOE09\\Process(backgroundTaskHost)\\IO Read Bytes/sec"}}
	Line 273454: 2020-05-07T18:18:42.159+0200	DEBUG	[perfmon]	perfmon/data.go:51	Counter value retrieval returned	{"error": "The data is not valid.", "cstatus": "The returned data is not valid.", "perfmon": {"query": "\\\\DESKTOP-RFOOE09\\Process(backgroundTaskHost)\\IO Write Operations/sec"}}
```
