### PR TITLE
Fix byte counters for source/destination/server/client

### DIFF
--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -73,9 +73,9 @@ processors:
         event.outcome: 30
         network.bytes: 31
         client.bytes: 32
-        destination.bytes: 32
+        source.bytes: 32
         server.bytes: 33
-        source.bytes: 33
+        destination.bytes: 33
         network.packets: 34
         event.start: 35
         event.duration: 36


### PR DESCRIPTION
- Bug

## What does this PR do?

The original code mixes source/destination/server/client for byte counters.
Original:
        client.bytes: 32
        destination.bytes: 32
        server.bytes: 33
        source.bytes: 33
But client is source, not destination.
Fix is:
        client.bytes: 32
        source.bytes: 32
        server.bytes: 33
        destination.bytes: 33

## Why is it important?

Because with original code source and destination counters are wrong.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
