### PR TITLE
Don't send bulk structure, if empty

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -65,7 +65,7 @@ type indexStats struct {
 		IndexTimeInMillis    int `json:"index_time_in_millis"`
 		ThrottleTimeInMillis int `json:"throttle_time_in_millis"`
 	} `json:"indexing"`
-	Bulk   bulkStats `json:"bulk"`
+	Bulk   *bulkStats `json:"bulk,omitempty"`
 	Merges struct {
 		TotalSizeInBytes int `json:"total_size_in_bytes"`
 	} `json:"merges"`


### PR DESCRIPTION
## What does this PR do?

Omits the `index_stats.total.bulk` and `index_stats.primaries.bulk` fields if they are empty.

## Why is it important?

We only collect `bulk` metrics from versions of Elasticsearch that offer them in the `GET _stats` API. For other versions, there's no point in reporting empty `bulk` metrics.