### PR TITLE
Cherry-pick #18626 to 7.8: Fix bad field mappings in winlogbeat sysmon module

### DIFF
--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -632,14 +632,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["process"],
-                "event.type": ["start", "process_start"],
+                category: ["process"],
+                type: ["start", "process_start"],
             },
-            target: "",
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -701,13 +700,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"],
-                "event.type": ["change"],
+                category: ["file"],
+                type: ["change"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -744,13 +743,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["network"],
-                "event.type": ["connection", "start", "protocol"],
+                category: ["network"],
+                type: ["connection", "start", "protocol"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -825,17 +824,16 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["process"],
-                "event.type": ["change"],
+                category: ["process"],
+                type: ["change"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
-                    from: "winlog.event_data.UtcTime",
-                    to: "@timestamp",
-                },
-            ],
+            fields: [{
+                from: "winlog.event_data.UtcTime",
+                to: "@timestamp",
+            }, ],
             mode: "rename",
             ignore_missing: true,
             fail_on_error: false,
@@ -848,14 +846,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["process"],
-                "event.type": ["end", "process_end"],
+                category: ["process"],
+                type: ["end", "process_end"],
             },
-            target: "",
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -887,13 +884,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["driver"],
-                "event.type": ["start"],
+                category: ["driver"],
+                type: ["start"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -907,8 +904,7 @@ var sysmon = (function () {
             fail_on_error: false,
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.Signature",
                     to: "file.code_signature.subject_name",
                 },
@@ -931,13 +927,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["process"],
-                "event.type": ["change"],
+                category: ["process"],
+                type: ["change"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -964,8 +960,7 @@ var sysmon = (function () {
             fail_on_error: false,
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.Signature",
                     to: "file.code_signature.subject_name",
                 },
@@ -988,8 +983,7 @@ var sysmon = (function () {
     var event8 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1020,8 +1014,7 @@ var sysmon = (function () {
     var event9 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1058,13 +1051,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["process"],
-                "event.type": ["access"],
+                category: ["process"],
+                type: ["access"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1101,13 +1094,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"],
-                "event.type": ["creation"],
+                category: ["file"],
+                type: ["creation"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1143,8 +1136,7 @@ var sysmon = (function () {
     var event12 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1176,8 +1168,7 @@ var sysmon = (function () {
     var event13 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1209,8 +1200,7 @@ var sysmon = (function () {
     var event14 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1243,13 +1233,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"],
-                "event.type": ["access"],
+                category: ["file"],
+                type: ["access"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1286,12 +1276,10 @@ var sysmon = (function () {
     var event16 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
-                    from: "winlog.event_data.UtcTime",
-                    to: "@timestamp",
-                },
-            ],
+            fields: [{
+                from: "winlog.event_data.UtcTime",
+                to: "@timestamp",
+            }, ],
             mode: "rename",
             ignore_missing: true,
             fail_on_error: false,
@@ -1304,13 +1292,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"], // pipes are files
-                "event.type": ["creation"],
+                category: ["file"], // pipes are files
+                type: ["creation"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1346,13 +1334,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"], // pipes are files
-                "event.type": ["access"],
+                category: ["file"], // pipes are files
+                type: ["access"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1387,12 +1375,10 @@ var sysmon = (function () {
     var event19 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
-                    from: "winlog.event_data.UtcTime",
-                    to: "@timestamp",
-                },
-            ],
+            fields: [{
+                from: "winlog.event_data.UtcTime",
+                to: "@timestamp",
+            }, ],
             mode: "rename",
             ignore_missing: true,
             fail_on_error: false,
@@ -1406,8 +1392,7 @@ var sysmon = (function () {
     var event20 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1430,12 +1415,10 @@ var sysmon = (function () {
     var event21 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
-                    from: "winlog.event_data.UtcTime",
-                    to: "@timestamp",
-                },
-            ],
+            fields: [{
+                from: "winlog.event_data.UtcTime",
+                to: "@timestamp",
+            }, ],
             mode: "rename",
             ignore_missing: true,
             fail_on_error: false,
@@ -1450,16 +1433,19 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["network"],
-                "event.type": ["connection", "protocol", "info"],
+                category: ["network"],
+                type: ["connection", "protocol", "info"],
             },
-            network: {
+            target: "event",
+        })
+        .AddFields({
+            fields: {
                 protocol: "dns",
             },
+            target: "network",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1507,13 +1493,13 @@ var sysmon = (function () {
         .Add(parseUtcTime)
         .AddFields({
             fields: {
-                "event.category": ["file"], // pipes are files
-                "event.type": ["deletion"],
+                category: ["file"], // pipes are files
+                type: ["deletion"],
             },
+            target: "event",
         })
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },
@@ -1565,8 +1551,7 @@ var sysmon = (function () {
     var event255 = new processor.Chain()
         .Add(parseUtcTime)
         .Convert({
-            fields: [
-                {
+            fields: [{
                     from: "winlog.event_data.UtcTime",
                     to: "@timestamp",
                 },

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -25,28 +25,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
@@ -108,28 +107,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -192,28 +190,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -280,28 +277,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
@@ -363,28 +359,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -453,28 +448,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -532,28 +526,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -620,28 +613,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -695,28 +687,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -786,28 +777,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -909,28 +899,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -988,28 +977,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1071,28 +1059,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1159,28 +1146,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1234,28 +1220,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1323,28 +1308,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1406,28 +1390,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1489,28 +1472,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1599,28 +1581,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1689,28 +1670,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1824,28 +1804,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -1947,28 +1926,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2075,28 +2053,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2168,28 +2145,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2298,28 +2274,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2431,28 +2406,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2510,28 +2484,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2634,28 +2607,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2717,28 +2689,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2841,28 +2812,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2920,28 +2890,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -2999,28 +2968,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3117,28 +3085,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3224,28 +3191,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3303,28 +3269,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3417,28 +3382,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3546,28 +3510,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3676,28 +3639,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3755,28 +3717,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -3884,28 +3845,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4007,28 +3967,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4086,28 +4045,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4161,28 +4119,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4253,28 +4210,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4372,28 +4328,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4495,28 +4450,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4582,28 +4536,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4712,28 +4665,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4800,28 +4752,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4908,28 +4859,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -4991,28 +4941,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5070,28 +5019,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5136,28 +5084,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5202,28 +5149,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5326,28 +5272,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5414,28 +5359,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5493,28 +5437,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5617,28 +5560,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5705,28 +5647,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5829,28 +5770,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -5908,28 +5848,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6002,28 +5941,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6096,28 +6034,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6176,28 +6113,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6300,28 +6236,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6430,28 +6365,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6560,28 +6494,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6684,28 +6617,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6772,28 +6704,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6866,28 +6797,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -6945,28 +6875,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7069,28 +6998,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7203,28 +7131,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7326,28 +7253,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7409,28 +7335,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7538,28 +7463,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7621,28 +7545,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7750,28 +7673,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7874,28 +7796,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -7976,28 +7897,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8106,28 +8026,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8210,28 +8129,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8285,28 +8203,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8409,28 +8326,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8503,28 +8419,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8578,28 +8493,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8702,28 +8616,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8827,28 +8740,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -8931,28 +8843,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9055,28 +8966,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9168,28 +9078,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9281,28 +9190,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9415,28 +9323,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9540,28 +9447,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9658,28 +9564,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9782,28 +9687,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9906,28 +9810,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -9989,28 +9892,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10111,28 +10013,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10194,28 +10095,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10288,28 +10188,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10372,28 +10271,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10456,28 +10354,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10539,28 +10436,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10623,28 +10519,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
@@ -10702,28 +10597,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10790,28 +10684,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10873,28 +10766,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -10960,28 +10852,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11043,28 +10934,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11126,28 +11016,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11209,28 +11098,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11339,28 +11227,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11433,28 +11320,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11518,28 +11404,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11643,28 +11528,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11718,28 +11602,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11801,28 +11684,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -11930,28 +11812,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12009,28 +11890,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12092,28 +11972,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12219,28 +12098,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12352,28 +12230,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12435,28 +12312,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12564,28 +12440,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12694,28 +12569,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12819,28 +12693,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -12939,28 +12812,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13069,28 +12941,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13403,28 +13274,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13547,28 +13417,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13626,28 +13495,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13713,28 +13581,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13779,28 +13646,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13862,28 +13728,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -13992,28 +13857,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14122,28 +13986,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14205,28 +14068,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14329,28 +14191,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14453,28 +14314,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14576,28 +14436,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14688,28 +14547,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14771,28 +14629,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14854,28 +14711,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -14978,28 +14834,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -15073,28 +14928,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -15203,28 +15057,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -15282,28 +15135,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
@@ -15365,28 +15217,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
@@ -15444,28 +15295,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
@@ -15510,28 +15360,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
@@ -15575,28 +15424,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e9f7-5d2f-0000-001031039c00}",
@@ -15640,28 +15488,27 @@
       }
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-b1a2-5d2f-0000-001016f70000}",
@@ -15727,28 +15574,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
@@ -15806,28 +15652,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
@@ -15919,28 +15764,27 @@
       ]
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 22,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "protocol",
-          "info"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "protocol",
+        "info"
+      ]
     },
     "host": {
       "name": "vagrant-2016"
     },
     "log": {
       "level": "information"
+    },
+    "network": {
+      "protocol": "dns"
     },
     "process": {
       "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
@@ -2,20 +2,16 @@
   {
     "@timestamp": "2020-05-07T08:14:44.489Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 23,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "deletion"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "deletion"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\1\\go-build583768550\\b001",
@@ -91,20 +87,16 @@
   {
     "@timestamp": "2020-05-07T07:27:18.722Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 23,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "deletion"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "deletion"
+      ]
     },
     "file": {
       "directory": "C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local",
@@ -173,20 +165,16 @@
   {
     "@timestamp": "2020-05-12T06:48:27.084Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 23,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "deletion"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "deletion"
+      ]
     },
     "file": {
       "directory": "C:\\Windows\\System32\\LogFiles\\Scm",

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -39,20 +39,16 @@
   {
     "@timestamp": "2019-03-18T16:57:38.011Z",
     "event": {
+      "category": [
+        "process"
+      ],
       "code": 4,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "process"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -468,22 +464,18 @@
       "port": 53
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -549,22 +541,18 @@
       "port": 53
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -631,22 +619,18 @@
       "port": 443
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -713,22 +697,18 @@
       "port": 443
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -795,22 +775,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -881,22 +857,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -965,22 +937,18 @@
       "port": 5355
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1047,22 +1015,18 @@
       "port": 5355
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1128,22 +1092,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1212,22 +1172,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1296,22 +1252,18 @@
       "port": 5355
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1377,22 +1329,18 @@
       "port": 5355
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1458,22 +1406,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1543,22 +1487,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1628,22 +1568,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1713,22 +1649,18 @@
       "port": 137
     },
     "event": {
+      "category": [
+        "network"
+      ],
       "code": 3,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "network"
-        ],
-        "type": [
-          "connection",
-          "start",
-          "protocol"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "connection",
+        "start",
+        "protocol"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1894,20 +1826,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.387Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data",
@@ -1957,20 +1885,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.417Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data",
@@ -2020,20 +1944,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.417Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default",
@@ -2083,20 +2003,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.417Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default",
@@ -2196,20 +2112,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.433Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\nmmhkkegccagdldgiimedpiccmgmieda\\def",
@@ -2259,20 +2171,16 @@
   {
     "@timestamp": "2019-03-18T16:57:52.433Z",
     "event": {
+      "category": [
+        "file"
+      ],
       "code": 2,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
-    },
-    "fields": {
-      "event": {
-        "category": [
-          "file"
-        ],
-        "type": [
-          "change"
-        ]
-      }
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "file": {
       "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\gfdkimpbcpahaombhbimeihdjnejgicl\\def",


### PR DESCRIPTION
Cherry-pick of PR #18626 to 7.8 branch. Original message: 

## What does this PR do?

Fixes bad field mappings that were missing a `target` parameter in an `AddFields` invocation.