### PR TITLE
Cherry-pick #16733 to 7.x: [Metricbeat] Rename tags to tags_filter for cloudwatch metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -535,7 +535,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Journalbeat*
 
 *Metricbeat*
-
+- Deprecate tags config parameter in cloudwatch metricset. {pull}16733[16733]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #16733 to 7.x branch. Original message: 

This PR is to deprecate `tags` in cloudwatch metricset config. This is replaced by `tags_filter`, which is a metricset level config parameter for all metricsets under aws module. 