### PR TITLE
Cherry-pick #18447 to 7.8: changed input from syslog to tcp/udp due to unsupported RFC

### DIFF
--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -37,20 +37,26 @@ include::../include/config-option-intro.asciidoc[]
 ----
 - module: fortinet
   firewall:
+    enabled: true
+    var.input: udp
     var.syslog_host: 0.0.0.0
     var.syslog_port: 9004
 ----
 
 include::../include/var-paths.asciidoc[]
 
+*`var.input`*::
+
+The input to use, can be either the value `tcp`, `udp` or `file`.
+
 *`var.syslog_host`*::
 
-The interface to listen to UDP based syslog traffic. Defaults to localhost.
+The interface to listen to all syslog traffic. Defaults to localhost.
 Set to 0.0.0.0 to bind to all available interfaces.
 
 *`var.syslog_port`*::
 
-The UDP port to listen for syslog traffic. Defaults to 9004.
+The port to listen for syslog traffic. Defaults to 9004.
 
 [float]
 ==== Fortinet ECS fields

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -485,14 +485,14 @@ filebeat.modules:
   firewall:
     enabled: true
 
-    # Set which input to use between syslog (default) or file.
-    #var.input: syslog
+    # Set which input to use between tcp, udp (default) or file.
+    #var.input: udp
 
-    # The interface to listen to UDP based syslog traffic. Defaults to
+    # The interface to listen to syslog traffic. Defaults to
     # localhost. Set to 0.0.0.0 to bind to all available interfaces.
     #var.syslog_host: localhost
 
-    # The UDP port to listen for syslog traffic. Defaults to 9004.
+    # The port to listen for syslog traffic. Defaults to 9004.
     #var.syslog_port: 9004
 
 #----------------------------- Google Cloud Module -----------------------------

--- a/x-pack/filebeat/module/fortinet/_meta/config.yml
+++ b/x-pack/filebeat/module/fortinet/_meta/config.yml
@@ -2,12 +2,12 @@
   firewall:
     enabled: true
 
-    # Set which input to use between syslog (default) or file.
-    #var.input: syslog
+    # Set which input to use between tcp, udp (default) or file.
+    #var.input: udp
 
-    # The interface to listen to UDP based syslog traffic. Defaults to
+    # The interface to listen to syslog traffic. Defaults to
     # localhost. Set to 0.0.0.0 to bind to all available interfaces.
     #var.syslog_host: localhost
 
-    # The UDP port to listen for syslog traffic. Defaults to 9004.
+    # The port to listen for syslog traffic. Defaults to 9004.
     #var.syslog_port: 9004

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -32,20 +32,26 @@ include::../include/config-option-intro.asciidoc[]
 ----
 - module: fortinet
   firewall:
+    enabled: true
+    var.input: udp
     var.syslog_host: 0.0.0.0
     var.syslog_port: 9004
 ----
 
 include::../include/var-paths.asciidoc[]
 
+*`var.input`*::
+
+The input to use, can be either the value `tcp`, `udp` or `file`.
+
 *`var.syslog_host`*::
 
-The interface to listen to UDP based syslog traffic. Defaults to localhost.
+The interface to listen to all syslog traffic. Defaults to localhost.
 Set to 0.0.0.0 to bind to all available interfaces.
 
 *`var.syslog_port`*::
 
-The UDP port to listen for syslog traffic. Defaults to 9004.
+The port to listen for syslog traffic. Defaults to 9004.
 
 [float]
 ==== Fortinet ECS fields

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -1,8 +1,12 @@
-{{ if eq .input "syslog" }}
+{{ if eq .input "tcp" }}
 
-type: syslog
-protocol.udp:
-  host: "{{.syslog_host}}:{{.syslog_port}}"
+type: tcp
+host: "{{.syslog_host}}:{{.syslog_port}}"
+
+{{ else if eq .input "udp" }}
+
+type: udp
+host: "{{.syslog_host}}:{{.syslog_port}}"
 
 {{ else if eq .input "file" }}
 
@@ -11,6 +15,7 @@ paths:
 {{ range $i, $path := .paths }}
   - {{$path}}
 {{ end }}
+
 exclude_files: [".gz$"]
 
 {{ end }}

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -128,6 +128,9 @@ processors:
     field: fortinet.firewall.transip
     if: "ctx.fortinet?.firewall?.transip == 'N/A'"
 - remove:
+    field: fortinet.firewall.tunnelip
+    if: "ctx.fortinet?.firewall?.tunnelip == 'N/A'"
+- remove:
     field:
     - _temp
     - message

--- a/x-pack/filebeat/module/fortinet/firewall/manifest.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/manifest.yml
@@ -8,7 +8,7 @@ var:
   - name: syslog_port
     default: 9004
   - name: input
-    default: syslog
+    default: udp
 
 ingest_pipeline:
   - ingest/pipeline.yml

--- a/x-pack/filebeat/modules.d/fortinet.yml.disabled
+++ b/x-pack/filebeat/modules.d/fortinet.yml.disabled
@@ -5,12 +5,12 @@
   firewall:
     enabled: true
 
-    # Set which input to use between syslog (default) or file.
-    #var.input: syslog
+    # Set which input to use between tcp, udp (default) or file.
+    #var.input: udp
 
-    # The interface to listen to UDP based syslog traffic. Defaults to
+    # The interface to listen to syslog traffic. Defaults to
     # localhost. Set to 0.0.0.0 to bind to all available interfaces.
     #var.syslog_host: localhost
 
-    # The UDP port to listen for syslog traffic. Defaults to 9004.
+    # The port to listen for syslog traffic. Defaults to 9004.
     #var.syslog_port: 9004


### PR DESCRIPTION
Cherry-pick of PR #18447 to 7.8 branch. Original message: 

## What does this PR do?

Changes beat input in docs and configuration file due to unsupported RFC syslog pattern.

## Why is it important?

Module needs this fix to work properly.

## Checklist

Added the changes, updated the documentation, ran nosetests and confirmed by testing with netcat to simulate the syslog input.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
