### PR TITLE
Remove calls to 6.x ES `_xpack/*` API endpoints

### DIFF
--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -151,14 +151,7 @@ func newMonitoringBulkRequest(
 	params map[string]string,
 	body BodyEncoder,
 ) (*bulkRequest, error) {
-	var path string
-	var err error
-	if esVersion.Major < 7 {
-		path, err = makePath("_xpack", "monitoring", "_bulk")
-	} else {
-		path, err = makePath("_monitoring", "bulk", "")
-	}
-
+	path, err := makePath("_monitoring", "bulk", "")
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -261,11 +261,6 @@ func GetLicense(http *helper.HTTP, resetURI string) (*License, error) {
 	}
 
 	// License not found in cache, fetch it from Elasticsearch
-	info, err := GetInfo(http, resetURI)
-	if err != nil {
-		return nil, err
-	}
-
 	content, err := fetchPath(http, resetURI, "_license", "")
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -265,14 +265,8 @@ func GetLicense(http *helper.HTTP, resetURI string) (*License, error) {
 	if err != nil {
 		return nil, err
 	}
-	var licensePath string
-	if info.Version.Number.Major < 7 {
-		licensePath = "_xpack/license"
-	} else {
-		licensePath = "_license"
-	}
 
-	content, err := fetchPath(http, resetURI, licensePath, "")
+	content, err := fetchPath(http, resetURI, "_license", "")
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 const (
-	jobPathSuffix = "/anomaly_detectors/_all/_stats"
+	statsPath = "/_ml/anomaly_detectors/_all/_stats"
 )
 
 // MetricSet for ml job
@@ -44,7 +44,7 @@ type MetricSet struct {
 // any MetricSet specific configuration options if there are any.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Get the stats from the local node
-	ms, err := elasticsearch.NewMetricSet(base, "") // servicePath will be set in Fetch() based on ES version
+	ms, err := elasticsearch.NewMetricSet(base, statsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -69,12 +69,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		return err
-	}
-
-	if info.Version.Number.Major < 7 {
-		m.SetServiceURI("/_xpack/ml" + jobPathSuffix)
-	} else {
-		m.SetServiceURI("/_ml" + jobPathSuffix)
 	}
 
 	content, err := m.HTTP.FetchContent()


### PR DESCRIPTION
⚠️ **DO NOT BACKPORT - should go out only in 8.0.0!** ⚠️ 

## What does this PR do?

Removes conditional code that supported Beats talking to various `_xpack/*` Elasticsearch API endpoints deprecated in 6.x and removed in 7.0 of Elasticsearch.

## Why is it important?

Several `_xpack/*` API endpoints were deprecated in Elasticsearch in 6.x and removed in 7.0. The Beats codebase through 7.x had conditional code to call these endpoints if the Beat was talking to a 6.x Elasticsearch cluster. Starting 8.0.0, Beats should not be expected to talk to a 6.x Elasticsearch cluster, so we can remove these conditional bits of code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~ Not a user- or developer-facing change.

## Related issues

- Relates to elastic/beats#9424