### PR TITLE
Fix bdist during installation of Python requirements

### DIFF
--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -213,7 +213,7 @@ func PythonVirtualenv() (string, error) {
 	// First ensure that wheel is installed so that
 	// bdists build cleanly
 	wheelArgs := []string{"install"}
-	wheelArgs = append(wheelArgs, "-Ur", "wheel")
+	wheelArgs = append(wheelArgs, "-U", "wheel")
 	if err := sh.RunWith(env, pip, wheelArgs...); err != nil {
 		return "", err
 	}

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -210,6 +210,13 @@ func PythonVirtualenv() (string, error) {
 		args = append(args, "-Ur", req)
 	}
 
+    // First ensure that wheel is installed so that
+    // bdists build cleanly
+    wheel_args := append(args, "-Ur", "wheel")
+	if err := sh.RunWith(env, pip, wheel_args...); err != nil {
+		return "", err
+	}
+
 	// Execute pip to install the dependencies.
 	if err := sh.RunWith(env, pip, args...); err != nil {
 		return "", err

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -210,10 +210,8 @@ func PythonVirtualenv() (string, error) {
 		args = append(args, "-Ur", req)
 	}
 
-	// First ensure that wheel is installed so that
-	// bdists build cleanly
-    wheelArgs := []string{"install", "-U", "wheel"}
-	if err := sh.RunWith(env, pip, wheelArgs...); err != nil {
+	// First ensure that wheel is installed so that bdists build cleanly.
+	if err = sh.RunWith(env, pip, "install", "-U", "wheel"); err != nil {
 		return "", err
 	}
 

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -212,7 +212,8 @@ func PythonVirtualenv() (string, error) {
 
     // First ensure that wheel is installed so that
     // bdists build cleanly
-    wheel_args := append(args, "-Ur", "wheel")
+	wheel_args := []string{"install"}
+    wheel_args = append(wheel_args, "-Ur", "wheel")
 	if err := sh.RunWith(env, pip, wheel_args...); err != nil {
 		return "", err
 	}

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -210,11 +210,11 @@ func PythonVirtualenv() (string, error) {
 		args = append(args, "-Ur", req)
 	}
 
-    // First ensure that wheel is installed so that
-    // bdists build cleanly
-	wheel_args := []string{"install"}
-    wheel_args = append(wheel_args, "-Ur", "wheel")
-	if err := sh.RunWith(env, pip, wheel_args...); err != nil {
+	// First ensure that wheel is installed so that
+	// bdists build cleanly
+	wheelArgs := []string{"install"}
+	wheelArgs = append(wheelArgs, "-Ur", "wheel")
+	if err := sh.RunWith(env, pip, wheelArgs...); err != nil {
 		return "", err
 	}
 

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -212,8 +212,7 @@ func PythonVirtualenv() (string, error) {
 
 	// First ensure that wheel is installed so that
 	// bdists build cleanly
-	wheelArgs := []string{"install"}
-	wheelArgs = append(wheelArgs, "-U", "wheel")
+    wheelArgs := []string{"install", "-U", "wheel"}
 	if err := sh.RunWith(env, pip, wheelArgs...); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR addresses an issue in the build system which produces errors similar to the following:

```
09:10:15  Building wheels for collected packages: autopep8, backports.ssl-match-hostname, dockerpty, docopt, ipaddress, MarkupSafe, nose-timer, PyYAML, termcolor, texttable, jsondiff, stomp.py, ordered-set
09:10:15    Running setup.py bdist_wheel for autopep8: started
09:10:15    Running setup.py bdist_wheel for autopep8: finished with status 'error'
09:10:15    Complete output from command /tmp/tmp.mtLXh51exX/python-env/build/ve/linux/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-a_wqse9r/autopep8/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpxy52gjolpip-wheel- --python-tag cp36:
09:10:15    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
09:10:15       or: -c --help [cmd1 cmd2 ...]
09:10:15       or: -c --help-commands
09:10:15       or: -c cmd --help
09:10:15    
09:10:15    error: invalid command 'bdist_wheel'
09:10:15    
09:10:15    ----------------------------------------
09:10:15    Failed building wheel for autopep8
09:10:15    Running setup.py clean for autopep8
09:10:15    Running setup.py bdist_wheel for backports.ssl-match-hostname: started
09:10:16    Running setup.py bdist_wheel for backports.ssl-match-hostname: finished with status 'error'
09:10:16    Complete output from command /tmp/tmp.mtLXh51exX/python-env/build/ve/linux/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-a_wqse9r/backports.ssl-match-hostname/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpzd52u8z1pip-wheel- --python-tag cp36:
09:10:16    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
09:10:16       or: -c --help [cmd1 cmd2 ...]
09:10:16       or: -c --help-commands
09:10:16       or: -c cmd --help
09:10:16    
09:10:16    error: invalid command 'bdist_wheel'
```

Note that these errors are from the APM CI where they have been discovered in builds for the APM Server project but the source of the errors appears to stem from libbeat. 

A full discussion and background on this issue can be found here: https://github.com/elastic/apm-server/issues/3661

## Cause and resolution

I believe this [may have been introduced during the migration to Python 3](https://github.com/elastic/beats/pull/14798) but I don't have a test history that goes back far enough to confirm this.

This is a difficult-to-reproduce problem and I have yet to be able to do so locally. However, it seems clear that the issue is that the `wheel` Python package needs to be present in order for the wheels to be created. This fix attempts to simply simply tell `pip` to install `wheel` into the newly-created virtual environment before it proceeds with installing packages from the requirements file. 

## Why is it important?

Fixes errors found in the CI on package which depend on `libbeat`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

I haven't found a way to just run the `PythonVirtualenv` target with mage but I did run `mage pythonUnitTest` which does seem to exercise this code path.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/apm-server/issues/3661
