### PR TITLE
[WIP] Adding the other selectors for debug output

### DIFF
--- a/libbeat/docs/debugging.asciidoc
+++ b/libbeat/docs/debugging.asciidoc
@@ -35,6 +35,8 @@ with the `publish` selector like this:
 {beatname_lc} -e -d "publish"
 ------------------------------------------------------------
 
+Other selectors are `beat` and `service`
+
 If you want all the debugging output (fair warning, it's quite a lot), you can
 use `*`, like this:
 


### PR DESCRIPTION


cc: @evkortright @jenyphur @bmorelli25

## What does this PR do?

The reference Beat configs (e.g., filebeat.reference.yml) list all of the debug selectors, but the docs and --help do not.  Adding to the docs.  

## Why is it important?

question came up in training course

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [n/a, already there] I have made corresponding change to the default configuration files
- [n/a, but I did test] I have added tests that prove my fix is effective or that my feature works
- [n/a] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


