### PR TITLE
Only run module-specific tests, when possible

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1133,8 +1133,6 @@ def isDocChangedOnly(){
   name of the changed module so we can skip tests for all other modules
 **/
 def moduleToTest() {
-  log(level: 'INFO', text: "right inside moduleToTest")
-
   if (params.runAllStages || !env.CHANGE_ID?.trim()) {
     log(level: 'INFO', text: 'Speed build for specific module only is disabled for branches/tags or when forcing with the runAllStages parameter.')
     return 'false'
@@ -1144,6 +1142,7 @@ def moduleToTest() {
   def module = ""
   log(level: 'INFO', text: "before filesChanged() call")
   filesChanged().each{ String file ->
+    log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
     matches = (file =~ modulePattern).findAll()
       if (matches.size() == 1) {
         matchedModule = matches[0]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1143,7 +1143,7 @@ def moduleToTest() {
   log(level: 'INFO', text: "before filesChanged() call")
   filesChanged().each{ String file ->
     log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
-    matches = (file =~ modulePattern).findAll()
+    matches = file.findAll(modulePattern)
     if (matches.size() == 1) {
       matchedModule = matches[0]
       if (module == "") {
@@ -1169,7 +1169,6 @@ def filesChanged(Map params = [:]) {
   def to = params.get('to', env.GIT_BASE_COMMIT)
 
   def output = sh(script: "git diff --name-only ${from}...${to}", returnStdout: true)
-  log(level: 'INFO', text: output)
   return output.split('\n')
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1144,7 +1144,7 @@ def moduleToTest() {
   filesChanged().each{ String file ->
     log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
     matches = file =~ modulePattern
-    if (matches.size() == 2) {
+    if (matches.size == 2) {
       matchedModule = matches[1]
       if (module == "") {
         // Module not initialized; initialize it with matched module.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1144,16 +1144,16 @@ def moduleToTest() {
   filesChanged().each{ String file ->
     log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
     matches = (file =~ modulePattern).findAll()
-      if (matches.size() == 1) {
-        matchedModule = matches[0]
-        if (module == "") {
-          // Module not initialized; initialize it with matched module.
-          module = matchedModule
-        } else if (module != matchedModule) {
-          // Module already initialized and is different from matched module. Multiple
-          // modules were changed, so don't return any specific module.
-          return ""
-        }
+    if (matches.size() == 1) {
+      matchedModule = matches[0]
+      if (module == "") {
+        // Module not initialized; initialize it with matched module.
+        module = matchedModule
+      } else if (module != matchedModule) {
+        // Module already initialized and is different from matched module. Multiple
+        // modules were changed, so don't return any specific module.
+        return ""
+      }
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1133,6 +1133,8 @@ def isDocChangedOnly(){
   name of the changed module so we can skip tests for all other modules
 **/
 def moduleToTest() {
+  log(level: 'INFO', text: "right inside moduleToTest")
+
   if (params.runAllStages || !env.CHANGE_ID?.trim()) {
     log(level: 'INFO', text: 'Speed build for specific module only is disabled for branches/tags or when forcing with the runAllStages parameter.')
     return 'false'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1143,9 +1143,9 @@ def moduleToTest() {
   log(level: 'INFO', text: "before filesChanged() call")
   filesChanged().each{ String file ->
     log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
-    matches = file.findAll(modulePattern)
-    if (matches.size() == 1) {
-      matchedModule = matches[0]
+    matches = file =~ modulePattern
+    if (matches.size() == 2) {
+      matchedModule = matches[1]
       if (module == "") {
         // Module not initialized; initialize it with matched module.
         module = matchedModule
@@ -1155,6 +1155,7 @@ def moduleToTest() {
         return ""
       }
     }
+    log(level: 'INFO', text: matches)
   }
 
   return module

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1169,6 +1169,7 @@ def filesChanged() {
   def to = params.get('to', env.GIT_BASE_COMMIT)
 
   def output = sh(script: "git diff --name-only ${from}...${to}", returnStdout: true)
+  log(level: 'INFO', text: output)
   return output.split('\n')
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1164,7 +1164,7 @@ def moduleToTest() {
  TODO: add error checking for from/to.
  TODO: move into https://github.com/elastic/apm-pipeline-library/ and potentially reuse in isGitRegionMatch definition.
 **/
-def filesChanged() {
+def filesChanged(Map params = [:]) {
   def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)
   def to = params.get('to', env.GIT_BASE_COMMIT)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1140,9 +1140,7 @@ def moduleToTest() {
 
   def modulePattern = /beat\/module\/([^\/]+)/
   def module = ""
-  log(level: 'INFO', text: "before filesChanged() call")
   filesChanged().each{ String file ->
-    log(level: 'INFO', text: "inside filesChanged() results loop, file: " + file)
     matches = file =~ modulePattern
     if (matches.size == 2) {
       matchedModule = matches[1]
@@ -1155,15 +1153,14 @@ def moduleToTest() {
         return ""
       }
     }
-    log(level: 'INFO', text: matches)
   }
 
   return module
 }
 
 /**
- TODO: add error checking for from/to.
  TODO: move into https://github.com/elastic/apm-pipeline-library/ and potentially reuse in isGitRegionMatch definition.
+ TODO: add error checking for from/to.
 **/
 def filesChanged(Map params = [:]) {
   def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1140,6 +1140,7 @@ def moduleToTest() {
 
   def modulePattern = /beat\/module\/([^\/]+)/
   def module = ""
+  log(level: 'INFO', text: "before filesChanged() call")
   filesChanged().each{ String file ->
     matches = (file =~ modulePattern).findAll()
       if (matches.size() == 1) {


### PR DESCRIPTION
## What does this PR do?

This PR only runs integration tests (go and python) for a specific module, if only that module's files have been changed.

## Why is it important?

Often developers work on a specific module at a time, so their PRs only contain changes for that module. In such cases, it would be much faster if we only run integration tests for that specific module rather than for all modules.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Try changing only one module and make sure only it's integration tests are run.
- [ ] Try changing two modules and make sure all modules' integration tests are run. In a future PR we can add an optimization for this scenario.
- [ ] Try changing only one module but also code outside a module folder and make sure all modules' integration tests are run.
- [ ] Try changing no modules but just code outside a module folder and make sure all modules' integration tests are run.
