### PR TITLE
Cherry-pick #18389 to 7.x: Remove unused flag in Checkpoint module configuration

### DIFF
--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -357,10 +357,6 @@ filebeat.modules:
     # The UDP port to listen for syslog traffic. Defaults to 9001.
     #var.syslog_port: 9001
 
-    # Set the log level from 1 (alerts only) to 7 (include all messages).
-    # Messages with a log level higher than the specified will be dropped.
-    # See https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs-sev-level.html
-    #var.log_level: 7
 #-------------------------------- Cisco Module --------------------------------
 - module: cisco
   asa:

--- a/x-pack/filebeat/module/checkpoint/_meta/config.yml
+++ b/x-pack/filebeat/module/checkpoint/_meta/config.yml
@@ -11,8 +11,3 @@
 
     # The UDP port to listen for syslog traffic. Defaults to 9001.
     #var.syslog_port: 9001
-
-    # Set the log level from 1 (alerts only) to 7 (include all messages).
-    # Messages with a log level higher than the specified will be dropped.
-    # See https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs-sev-level.html
-    #var.log_level: 7

--- a/x-pack/filebeat/module/checkpoint/firewall/manifest.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/manifest.yml
@@ -9,8 +9,6 @@ var:
     default: 9001
   - name: input
     default: syslog
-  - name: log_level
-    default: 7
 
 ingest_pipeline: 
   - ingest/pipeline.json

--- a/x-pack/filebeat/modules.d/checkpoint.yml.disabled
+++ b/x-pack/filebeat/modules.d/checkpoint.yml.disabled
@@ -14,8 +14,3 @@
 
     # The UDP port to listen for syslog traffic. Defaults to 9001.
     #var.syslog_port: 9001
-
-    # Set the log level from 1 (alerts only) to 7 (include all messages).
-    # Messages with a log level higher than the specified will be dropped.
-    # See https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs-sev-level.html
-    #var.log_level: 7


### PR DESCRIPTION
Cherry-pick of PR #18389 to 7.x branch. Original message: 

## What does this PR do?

This removes references to `var.log_level` in checkpoint module's configuration. This variable is not used, just a left-over from using the cisco module as a base.

## Why is it important?

Avoid confusing users with a configuration option that does nothing and references docs from a different vendor.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
