### PR TITLE
Cherry-pick #18714 to 7.x: Add clarification about indexers/matchers in add_kubernetes_metadata

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -53,16 +53,24 @@ examples in <<kubernetes-indexers-and-matchers>>.
 The configuration below enables the processor when {beatname_lc} is run as a pod in
 Kubernetes.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 -------------------------------------------------------------------------------
 processors:
   - add_kubernetes_metadata:
+ifndef::kubernetes_default_indexers[]
+      # Defining indexers and matchers manually is required for {beatname_lc}, for instance:
+      #indexers:
+      #  - ip_port:
+      #matchers:
+      #  - fields:
+      #      lookup_fields: ["metricset.host"]
+endif::kubernetes_default_indexers[]
 -------------------------------------------------------------------------------
 
 The configuration below enables the processor on a Beat running as a process on
 the Kubernetes node.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 -------------------------------------------------------------------------------
 processors:
   - add_kubernetes_metadata:
@@ -70,6 +78,14 @@ processors:
       # If kube_config is not set, KUBECONFIG environment variable will be checked
       # and if not present it will fall back to InCluster
       kube_config: ${HOME}/.kube/config
+ifndef::kubernetes_default_indexers[]
+      # Defining indexers and matchers manually is required for {beatname_lc}, for instance:
+      #indexers:
+      #  - ip_port:
+      #matchers:
+      #  - fields:
+      #      lookup_fields: ["metricset.host"]
+endif::kubernetes_default_indexers[]
 -------------------------------------------------------------------------------
 
 The configuration below has the default indexers and matchers disabled and


### PR DESCRIPTION
Cherry-pick of PR #18714 to 7.x branch. Original message: 

## What does this PR do?
This PR improves the documentation of `add_kubernetes_metadata` processor regarding the importance of indexers/matches in some Beats like Heartbeat.

## Why is it important?
Only Filebeat and Metricbeat have default indexers and matchers. A beat like Heartbeat is not able to start without defining matchers:
```
2020-05-21T13:10:19.192Z        INFO    add_kubernetes_metadata/kubernetes.go:71        add_kubernetes_metadata: kubernetes env detected, with version: v1.15.9-gke.24
2020-05-21T13:10:19.192Z        DEBUG   [kubernetes]    add_kubernetes_metadata/kubernetes.go:145       Could not initialize kubernetes plugin with zero matcher plugins        {"libbeat.processor": "add_kubernetes_metadata"}
```
We need to make it clear in the docs, to avoid confusion.

cc: @exekias @david-kow 