### PR TITLE
Cherry-pick #18392 to 7.8: Cisco asa/ftd: Remove _temp_ fields on failure

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,6 +159,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
 - Unescape file name from SQS message. {pull}18370[18370]
+- Improve cisco asa and ftd pipelines' failure handler to avoid mapping temporary fields. {issue}18391[18391] {pull}18392[18392]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -1275,6 +1275,16 @@ processors:
       ignore_missing: true
 
 on_failure:
+  # Copy any fields under _temp_.cisco to its final destination. Those can help
+  # with diagnosing the failure.
+  - rename:
+      field: _temp_.cisco
+      target_field: "cisco.{< .internal_prefix >}"
+      ignore_failure: true
+  # Remove _temp_ to avoid adding a lot of unnecessary fields to the index.
+  - remove:
+      field: _temp_
+      ignore_missing: true
   - append:
       field: "error.message"
       value: "{{ _ingest.on_failure_message }}"


### PR DESCRIPTION
Cherry-pick of PR #18392 to 7.8 branch. Original message: 

## What does this PR do?

Updates the shared cisco asa/ftd ingest pipeline to remove the fields under `_temp_` in the case of failure.

## Why is it important?

Not removing the temporary fields can cause the index mapping to grow too big.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Unfortunately I couldn't add a test because Filebeat module's tests don't allow documents that cause errors.

Tested it locally by adding a test file that would cause an error in the pipeline:

> cat module/cisco/asa/test/failure.log
```
%ASA-5-734001: This message will cause a parsing failure
```

And confirmed that with the fix, `_temp_` fields are no longer part of the output document:

```json
{
  "agent": {
    "hostname": "Adrian-Elastic.local",
    "name": "Adrian-Elastic.local",
    "id": "006114b6-35f7-4c9d-8b9b-99e4dcc9dc50",
    "ephemeral_id": "16b9a465-ad71-4cdc-af6b-0030fdec1984",
    "type": "filebeat",
    "version": "8.0.0"
  },
  "log": {
    "file": {
      "path": "/Users/adrian/go/src/github.com/elastic/beats/x-pack/filebeat/module/cisco/asa/test/failure.log"
    },
    "original": "%ASA-5-734001: This message will cause a parsing failure",
    "offset": 0,
    "level": "notification"
  },
  "message": "This message will cause a parsing failure",
  "fileset": {
    "name": "asa"
  },
  "error": {
    "message": [
      "field [raw_date] not present as part of path [_temp_.raw_date]",
      "Unable to find match for dissect pattern: DAP: User %{user.email}, Addr %{source.address}, Connection %{_temp_.cisco.connection_type}: The following DAP records were selected for this connection: %{_temp_.cisco.dap_records->} against source: This message will cause a parsing failure"
    ]
  },
  "tags": [
    "cisco-asa"
  ],
  "input": {
    "type": "log"
  },
  "@timestamp": "2020-05-08T16:48:31.544Z",
  "ecs": {
    "version": "1.5.0"
  },
  "service": {
    "type": "cisco"
  },
  "host": {
    "name": "Adrian-Elastic.local"
  },
  "event": {
    "severity": 5,
    "timezone": "-02:00",
    "module": "cisco",
    "action": "firewall-rule",
    "dataset": "cisco.asa"
  },
  "cisco": {
    "asa": {
      "message_id": "734001"
    }
  }
}
```

while before this patch one would get some of them:

```json
{
  "agent": {
    "hostname": "Adrian-Elastic.local",
    "name": "Adrian-Elastic.local",
    "id": "006114b6-35f7-4c9d-8b9b-99e4dcc9dc50",
    "type": "filebeat",
    "ephemeral_id": "ab823767-aa1d-449b-8954-f143b1f03a02",
    "version": "8.0.0"
  },
  "_temp_": {
    "cisco": {
      "message_id": "734001"
    }
  },
  "log": {
    "file": {
      "path": "/Users/adrian/go/src/github.com/elastic/beats/x-pack/filebeat/module/cisco/asa/test/failure.log"
    },
    "original": "%ASA-5-734001: This message will cause a parsing failure",
    "offset": 0,
    "level": "notification"
  },
  "fileset": {
    "name": "asa"
  },
  "message": "This message will cause a parsing failure",
  "error": {
    "message": [
      "field [raw_date] not present as part of path [_temp_.raw_date]",
      "Unable to find match for dissect pattern: DAP: User %{user.email}, Addr %{source.address}, Connection %{_temp_.cisco.connection_type}: The following DAP records were selected for this connection: %{_temp_.cisco.dap_records->} against source: This message will cause a parsing failure"
    ]
  },
  "tags": [
    "cisco-asa"
  ],
  "input": {
    "type": "log"
  },
  "@timestamp": "2020-05-08T16:46:14.593Z",
  "ecs": {
    "version": "1.5.0"
  },
  "service": {
    "type": "cisco"
  },
  "host": {
    "name": "Adrian-Elastic.local"
  },
  "event": {
    "severity": 5,
    "timezone": "-02:00",
    "module": "cisco",
    "action": "firewall-rule",
    "dataset": "cisco.asa"
  }
}
```

## Related issues

- Closes #18391