### PR TITLE
[Auditbeat] System: Document `entity_id` fields

### DIFF
--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -38,6 +38,26 @@ The frequency of these polls is controlled by the `period` configuration
 parameter.
 
 [float]
+==== Entity IDs
+
+This module populates `entity_id` fields to uniquely identify entities (users,
+packages, processes...) within a host. This requires {beatname_uc}
+to obtain a unique identifier for the host:
+
+- Windows: Uses the `HKLM\Software\Microsoft\Cryptography\MachineGuid` registry
+key.
+- macOS: Uses the value returned by `gethostuuid(2)` system call.
+- Linux: Uses the content of one of the following files, created by either
+`systemd` or `dbus`:
+ * /etc/machine-id
+ * /var/lib/dbus/machine-id
+ * /var/db/dbus/machine-id
+
+NOTE: Under CentOS 6.x, it's possible that none of the files above exist.
+In that case, running `dbus-uuidgen --ensure` (provided by the `dbus` package)
+will generate one for you.
+
+[float]
 ==== Example dashboard
 
 The module comes with a sample dashboard:

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -31,6 +31,26 @@ The frequency of these polls is controlled by the `period` configuration
 parameter.
 
 [float]
+==== Entity IDs
+
+This module populates `entity_id` fields to uniquely identify entities (users,
+packages, processes...) within a host. This requires {beatname_uc}
+to obtain a unique identifier for the host:
+
+- Windows: Uses the `HKLM\Software\Microsoft\Cryptography\MachineGuid` registry
+key.
+- macOS: Uses the value returned by `gethostuuid(2)` system call.
+- Linux: Uses the content of one of the following files, created by either
+`systemd` or `dbus`:
+ * /etc/machine-id
+ * /var/lib/dbus/machine-id
+ * /var/db/dbus/machine-id
+
+NOTE: Under CentOS 6.x, it's possible that none of the files above exist.
+In that case, running `dbus-uuidgen --ensure` (provided by the `dbus` package)
+will generate one for you.
+
+[float]
 ==== Example dashboard
 
 The module comes with a sample dashboard:


### PR DESCRIPTION
## What does this PR do?

Update Auditbeat's `system` module docs:
- Document `entity_id` fields.
- Explain host ID sources for different OSes.
- Add workaround for CentOS 6

## Why is it important?

Because users could get confused by the following warning, not finding anything related to host ID or entity_id fields in the docs:
> WARN [system] system/system.go:64 Could not get host ID, will not fill entity_id fields.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- [ ] Check for style and typos

## How to test this PR locally

Run `make docs-preview` in `{BEATS}/auditbeat` (NOT `{BEATS}/x-pack/auditbeat`).

## Screenshots

<img width="771" alt="image" src="https://user-images.githubusercontent.com/15056957/82574028-d33af200-9b86-11ea-981a-491d9fd2c866.png">
