### PR TITLE
WIP: honor MODULE env var in Filebeat system tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1224,6 +1224,7 @@ def loadConfigEnvVars(){
   // For such, it's required to look for changes under the module folder and exclude anything else
   // such as ascidoc and png files.
   env.MODULE = getGitMatchingGroup(pattern: '[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*', exclude: '^(((?!\\/module\\/).)*$|.*\\.asciidoc|.*\\.png)')
+  env.TESTING_FILEBEAT_MODULES = env.MODULE
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Makes the Filebeat module system tests honor the `MODULE` environment variable.

## Why is it important?

In https://github.com/elastic/beats/pull/18592 we introduced the `MODULE` environment variable. The idea was that when tests are run in a CI environment, if the PR being tested only contains changes for a single module, the `MODULE` environment variable would be set to the name of that module. This should help speed up the CI build as unrelated tests wouldn't get run.

The Filebeat system tests are currently not honoring the `MODULE` environment variable. This PR teaches them to do that.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
