### PR TITLE
Cherry-pick #18466 to 7.8: [Metricbeat] Change visualization interval from 15m to >=15m

### DIFF
--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-storage-overview.json
@@ -156,8 +156,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-05-04T22:20:05.420Z",
-      "version": "WzMyMDUsMV0="
+      "updated_at": "2020-05-12T22:08:40.264Z",
+      "version": "Wzg5OCwyXQ=="
     },
     {
       "attributes": {
@@ -248,8 +248,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:50:39.450Z",
-      "version": "WzMxODEsMV0="
+      "updated_at": "2020-05-12T20:42:02.393Z",
+      "version": "WzQ2NiwyXQ=="
     },
     {
       "attributes": {
@@ -281,7 +281,7 @@
             "drop_last_bucket": 1,
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "15m",
+            "interval": "\u003e=15m",
             "isModelInvalid": false,
             "series": [
               {
@@ -318,6 +318,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "",
+            "time_range_mode": "last_value",
             "type": "top_n"
           },
           "title": "Storage Total Bytes [Metricbeat GoogleCloud]",
@@ -330,8 +331,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T22:16:39.457Z",
-      "version": "WzMyMDIsMV0="
+      "updated_at": "2020-05-12T22:08:00.766Z",
+      "version": "Wzg5NSwyXQ=="
     },
     {
       "attributes": {
@@ -365,7 +366,7 @@
             "gauge_width": 10,
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "15m",
+            "interval": "\u003e=15m",
             "isModelInvalid": false,
             "series": [
               {
@@ -413,8 +414,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-05T00:08:18.595Z",
-      "version": "WzMyMTksMV0="
+      "updated_at": "2020-05-12T22:08:13.670Z",
+      "version": "Wzg5NiwyXQ=="
     },
     {
       "attributes": {
@@ -435,7 +436,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -479,8 +480,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:52:37.984Z",
-      "version": "WzMxODMsMV0="
+      "updated_at": "2020-05-12T22:08:30.520Z",
+      "version": "Wzg5NywyXQ=="
     },
     {
       "attributes": {
@@ -501,7 +502,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -545,8 +546,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:54:43.407Z",
-      "version": "WzMxODUsMV0="
+      "updated_at": "2020-05-12T22:07:26.735Z",
+      "version": "Wzg5NCwyXQ=="
     },
     {
       "attributes": {
@@ -567,7 +568,7 @@
             "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
-            "interval": "5m",
+            "interval": "\u003e=5m",
             "isModelInvalid": false,
             "series": [
               {
@@ -611,8 +612,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-05-04T21:55:05.577Z",
-      "version": "WzMxODYsMV0="
+      "updated_at": "2020-05-12T22:06:26.974Z",
+      "version": "Wzg3NywyXQ=="
     }
   ],
   "version": "7.6.2"


### PR DESCRIPTION
Cherry-pick of PR #18466 to 7.8 branch. Original message: 

This PR is to change visualization interval from a value to `>=` the value to avoid `[tsvb] max_bucket exceeded` error.

Before this change:
<img width="613" alt="81604431-b8959b80-9384-11ea-9e1f-b80f34bc83d6" src="https://user-images.githubusercontent.com/14081635/81751158-1c46c400-946c-11ea-94b5-810f7d5ca632.png">

Quote from Chris on why this is happening: 
_The problem is the interval on all those visualizations is set to 15m instead of >=15m. When you increase the time range, you will eventually hit the circuit breakers because the time series produces too many buckets._

After this change:
<img width="842" alt="Screen Shot 2020-05-12 at 4 16 23 PM" src="https://user-images.githubusercontent.com/14081635/81751144-0d601180-946c-11ea-8c9d-7533ba1deaf2.png">
