### PR TITLE
Cherry-pick #18418 to 7.x: Fix libbeat import path in seccomp policy template

### DIFF
--- a/libbeat/common/seccomp/policy.go.tpl
+++ b/libbeat/common/seccomp/policy.go.tpl
@@ -7,7 +7,7 @@ package {{.Package}}
 import (
 	"github.com/elastic/go-seccomp-bpf"
 
-	beat "github.com/elastic/beats/libbeat/common/seccomp"
+	beat "github.com/elastic/beats/v7/libbeat/common/seccomp"
 )
 
 func init() {


### PR DESCRIPTION
Cherry-pick of PR #18418 to 7.x branch. Original message: 

- Bug

## What does this PR do?

Fix the libbeat import path in the seccomp policy template

## Why is it important?

The template is used to generate Beats code from time to time. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~