### PR TITLE
[docs] Fix broken doc structure

### DIFF
--- a/libbeat/docs/outputs-list.asciidoc
+++ b/libbeat/docs/outputs-list.asciidoc
@@ -83,5 +83,9 @@ ifdef::requires_xpack[]
 endif::[]
 include::{libbeat-outputs-dir}/codec/docs/codec.asciidoc[]
 endif::[]
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 
 //# end::outputs-include[]

--- a/libbeat/docs/shared-kerberos-config.asciidoc
+++ b/libbeat/docs/shared-kerberos-config.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Kerberos</titleabbrev>
 ++++
 
-You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
+You can specify Kerberos options with any output or input that supports Kerberos, like {es}.
 
 The following encryption types are supported:
 
@@ -86,4 +86,3 @@ This option can only be configured for Kafka. It is the name of the Kafka servic
 ==== `realm`
 
 Name of the realm where the output resides.
-

--- a/libbeat/docs/shared-kerberos-config.asciidoc
+++ b/libbeat/docs/shared-kerberos-config.asciidoc
@@ -1,6 +1,10 @@
 [[configuration-kerberos]]
 == Configure Kerberos
 
+++++
+<titleabbrev>Kerberos</titleabbrev>
+++++
+
 You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
 
 The following encryption types are supported:

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -682,5 +682,3 @@ See <<configuration-ssl>> for more information.
 Configuration options for Kerberos authentication.
 
 See <<configuration-kerberos>> for more information.
-
-include::{libbeat-dir}/shared-kerberos-config.asciidoc[]


### PR DESCRIPTION
Fixes broken doc structure introduced with https://github.com/elastic/beats/pull/17927.

Before (note that all outputs but ES are nested under the Kerberos topic):

![image](https://user-images.githubusercontent.com/14206422/82497010-736b1b00-9aa2-11ea-9d2e-ff19563b986c.png)


After:

![image](https://user-images.githubusercontent.com/14206422/82496910-4cace480-9aa2-11ea-90bf-8a784fee5b48.png)
