### PR TITLE
Removing mention of ML jobs from setup help text

### DIFF
--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -54,7 +54,6 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 
  * Index mapping template in Elasticsearch to ensure fields are mapped.
  * Kibana dashboards (where available).
- * ML jobs (where available).
  * Ingest pipelines (where available).
  * ILM policy (for Elasticsearch 6.5 and newer).
 `,


### PR DESCRIPTION
### **DO NOT BACKPORT THIS PR TO 7.x**

## What does this PR do?

Updates the `setup` command's help texts to remove mention of ML jobs.

## Why is it important?

This PR is a follow up to #14705. In #14705, we removed the ability for Beats to setup ML jobs. So we should not say in the `setup` command's help text that Beats can set them up.
