### PR TITLE
WIP: Add a way to test autodiscover

### DIFF
--- a/libbeat/cmd/test/autodiscover.go
+++ b/libbeat/cmd/test/autodiscover.go
@@ -15,25 +15,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmd
+package test
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/cmd/instance"
-	"github.com/elastic/beats/v7/libbeat/cmd/test"
 )
 
-func genTestCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
-	exportCmd := &cobra.Command{
-		Use:   "test",
-		Short: "Test config",
+func GenTestAutodiscoverCmd() *cobra.Command {
+	configTestCmd := cobra.Command{
+		Use:   "autodiscover",
+		Short: "Test autodiscover configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: test autodiscover
+			//b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
+			//if err != nil {
+			//	fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
+			//	os.Exit(1)
+			//}
+
+			//if err = b.TestConfig(settings, beatCreator); err != nil {
+			//	os.Exit(1)
+			//}
+		},
 	}
 
-	exportCmd.AddCommand(test.GenTestConfigCmd(settings, beatCreator))
-	exportCmd.AddCommand(test.GenTestOutputCmd(settings))
-	exportCmd.AddCommand(test.GenTestAutodiscoverCmd()) // TODO: pass any necessary args
-
-	return exportCmd
+	return &configTestCmd
 }


### PR DESCRIPTION
## What does this PR do?

Adds a way for users to test their Beat's autodiscover configuration.

## Why is it important?

Configuring autodiscover templates may be challenging sometimes. This PR provides tooling to make the configuration process easier for users.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #17922.
