### PR TITLE
Support "cluster" scope in Metricbeat elasticsearch module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -611,6 +611,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
 - Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
+- Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -610,9 +610,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
-- Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
-- Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
-- Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -612,6 +612,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
 - Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
+- Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -610,6 +610,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
+- Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -613,6 +613,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add `hosts_mode` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
+- Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -18,6 +18,7 @@ The `elasticsearch` module works with {es} 6.7.0 and later.
 Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
 This setting can contain a list of entries. The related `scope` setting determines how each entry in
 the `hosts` list is interpreted by the module.
+
 * If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
@@ -55,16 +56,7 @@ metricbeat.modules:
 
   #index_recovery.active_only: true
   #xpack.enabled: false
-<<<<<<< HEAD
   #scope: node
-=======
-
-  # Set to cluster to treat each item in the hosts list as an endpoint for
-  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
-  # Set to node (default) to treat each item in the hosts list as an individual
-  # node in the Elasticsearch cluster.
-  #hosts_mode: node
->>>>>>> Adding configuration for hosts_mode
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -13,7 +13,15 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Module-specific configuration notes
+
+Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
+This setting can contain a list of entries. The related `scope` setting determines how each entry in
+the `hosts` list is interpreted by the module.
+* If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
+  {es} cluster.
+* If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
+  {es} cluster (e.g. a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -110,4 +110,3 @@ include::elasticsearch/node_stats.asciidoc[]
 include::elasticsearch/pending_tasks.asciidoc[]
 
 include::elasticsearch/shard.asciidoc[]
-

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -51,6 +51,12 @@ metricbeat.modules:
   # Set to true to send data collected by module to X-Pack
   # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+
+  # Set to cluster to treat each item in the hosts list as an endpoint for
+  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
+  # Set to node (default) to treat each item in the hosts list as an individual
+  # node in the Elasticsearch cluster.
+  #hosts_mode: node
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -110,3 +110,4 @@ include::elasticsearch/node_stats.asciidoc[]
 include::elasticsearch/pending_tasks.asciidoc[]
 
 include::elasticsearch/shard.asciidoc[]
+

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -53,17 +53,8 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
-
-  # Set to cluster to treat each item in the hosts list as an endpoint for
-  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
-  # Set to node (default) to treat each item in the hosts list as an individual
-  # node in the Elasticsearch cluster.
   #scope: node
 ----
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -56,7 +56,7 @@ metricbeat.modules:
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
-  #hosts_mode: node
+  #scope: node
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -55,7 +55,16 @@ metricbeat.modules:
 
   #index_recovery.active_only: true
   #xpack.enabled: false
+<<<<<<< HEAD
   #scope: node
+=======
+
+  # Set to cluster to treat each item in the hosts list as an endpoint for
+  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
+  # Set to node (default) to treat each item in the hosts list as an individual
+  # node in the Elasticsearch cluster.
+  #hosts_mode: node
+>>>>>>> Adding configuration for hosts_mode
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -21,7 +21,7 @@ the `hosts` list is interpreted by the module.
 * If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
-  {es} cluster (e.g. a load-balancing proxy fronting the cluster).
+  {es} cluster (for example, a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -273,17 +273,8 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
-
-  # Set to cluster to treat each item in the hosts list as an endpoint for
-  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
-  # Set to node (default) to treat each item in the hosts list as an individual
-  # node in the Elasticsearch cluster.
   #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -280,6 +280,12 @@ metricbeat.modules:
   # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
 
+  # Set to cluster to treat each item in the hosts list as an endpoint for
+  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
+  # Set to node (default) to treat each item in the hosts list as an individual
+  # node in the Elasticsearch cluster.
+  #hosts_mode: node
+
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   metricsets: ["server"]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -284,7 +284,7 @@ metricbeat.modules:
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
-  #hosts_mode: node
+  #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -13,15 +13,6 @@
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
-
-  # Set to cluster to treat each item in the hosts list as an endpoint for
-  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
-  # Set to node (default) to treat each item in the hosts list as an individual
-  # node in the Elasticsearch cluster.
   #scope: node

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -24,8 +24,4 @@
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
-<<<<<<< HEAD
   #scope: node
-=======
-  #hosts_mode: node
->>>>>>> Adding configuration for hosts_mode

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -24,4 +24,8 @@
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
+<<<<<<< HEAD
   #scope: node
+=======
+  #hosts_mode: node
+>>>>>>> Adding configuration for hosts_mode

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -24,4 +24,4 @@
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
-  #hosts_mode: node
+  #scope: node

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -19,3 +19,9 @@
   # Set to true to send data collected by module to X-Pack
   # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+
+  # Set to cluster to treat each item in the hosts list as an endpoint for
+  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
+  # Set to node (default) to treat each item in the hosts list as an individual
+  # node in the Elasticsearch cluster.
+  #hosts_mode: node

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -6,7 +6,15 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Module-specific configuration notes
+
+Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
+This setting can contain a list of entries. The related `scope` setting determines how each entry in
+the `hosts` list is interpreted by the module.
+* If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
+  {es} cluster.
+* If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
+  {es} cluster (e.g. a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -14,7 +14,7 @@ the `hosts` list is interpreted by the module.
 * If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
-  {es} cluster (e.g. a load-balancing proxy fronting the cluster).
+  {es} cluster (for example, a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -11,6 +11,7 @@ The `elasticsearch` module works with {es} 6.7.0 and later.
 Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
 This setting can contain a list of entries. The related `scope` setting determines how each entry in
 the `hosts` list is interpreted by the module.
+
 * If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -56,15 +56,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each follower shard from the _ccr/stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch ccr stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch ccr stats from a non-master node")
+			return nil
+		}
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -61,8 +61,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch ccr stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -58,7 +58,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -56,8 +56,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch cluster stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -51,15 +51,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch cluster stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch cluster stats from a non-master node")
+			return nil
+		}
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -53,7 +53,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -18,8 +18,6 @@
 package cluster_stats
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -51,19 +49,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch cluster stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -436,6 +436,28 @@ func IsMLockAllEnabled(http *helper.HTTP, resetURI, nodeID string) (bool, error)
 	return false, fmt.Errorf("could not determine if mlockall is enabled on node ID = %v", nodeID)
 }
 
+// GetMasterNodeID returns the ID of the Elasticsearch cluster's master node
+func GetMasterNodeID(http *helper.HTTP, resetURI string) (string, error) {
+	content, err := fetchPath(http, resetURI, "_nodes/_master", "filter_path=nodes.*.name")
+	if err != nil {
+		return "", err
+	}
+
+	var response struct {
+		Nodes map[string]interface{} `json:"nodes"`
+	}
+
+	if err := json.Unmarshal(content, &response); err != nil {
+		return "", err
+	}
+
+	for nodeID, _ := range response.Nodes {
+		return nodeID, nil
+	}
+
+	return "", errors.New("could not determine master node ID")
+}
+
 // PassThruField copies the field at the given path from the given source data object into
 // the same path in the given target data object.
 func PassThruField(fieldPath string, sourceData, targetData common.MapStr) error {

--- a/metricbeat/module/elasticsearch/enrich/enrich.go
+++ b/metricbeat/module/elasticsearch/enrich/enrich.go
@@ -60,8 +60,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch enrich stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/enrich/enrich.go
+++ b/metricbeat/module/elasticsearch/enrich/enrich.go
@@ -57,7 +57,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/enrich/enrich.go
+++ b/metricbeat/module/elasticsearch/enrich/enrich.go
@@ -55,15 +55,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each enrich coordinator node
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch enrich stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch enrich stats from a non-master node")
+			return nil
+		}
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/enrich/enrich.go
+++ b/metricbeat/module/elasticsearch/enrich/enrich.go
@@ -55,19 +55,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each enrich coordinator node
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch enrich stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -59,16 +59,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
-
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch index stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch index stats from a non-master node")
+			return nil
+		}
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI)

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -61,7 +61,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -65,8 +65,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch index stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -59,19 +59,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch index stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI)

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -18,8 +18,6 @@
 package index_recovery
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -67,19 +65,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -67,15 +67,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
+			return nil
+		}
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -69,7 +69,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -72,8 +72,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -67,8 +67,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch index summary stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -64,7 +64,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -62,15 +62,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch index summary stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch index summary stats from a non-master node")
+			return nil
+		}
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -62,19 +62,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch index summary stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -38,26 +38,26 @@ var (
 	}.Build()
 )
 
