### PR TITLE
[libbeat] Remove global loggers from libbbeat/dashboard

### DIFF
--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -19,6 +19,7 @@ package dashboards
 
 import "time"
 
+// Config represents the config values for dashboards
 type Config struct {
 	Enabled        bool   `config:"enabled"`
 	KibanaIndex    string `config:"kibana_index"`
@@ -33,6 +34,7 @@ type Config struct {
 	Retry          *Retry `config:"retry"`
 }
 
+// Retry handles query retries
 type Retry struct {
 	Enabled  bool          `config:"enabled"`
 	Interval time.Duration `config:"interval"`

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -51,7 +51,7 @@ func ImportDashboards(
 	}
 
 	if !kibanaConfig.Enabled() {
-		return errors.New("kibana configuration missing for loading dashboards.")
+		return errors.New("kibana configuration missing for loading dashboards")
 	}
 
 	return setupAndImportDashboardsViaKibana(ctx, beatInfo.Hostname, kibanaConfig, &dashConfig, msgOutputter, pattern)

--- a/libbeat/dashboards/decode.go
+++ b/libbeat/dashboards/decode.go
@@ -45,7 +45,8 @@ func DecodeExported(result common.MapStr) common.MapStr {
 			// All fields are optional, so errors are not caught
 			err := decodeValue(o, key)
 			if err != nil {
-				logp.Debug("dashboards", "Error while decoding dashboard objects: %+v", err)
+				logger := logp.NewLogger("dashboards")
+				logger.Debugf("Error while decoding dashboard objects: %+v", err)
 			}
 		}
 	}

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -50,6 +50,7 @@ func newErrNotFound(s string, a ...interface{}) *ErrNotFound {
 // into this module.
 type MessageOutputter func(msg string, a ...interface{})
 
+// Importer is a type to import dashboards
 type Importer struct {
 	cfg     *Config
 	version common.Version
@@ -90,12 +91,14 @@ func (imp Importer) Import() error {
 	return nil
 }
 
+// ImportDashboard imports a dashboard
 func (imp Importer) ImportDashboard(file string) error {
 	imp.loader.statusMsg("Import dashboard %s", file)
 
 	return imp.loader.ImportDashboard(file)
 }
 
+// ImportFile imports a file
 func (imp Importer) ImportFile(fileType string, file string) error {
 	imp.loader.statusMsg("Import %s from %s", fileType, file)
 
@@ -107,6 +110,7 @@ func (imp Importer) ImportFile(fileType string, file string) error {
 	return fmt.Errorf("Unexpected file type %s", fileType)
 }
 
+// ImportDir imports a directory
 func (imp Importer) ImportDir(dirType string, dir string) error {
 	imp.loader.statusMsg("Import directory %s", dir)
 
@@ -191,6 +195,7 @@ func (imp Importer) unzip(archive, target string) error {
 	return nil
 }
 
+// ImportArchive imports a zip archive
 func (imp Importer) ImportArchive() error {
 	var archive string
 
@@ -292,7 +297,7 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 	return targetPath, nil
 }
 
-// import Kibana dashboards and index-pattern or only one of these
+// ImportKibanaDir imports dashboards and index-pattern or only one of these
 func (imp Importer) ImportKibanaDir(dir string) error {
 	var err error
 

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -37,11 +37,12 @@ var importAPI = "/api/kibana/dashboards/import"
 
 // KibanaLoader loads Kibana files
 type KibanaLoader struct {
-	client       *kibana.Client
-	config       *Config
-	version      common.Version
-	hostname     string
-	msgOutputter MessageOutputter
+	client        *kibana.Client
+	config        *Config
+	version       common.Version
+	hostname      string
+	msgOutputter  MessageOutputter
+	defaultLogger *logp.Logger
 }
 
 // NewKibanaLoader creates a new loader to load Kibana files
@@ -57,11 +58,12 @@ func NewKibanaLoader(ctx context.Context, cfg *common.Config, dashboardsConfig *
 	}
 
 	loader := KibanaLoader{
-		client:       client,
-		config:       dashboardsConfig,
-		version:      client.GetVersion(),
-		hostname:     hostname,
-		msgOutputter: msgOutputter,
+		client:        client,
+		config:        dashboardsConfig,
+		version:       client.GetVersion(),
+		hostname:      hostname,
+		msgOutputter:  msgOutputter,
+		defaultLogger: logp.NewLogger("dashboards"),
 	}
 
 	version := client.GetVersion()
@@ -155,7 +157,6 @@ func (loader KibanaLoader) statusMsg(msg string, a ...interface{}) {
 	if loader.msgOutputter != nil {
 		loader.msgOutputter(msg, a...)
 	} else {
-		logger := logp.NewLogger("dashboards")
-		logger.Debugf("%s %v", msg, a)
+		loader.defaultLogger.Debugf("%s %v", msg, a)
 	}
 }

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -35,6 +35,7 @@ import (
 
 var importAPI = "/api/kibana/dashboards/import"
 
+// KibanaLoader loads Kibana files
 type KibanaLoader struct {
 	client       *kibana.Client
 	config       *Config
@@ -145,6 +146,7 @@ func (loader KibanaLoader) ImportDashboard(file string) error {
 	return loader.client.ImportJSON(importAPI, params, content)
 }
 
+// Close closes the client
 func (loader KibanaLoader) Close() error {
 	return loader.client.Close()
 }
@@ -153,6 +155,7 @@ func (loader KibanaLoader) statusMsg(msg string, a ...interface{}) {
 	if loader.msgOutputter != nil {
 		loader.msgOutputter(msg, a...)
 	} else {
-		logp.Debug("dashboards", msg, a...)
+		logger := logp.NewLogger("dashboards")
+		logger.Debugf("%s %v", msg, a)
 	}
 }

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -157,6 +157,6 @@ func (loader KibanaLoader) statusMsg(msg string, a ...interface{}) {
 	if loader.msgOutputter != nil {
 		loader.msgOutputter(msg, a...)
 	} else {
-		loader.defaultLogger.Debugf("%s %v", msg, a)
+		loader.defaultLogger.Debugf(msg, a...)
 	}
 }

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
+// JSONObjectAttribute contains the attributes for a Kibana json object
 type JSONObjectAttribute struct {
 	Description           string                 `json:"description"`
 	KibanaSavedObjectMeta map[string]interface{} `json:"kibanaSavedObjectMeta"`
@@ -35,14 +36,17 @@ type JSONObjectAttribute struct {
 	Type                  string                 `json:"type"`
 }
 
+// JSONObject is an Object with a given JSON attribute
 type JSONObject struct {
 	Attributes JSONObjectAttribute `json:"attributes"`
 }
 
+// JSONFormat contains a list of JSON object
 type JSONFormat struct {
 	Objects []JSONObject `json:"objects"`
 }
 
+// ReplaceIndexInIndexPattern replaces an index in a dashboard content body
 func ReplaceIndexInIndexPattern(index string, content common.MapStr) (err error) {
 	if index == "" {
 		return nil
@@ -108,12 +112,13 @@ func replaceIndexInSearchObject(index string, savedObject string) (string, error
 	return string(searchSourceJSON), nil
 }
 
-func ReplaceIndexInSavedObject(index string, kibanaSavedObject map[string]interface{}) map[string]interface{} {
+// ReplaceIndexInSavedObject replaces an index in a kibana object
+func ReplaceIndexInSavedObject(logger *logp.Logger, index string, kibanaSavedObject map[string]interface{}) map[string]interface{} {
 
 	if searchSourceJSON, ok := kibanaSavedObject["searchSourceJSON"].(string); ok {
 		searchSourceJSON, err := replaceIndexInSearchObject(index, searchSourceJSON)
 		if err != nil {
-			logp.Err("Fail to replace searchSourceJSON: %v", err)
+			logger.Errorf("Fail to replace searchSourceJSON: %v", err)
 			return kibanaSavedObject
 		}
 		kibanaSavedObject["searchSourceJSON"] = searchSourceJSON
@@ -123,12 +128,12 @@ func ReplaceIndexInSavedObject(index string, kibanaSavedObject map[string]interf
 }
 
 // ReplaceIndexInVisState replaces index appearing in visState params objects
-func ReplaceIndexInVisState(index string, visStateJSON string) string {
+func ReplaceIndexInVisState(logger *logp.Logger, index string, visStateJSON string) string {
 
 	var visState map[string]interface{}
 	err := json.Unmarshal([]byte(visStateJSON), &visState)
 	if err != nil {
-		logp.Err("Fail to unmarshal visState: %v", err)
+		logger.Errorf("Fail to unmarshal visState: %v", err)
 		return visStateJSON
 	}
 
@@ -146,7 +151,7 @@ func ReplaceIndexInVisState(index string, visStateJSON string) string {
 
 	d, err := json.Marshal(visState)
 	if err != nil {
-		logp.Err("Fail to marshal visState: %v", err)
+		logger.Errorf("Fail to marshal visState: %v", err)
 		return visStateJSON
 	}
 
@@ -155,6 +160,7 @@ func ReplaceIndexInVisState(index string, visStateJSON string) string {
 
 // ReplaceIndexInDashboardObject replaces references to the index pattern in dashboard objects
 func ReplaceIndexInDashboardObject(index string, content common.MapStr) common.MapStr {
+	logger := logp.NewLogger("dashboards")
 	if index == "" {
 		return content
 	}
@@ -176,11 +182,11 @@ func ReplaceIndexInDashboardObject(index string, content common.MapStr) common.M
 		}
 
 		if kibanaSavedObject, ok := attributes["kibanaSavedObjectMeta"].(map[string]interface{}); ok {
-			attributes["kibanaSavedObjectMeta"] = ReplaceIndexInSavedObject(index, kibanaSavedObject)
+			attributes["kibanaSavedObjectMeta"] = ReplaceIndexInSavedObject(logger, index, kibanaSavedObject)
 		}
 
 		if visState, ok := attributes["visState"].(string); ok {
-			attributes["visState"] = ReplaceIndexInVisState(index, visState)
+			attributes["visState"] = ReplaceIndexInVisState(logger, index, visState)
 		}
 
 		objects[i] = objectMap
@@ -190,6 +196,7 @@ func ReplaceIndexInDashboardObject(index string, content common.MapStr) common.M
 	return content
 }
 
+// ReplaceStringInDashboard replaces a string field in a dashboard
 func ReplaceStringInDashboard(old, new string, content common.MapStr) (common.MapStr, error) {
 	marshaled, err := json.Marshal(content)
 	if err != nil {


### PR DESCRIPTION

## What does this PR do?

See elastic/beats#18500 for the meta-issue. This remove any global loggers. I was a tad hesitant to turn "soft" errors into hard errors, so I worked around some of the error handling for the sake of not breaking anything. This still technically contains "breaking" changes, so not sure if we wanna backport it.

## Why is it important?

We want to remove the global logger from libbeat.

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
