### PR TITLE
Change decode json failed from warning to error to keep the SQS message

### DIFF
--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -533,7 +533,8 @@ func (p *s3Input) decodeJSONWithKey(decoder *json.Decoder, objectHash string, s3
 				}
 			}
 		} else if err != nil {
-			// decode json failed, skip this file for now and put the SQS message back into the queue.
+			// decode json failed, skip this file for now and put the SQS
+			// message back into the queue after visibility timeout runs out.
 			err = errors.Wrapf(err, fmt.Sprintf("Decode json failed for '%s', skipping this file", s3Info.key))
 			p.logger.Error(err)
 			return err

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -533,9 +533,10 @@ func (p *s3Input) decodeJSONWithKey(decoder *json.Decoder, objectHash string, s3
 				}
 			}
 		} else if err != nil {
-			// decode json failed, skip this log file
-			p.logger.Warnf(fmt.Sprintf("Decode json failed for '%s', skipping this file: %s", s3Info.key, err))
-			return nil
+			// decode json failed, skip this file for now and put the SQS message back into the queue.
+			err = errors.Wrapf(err, fmt.Sprintf("Decode json failed for '%s', skipping this file", s3Info.key))
+			p.logger.Error(err)
+			return err
 		}
 
 		textValues, ok := jsonFields[p.config.ExpandEventListFromField]


### PR DESCRIPTION
When decode json failed in S3 input on a log file, report this error message and send the SQS message back to the queue instead of deleting it. 