### PR TITLE
filebeat: support reading gzip-compressed batches from google-pubsub

### DIFF
--- a/x-pack/filebeat/input/googlepubsub/input.go
+++ b/x-pack/filebeat/input/googlepubsub/input.go
@@ -177,7 +177,7 @@ func (in *pubsubInput) run() error {
 		}
 
 		var rawRecords [][]byte
-		if msg.Attributes["filebeat.ndjson"] == "true" {
+		if msg.Attributes["filebeat.multiline"] == "true" {
 			rawRecords = bytes.Split(msg.Data, []byte("\n"))
 		} else {
 			rawRecords = [][]byte{msg.Data}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This patch introduces two features to filebeat's `google-pubsub` input designed to work together: compression and batching.

It uses gzip for the (de-)compression, and newline delimiters (e.g. ndjson) for the batching.

Gzip was chosen because it's ubiquitous. Though the design is flexible enough to allow other algorithms to be supported in the future.

The batching was added to allow compression across multiple events, since that's where it will be most effective. I was unable to find a way to perform this splitting with processors, but if there is a more general solution to it, I'd love to change that part.

Configuration: Instead of using a config flag, it works based on attributes added to the `pubsub.Message`. This allows for forward- and backward-compatibility. Once the patched version of filebeat is deployed, the features can be toggled on the sender side.

It's based on a series of similar patches to pubsubbeat: https://github.com/GoogleCloudPlatform/pubsubbeat/pull/44, https://github.com/GoogleCloudPlatform/pubsubbeat/pull/45.

One thing we noticed while profiling pubsubbeat is that there is lock contention on `beat.client.Publish()` (https://github.com/GoogleCloudPlatform/pubsubbeat/pull/40). It's likely that filebeat suffers from this too. Batching at the input stage presents an opportunity to improve that by using `beat.client.PublishAll()` -- though this may be trickier to change in filebeat, because the current interface for Outletter is still constrained to one-event-at-a-time.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The main reason is [reducing costs](https://cloud.google.com/pubsub/pricing) on pubsub. The service is priced per byte published and delivered. Thus, there is an incentive to reduce the size of messages.

Compression: We can reduce the size of messages by applying compression. Effectively trading CPU resources for a size reduction. Decompression is cheap, the CPU cost is mostly paid when compressing.

Batching: In order for compression to be effective, we need to compress across events. Thus it makes sense to batch multiple events into a single pubsub message.

Most logs are in text or JSON format and thus highly compressible.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Gather initial feedback on the overall idea and design
- [ ] Write tests for this implementation

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Here is a mock-up that was used to test an earlier version of this patch:

```
pubsub = (Gcloud.new @project, @key).pubsub
@client = pubsub.topic @topic

# before

@client.publish do |batch|
  msgs.each do |m|
    batch.publish m
  end
end

# after

batched = msgs.join("\n")
compressed = Zlib.gzip(batched, level: @gzip_level)
@client.publish(
  compressed,
  'filebeat.multiline' => 'true',
  'filebeat.compression' => 'gzip'
)
```

More test cases and scripts will follow if there is agreement on the general approach.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/GoogleCloudPlatform/pubsubbeat/pull/44, https://github.com/GoogleCloudPlatform/pubsubbeat/pull/45
- Relates https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/10219

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
