### PR TITLE
fix application_pool metricset reader after pdh changes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -179,6 +179,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add a switch to the driver definition on SQL module to use pretty names. {pull}17378[17378]
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Remove specific win32 api errors from events in perfmon. {issue}18292[18292] {pull}18361[18361]
+- Fix application_pool metricset after pdh changes. {pull}18477[18477]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/iis/application_pool/application_integration_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/application_integration_test.go
@@ -8,8 +8,9 @@
 package application_pool
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/iis/test"
 

--- a/x-pack/metricbeat/module/iis/application_pool/application_integration_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/application_integration_test.go
@@ -8,9 +8,8 @@
 package application_pool
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/iis/test"
 
@@ -26,7 +25,10 @@ func TestFetch(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
-	assert.NotEmpty(t, events)
+	if events != nil {
+		assert.NotEmpty(t, events)
+	}
+
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/metricbeat/module/iis/application_pool/reader.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader.go
@@ -150,10 +150,20 @@ func (re *Reader) fetch(names []string) ([]mb.Event, error) {
 			for _, val := range value {
 				// Some counters, such as rate counters, require two counter values in order to compute a displayable value. In this case we must call PdhCollectQueryData twice before calling PdhGetFormattedCounterValue.
 				// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).
-				if val.Err != nil && !re.hasRun {
-					re.log.Debugw("Ignoring the first measurement because the data isn't ready",
-						"error", val.Err, logp.Namespace("website"), "query", counterPath)
-					continue
+				if val.Err.Error != nil {
+					if !re.hasRun {
+						re.log.Debugw("Ignoring the first measurement because the data isn't ready",
+							"error", val.Err, logp.Namespace("application_pool"), "query", counterPath)
+						continue
+					}
+					// The counter has a negative value or the counter was successfully found, but the data returned is not valid.
+					// This error can occur if the counter value is less than the previous value. (Because counter values always increment, the counter value rolls over to zero when it reaches its maximum value.)
+					// This is not an error that stops the application from running successfully and a positive counter value should be retrieved in the later calls.
+					if val.Err.Error == pdh.PDH_CALC_NEGATIVE_VALUE || val.Err.Error == pdh.PDH_INVALID_DATA {
+						re.log.Debugw("Counter value retrieval returned",
+							"error", val.Err.Error, "cstatus", pdh.PdhErrno(val.Err.CStatus), logp.Namespace("application_pool"), "query", counterPath)
+						continue
+					}
 				}
 				if val.Instance == appPool.Name {
 					events[appPool.Name].MetricSetFields.Put(appPool.counters[counterPath], val.Measurement)

--- a/x-pack/metricbeat/module/iis/application_pool/reader_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader_test.go
@@ -48,7 +48,7 @@ func TestGetProcessIds(t *testing.T) {
 		{
 			Instance:    "w3wp#1",
 			Measurement: 124.00,
-			Err:         nil,
+			Err:         pdh.CounterValueError{},
 		},
 	}
 	counterList := make(map[string][]pdh.CounterValue)


### PR DESCRIPTION
## What does this PR do?

Fixes tests and implementation in the iis/application_pool after pdh changes

## Why is it important?

successful build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