-type HostsMode int
+type Scope int
 
 const (
 	// Indicates that each item in the hosts list points to a distinct Elasticsearch node in a
 	// cluster.
-	HostsModeNode HostsMode = iota
+	ScopeNode Scope = iota
 
 	// Indicates that each item in the hosts lists points to a endpoint for a distinct Elasticsearch
 	// cluster (e.g. a load-balancing proxy) fronting the cluster.
-	HostsModeCluster
+	ScopeCluster
 )
 
-func (h *HostsMode) Unpack(str string) error {
+func (h *Scope) Unpack(str string) error {
 	switch str {
 	case "node":
-		*h = HostsModeNode
+		*h = ScopeNode
 	case "cluster":
-		*h = HostsModeCluster
+		*h = ScopeCluster
 	default:
-		return fmt.Errorf("invalid hosts_mode: %v", str)
+		return fmt.Errorf("invalid scope: %v", str)
 	}
 
 	return nil
@@ -69,8 +69,8 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	servicePath string
 	*helper.HTTP
-	XPack     bool
-	HostsMode HostsMode
+	XPack bool
+	Scope Scope
 }
 
 // NewMetricSet creates an metric set that can be used to build other metric
@@ -82,11 +82,11 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 	}
 
 	config := struct {
-		XPack     bool      `config:"xpack.enabled"`
-		HostsMode HostsMode `config:"hosts_mode"`
+		XPack bool  `config:"xpack.enabled"`
+		Scope Scope `config:"scope"`
 	}{
-		XPack:     false,
-		HostsMode: HostsModeNode,
+		XPack: false,
+		Scope: ScopeNode,
 	}
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 		servicePath,
 		http,
 		config.XPack,
