### PR TITLE
Cherry-pick #18405 to 7.8: Cleaner output of inspect command

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -56,3 +56,4 @@
 - Do not require unnecessary configuration {pull}18003[18003]
 - Use nested objects so fleet can handle metadata correctly {pull}18234[18234]
 - Enable debug log level for Metricbeat and Filebeat when run under the Elastic Agent. {pull}17935[17935]
+- More clear output of inspect command {pull}18405[18405]

--- a/x-pack/elastic-agent/pkg/agent/application/introspect_config_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/introspect_config_cmd.go
@@ -53,7 +53,7 @@ func (c *IntrospectConfigCmd) introspectConfig() error {
 	if err != nil {
 		return err
 	} else if fleetConfig == nil {
-		return errors.New("no fleet config retrieved yet")
+		return fmt.Errorf("no fleet config retrieved yet")
 	}
 
 	return printMapStringConfig(fleetConfig)

--- a/x-pack/elastic-agent/pkg/agent/application/introspect_output_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/introspect_output_cmd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/urso/ecslog/backend/layout"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filters"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
@@ -69,7 +68,7 @@ func (c *IntrospectOutputCmd) introspectOutputs() error {
 	if err != nil {
 		return err
 	} else if fleetConfig == nil {
-		return errors.New("no fleet config retrieved yet")
+		return fmt.Errorf("no fleet config retrieved yet")
 	}
 
 	return listOutputsFromMap(l, fleetConfig)
@@ -122,7 +121,7 @@ func (c *IntrospectOutputCmd) introspectOutput() error {
 	if err != nil {
 		return err
 	} else if fleetConfig == nil {
-		return errors.New("no fleet config retrieved yet")
+		return fmt.Errorf("no fleet config retrieved yet")
 	}
 
 	return printOutputFromMap(l, c.output, c.program, fleetConfig)
@@ -153,16 +152,16 @@ func printOutputFromConfig(log *logger.Logger, output, programName string, cfg *
 		}
 
 		if !programFound {
-			fmt.Printf("program '%s' is not recognized within output '%s', try running `elastic-agent introspect output` to find available outputs.\n",
+			return fmt.Errorf("program '%s' is not recognized within output '%s', try running `elastic-agent introspect output` to find available outputs",
 				programName,
 				output)
 		}
+
 		return nil
 	}
 
-	fmt.Printf("output '%s' is not recognized, try running `elastic-agent introspect output` to find available outputs.\n", output)
+	return fmt.Errorf("output '%s' is not recognized, try running `elastic-agent introspect output` to find available outputs", output)
 
-	return nil
 }
 
 func printOutputFromMap(log *logger.Logger, output, programName string, cfg map[string]interface{}) error {

--- a/x-pack/elastic-agent/pkg/agent/errors/error.go
+++ b/x-pack/elastic-agent/pkg/agent/errors/error.go
@@ -27,6 +27,11 @@ type agentError struct {
 	meta    map[string]interface{}
 }
 
+// Unwrap returns nested error.
+func (e agentError) Unwrap() error {
+	return e.err
+}
+
 // Error returns a string consisting of a message and originating error.
 func (e agentError) Error() string {
 	if e.msg != "" {


### PR DESCRIPTION
Cherry-pick of PR #18405 to 7.8 branch. Original message:

## What does this PR do?

Use of classic errors instead of custom type for inspect command. custom type is more suitable for logs where it carries call stack and error history here we just need an output displayed to user.

## Why is it important?

call stack is confusing for user

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test

build agent and provide config with `management.mode=fleet` without enrolling. then run `./elastic-agent inspect`
You should see error without call stack

Fixes: #18344