### PR TITLE
Cherry-pick #18365 to 7.x: [Fleet] Fix agent enrollment script to not create a new enrollment token

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -30,19 +30,31 @@ function enroll(){
     if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]] && [[ ${FLEET_ENROLLMENT_TOKEN} == 1 ]]; then
       apikey = "${FLEET_ENROLLMENT_TOKEN}"
     else
-      enrollResp=$(curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \
+      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \
         -H 'Content-Type: application/json' \
         -H 'kbn-xsrf: true' \
-        -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} \
-        -d '{"name":"'"${FLEET_TOKEN_NAME:-demotoken}"'","config_id":"'"${FLEET_CONFIG_ID:-default}"'"}')
+        -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )
 
       local exitCode=$?
       if [ $exitCode -ne 0 ]; then
         exit $exitCode
       fi
+      echo $enrollResp
+      local apikeyId=$(echo $enrollResp | jq -r '.list[0].id')
+      echo $apikeyId
 
-      apikey=$(echo $enrollResp | jq -r '.item.api_key')
+      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys/$apikeyId \
+        -H 'Content-Type: application/json' \
+        -H 'kbn-xsrf: true' \
+        -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )
+
+      exitCode=$?
+      if [ $exitCode -ne 0 ]; then
+        exit $exitCode
+      fi
     fi
+    apikey=$(echo $enrollResp | jq -r '.item.api_key')
+    echo $apikey
 
     ./{{ .BeatName }} enroll ${KIBANA_HOST:-http://localhost:5601} $apikey -f
 }


### PR DESCRIPTION
Cherry-pick of PR #18365 to 7.x branch. Original message: 

## Description

This script is creating a new enrollment token associated to a non existing config (`default` is not a valid id, the id of the default config is a random uuid)

I updated this script to get the default enrollment token created during fleet setup instead.

Related to https://github.com/elastic/kibana/issues/65669

Also created an issue on kibana  https://github.com/elastic/kibana/issues/65752 to not allow the creation of an enrollment token for a non existing agent config id.