### PR TITLE
Cherry-pick #12905 to 7.x: Allow the Docker image to be run with a random user id

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -303,6 +303,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Kerberos support to Elasticsearch output. {pull}17927[17927]
 - Add support for fixed length extraction in `dissect` processor. {pull}17191[17191]
 - Update RPM packages contained in Beat Docker images. {issue}17035[17035]
+- Change ownership of files in docker images so they can be used in secured environments. {pull}12905[12905]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -186,8 +186,13 @@ func checkDocker(t *testing.T, file string) {
 	checkDockerEntryPoint(t, p, info)
 	checkDockerLabels(t, p, info, file)
 	checkDockerUser(t, p, info, *rootUserContainer)
-	checkConfigPermissionsWithMode(t, p, os.FileMode(0640))
-	checkManifestPermissionsWithMode(t, p, os.FileMode(0640))
+
+	// The configuration file in the Docker image is expected to be readable and writable by any user who belongs to
+	// the root group. This is done in order to allow the docker image to run on secured Kubernetes environment where
+	// the user ID used to run a container can't be known in advance.
+	checkConfigPermissionsWithMode(t, p, os.FileMode(0660))
+	checkManifestPermissionsWithMode(t, p, os.FileMode(0660))
+
 	checkModulesPresent(t, "", p)
 	checkModulesDPresent(t, "", p)
 }

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -30,10 +30,10 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint
 RUN groupadd --gid 1000 {{ .BeatName }}
 
 RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
-    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
-    find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
-    find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
-    chmod 0750 {{ $beatBinary }} && \
+    chown -R root:root {{ $beatHome }} && \
+    find {{ $beatHome }} -type d -exec chmod 0770 {} \; && \
+    find {{ $beatHome }} -type f -exec chmod 0660 {} \; && \
+    chmod 0770 {{ $beatBinary }} && \
 {{- if .linux_capabilities }}
     setcap {{ .linux_capabilities }} {{ $beatBinary }} && \
 {{- end }}
@@ -43,7 +43,7 @@ RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
     chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
 
 {{- if ne .user "root" }}
-RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
+RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
 {{- end }}
 USER {{ .user }}
 


### PR DESCRIPTION
Cherry-pick of PR #12905 to 7.x branch. Original message: 

On secured Kubernetes environments _(not only Openshift)_ the user ID used to run a container can't be known in advance. Consequently the APM server container can't be started on these environments because it expects to run with the user 1000 or 0.

This PR brings some compatibility with such environments, based on the fact that on secured Kubernetes clusters and on Openshift the only thing you know is that the user is always a member of the root group.

You can find more details here: https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines

See https://github.com/elastic/apm-server/pull/2325 and https://github.com/elastic/beats/issues/12686