### PR TITLE
Cherry-pick #18585 to 7.x: Add support for array parsing in azure-eventhub input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -411,7 +411,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for v10, v11 and v12 logs on Postgres {issue}13810[13810] {pull}17732[17732]
 - Add dashboard for Google Cloud Audit and AWS CloudTrail. {pull}17379[17379]
 - Add support for array parsing in azure-eventhub input. {pull}18585[18585]
-- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
 - The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
 - Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
 - Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -410,6 +410,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings in osquery module. {issue}16176[16176] {pull}17881[17881]
 - Add support for v10, v11 and v12 logs on Postgres {issue}13810[13810] {pull}17732[17732]
 - Add dashboard for Google Cloud Audit and AWS CloudTrail. {pull}17379[17379]
+- Add support for array parsing in azure-eventhub input. {pull}18585[18585]
+- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
 - The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
 - Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
 - Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]

--- a/x-pack/filebeat/input/azureeventhub/input.go
+++ b/x-pack/filebeat/input/azureeventhub/input.go
@@ -203,14 +203,32 @@ func (a *azureInput) processEvents(event *eventhub.Event, partitionID string) bo
 
 // parseMultipleMessages will try to split the message into multiple ones based on the group field provided by the configuration
 func (a *azureInput) parseMultipleMessages(bMessage []byte) []string {
-	var obj map[string][]interface{}
-	err := json.Unmarshal(bMessage, &obj)
-	if err != nil {
-		a.log.Errorw(fmt.Sprintf("deserializing multiple messages using the group object `records`"), "error", err)
-	}
+	var mapObject map[string][]interface{}
 	var messages []string
-	if len(obj[expandEventListFromField]) > 0 {
-		for _, ms := range obj[expandEventListFromField] {
+	// check if the message is a "records" object containing a list of events
+	err := json.Unmarshal(bMessage, &mapObject)
+	if err == nil {
+		if len(mapObject[expandEventListFromField]) > 0 {
+			for _, ms := range mapObject[expandEventListFromField] {
+				js, err := json.Marshal(ms)
+				if err == nil {
+					messages = append(messages, string(js))
+				} else {
+					a.log.Errorw(fmt.Sprintf("serializing message %s", ms), "error", err)
+				}
+			}
+		}
+	} else {
+		a.log.Debugf("deserializing multiple messages to a `records` object returning error: %s", err)
+		// in some cases the message is an array
+		var arrayObject []interface{}
+		err = json.Unmarshal(bMessage, &arrayObject)
+		if err != nil {
+			// return entire message
+			a.log.Debugf("deserializing multiple messages to an array returning error: %s", err)
+			return []string{string(bMessage)}
+		}
+		for _, ms := range arrayObject {
 			js, err := json.Marshal(ms)
 			if err == nil {
 				messages = append(messages, string(js))


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#18585 to 7.x branch. Original message:

## What does this PR do?

Adds support to parse array of eventhub messages into separate events.
Expected type was an object containing a list of messages.

## Why is it important?

List of eventhub messages were published in single Elasticsearch event.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Ex before:
```
          "message" : """[{"data":"{\"Id\":\"https://testnamekey.vault.azure.net/keys/weewewew/....\",\"VaultName\":\"testnamekey\",\"ObjectType\":\"Key\",\"ObjectName\":\"weewewew\",\"Version\":\"....\",\"NBF\":null,\"EXP\":null}","dataschema":"#1","id":"tt589454itekjter94oi","source":"/subscriptions/.../resourceGroups/obs-infrastructure/providers/Microsoft.KeyVault/vaults/testnamekey","specversion":"1.0","subject":"weewewew","time":"2020-05-15T12:08:09.616451Z","type":"Microsoft.KeyVault.KeyNewVersionCreated"}]""",
          "azure" : {
            "offset" : 2560,
            "sequence_number" : 3,
            "enqueued_time" : "2020-05-15T12:08:11.232Z",
            "eventhub" : "keyvalut",
            "consumer_group" : "test"
          },
          "input" : {
            "type" : "azure-eventhub"
          }
        },
```
to:
```
          "message" : """{"data":"{\"Id\":\"https://testnamekey.vault.azure.net/keys/weewewew/....\",\"VaultName\":\"testnamekey\",\"ObjectType\":\"Key\",\"ObjectName\":\"weewewew\",\"Version\":\"tt589454itekjter94oi\",\"NBF\":null,\"EXP\":null}","dataschema":"#1","id":"....","source":"/subscriptions/...../resourceGroups/obs-infrastructure/providers/Microsoft.KeyVault/vaults/testnamekey","specversion":"1.0","subject":"weewewew","time":"2020-05-15T12:08:09.616451Z","type":"Microsoft.KeyVault.KeyNewVersionCreated"}""",
          "azure" : {
            "offset" : 2560,
            "sequence_number" : 3,
            "enqueued_time" : "2020-05-15T12:08:11.232Z",
            "eventhub" : "keyvalut",
            "consumer_group" : "test"
          },
          "input" : {
            "type" : "azure-eventhub"
          }
        },
```

