### PR TITLE
[CI] Optimise stash/unstash performance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1195,7 +1195,7 @@ def runbld() {
 
 def stashV2(Map args = [:]) {
   // TODO: zip does not compress the .git folder let' see what's going on
-  zip dir: '', glob: '', zipFile: "${args.name}.tgz"
+  zip dir: '', glob: '**/*.*', zipFile: "${args.name}.tgz"
   googleStorageUpload(
     bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${args.name}",
     credentialsId: "${JOB_GCS_CREDENTIALS}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1226,8 +1226,8 @@ def unstashV2(String name) {
     pathPrefix: "${JOB_NAME}-${BUILD_NUMBER}/${name}/"
   )
   if(isUnix()) {
+    unzipCommand += "; rm ${zipFile} ; chmod -R 0755 ."
     sh(label: 'Unzip', script: unzipCommand)
-    sh(label: 'Delete zip', script: "rm ${zipFile}", returnStatus: true)
   } else {
     bat(label: 'Unzip', script: unzipCommand)
     bat(label: 'Delete zip', script: "del ${zipFile}", returnStatus: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1196,7 +1196,8 @@ def runbld() {
 def stashV2(Map args = [:]) {
   def name = args.name
   def filename = "${name}.zip"
-  def command = "tar -czf ${filename} ."
+  writeFile file: "${filename}", text: ''
+  def command = "tar --exclude=${filename} -czf ${filename} ."
   if(isUnix()) {
     sh(label: 'Archive', script: command)
   } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1194,6 +1194,7 @@ def runbld() {
 }
 
 def stashV2(Map args = [:]) {
+  // TODO: zip does not compress the .git folder let' see what's going on
   zip dir: '', glob: '', zipFile: "${args.name}.tgz"
   googleStorageUpload(
     bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${args.name}",
@@ -1212,4 +1213,6 @@ def unstashV2(String id) {
     pathPrefix: "${JOB_NAME}-${BUILD_NUMBER}/${id}/"
   )
   unzip dir: '', glob: '', quiet: true, zipFile: "${id}.tgz"
+  // Fixes the permission denied :S
+  sh(label: 'Fix permissions', script: 'chmod -R 0755 .')
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        stashV2(allowEmpty: true, name: 'source', useDefaultExcludes: false)
         dir("${BASE_DIR}"){
           loadConfigEnvVars()
         }
@@ -722,7 +722,7 @@ def withBeatsEnv(boolean archive, Closure body) {
     "DOCKER_PULL=0",
   ]) {
     deleteDir()
-    unstash 'source'
+    unstashV2('source')
     if(isDockerInstalled()){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
     }
@@ -763,7 +763,7 @@ def withBeatsEnvWin(Closure body) {
     "RACE_DETECTOR=true",
   ]){
     deleteDir()
-    unstash 'source'
+    unstashV2('source')
     dir("${env.BASE_DIR}"){
       installTools()
       try {
@@ -1015,7 +1015,7 @@ def startCloudTestEnv(String name, environments = []) {
         // Archive terraform states in case manual cleanup is needed.
         archiveArtifacts(allowEmptyArchive: true, artifacts: '**/terraform.tfstate')
       }
-      stash(name: "terraform-${name}", allowEmpty: true, includes: '**/terraform.tfstate,**/.terraform/**')
+      stashV2(name: "terraform-${name}", allowEmpty: true, includes: '**/terraform.tfstate,**/.terraform/**')
     }
   }
 }
@@ -1027,7 +1027,7 @@ def terraformCleanup(String stashName, String directory) {
   stage("Remove cloud scenarios in ${directory}"){
     withCloudTestEnv() {
       withBeatsEnv(false) {
-        unstash "terraform-${stashName}"
+        unstashV2("terraform-${stashName}")
         retry(2) {
           sh(label: "Terraform Cleanup", script: ".ci/scripts/terraform-cleanup.sh ${directory}")
         }
@@ -1163,7 +1163,7 @@ def junitAndStore(Map params = [:]){
   junit(params)
   // STAGE_NAME env variable could be null in some cases, so let's use the currentmilliseconds
   def stageName = env.STAGE_NAME ? env.STAGE_NAME.replaceAll("[\\W]|_",'-') : "uncategorized-${new java.util.Date().getTime()}"
-  stash(includes: params.testResults, allowEmpty: true, name: stageName, useDefaultExcludes: true)
+  stashV2(includes: params.testResults, allowEmpty: true, name: stageName, useDefaultExcludes: true)
   stashedTestReports[stageName] = stageName
 }
 
@@ -1176,7 +1176,7 @@ def runbld() {
         // Unstash the test reports
         stashedTestReports.each { k, v ->
           dir(k) {
-            unstash v
+            unstashV2(v)
           }
         }
         sh(label: 'Process JUnit reports with runbld',
@@ -1189,4 +1189,12 @@ def runbld() {
       }
     }
   }
+}
+
+def stashV2(Map args = [:]) {
+  stash(args)
+}
+
+def unstashV2(String id) {
+  unstash(id)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1196,15 +1196,11 @@ def runbld() {
 def stashV2(Map args = [:]) {
   def name = args.name
   def filename = "${name}.zip"
-  def folder = '.artefacts'
-  dir(folder) {
-    log(level: 'DEBUG', text: 'stashV2: create artefacts folder to fix the tar: file changed as we read it.')
-  }
-  def command = "tar -czf"
+  def command = "tar -czf ${filename} ."
   if(isUnix()) {
-    sh(label: 'Archive', script: "${command} ${folder}/${filename} --exclude=${folder} . ; mv ${folder}/${filename} ${filename}")
+    sh(label: 'Archive', script: command)
   } else {
-    bat(label: 'Archive', script: "${command} ${folder}\\${filename} --exclude=${folder} . && move ${folder}\\${filename} ${filename}")
+    bat(label: 'Archive', script: command)
   }
   googleStorageUpload(
     bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${name}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/stashv2') _
+@Library('apm@current') _
 
 import groovy.transform.Field
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1208,7 +1208,8 @@ def unstashV2(String id) {
   googleStorageDownload(
     bucketUri: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${id}/${id}.tgz",
     credentialsId: "${JOB_GCS_CREDENTIALS}",
-    localDirectory: ''
+    localDirectory: '',
+    pathPrefix: "${JOB_NAME}-${BUILD_NUMBER}/${id}/"
   )
   unzip dir: '', glob: '', quiet: true, zipFile: "${id}.tgz"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1196,11 +1196,15 @@ def runbld() {
 def stashV2(Map args = [:]) {
   def name = args.name
   def filename = "${name}.zip"
-  def command = "tar -czf ${filename} ."
+  def folder = '.artefacts'
+  dir(folder) {
+    log(level: 'DEBUG', text: 'stashV2: create artefacts folder to fix the tar: file changed as we read it.')
+  }
+  def command = "tar -czf"
   if(isUnix()) {
-    sh(label: 'Archive', script: command)
+    sh(label: 'Archive', script: "${command} ${folder}/${filename} --exclude=${folder} . ; mv ${folder}/${filename} ${filename}")
   } else {
-    bat(label: 'Archive', script: command)
+    bat(label: 'Archive', script: "${command} ${folder}\\${filename} --exclude=${folder} . && move ${folder}\\${filename} ${filename}")
   }
   googleStorageUpload(
     bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${name}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1195,41 +1195,41 @@ def runbld() {
 
 def stashV2(Map args = [:]) {
   def name = args.name
-  def zipFile = "${name}.zip"
-  def zipCommand = "jar -cfM ${zipFile} ."
+  def filename = "${name}.zip"
+  def command = "tar -czf ${filename} ."
   if(isUnix()) {
-    sh(label: 'Zip', script: zipCommand)
+    sh(label: 'Archive', script: command)
   } else {
-    bat(label: 'Zip', script: zipCommand)
+    bat(label: 'Archive', script: command)
   }
   googleStorageUpload(
     bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${name}",
     credentialsId: "${JOB_GCS_CREDENTIALS}",
-    pattern: "${zipFile}",
+    pattern: "${filename}",
     sharedPublicly: false,
     showInline: true
   )
   if(isUnix()) {
-    sh(label: 'Delete zip', script: "rm ${zipFile}", returnStatus: true)
+    sh(label: 'Delete zip', script: "rm ${filename}", returnStatus: true)
   } else {
-    bat(label: 'Delete zip', script: "del ${zipFile}", returnStatus: true)
+    bat(label: 'Delete zip', script: "del ${filename}", returnStatus: true)
   }
 }
 
 def unstashV2(String name) {
-  def zipFile = "${name}.zip"
-  def unzipCommand = "jar -xf ${zipFile}"
+  def filename = "${name}.zip"
+  def command = "tar -xpf ${filename}"
   googleStorageDownload(
-    bucketUri: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${name}/${zipFile}",
+    bucketUri: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}-${BUILD_NUMBER}/${name}/${filename}",
     credentialsId: "${JOB_GCS_CREDENTIALS}",
     localDirectory: '',
     pathPrefix: "${JOB_NAME}-${BUILD_NUMBER}/${name}/"
   )
   if(isUnix()) {
-    unzipCommand += "; rm ${zipFile} ; chmod -R 0755 ."
-    sh(label: 'Unzip', script: unzipCommand)
+    command += "; rm ${filename}"
+    sh(label: 'Extract', script: command)
   } else {
-    bat(label: 'Unzip', script: unzipCommand)
-    bat(label: 'Delete zip', script: "del ${zipFile}", returnStatus: true)
+    bat(label: 'Extract', script: command)
+    bat(label: 'Delete zip', script: "del ${filename}", returnStatus: true)
   }
 }


### PR DESCRIPTION
## What does this PR do?

Stash and unstash with the Google storage plugin, this could help to have a more predictable time, since it does run in the workers rather than in the master.

Compress/uncompress is required as long as the Google storage plugin does not support multiple wildcards. Although I'd suggest to use a zip/tarball rather than uploading each of the 40k files....

## Why is it important?

Speed up the overall build time when there are build peaks. There was an initial approach to tackle the performance issues in https://github.com/elastic/beats/pull/17939.

## Tasks
- [x] Benchmark the overall stash/unstash time
- [x] Run manual tests

## Performance

### Linux
 What                 | Average                      | Peaks                          |
---------------  | --------------------- | --------------------- |
Stash                 |  1.30m.                          | 12mnts                        |
**StashV2**       |  1.40m `(similar)`        | `(9x faster)`               |
Unstash              |  5mnts.                         | 40mnts                       |
**UnstashV2**   |  35sec `(~9x faster)` | `(~50x faster)`           |

![image](https://user-images.githubusercontent.com/2871786/81843036-ee817e00-9544-11ea-9daa-f74c7bde5063.png)

![image](https://user-images.githubusercontent.com/2871786/81842961-cdb92880-9544-11ea-81c5-afc8734ff338.png)


### Windows
 What                 | Average                      | Peaks                        |
---------------  | -------------------- | -------------------- |
Unstash.           |  7mnts.                         | 40mnts                      |
**UnstashV2** |  1.40m `(~3x faster)` | `(~30x faster)`          |

## Issues

- `zip` step does not compress the `.git` folder
- `jar` command does not preserve permissions.
