### PR TITLE
Cherry-pick #18656 to 7.x: Clean action store after enrolling to new configuration 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 - Fix jq: command not found {pull}18408[18408]
 - Avoid Chown on windows {pull}18512[18512]
 - Remove fleet admin from setup script {pull}18611[18611]
+- Clean action store after enrolling to new configuration {pull}18656[18656]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"gopkg.in/yaml.v2"
 
@@ -176,6 +177,12 @@ func (c *EnrollCmd) Execute() error {
 	}
 
 	if _, err := info.NewAgentInfo(); err != nil {
+		return err
+	}
+
+	// clear action store
+	// fail only if file exists and there was a failure
+	if err := os.Remove(info.AgentActionStoreFile()); !os.IsNotExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #18656 to 7.x branch. Original message:

## What does this PR do?

Removes an `action_store` file after agent enrolls to a new config. 

## Why is it important?

Gets rid of error messages which are related to old configuration and wont go away

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #17389