### PR TITLE
Add x-pack filebeat and metricbeat stages for Windows and OSX

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
             mageTarget("Filebeat oss Mac OS X", "filebeat", "build unitTest")
           }
         }
-        stage('Filebeat Mac OS X'){
+        stage('Filebeat x-pack Mac OS X'){
           agent { label 'macosx' }
           options { skipDefaultCheckout() }
           when {
@@ -198,7 +198,7 @@ pipeline {
             }
           }
           steps {
-            mageTargetWin("Filebeat x-pack Windows", "x-pack/filebeat", "update build test")
+            mageTargetWin("Filebeat x-pack Windows", "x-pack/filebeat", "build unitTest")
           }
         }
         stage('Heartbeat'){
@@ -455,7 +455,7 @@ pipeline {
             }
           }
           steps {
-            mageTarget("Metricbeat x-pack Mac OS X", "metricbeat", "build unitTest")
+            mageTarget("Metricbeat x-pack Mac OS X", "x-pack/metricbeat", "build unitTest")
           }
         }
         stage('Metricbeat Windows'){
@@ -481,7 +481,7 @@ pipeline {
             }
           }
           steps {
-            mageTargetWin("Metricbeat x-pack Windows", "x-pack/metricbeat", "build test")
+            mageTargetWin("Metricbeat x-pack Windows", "x-pack/metricbeat", "build unitTest")
           }
         }
         stage('Packetbeat'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,19 +149,6 @@ pipeline {
             mageTarget("Filebeat x-pack Linux", "x-pack/filebeat", "update build test")
           }
         }
-        stage('Filebeat x-pack Windows'){
-          agent { label 'windows-immutable && windows-2019' }
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            expression {
-              return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
-            }
-          }
-          steps {
-            mageTargetWin("Filebeat x-pack Windows", "x-pack/filebeat", "update build test")
-          }
-        }
         stage('Filebeat Mac OS X'){
           agent { label 'macosx' }
           options { skipDefaultCheckout() }
@@ -175,6 +162,19 @@ pipeline {
             mageTarget("Filebeat oss Mac OS X", "filebeat", "build unitTest")
           }
         }
+        stage('Filebeat Mac OS X'){
+          agent { label 'macosx' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_XPACK_FILEBEAT != "false" && params.macosTest
+            }
+          }
+          steps {
+            mageTarget("Filebeat x-pack Mac OS X", "x-pack/filebeat", "build unitTest")
+          }
+        }
         stage('Filebeat Windows'){
           agent { label 'windows-immutable && windows-2019' }
           options { skipDefaultCheckout() }
@@ -186,6 +186,19 @@ pipeline {
           }
           steps {
             mageTargetWin("Filebeat oss Windows Unit test", "filebeat", "build unitTest")
+          }
+        }
+        stage('Filebeat x-pack Windows'){
+          agent { label 'windows-immutable && windows-2019' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
+            }
+          }
+          steps {
+            mageTargetWin("Filebeat x-pack Windows", "x-pack/filebeat", "update build test")
           }
         }
         stage('Heartbeat'){
@@ -406,19 +419,6 @@ pipeline {
             }
           }
         }
-        stage('Metricbeat x-pack Windows'){
-          agent { label 'windows-immutable && windows-2019' }
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            expression {
-              return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
-            }
-          }
-          steps {
-            mageTargetWin("Metricbeat x-pack Windows", "x-pack/metricbeat", "build test")
-          }
-        }
         stage('Metricbeat crosscompile'){
           agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }
@@ -445,6 +445,19 @@ pipeline {
             mageTarget("Metricbeat OSS Mac OS X", "metricbeat", "build unitTest")
           }
         }
+        stage('Metricbeat x-pack Mac OS X'){
+          agent { label 'macosx' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_METRICBEAT_XPACK != "false" && params.macosTest
+            }
+          }
+          steps {
+            mageTarget("Metricbeat x-pack Mac OS X", "metricbeat", "build unitTest")
+          }
+        }
         stage('Metricbeat Windows'){
           agent { label 'windows-immutable && windows-2019' }
           options { skipDefaultCheckout() }
@@ -456,6 +469,19 @@ pipeline {
           }
           steps {
             mageTargetWin("Metricbeat Windows Unit test", "metricbeat", "build unitTest")
+          }
+        }
+        stage('Metricbeat x-pack Windows'){
+          agent { label 'windows-immutable && windows-2019' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
+            }
+          }
+          steps {
+            mageTargetWin("Metricbeat x-pack Windows", "x-pack/metricbeat", "build test")
           }
         }
         stage('Packetbeat'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -393,6 +393,19 @@ pipeline {
             }
           }
         }
+        stage('Metricbeat x-pack Windows'){
+          agent { label 'windows-immutable && windows-2019' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
+            }
+          }
+          steps {
+            mageTargetWin("Metricbeat x-pack Windows", "x-pack/metricbeat", "build test")
+          }
+        }
         stage('Metricbeat crosscompile'){
           agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,6 +149,19 @@ pipeline {
             mageTarget("Filebeat x-pack Linux", "x-pack/filebeat", "update build test")
           }
         }
+        stage('Filebeat x-pack Windows'){
+          agent { label 'windows-immutable && windows-2019' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression {
+              return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
+            }
+          }
+          steps {
+            mageTargetWin("Filebeat x-pack Windows", "x-pack/filebeat", "update build test")
+          }
+        }
         stage('Filebeat Mac OS X'){
           agent { label 'macosx' }
           options { skipDefaultCheckout() }


### PR DESCRIPTION
Jenkins pipeline is not executing the tests on Windows and OSX for some x-pack
beats, so we cannot detect specific issues on these platforms, like the compilation
error in Windows solved by #18477, that was introduced after a green build.

Run x-pack Filebeat and Metricbeat builds and unit tests in Windows and OSX.

Related to  #18515.