### PR TITLE
Remove duplicate import and fix gofmt warnings around include imports

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -42,6 +42,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
 
+	// Register includes.
 	_ "github.com/elastic/beats/v7/filebeat/include"
 
 	// Add filebeat level processors

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -27,7 +27,6 @@ import (
 	"github.com/elastic/beats/v7/filebeat/channel"
 	cfg "github.com/elastic/beats/v7/filebeat/config"
 	"github.com/elastic/beats/v7/filebeat/fileset"
-	_ "github.com/elastic/beats/v7/filebeat/include"
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/filebeat/registrar"
 	"github.com/elastic/beats/v7/libbeat/autodiscover"

--- a/generator/_templates/beat/{beat}/main.go
+++ b/generator/_templates/beat/{beat}/main.go
@@ -5,6 +5,7 @@ import (
 
 	"{beat_path}/cmd"
 
+	// Make sure all your modules and metricsets are linked in this file
 	_ "{beat_path}/include"
 )
 

--- a/journalbeat/beater/journalbeat.go
+++ b/journalbeat/beater/journalbeat.go
@@ -31,6 +31,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/beats/v7/journalbeat/config"
+
+	// Register includes.
 	_ "github.com/elastic/beats/v7/journalbeat/include"
 
 	// Add dedicated processors


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

While looking at the filebeat/beater code, I noticed a duplicate import, as well as gofmt warnings due to lack of comments on the reason for those imports.
This change fixes both of those small issues.

## Why is it important?

This fixes gofmt warnings, as well as removes a package being imported twice. It's a purely cosmetic change, there should be no behavior change.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

I supppose running the package tests should be enough.

## Use cases

This PR does not introduce any behavior change.