### PR TITLE
[7.x] [docs] Fix broken doc structure (#18677)

### DIFF
--- a/libbeat/docs/outputs-list.asciidoc
+++ b/libbeat/docs/outputs-list.asciidoc
@@ -83,5 +83,9 @@ ifdef::requires_xpack[]
 endif::[]
 include::{libbeat-outputs-dir}/codec/docs/codec.asciidoc[]
 endif::[]
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 
 //# end::outputs-include[]

--- a/libbeat/docs/shared-kerberos-config.asciidoc
+++ b/libbeat/docs/shared-kerberos-config.asciidoc
@@ -1,7 +1,11 @@
 [[configuration-kerberos]]
 == Configure Kerberos
 
-You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
+++++
+<titleabbrev>Kerberos</titleabbrev>
+++++
+
+You can specify Kerberos options with any output or input that supports Kerberos, like {es}.
 
 The following encryption types are supported:
 
@@ -82,4 +86,3 @@ This option can only be configured for Kafka. It is the name of the Kafka servic
 ==== `realm`
 
 Name of the realm where the output resides.
-

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -682,5 +682,3 @@ See <<configuration-ssl>> for more information.
 Configuration options for Kerberos authentication.
 
 See <<configuration-kerberos>> for more information.
-
-include::{libbeat-dir}/shared-kerberos-config.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Fix broken doc structure (#18677)