-		config.HostsMode,
+		config.Scope,
 	}
 
 	ms.SetServiceURI(servicePath)

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -18,6 +18,8 @@
 package elasticsearch
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -47,6 +49,19 @@ const (
 	// cluster (e.g. a load-balancing proxy) fronting the cluster.
 	HostsModeCluster
 )
+
+func (h *hostsMode) Unpack(str string) error {
+	switch str {
+	case "node":
+		*h = HostsModeNode
+	case "cluster":
+		*h = HostsModeCluster
+	default:
+		return fmt.Errorf("invalid hosts_mode: %v", str)
+	}
+
+	return nil
+}
 
 // MetricSet can be used to build other metric sets that query RabbitMQ
 // management plugin

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -38,19 +38,19 @@ var (
 	}.Build()
 )
 
-type hostsMode int
+type HostsMode int
 
 const (
 	// Indicates that each item in the hosts list points to a distinct Elasticsearch node in a
 	// cluster.
-	HostsModeNode hostsMode = iota
+	HostsModeNode HostsMode = iota
 
 	// Indicates that each item in the hosts lists points to a endpoint for a distinct Elasticsearch
 	// cluster (e.g. a load-balancing proxy) fronting the cluster.
 	HostsModeCluster
 )
 
-func (h *hostsMode) Unpack(str string) error {
+func (h *HostsMode) Unpack(str string) error {
 	switch str {
 	case "node":
 		*h = HostsModeNode
@@ -70,7 +70,7 @@ type MetricSet struct {
 	servicePath string
 	*helper.HTTP
 	XPack     bool
-	HostsMode hostsMode
+	HostsMode HostsMode
 }
 
 // NewMetricSet creates an metric set that can be used to build other metric
@@ -83,7 +83,7 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 
 	config := struct {
 		XPack     bool      `config:"xpack.enabled"`
-		HostsMode hostsMode `config:"hosts_mode"`
+		HostsMode HostsMode `config:"hosts_mode"`
 	}{
 		XPack:     false,
 		HostsMode: HostsModeNode,

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -54,16 +54,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
-
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch machine learning job stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch machine learning job stats from a non-master node")
+			return nil
+		}
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -56,7 +56,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -60,8 +60,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch machine learning job stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -187,7 +187,6 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 		return errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
 	}
 
-	// TODO: call GET _nodes/_master?filter_path=nodes.*.name to figure out the ID of the master node
 	masterNodeID, err := elasticsearch.GetMasterNodeID(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
 		return err

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -188,7 +188,10 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 	}
 
 	// TODO: call GET _nodes/_master?filter_path=nodes.*.name to figure out the ID of the master node
-	masterNodeID := "TODO"
+	masterNodeID, err := elasticsearch.GetMasterNodeID(m.HTTP, m.HTTP.GetURI())
+	if err != nil {
+		return err
+	}
 
 	var errs multierror.Errors
 	for nodeID, node := range nodesStruct.Nodes {

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -187,18 +187,12 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 		return errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
 	}
 
-	// Normally the nodeStruct should only contain one node. But if _local is removed
-	// from the path and Metricbeat is not installed on the same machine as the node
-	// it will provid the data for multiple nodes. This will mean the detection of the
-	// master node will not be accurate anymore as often in these cases a proxy is in front
-	// of ES and it's not know if the request will be routed to the same node as before.
+	// TODO: call GET _nodes/_master?filter_path=nodes.*.name to figure out the ID of the master node
+	masterNodeID := "TODO"
+
 	var errs multierror.Errors
 	for nodeID, node := range nodesStruct.Nodes {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HTTP.GetURI())
-		if err != nil {
-			errs = append(errs, errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
-			continue
-		}
+		isMaster := nodeID == masterNodeID
 
 		event := mb.Event{}
 
@@ -207,6 +201,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 			errs = append(errs, errors.Wrap(err, "failure to apply node schema"))
 			continue
 		}
+
 		nodeData["node_master"] = isMaster
 		nodeData["node_id"] = nodeID
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -91,7 +91,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 }
 
 func (m *MetricSet) updateServiceURI() error {
-	u, err := getServiceURI(m.GetURI(), m.HostsMode)
+	u, err := getServiceURI(m.GetURI(), m.Scope)
 	if err != nil {
 		return err
 	}
@@ -101,14 +101,14 @@ func (m *MetricSet) updateServiceURI() error {
 
 }
 
-func getServiceURI(currURI string, hostsMode elasticsearch.HostsMode) (string, error) {
+func getServiceURI(currURI string, scope elasticsearch.Scope) (string, error) {
 	u, err := url.Parse(currURI)
 	if err != nil {
 		return "", err
 	}
 
 	u.Path = nodeLocalStatsPath
-	if hostsMode == elasticsearch.HostsModeCluster {
+	if scope == elasticsearch.ScopeCluster {
 		u.Path = nodesAllStatsPath
 	}
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -53,6 +53,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
+	// TODO: Get all nodes stats if we're in HostsModeCluster
+
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		return err

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -47,7 +47,7 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Get the stats from the local node
-	ms, err := elasticsearch.NewMetricSet(base, nodeLocalStatsPath)
+	ms, err := elasticsearch.NewMetricSet(base, "") // servicePath will be set in Fetch()
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -18,6 +18,8 @@
 package node_stats
 
 import (
+	"net/url"
+
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -33,7 +35,8 @@ func init() {
 }
 
 const (
-	nodeStatsPath = "/_nodes/_local/stats"
+	nodeLocalStatsPath = "/_nodes/_local/stats"
+	nodesAllStatsPath  = "/_nodes/_all/stats"
 )
 
 // MetricSet type defines all fields of the MetricSet
@@ -44,7 +47,7 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Get the stats from the local node
-	ms, err := elasticsearch.NewMetricSet(base, nodeStatsPath)
+	ms, err := elasticsearch.NewMetricSet(base, nodeLocalStatsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +56,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// TODO: Get all nodes stats if we're in HostsModeCluster
+	if err := m.updateServiceURI(); err != nil {
+		if m.XPack {
+			m.Logger().Error(err)
+			return nil
+		}
+		return err
+	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
@@ -79,4 +88,29 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	return nil
+}
+
+func (m *MetricSet) updateServiceURI() error {
+	u, err := getServiceURI(m.GetURI(), m.HostsMode)
+	if err != nil {
+		return err
+	}
+
+	m.HTTP.SetURI(u)
+	return nil
+
+}
+
+func getServiceURI(currURI string, hostsMode elasticsearch.HostsMode) (string, error) {
+	u, err := url.Parse(currURI)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = nodeLocalStatsPath
+	if hostsMode == elasticsearch.HostsModeCluster {
+		u.Path = nodesAllStatsPath
+	}
+
+	return u.String(), nil
 }

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -47,7 +47,11 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Get the stats from the local node
+<<<<<<< HEAD
 	ms, err := elasticsearch.NewMetricSet(base, "") // servicePath will be set in Fetch()
+=======
+	ms, err := elasticsearch.NewMetricSet(base, nodeLocalStatsPath)
+>>>>>>> Set correct service URI
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -47,11 +47,7 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Get the stats from the local node
-<<<<<<< HEAD
 	ms, err := elasticsearch.NewMetricSet(base, "") // servicePath will be set in Fetch()
-=======
-	ms, err := elasticsearch.NewMetricSet(base, nodeLocalStatsPath)
->>>>>>> Set correct service URI
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
@@ -27,22 +27,22 @@ import (
 
 func TestGetServiceURI(t *testing.T) {
 	tests := map[string]struct {
-		hostsMode   elasticsearch.HostsMode
+		scope       elasticsearch.Scope
 		expectedURI string
 	}{
-		"mode_node": {
-			hostsMode:   elasticsearch.HostsModeNode,
+		"scope_node": {
+			scope:       elasticsearch.ScopeNode,
 			expectedURI: "/_nodes/_local/stats",
 		},
-		"mode_cluster": {
-			hostsMode:   elasticsearch.HostsModeCluster,
+		"scope_cluster": {
+			scope:       elasticsearch.ScopeCluster,
 			expectedURI: "/_nodes/_all/stats",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			newURI, err := getServiceURI("/foo/bar", test.hostsMode)
+			newURI, err := getServiceURI("/foo/bar", test.scope)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedURI, newURI)
 		})

--- a/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node_stats
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServiceURI(t *testing.T) {
+	tests := map[string]struct {
+		hostsMode   elasticsearch.HostsMode
+		expectedURI string
+	}{
+		"mode_node": {
+			hostsMode:   elasticsearch.HostsModeNode,
+			expectedURI: "/_nodes/_local/stats",
+		},
+		"mode_cluster": {
+			hostsMode:   elasticsearch.HostsModeCluster,
+			expectedURI: "/_nodes/_all/stats",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newURI, err := getServiceURI("/foo/bar", test.hostsMode)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedURI, newURI)
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -18,8 +18,6 @@
 package pending_tasks
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -59,19 +57,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch pending tasks from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -61,7 +61,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -64,8 +64,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch pending tasks from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -58,8 +58,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
-	// Not master, no event sent
-	if !isMaster {
+	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
+	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
 		m.Logger().Debug("trying to fetch shard stats from a non-master node")
 		return nil
 	}

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -18,8 +18,6 @@
 package shard
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -53,19 +51,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
-	// we don't collect the same stats from every node and end up duplicating them.
-	if m.Scope == elasticsearch.ScopeNode {
-		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
-		if err != nil {
-			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		}
-
-		// Not master, no event sent
-		if !isMaster {
-			m.Logger().Debug("trying to fetch shard stats from a non-master node")
-			return nil
-		}
+	shouldSkip, err := m.ShouldSkipFetch()
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -55,7 +55,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
 	// we don't collect the same stats from every node and end up duplicating them.
-	if m.HostsMode == elasticsearch.HostsModeNode {
+	if m.Scope == elasticsearch.ScopeNode {
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
 		if err != nil {
 			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -53,15 +53,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
-	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-	}
+	// If we're talking to a set of ES nodes directly, only collect stats from the master node so
+	// we don't collect the same stats from every node and end up duplicating them.
+	if m.HostsMode == elasticsearch.HostsModeNode {
+		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
+		if err != nil {
+			return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		}
 
-	// Not master and we're talking to a set of ES nodes, not clusters == no event sent
-	if !isMaster && m.HostsMode == elasticsearch.HostsModeNode {
-		m.Logger().Debug("trying to fetch shard stats from a non-master node")
-		return nil
+		// Not master, no event sent
+		if !isMaster {
+			m.Logger().Debug("trying to fetch shard stats from a non-master node")
+			return nil
+		}
 	}
 
 	content, err := m.HTTP.FetchContent()

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -489,6 +489,12 @@ metricbeat.modules:
   # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
 
+  # Set to cluster to treat each item in the hosts list as an endpoint for
+  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
+  # Set to node (default) to treat each item in the hosts list as an individual
+  # node in the Elasticsearch cluster.
+  #hosts_mode: node
+
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   metricsets: ["server"]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -493,7 +493,7 @@ metricbeat.modules:
   # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
   # Set to node (default) to treat each item in the hosts list as an individual
   # node in the Elasticsearch cluster.
-  #hosts_mode: node
+  #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -482,17 +482,8 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
-
-  # Set to cluster to treat each item in the hosts list as an endpoint for
-  # a distinct Elasticsearch cluster, e.g. a load-balancer fronting the cluster.
-  # Set to node (default) to treat each item in the hosts list as an individual
-  # node in the Elasticsearch cluster.
   #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `scope` setting for the `elasticsearch` Metricbeat module. This setting can take one of two values: 
- `node` (default): 	indicates that each item in the `hosts` list points to a distinct Elasticsearch node in a cluster, or
-  `cluster`: indicates that each item in the `hosts` lists points to a single endpoint for a distinct Elasticsearch cluster (e.g. a load-balancing proxy fronting the cluster).

## Why is it important?

Sometimes it may not be possible for Metricbeat to reach individual Elasticsearch nodes. It might only have access to a single endpoint that fronts the entire Elasticsearch cluster.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Manual testing
Testing the new `scope: cluster` functionality introduced in this PR requires an Elasticsearch cluster with multiple nodes. The easiest way is probably to spin up an Elastic Cloud cluster.

1. Enable the `elasticsearch-xpack` module. 
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```

2. Configure the module (`./modules.d/elasticsearch-xpack.yml`) like so:
   ```
   - module: elasticsearch
     xpack.enabled: true
     period: 10s
     hosts:
       - XXXXX
     scope: cluster
     username: XXXXX
     password: XXXXX
   ```
   Obviously, replace the `XXXXX` placeholders with your own.

   The key is that **there should be exactly one item under `hosts`, pointing to single endpoint for your cluster**. This could be the Elasticsearch endpoint obtained from Elastic Cloud or the address of a single node in your on-prem/local Elasticsearch cluster.

3. Configure Metricbeat to send the collected stats to an Elasticsearch cluster. This will act as your Monitoring Cluster. It could be the same cluster you're using to collect stats from (as configured in your `elasticsearch-xpack` module configuration above) or it could be an entirely separate cluster.
   ```
   metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
   reload.enabled: false

   output.elasticsearch:
     enabled: true
     hosts:
       - XXXXXX
     username: XXXXXX
     password: XXXXXX
   ```

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Let Metricbeat run for ~30 seconds. Make sure there are no errors in the Metricbeat logs.

6. Perform the following query against your Monitoring Cluster.
   ```
   POST .monitoring-es-7-mb-*/_search
   {
     "size": 0,
     "aggs": {
       "by_cluster_uuid": {
         "terms": {
           "field": "cluster_uuid"
         }
       },
       "cluster_stats": {
         "filter": {
           "term": {
             "type": "cluster_stats"
           }
         },
         "aggs": {
           "by_period": {
             "date_histogram": {
               "field": "timestamp",
               "interval": "10s"
             }
           }
         }
       },
       "node_stats": {
         "filter": {
           "term": {
             "type": "node_stats"
           }
         },
         "aggs": {
           "by_period": {
             "date_histogram": {
               "field": "timestamp",
               "interval": "10s"
             }
           }
         }
       }
     }
   }
   ```

   This query checks 3 things:
   1. The `aggs.by_cluster_uuid` aggregation checks that we are only seeing data for a single cluster and that all documents contain that single cluster UUID.
      - Verify that `aggregations.by_cluster_uuid.buckets` only contains a single bucket, for the single cluster UUID of the Elasticsearch cluster you are monitoring.
      - Verify that `aggregations.by_cluster_uuid.buckets[0].doc_count` is the same as the `hits.total.value`.
   2. The `aggs.cluster_stats` aggregation checks that `type: cluster_stats` documents are only indexed once every collection period (10 seconds) and that there is at most one document per collection period. We are using `type: cluster_stats` here as an example; the same should be true for any `type`s other than `type: node_stats`.
      - Verify that `aggregations.cluster_stats.by_period.buckets` have several buckets, each corresponding to a time period. Each buckets should be 10 seconds "wide". Within each bucket, verify that `doc_count` is <= 1.
   2. The `aggs.node_stats` aggregation checks that `type: node_stats` documents are only indexed once every collection period (10 seconds) and that there are at most `N` documents per collection period, where `N` is the number of nodes in the cluster you are monitoring.
      - Verify that `aggregations.node_stats.by_period.buckets` have several buckets, each corresponding to a time period. Each buckets should be 10 seconds "wide". Within each bucket, verify that `doc_count` is <= `N`, where `N` is the number of nodes in the cluster you are monitoring.


## Related issues
-  Resolves https://github.com/elastic/beats/issues/18539.