### PR TITLE
Cherry-pick #18483 to 7.x: Add a file lock to the data directory on startup to prevent multiple agents.

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/locker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/locker.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gofrs/flock"
+)
+
+const lockFileName = "agent.lock"
+
+// ErrAppAlreadyRunning error returned when another elastic-agent is already holding the lock.
+var ErrAppAlreadyRunning = fmt.Errorf("another elastic-agent is already running")
+
+// AppLocker locks the agent.lock file inside the provided directory.
+type AppLocker struct {
+	lock *flock.Flock
+}
+
+// NewAppLocker creates an AppLocker that locks the agent.lock file inside the provided directory.
+func NewAppLocker(dir string) *AppLocker {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		_ = os.Mkdir(dir, 0755)
+	}
+	return &AppLocker{
+		lock: flock.New(filepath.Join(dir, lockFileName)),
+	}
+}
+
+// TryLock tries to grab the lock file and returns error if it cannot.
+func (a *AppLocker) TryLock() error {
+	locked, err := a.lock.TryLock()
+	if err != nil {
+		return err
+	}
+	if !locked {
+		return ErrAppAlreadyRunning
+	}
+	return nil
+}
+
+// Unlock releases the lock file.
+func (a *AppLocker) Unlock() error {
+	return a.lock.Unlock()
+}

--- a/x-pack/elastic-agent/pkg/agent/application/locker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/locker_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppLocker(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "locker")
+	defer os.RemoveAll(tmp)
+
+	locker1 := NewAppLocker(tmp)
+	locker2 := NewAppLocker(tmp)
+
+	require.NoError(t, locker1.TryLock())
+	assert.Error(t, locker2.TryLock())
+	require.NoError(t, locker1.Unlock())
+	require.NoError(t, locker2.TryLock())
+	assert.Error(t, locker1.TryLock())
+	require.NoError(t, locker2.Unlock())
+}

--- a/x-pack/elastic-agent/pkg/agent/application/periodic.go
+++ b/x-pack/elastic-agent/pkg/agent/application/periodic.go
@@ -23,21 +23,24 @@ type periodic struct {
 }
 
 func (p *periodic) Start() error {
-	if err := p.work(); err != nil {
-		p.log.Debugf("Failed to read configuration, error: %s", err)
-	}
-
-	for {
-		select {
-		case <-p.done:
-			break
-		case <-time.After(p.period):
-		}
-
+	go func() {
 		if err := p.work(); err != nil {
 			p.log.Debugf("Failed to read configuration, error: %s", err)
 		}
-	}
+
+		for {
+			select {
+			case <-p.done:
+				break
+			case <-time.After(p.period):
+			}
+
+			if err := p.work(); err != nil {
+				p.log.Debugf("Failed to read configuration, error: %s", err)
+			}
+		}
+	}()
+	return nil
 }
 
 func (p *periodic) work() error {

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
@@ -46,6 +47,12 @@ func run(flags *globalFlags, streams *cli.IOStreams) error {
 	if err != nil {
 		return err
 	}
+
+	locker := application.NewAppLocker(paths.Data())
+	if err := locker.TryLock(); err != nil {
+		return err
+	}
+	defer locker.Unlock()
 
 	app, err := application.New(logger, pathConfigFile)
 	if err != nil {

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/downloader.go
@@ -42,7 +42,7 @@ func NewDownloader(config *artifact.Config) *Downloader {
 func (e *Downloader) Download(_ context.Context, programName, version string) (string, error) {
 	// create a destination directory root/program
 	destinationDir := filepath.Join(e.config.TargetDirectory, programName)
-	if err := os.MkdirAll(destinationDir, os.ModeDir); err != nil {
+	if err := os.MkdirAll(destinationDir, 0755); err != nil {
 		return "", errors.New(err, "creating directory for downloaded artifact failed", errors.TypeFilesystem, errors.M(errors.MetaKeyPath, destinationDir))
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #18483 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds an `agent.lock` to the `path.data` directory.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Prevents the ability to run multiple agents on the same host.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Multiple agents cannot be started at the same time.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Try to start two `elastic-agent` at the same time on the same host and see that the second one started errors out with `another elastic-agent is already running`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #18243
