### PR TITLE
Cherry-pick #18512 to 7.x: Avoid Chown on windows 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@
 - Ensure that the beats uses the params prefer_v2_templates on bulk request. {pull}18318[18318]
 - Stop monitoring on config change {pull}18284[18284]
 - Fix jq: command not found {pull}18408[18408]
+- Avoid Chown on windows {pull}18512[18512]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"unicode"
 
@@ -139,7 +140,7 @@ func (b *Monitor) Prepare(process, pipelineID string, uid, gid int) error {
 			}
 		}
 
-		if err := os.Chown(drop, uid, gid); err != nil {
+		if err := changeOwner(drop, uid, gid); err != nil {
 			return err
 		}
 	}
@@ -228,4 +229,13 @@ func isWindowsPath(path string) bool {
 		return false
 	}
 	return unicode.IsLetter(rune(path[0])) && path[1] == ':'
+}
+
+func changeOwner(path string, uid, gid int) error {
+	if runtime.GOOS == "windows" {
+		// on windows it always returns the syscall.EWINDOWS error, wrapped in *PathError
+		return nil
+	}
+
+	return os.Chown(path, uid, gid)
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/start.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/start.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -319,7 +320,7 @@ func (a *Application) configureByFile(spec *ProcessSpec, config map[string]inter
 	defer f.Close()
 
 	// change owner
-	if err := os.Chown(filePath, a.uid, a.gid); err != nil {
+	if err := changeOwner(filePath, a.uid, a.gid); err != nil {
 		return err
 	}
 
@@ -382,4 +383,13 @@ func isWindowsPath(path string) bool {
 		return false
 	}
 	return unicode.IsLetter(rune(path[0])) && path[1] == ':'
+}
+
+func changeOwner(path string, uid, gid int) error {
+	if runtime.GOOS == "windows" {
+		// on windows it always returns the syscall.EWINDOWS error, wrapped in *PathError
+		return nil
+	}
+
+	return os.Chown(path, uid, gid)
 }


### PR DESCRIPTION
Cherry-pick of PR #18512 to 7.x branch. Original message:

## What does this PR do?

Chown function returns error on windows on each call, we need to avoid that

## Why is it important?

WOuld not work on windows

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #18495
Verified and tested on a windows 10 VM