### PR TITLE
[7.x] [docs] Rename monitoring collection from legacy internal collection to legacy collection (#18504)

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -27,8 +27,8 @@ ifndef::serverless[]
 {metricbeat} collects monitoring data from your {beatname_uc} instance
 and sends it directly to your monitoring cluster.
 endif::[]
-* <<monitoring-internal-collection-legacy,Legacy internal collection (deprecated)>> - 
-Legacy internal collectors send monitoring data to your production cluster.
+* <<monitoring-internal-collection-legacy,Legacy collection (deprecated)>> - 
+Legacy collectors send monitoring data to your production cluster.
 
 
 //Commenting out this link temporarily until the general monitoring docs can be

--- a/libbeat/docs/monitoring/monitoring-internal-collection-legacy.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection-legacy.asciidoc
@@ -11,9 +11,9 @@
 
 [role="xpack"]
 [[monitoring-internal-collection-legacy]]
-== Use legacy internal collection to send monitoring data
+== Use legacy collection to send monitoring data
 ++++
-<titleabbrev>Use legacy internal collection (deprecated)</titleabbrev>
+<titleabbrev>Use legacy collection (deprecated)</titleabbrev>
 ++++
 
 deprecated[7.2.0]
@@ -23,10 +23,10 @@ that sent monitoring data to the production cluster, which would either index
 the data locally, or forward the data to a dedicated monitoring cluster via HTTP
 exporters.
 
-Starting in {beatname_uc} version 7.2, the legacy settings for internal
-collection are deprecated and will be removed in version 8.0.0. Instead of
-sending monitoring data to your production cluster, it's recommended that you
-use the configuration described under
+Starting in {beatname_uc} version 7.2, legacy collection settings are deprecated
+and will be removed in version 8.0.0. Instead of sending monitoring data to your
+production cluster, it's recommended that you use the configuration described
+under
 <<monitoring-internal-collection,internal collection>> to route
 monitoring data directly to your monitoring cluster.
 

--- a/libbeat/docs/monitoring/shared-monitor-config-legacy.asciidoc
+++ b/libbeat/docs/monitoring/shared-monitor-config-legacy.asciidoc
@@ -12,7 +12,7 @@
 
 [role="xpack"]
 [[configuration-monitor-legacy]]
-=== Settings for legacy internal collection
+=== Settings for legacy collection
 
 deprecated::[7.2.0,These settings are deprecated and will be removed in version 8.0.0. Instead of sending monitoring data to your production cluster it's recommended that you use the configuration described under <<monitoring-internal-collection>> to route monitoring data directly to your monitoring cluster.]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Rename monitoring collection from legacy internal collection to legacy collection (#18504)