### PR TITLE
Cherry-pick #18524 to 7.8: [Metricbeat] Fix tags_filter for cloudwatch metricset in aws module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -232,6 +232,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - Remove specific win32 api errors from events in perfmon. {issue}18292[18292] {pull}18361[18361]
 - Fix application_pool metricset after pdh changes. {pull}18477[18477]
+- Fix tags_filter for cloudwatch metricset in aws. {pull}18524[18524]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -90,6 +90,9 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		TagsFilter:    config.TagsFilter,
 	}
 
+	base.Logger().Debug("Metricset level config for period: ", metricSet.Period)
+	base.Logger().Debug("Metricset level config for tags filter: ", metricSet.TagsFilter)
+
 	// Get IAM account name
 	awsConfig.Region = "us-east-1"
 	svcIam := iam.New(awscommon.EnrichAWSConfigWithEndpoint(
@@ -129,11 +132,13 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		}
 
 		metricSet.RegionsList = completeRegionsList
+		base.Logger().Debug("Metricset level config for regions: ", metricSet.RegionsList)
 		return &metricSet, nil
 	}
 
 	// Construct MetricSet with specific regions list from config
 	metricSet.RegionsList = config.Regions
+	base.Logger().Debug("Metricset level config for regions: ", metricSet.RegionsList)
 	return &metricSet, nil
 }
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -146,6 +146,7 @@ func TestConstructLabel(t *testing.T) {
 
 func TestReadCloudwatchConfig(t *testing.T) {
 	m := MetricSet{}
+	m.MetricSet = &aws.MetricSet{Period: 5}
 	resourceTypeFiltersEC2 := map[string][]aws.Tag{}
 	resourceTypeFiltersEC2["ec2:instance"] = nil
 
@@ -1311,6 +1312,46 @@ func TestCreateEventsWithoutIdentifier(t *testing.T) {
 	dimension, err := events[expectedID].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value2, dimension)
+}
+
+func TestCreateEventsWithTagsFilter(t *testing.T) {
+	m := MetricSet{}
+	m.CloudwatchConfigs = []Config{{Statistic: []string{"Average"}}}
+	m.MetricSet = &aws.MetricSet{Period: 5}
+	m.logger = logp.NewLogger("test")
+
+	mockTaggingSvc := &MockResourceGroupsTaggingClient{}
+	mockCloudwatchSvc := &MockCloudWatchClient{}
+	listMetricWithStatsTotal := []metricsWithStatistics{
+		{
+			cloudwatch.Metric{
+				Dimensions: []cloudwatch.Dimension{{
+					Name:  awssdk.String("InstanceId"),
+					Value: awssdk.String("i-1"),
+				}},
+				MetricName: awssdk.String("CPUUtilization"),
+				Namespace:  awssdk.String("AWS/EC2"),
+			},
+			[]string{"Average"},
+			[]aws.Tag{
+				{Key: "name", Value: "test-ec2"},
+			},
+		},
+	}
+
+	// Specify a tag filter that does not match the tag for i-1
+	resourceTypeTagFilters := map[string][]aws.Tag{}
+	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
+		{
+			Key:   "name",
+			Value: "foo",
+		},
+	}
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period)
+
+	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(events))
 }
 
 func TestInsertTags(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #18524 to 7.8 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix `tags_filter` for cloudwatch metricset. Without this fix, when user tries to specify `tags_filter` in aws module config, it does not apply the filter on what events to send to ES.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

