### PR TITLE
Cherry-pick #18550 to 7.x: [libbeat] Remove global loggers from jsontransform

### DIFF
--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -28,6 +28,7 @@ import (
 
 // WriteJSONKeys writes the json keys to the given event based on the overwriteKeys option and the addErrKey
 func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys bool, addErrKey bool) {
+	logger := logp.NewLogger("jsonhelper")
 	if !overwriteKeys {
 		// @timestamp and @metadata fields are root-level fields. We remove them so they
 		// don't become part of event.Fields.
@@ -43,7 +44,7 @@ func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys
 		case "@timestamp":
 			vstr, ok := v.(string)
 			if !ok {
-				logp.Err("JSON: Won't overwrite @timestamp because value is not string")
+				logger.Error("JSON: Won't overwrite @timestamp because value is not string")
 				event.SetErrorWithOption(createJSONError("@timestamp not overwritten (not string)"), addErrKey)
 				continue
 			}
@@ -51,7 +52,7 @@ func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys
 			// @timestamp must be of format RFC3339
 			ts, err := time.Parse(time.RFC3339, vstr)
 			if err != nil {
-				logp.Err("JSON: Won't overwrite @timestamp because of parsing error: %v", err)
+				logger.Errorf("JSON: Won't overwrite @timestamp because of parsing error: %v", err)
 				event.SetErrorWithOption(createJSONError(fmt.Sprintf("@timestamp not overwritten (parse error on %s)", vstr)), addErrKey)
 				continue
 			}
@@ -74,12 +75,12 @@ func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys
 		case "type":
 			vstr, ok := v.(string)
 			if !ok {
-				logp.Err("JSON: Won't overwrite type because value is not string")
+				logger.Error("JSON: Won't overwrite type because value is not string")
 				event.SetErrorWithOption(createJSONError("type not overwritten (not string)"), addErrKey)
 				continue
 			}
 			if len(vstr) == 0 || vstr[0] == '_' {
-				logp.Err("JSON: Won't overwrite type because value is empty or starts with an underscore")
+				logger.Error("JSON: Won't overwrite type because value is empty or starts with an underscore")
 				event.SetErrorWithOption(createJSONError(fmt.Sprintf("type not overwritten (invalid value [%s])", vstr)), addErrKey)
 				continue
 			}


### PR DESCRIPTION
Cherry-pick of PR #18550 to 7.x branch. Original message: 

This PR is to remove global loggers for libbeat/common/jsontransform. 
Please see https://github.com/elastic/beats/issues/15699 for the meta-issue and more details. 