### PR TITLE
Update version when bulk param is available in ES stats API

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -66,7 +66,7 @@ var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 var EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
 
 // BulkStatsAvailableVersion is the version since when bulk indexing stats are available
-var BulkStatsAvailableVersion = common.MustNewVersion("7.8.0")
+var BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
 
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -37,7 +37,7 @@ func TestGetServiceURI(t *testing.T) {
 			expectedPath: statsPath,
 		},
 		"bulk_stats_available": {
-			esVersion:    common.MustNewVersion("7.8.0"),
+			esVersion:    common.MustNewVersion("8.0.0"),
 			expectedPath: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
 		},
 	}
@@ -58,7 +58,7 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 		var uri string
 		var err error
 		for i := uint(0); i < numCalls; i++ {
-			uri, err = getServicePath(*common.MustNewVersion("7.8.0"))
+			uri, err = getServicePath(*common.MustNewVersion("8.0.0"))
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
## What does this PR do?

Updates the minimum version of Elasticsearch that allows the `GET _stats` API to accept the `bulk` parameter.

## Why is it important?

Elasticsearch added the new `bulk` parameter to the `GET _stats` API in https://github.com/elastic/elasticsearch/pull/52208. That PR has been merged so this parameter is available in `master` / `8.0.0` of Elasticsearch. However, that PR has not yet been backported (see https://github.com/elastic/elasticsearch/pull/55447), so this parameter is not available in earlier versions of Elasticsearch yet.

So for now we tell the `elasticsearch` Metricbeat module to only add the `bulk` parameter to the `GET _stats` API call request if the version of Elasticsearch it's talking to is 8.0.0 or higher.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ Parity tests should start passing once this PR is merged.
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~ The feature that introduced this bug will be released in 7.8.0. Since that hasn't yet been released yet, no CHANGELOG entry for the bugfix is necessary.
