### PR TITLE
Include name of S3 bucket when logging S3 processing error

### DIFF
--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -391,7 +391,7 @@ func (p *s3Input) handleS3Objects(svc s3iface.ClientAPI, s3Infos []s3Info, errC 
 		p.logger.Debugf("Processing file from s3 bucket \"%s\" with name \"%s\"", info.name, info.key)
 		err := p.createEventsFromS3Info(svc, info, s3Ctx)
 		if err != nil {
-			err = errors.Wrapf(err, "createEventsFromS3Info failed for %v", info.key)
+			err = errors.Wrapf(err, "createEventsFromS3Info failed processing file from s3 bucket \"%s\" with name \"%s\"", info.name, info.key)
 			p.logger.Error(err)
 			s3Ctx.setError(err)
 		}


### PR DESCRIPTION
Enhancement

## What does this PR do?

Include name of S3 bucket in error logs when processing fails with s3 input plugin.

## Why is it important?

One possible wrapped error says `The specified bucket does not exist` and this is particularly difficult to troubleshoot when the bucket name is not given. I know that I can get the bucket name by running with logging.level:debug, but that's not helpful when I really need it from the moment of failure. Full error line below:

```
2020-05-20T21:56:52.119Z	ERROR	[s3]	s3/input.go:386	createEventsFromS3Info failed for AWSLogs/123456789/CloudFront/AB8B8BA8S8D.2020-05-19-22.6400e81a.gz: s3 get object request failed: NoSuchBucket: The specified bucket does not exist
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~