### PR TITLE
[Metricbeat] Change visualization interval from 15m to >=15m

### DIFF
--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -499,13 +499,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Storage Network Received Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -571,13 +565,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Storage Network Sent Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -255,7 +255,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+          "searchSourceJSON": {}
         },
         "title": "Storage Total Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -338,13 +338,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Storage Object Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -427,14 +421,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
+          "searchSourceJSON": {},
         "title": "Storage API Request Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
         "version": 1,

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -255,13 +255,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+            "searchSourceJSON": {}
         },
         "title": "Storage Total Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -421,7 +421,8 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {},
+            "searchSourceJSON": {}
+        },
         "title": "Storage API Request Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
         "version": 1,

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -421,7 +421,7 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+          "searchSourceJSON": {}
         },
         "title": "Storage API Request Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -156,8 +156,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-05-04T22:20:05.420Z",
-      "version": "WzMyMDUsMV0="
+      "updated_at": "2020-05-12T22:08:40.264Z",
+      "version": "Wzg5OCwyXQ=="
     },
     {
       "attributes": {
@@ -248,14 +248,20 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:50:39.450Z",
-      "version": "WzMxODEsMV0="
+      "updated_at": "2020-05-12T20:42:02.393Z",
+      "version": "WzQ2NiwyXQ=="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {}
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
         },
         "title": "Storage Total Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -281,7 +287,7 @@
             "drop_last_bucket": 1,
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "15m",
+            "interval": "\u003e=15m",
             "isModelInvalid": false,
             "series": [
               {
@@ -318,6 +324,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "",
+            "time_range_mode": "last_value",
             "type": "top_n"
           },
           "title": "Storage Total Bytes [Metricbeat GoogleCloud]",
@@ -330,14 +337,20 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T22:16:39.457Z",
-      "version": "WzMyMDIsMV0="
+      "updated_at": "2020-05-12T22:08:00.766Z",
+      "version": "Wzg5NSwyXQ=="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {}
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
         },
         "title": "Storage Object Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -365,7 +378,7 @@
             "gauge_width": 10,
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "15m",
+            "interval": "\u003e=15m",
             "isModelInvalid": false,
             "series": [
               {
@@ -413,14 +426,20 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-05T00:08:18.595Z",
-      "version": "WzMyMTksMV0="
+      "updated_at": "2020-05-12T22:08:13.670Z",
+      "version": "Wzg5NiwyXQ=="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {}
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
         },
         "title": "Storage API Request Count [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -435,7 +454,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -479,14 +498,20 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:52:37.984Z",
-      "version": "WzMxODMsMV0="
+      "updated_at": "2020-05-12T22:08:30.520Z",
+      "version": "Wzg5NywyXQ=="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {}
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
         },
         "title": "Storage Network Received Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -501,7 +526,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -545,14 +570,20 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:54:43.407Z",
-      "version": "WzMxODUsMV0="
+      "updated_at": "2020-05-12T22:07:26.735Z",
+      "version": "Wzg5NCwyXQ=="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {}
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
         },
         "title": "Storage Network Sent Bytes [Metricbeat GoogleCloud]",
         "uiStateJSON": {},
@@ -567,7 +598,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -611,8 +642,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:55:05.577Z",
-      "version": "WzMxODYsMV0="
+      "updated_at": "2020-05-12T22:06:26.974Z",
+      "version": "Wzg3NywyXQ=="
     }
   ],
   "version": "7.6.2"


### PR DESCRIPTION
This PR is to change visualization interval from a value to `>=` the value to avoid `[tsvb] max_bucket exceeded` error.

Before this change:
<img width="613" alt="81604431-b8959b80-9384-11ea-9e1f-b80f34bc83d6" src="https://user-images.githubusercontent.com/14081635/81751158-1c46c400-946c-11ea-94b5-810f7d5ca632.png">

Quote from Chris on why this is happening: 
_The problem is the interval on all those visualizations is set to 15m instead of >=15m. When you increase the time range, you will eventually hit the circuit breakers because the time series produces too many buckets._

After this change:
<img width="842" alt="Screen Shot 2020-05-12 at 4 16 23 PM" src="https://user-images.githubusercontent.com/14081635/81751144-0d601180-946c-11ea-8c9d-7533ba1deaf2.png">
