### PR TITLE
Cherry-pick #18564 to 7.8: [Autodiscover] Check if runner is already running before starting again

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -113,7 +113,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
 - Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
 - [Autodiscover] Check if runner is already running before starting again. {pull}18564[18564]
-- Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,6 +112,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix panic when assigning a key to a `nil` value in an event. {pull}18143[18143]
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
 - Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
+- [Autodiscover] Check if runner is already running before starting again. {pull}18564[18564]
+- Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
 
 *Auditbeat*
 

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -70,7 +70,7 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 			continue
 		}
 
-		if _, ok := stopList[hash]; ok {
+		if _, ok := r.runners[hash]; ok {
 			delete(stopList, hash)
 		} else {
 			startList[hash] = config

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -103,6 +103,28 @@ func TestReloadSameConfigs(t *testing.T) {
 	assert.Equal(t, state, list.copyRunnerList())
 }
 
+func TestReloadDuplicateConfig(t *testing.T) {
+	factory := &runnerFactory{}
+	list := NewRunnerList("", factory, nil)
+
+	list.Reload([]*reload.ConfigWithMeta{
+		createConfig(1),
+	})
+
+	state := list.copyRunnerList()
+	assert.Equal(t, len(state), 1)
+
+	// This can happen in Autodiscover when a container if getting restarted
+	// but the previous one is not cleaned yet.
+	list.Reload([]*reload.ConfigWithMeta{
+		createConfig(1),
+		createConfig(1),
+	})
+
+	// nothing changed
+	assert.Equal(t, state, list.copyRunnerList())
+}
+
 func TestReloadStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)


### PR DESCRIPTION
Cherry-pick of PR #18564 to 7.8 branch. Original message: 

## What does this PR do?
This PR fixes runner reload so as not to start a new runner if a runner for the same configuration is already running. This can happen in Autodiscover if we have a container queued for termination and a new one with the very same configuration. This will lead into having 2 identical configurations in reload. The first one will be skipped but the second one will create new runner while the previous is still running. This is the tricky `if/else` block that cause this problem when we have 2 identical configurations: https://github.com/elastic/beats/blob/e99074029172a9c6d01f953005c3cdc2b58d6cb2/libbeat/cfgfile/list.go#L73

For more information check the related Discuss topic: https://discuss.elastic.co/t/multiple-monitoring-cycles-after-recreating-docker-image/231565/9

## Why is it important?
In case of autodiscovery catches a new start event will try to start a new runner without checking if a runner is already running. This will lead in overriding the in list of runner the old one with the new one without stoping the old one. The result will be to have 2 runners running (one will be orphan and untracked).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Enable autodiscover:
```
metricbeat.autodiscover:
  providers:
    - type: docker
      templates:
        - condition:
            contains:
              docker.container.image: prometheus
          config:
            - module: prometheus
              metricsets: ["collector"]
              hosts: "${data.host}:${data.port}"
```
2. Start Metricbeat: `./metricbeat -e -d "module,autodiscover"`
3. Start a container that matches the template using this docker-compose project: https://github.com/ChrsMark/docker-prometheus-playground
4. Edit the Prometheus service by adding a new label on it:
```
  prometheus:
    labels:
    - "some=Some"
```
5. Restart the service with `docker-compose up -d`
6. Verify that no new runner start:
There is no: `2020-05-15T08:25:01.563Z	DEBUG	[module]	module/wrapper.go:127	Starting Wrapper[name=prometheus, len(metricSetWrappers)=1]`
And there is: 
```
2020-05-21T07:47:11.487Z	DEBUG	[autodiscover]	cfgfile/list.go:62	Starting reload procedure, current runners: 1
2020-05-21T07:47:11.487Z	DEBUG	[autodiscover]	cfgfile/list.go:80	Start list: 0, Stop list: 0
```

## Related issues
Discuss: https://discuss.elastic.co/t/multiple-monitoring-cycles-after-recreating-docker-image/231565/9

This might solve https://github.com/elastic/beats/issues/12011 too.