### PR TITLE
[7.x] Update version when bulk param is available in ES stats API (#18459)

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -66,7 +66,7 @@ var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 var EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
 
 // BulkStatsAvailableVersion is the version since when bulk indexing stats are available
-var BulkStatsAvailableVersion = common.MustNewVersion("7.8.0")
+var BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
 
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -37,7 +37,7 @@ func TestGetServiceURI(t *testing.T) {
 			expectedPath: statsPath,
 		},
 		"bulk_stats_available": {
-			esVersion:    common.MustNewVersion("7.8.0"),
+			esVersion:    common.MustNewVersion("8.0.0"),
 			expectedPath: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
 		},
 	}
@@ -58,7 +58,7 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 		var uri string
 		var err error
 		for i := uint(0); i < numCalls; i++ {
-			uri, err = getServicePath(*common.MustNewVersion("7.8.0"))
+			uri, err = getServicePath(*common.MustNewVersion("8.0.0"))
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update version when bulk param is available in ES stats API  (#18459)