### PR TITLE
Cherry-pick #18200 to 7.x: Add typeconv package

### DIFF
--- a/libbeat/common/transform/typeconv/typeconv.go
+++ b/libbeat/common/transform/typeconv/typeconv.go
@@ -1,0 +1,268 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package typeconv
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	structform "github.com/elastic/go-structform"
+	"github.com/elastic/go-structform/gotype"
+)
+
+// Converter converts structured data between arbitrary typed (serializable)
+// go structures and maps/slices/arrays. It uses go-structform/gotype for input
+// and output values each, such that any arbitrary structures can be used.
+//
+// The converter computes and caches mapping operations for go structures it
+// has visited.
+type Converter struct {
+	fold   *gotype.Iterator
+	unfold *gotype.Unfolder
+}
+
+type timeUnfolder struct {
+	gotype.BaseUnfoldState
+	to   *time.Time
+	a, b uint64
+	st   timeUnfoldState
+}
+
+type timeUnfoldState uint8
+
+const (
+	timeUnfoldInit timeUnfoldState = iota
+	timeUnfoldDone
+	timeUnfoldWaitA
+	timeUnfoldWaitB
+	timeUnfoldWaitDone
+)
+
+var convPool = sync.Pool{
+	New: func() interface{} {
+		return &Converter{}
+	},
+}
+
+// NewConverter creates a new converter with local state for tracking known
+// type conversations.
+func NewConverter() *Converter {
+	c := &Converter{}
+	return c
+}
+
+func (c *Converter) init() {
+	unfold, _ := gotype.NewUnfolder(nil, gotype.Unfolders(
+		unfoldTimestamp,
+	))
+	fold, err := gotype.NewIterator(unfold, gotype.Folders(
+		foldTimestamp,
+	))
+	if err != nil {
+		panic(err)
+	}
+
+	c.unfold = unfold
+	c.fold = fold
+}
+
+// Convert transforms the value of from into to, by translating the structure
+// from into a set of events (go-structform.Visitor) that can applied to the
+// value given by to.
+// The operation fails if the values are not compatible (for example trying to
+// convert an object into an int), or `to` is no pointer.
+func (c *Converter) Convert(to, from interface{}) (err error) {
+	if c.unfold == nil || c.fold == nil {
+		c.init()
+	}
+
+	defer func() {
+		if err != nil {
+			c.fold = nil
+			c.unfold = nil
+		}
+	}()
+
+	if err = c.unfold.SetTarget(to); err != nil {
+		return err
+	}
+
+	defer c.unfold.Reset()
+	return c.fold.Fold(from)
+}
+
+// Convert transforms the value of from into to, by translating the structure
+// from into a set of events (go-structform.Visitor) that can applied to the
+// value given by to.
+// The operation fails if the values are not compatible (for example trying to
+// convert an object into an int).
+// To `to` parameter must be a pointer, otherwise the operation fails.
+//
+// Go structures can influence the transformation via tags using the `struct` namespace.
+// If the tag is missing, the structs field names are used. Additional options are separates by `,`.
+// options:
+//   `squash`, `inline`: The fields in the child struct/map are assumed to be inlined, without reporting a sub-oject.
+//   `omitempty`: The field is not converted if it is "empty". For example an
+//                empty string, array or `nil` pointers are assumed to be empty. In either case the original value
+//                in `to` will not be overwritten.
+//   `omit`, `-`: Do not convert the field.
+func Convert(to, from interface{}) (err error) {
+	c := convPool.Get().(*Converter)
+	defer convPool.Put(c)
+	return c.Convert(to, from)
+}
+
+func foldTimestamp(in *time.Time, v structform.ExtVisitor) error {
+	extra, sec := timestampToBits(*in)
+
+	if err := v.OnArrayStart(2, structform.Uint64Type); err != nil {
+		return err
+	}
+	if err := v.OnUint64(extra); err != nil {
+		return err
+	}
+	if err := v.OnUint64(sec); err != nil {
+		return err
+	}
+	if err := v.OnArrayFinished(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unfoldTimestamp(to *time.Time) gotype.UnfoldState {
+	return &timeUnfolder{to: to}
+}
+
+func (u *timeUnfolder) OnString(ctx gotype.UnfoldCtx, in string) (err error) {
+	if u.st != timeUnfoldInit {
+		return fmt.Errorf("Unexpected string '%v' when trying to unfold a timestamp", in)
+	}
+
+	*u.to, err = time.Parse(time.RFC3339, in)
+	u.st = timeUnfoldDone
+	ctx.Done()
+	return err
+}
+
+func (u *timeUnfolder) OnArrayStart(ctx gotype.UnfoldCtx, len int, _ structform.BaseType) error {
+	if u.st != timeUnfoldInit {
+		return errors.New("unexpected array")
+	}
+
+	if len >= 0 && len != 2 {
+		return fmt.Errorf("%v is no valid encoded timestamp length", len)
+	}
+
+	u.st = timeUnfoldWaitA
+	return nil
+}
+
+func (u *timeUnfolder) OnInt(ctx gotype.UnfoldCtx, in int64) error {
+	return u.OnUint(ctx, uint64(in))
+}
+func (u *timeUnfolder) OnFloat(ctx gotype.UnfoldCtx, f float64) error {
+	return u.OnUint(ctx, uint64(f))
+}
+func (u *timeUnfolder) OnUint(ctx gotype.UnfoldCtx, in uint64) error {
+	switch u.st {
+	case timeUnfoldWaitA:
+		u.a = in
+		u.st = timeUnfoldWaitB
+	case timeUnfoldWaitB:
+		u.b = in
+		u.st = timeUnfoldWaitDone
+	default:
+		return fmt.Errorf("unexpected number '%v' in timestamp array", in)
+	}
+	return nil
+}
+
+func (u *timeUnfolder) OnArrayFinished(ctx gotype.UnfoldCtx) error {
+	defer ctx.Done()
+
+	if u.st != timeUnfoldWaitDone {
+		return errors.New("unexpected timestamp array closed")
+	}
+
+	u.st = timeUnfoldDone
+
+	ts, err := bitsToTimestamp(u.a, u.b)
+	if err != nil {
+		return err
+	}
+	*u.to = ts
+
+	return nil
+}
+
+func timestampToBits(ts time.Time) (uint64, uint64) {
+	var (
+		off int16
+		loc = ts.Location()
+	)
+
+	const encodingVersion = 0
+
+	if loc == time.UTC {
+		off = -1
+	} else {
+		_, offset := ts.Zone()
+		offset /= 60 // Note: best effort. If the zone offset has a factional minute, then we will ignore it here
+		if offset < -32768 || offset == -1 || offset > 32767 {
+			offset = 0 // Note: best effort. Ignore offset if it becomes an unexpected value
+		}
+		off = int16(offset)
+	}
+
+	sec := uint64(ts.Unix())
+	extra := (uint64(encodingVersion) << 56) |
+		(uint64(uint16(off)) << 32) |
+		uint64(ts.Nanosecond())
+
+	return extra, sec
+}
+
+func bitsToTimestamp(extra, sec uint64) (time.Time, error) {
+	var ts time.Time
+
+	version := (extra >> 56) & 0xff
+	if version != 0 {
+		return ts, fmt.Errorf("invalid timestamp [%x, %x]", extra, sec)
+	}
+
+	nsec := uint32(extra)
+	off := int16(extra >> 32)
+	ts = time.Unix(int64(sec), int64(nsec))
+
+	// adjust location by offset. time.Unix creates a timestamp in the local zone
+	// by default. Only change this if off does not match the local zone it's offset.
+	if off == -1 {
+		ts = ts.UTC()
+	} else if off != 0 {
+		_, locOff := ts.Zone()
+		if off != int16(locOff/60) {
+			ts = ts.In(time.FixedZone("", int(off*60)))
+		}
+	}
+
+	return ts, nil
+}

--- a/libbeat/common/transform/typeconv/typeconv_test.go
+++ b/libbeat/common/transform/typeconv/typeconv_test.go
@@ -1,0 +1,198 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package typeconv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestConversionWithMapStr(t *testing.T) {
+	t.Run("from MapStr", func(t *testing.T) {
+		type testStruct struct {
+			A int
+			B int
+		}
+
+		var v testStruct
+		Convert(&v, &common.MapStr{"a": 1})
+		assert.Equal(t, testStruct{1, 0}, v)
+	})
+
+	t.Run("to MapStr", func(t *testing.T) {
+		var m common.MapStr
+		err := Convert(&m, struct{ A string }{"test"})
+		require.NoError(t, err)
+		assert.Equal(t, common.MapStr{"a": "test"}, m)
+	})
+}
+
+func TestConversionBetweenGoTypes(t *testing.T) {
+	t.Run("int to uint", func(t *testing.T) {
+		var i = 42
+		var u uint
+		err := Convert(&u, i)
+		require.NoError(t, err)
+		assert.Equal(t, uint(42), u)
+	})
+
+	t.Run("between structs", func(t *testing.T) {
+		type To struct {
+			A uint
+			F float64
+			B string
+		}
+
+		input := struct {
+			A      int
+			F      float64
+			B      string
+			Ignore uint
+		}{100, 3.14, "test", 42}
+
+		var actual To
+		err := Convert(&actual, input)
+		require.NoError(t, err)
+
+		want := To{100, 3.14, "test"}
+		assert.Equal(t, want, actual)
+	})
+
+	t.Run("string is parsed to int", func(t *testing.T) {
+		var to int
+		require.NoError(t, Convert(&to, 1))
+		assert.Equal(t, 1, to)
+	})
+}
+
+func TestTimestamps(t *testing.T) {
+	t.Run("timestamp to MapStr", func(t *testing.T) {
+		var m common.MapStr
+		ts := time.Unix(1234, 5678).UTC()
+
+		off := int16(-1)
+		expected := []uint64{uint64(5678) | uint64(uint16(off))<<32, 1234}
+
+		err := Convert(&m, struct{ Timestamp time.Time }{ts})
+		require.NoError(t, err)
+		assert.Equal(t, common.MapStr{"timestamp": expected}, m)
+	})
+
+	t.Run("timestamp from encoded MapStr", func(t *testing.T) {
+		type testStruct struct {
+			Timestamp time.Time
+		}
+
+		var v testStruct
+		off := int16(-1)
+		err := Convert(&v, common.MapStr{
+			"timestamp": []uint64{5678 | (uint64(uint16(off)))<<32, 1234},
+		})
+		require.NoError(t, err)
+		expected := time.Unix(1234, 5678).UTC()
+		assert.Equal(t, testStruct{expected}, v)
+	})
+
+	t.Run("timestamp from string", func(t *testing.T) {
+		type testStruct struct {
+			Timestamp time.Time
+		}
+
+		var v testStruct
+		ts := time.Now()
+		err := Convert(&v, common.MapStr{
+			"timestamp": ts.Format(time.RFC3339Nano),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v.Timestamp.Format(time.RFC3339Nano), ts.Format(time.RFC3339Nano))
+	})
+}
+
+func TestComplexExampleWithIntermediateConversion(t *testing.T) {
+	type checkpoint struct {
+		Version            int
+		Position           string
+		RealtimeTimestamp  uint64
+		MonotonicTimestamp uint64
+	}
+
+	type (
+		stateInternal struct {
+			TTL     time.Duration
+			Updated time.Time
+		}
+
+		state struct {
+			Internal stateInternal
+			Cursor   interface{}
+		}
+	)
+
+	input := common.MapStr{
+		"_key": "test",
+		"internal": common.MapStr{
+			"ttl":     float64(1800000000000),
+			"updated": []interface{}{float64(515579904576), float64(1588432943)},
+		},
+		"cursor": common.MapStr{
+			"monotonictimestamp": float64(24881645756),
+			"position":           "s=86a99d3589f54f01804e844bebd787d5;i=4d19f;b=9c5d2b320b7946b4be53c0940a5b1289;m=5cb0fc8bc;t=5a488aeaa1130;x=ccbe23f507e8d0a4",
+			"realtimetimestamp":  float64(1588281836441904),
+			"version":            float64(1),
+		},
+	}
+
+	var st state
+	if err := Convert(&st, input); err != nil {
+		t.Fatalf("failed to unpack checkpoint: %+v", err)
+	}
+	assert.Equal(t, time.Duration(1800000000000), st.Internal.TTL)
+	assert.Equal(t, testDecodeTimestamp(t, 515579904576, 1588432943), st.Internal.Updated)
+	require.True(t, st.Cursor != nil)
+
+	var cp checkpoint
+	if err := Convert(&cp, st.Cursor); err != nil {
+		t.Fatalf("failed to unpack cursor: %+v", err)
+	}
+
+	assert.Equal(t, 1, cp.Version)
+	assert.Equal(t, "s=86a99d3589f54f01804e844bebd787d5;i=4d19f;b=9c5d2b320b7946b4be53c0940a5b1289;m=5cb0fc8bc;t=5a488aeaa1130;x=ccbe23f507e8d0a4", cp.Position)
+	assert.Equal(t, uint64(1588281836441904), cp.RealtimeTimestamp)
+	assert.Equal(t, uint64(24881645756), cp.MonotonicTimestamp)
+}
+
+func TestFailOnIncompatibleTypes(t *testing.T) {
+	t.Run("primitive value to struct fails", func(t *testing.T) {
+		var to struct{ A int }
+		require.Error(t, Convert(&to, 1))
+	})
+
+}
+
+func testDecodeTimestamp(t *testing.T, a, b uint64) time.Time {
+	ts, err := bitsToTimestamp(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}


### PR DESCRIPTION
Cherry-pick of PR #18200 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

The typeconv package provides helpers for converting values between
arbitrary go types, but converting the input value into a stream of
events (e.g. start object, end object events). The stream of events is
applied to the target value. If the source and destination type are
structurally compatible, the operation succeeds. An example for
incompatible types is the 'conversation' from `map[string]interface{}`
into `int`.

## Why is it important?

This package was introduced as part of the new filebeat registry format and input API refactoring. This PR is preparing the move of the new statestore into master.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 
