### PR TITLE
[7.x] [docs] Update links to the Logstash getting started (#18672)

### DIFF
--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -15,9 +15,9 @@ generated events.
 .Prerequisite
 To send events to {ls}, you also need to create a {ls} configuration pipeline
 that listens for incoming Beats connections and indexes the received events into
-{es}. For more information, see the section about
-{stack-gs}/get-started-elastic-stack.html#logstash-setup[configuring {ls}] in
-the {stack} getting started tutorial. Also see the documentation for the
+{es}. For more information, see
+{logstash-ref}/getting-started-with-logstash.html[Getting Started with {ls}].
+Also see the documentation for the
 {logstash-ref}/plugins-inputs-beats.html[{beats} input] and
 {logstash-ref}/plugins-outputs-elasticsearch.html[{es} output] plugins.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Update links to the Logstash getting started (#18672)