### PR TITLE
Report if index is hidden in index stats

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -534,6 +534,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for named ports in autodiscover. {pull}19398[19398]
 - Add param `aws_partition` to support aws-cn, aws-us-gov regions. {issue}18850[18850] {pull}19423[19423]
 - The `elasticsearch/index` metricset now collects metrics for hidden indices as well. {issue}18639[18639] {pull}18703[18703]
+- The `elasticsearch-xpack/index` metricset now reports hidden indices as such. {issue}18639[18639] {pull}18706[18706]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -379,7 +379,7 @@ func (b *boolStr) UnmarshalJSON(raw []byte) error {
 }
 
 type IndexSettings struct {
-	Hidden boolStr
+	Hidden bool
 }
 
 // GetIndicesSettings returns a map of index names to their settings.
@@ -394,7 +394,9 @@ func GetIndicesSettings(http *helper.HTTP, resetURI string) (map[string]IndexSet
 
 	var resp map[string]struct {
 		Settings struct {
-			Index IndexSettings `json:"index"`
+			Index struct {
+				Hidden boolStr `json:"hidden"`
+			} `json:"index"`
 		} `json:"settings"`
 	}
 
@@ -405,7 +407,9 @@ func GetIndicesSettings(http *helper.HTTP, resetURI string) (map[string]IndexSet
 
 	ret := make(map[string]IndexSettings, len(resp))
 	for index, settings := range resp {
-		ret[index] = settings.Settings.Index
+		ret[index] = IndexSettings{
+			Hidden: bool(settings.Settings.Index.Hidden),
+		}
 	}
 
 	return ret, nil

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -592,7 +592,6 @@ func ingestAndEnrichDoc(host string) error {
 
 func countIndices(elasticsearchHostPort string) (int, error) {
 	return countCatItems(elasticsearchHostPort, "indices", "&expand_wildcards=open,hidden")
-
 }
 
 func countShards(elasticsearchHostPort string) (int, error) {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -226,8 +226,10 @@ func TestGetAllIndices(t *testing.T) {
 			switch idx.Index {
 			case indexVisible:
 				idxVisibleExists = true
+				require.False(t, idx.Hidden)
 			case indexHidden:
 				idxHiddenExists = true
+				require.True(t, idx.Hidden)
 			}
 		}
 

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -154,7 +154,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 
 		settings, exists := indicesSettings[name]
 		if exists {
-			idx.Hidden = settings.Hidden
+			idx.Hidden = bool(settings.Hidden)
 		}
 
 		err = addClusterStateFields(&idx, clusterState)

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -154,7 +154,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 
 		settings, exists := indicesSettings[name]
 		if exists {
-			idx.Hidden = bool(settings.Hidden)
+			idx.Hidden = settings.Hidden
 		}
 
 		err = addClusterStateFields(&idx, clusterState)


### PR DESCRIPTION
## What does this PR do?

Enhances the `elasticsearch/index` metricset to report if an index is hidden or not. 

## Why is it important?

This will allow the Stack Monitoring UI to suitably mark the index in the UI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes elastic/beats#18639 
