### PR TITLE
Cherry-pick #18606 to 7.8: [ci] clean workspaces in static workers (#18606)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,11 @@ pipeline {
           steps {
             mageTarget("Elastic Agent x-pack Mac OS X", "x-pack/elastic-agent", "build unitTest")
           }
+          post {
+            always {
+              delete()
+            }
+          }
         }
 
         stage('Filebeat oss'){
@@ -161,6 +166,11 @@ pipeline {
           steps {
             mageTarget("Filebeat oss Mac OS X", "filebeat", "build unitTest")
           }
+          post {
+            always {
+              delete()
+            }
+          }
         }
         stage('Filebeat x-pack Mac OS X'){
           agent { label 'macosx' }
@@ -173,6 +183,11 @@ pipeline {
           }
           steps {
             mageTarget("Filebeat x-pack Mac OS X", "x-pack/filebeat", "build unitTest")
+          }
+          post {
+            always {
+              delete()
+            }
           }
         }
         stage('Filebeat Windows'){
@@ -228,6 +243,11 @@ pipeline {
               steps {
                 mageTarget("Heartbeat oss Mac OS X", "heartbeat", "build unitTest")
               }
+              post {
+                always {
+                  delete()
+                }
+              }
             }
             stage('Heartbeat Windows'){
               agent { label 'windows-immutable && windows-2019' }
@@ -275,6 +295,11 @@ pipeline {
               }
               steps {
                 mageTarget("Auditbeat oss Mac OS X", "auditbeat", "build unitTest")
+              }
+              post {
+                always {
+                  delete()
+                }
               }
             }
             stage('Auditbeat Windows'){
@@ -457,6 +482,11 @@ pipeline {
           steps {
             mageTarget("Metricbeat x-pack Mac OS X", "x-pack/metricbeat", "build unitTest")
           }
+          post {
+            always {
+              delete()
+            }
+          }
         }
         stage('Metricbeat Windows'){
           agent { label 'windows-immutable && windows-2019' }
@@ -591,6 +621,11 @@ pipeline {
               steps {
                 mageTarget("Functionbeat x-pack Mac OS X", "x-pack/functionbeat", "build unitTest")
               }
+              post {
+                always {
+                  delete()
+                }
+              }
             }
             stage('Functionbeat Windows'){
               agent { label 'windows-immutable && windows-2019' }
@@ -658,6 +693,11 @@ pipeline {
               steps {
                 makeTarget("Generators Metricbeat Mac OS X", "-C generator/_templates/metricbeat test")
               }
+              post {
+                always {
+                  delete()
+                }
+              }
             }
             stage('Generators Beat Mac OS X'){
               agent { label 'macosx' }
@@ -670,6 +710,11 @@ pipeline {
               }
               steps {
                 makeTarget("Generators Beat Mac OS X", "-C generator/_templates/beat test")
+              }
+              post {
+                always {
+                  delete()
+                }
               }
             }
           }
@@ -700,6 +745,17 @@ pipeline {
   }
 }
 
+def delete() {
+  dir("${env.BASE_DIR}") {
+    fixPermissions("${WORKSPACE}")
+  }
+  deleteDir()
+}
+
+def fixPermissions(location) {
+  sh(label: 'Fix permissions', script: "script/fix_permissions.sh ${location}")
+}
+
 def makeTarget(String context, String target, boolean clean = true) {
   withGithubNotify(context: "${context}") {
     withBeatsEnv(true) {
@@ -708,8 +764,8 @@ def makeTarget(String context, String target, boolean clean = true) {
         dumpMage()
       }
       sh(label: "Make ${target}", script: "make ${target}")
-      if (clean) {
-        sh(script: 'script/fix_permissions.sh ${HOME}')
+      whenTrue(clean) {
+        fixPermissions("${HOME}")
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.8:
 - ci: clean workspaces in static workers (#18606)