### PR TITLE
Cherry-pick #18723 to 7.8: Avoid watching monitor logs 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 - Fix jq: command not found {pull}18408[18408]
 - Avoid Chown on windows {pull}18512[18512]
 - Clean action store after enrolling to new configuration {pull}18656[18656]
+ [Ingest Manager] Avoid watching monitor logs {pull}18723[18723]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@
 - Fix jq: command not found {pull}18408[18408]
 - Avoid Chown on windows {pull}18512[18512]
 - Clean action store after enrolling to new configuration {pull}18656[18656]
- [Ingest Manager] Avoid watching monitor logs {pull}18723[18723]
+- Avoid watching monitor logs {pull}18723[18723]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/stateresolver"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring"
 	monitoringConfig "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
@@ -137,9 +138,11 @@ type testMonitorableApp struct {
 	monitor monitoring.Monitor
 }
 
-func (*testMonitorableApp) Name() string                                              { return "" }
-func (*testMonitorableApp) Start(_ context.Context, cfg map[string]interface{}) error { return nil }
-func (*testMonitorableApp) Stop()                                                     {}
+func (*testMonitorableApp) Name() string { return "" }
+func (*testMonitorableApp) Start(_ context.Context, _ app.Taggable, cfg map[string]interface{}) error {
+	return nil
+}
+func (*testMonitorableApp) Stop() {}
 func (*testMonitorableApp) Configure(_ context.Context, config map[string]interface{}) error {
 	return nil
 }
@@ -153,7 +156,7 @@ type testMonitor struct {
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *testMonitor) EnrichArgs(_ string, _ string, args []string) []string { return args }
+func (b *testMonitor) EnrichArgs(_ string, _ string, args []string, _ bool) []string { return args }
 
 // Cleanup cleans up all drops.
 func (b *testMonitor) Cleanup(string, string) error { return nil }

--- a/x-pack/elastic-agent/pkg/agent/operation/operation.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operation.go
@@ -7,6 +7,7 @@ package operation
 import (
 	"context"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app/monitoring"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/state"
 )
@@ -30,7 +31,7 @@ type operation interface {
 // Application is an application capable of being started, stopped and configured.
 type Application interface {
 	Name() string
-	Start(ctx context.Context, cfg map[string]interface{}) error
+	Start(ctx context.Context, p app.Taggable, cfg map[string]interface{}) error
 	Stop()
 	Configure(ctx context.Context, config map[string]interface{}) error
 	State() state.State
@@ -45,4 +46,5 @@ type Descriptor interface {
 	ID() string
 	Directory() string
 	IsGrpcConfigurable() bool
+	Tags() map[app.Tag]string
 }

--- a/x-pack/elastic-agent/pkg/agent/operation/operation_start.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operation_start.go
@@ -10,15 +10,14 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/operation/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 )
 
 // operationStart start installed process
 // skips if process is already running
 type operationStart struct {
-	program        app.Descriptor
 	logger         *logger.Logger
+	program        Descriptor
 	operatorConfig *config.Config
 	cfg            map[string]interface{}
 	eventProcessor callbackHooks
@@ -28,6 +27,7 @@ type operationStart struct {
 
 func newOperationStart(
 	logger *logger.Logger,
+	program Descriptor,
 	operatorConfig *config.Config,
 	cfg map[string]interface{},
 	eventProcessor callbackHooks) *operationStart {
@@ -35,6 +35,7 @@ func newOperationStart(
 
 	return &operationStart{
 		logger:         logger,
+		program:        program,
 		operatorConfig: operatorConfig,
 		cfg:            cfg,
 		eventProcessor: eventProcessor,
@@ -72,5 +73,5 @@ func (o *operationStart) Run(ctx context.Context, application Application) (err 
 		}
 	}()
 
-	return application.Start(ctx, o.cfg)
+	return application.Start(ctx, o.program, o.cfg)
 }

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -152,7 +152,7 @@ func (o *Operator) start(p Descriptor, cfg map[string]interface{}) (err error) {
 		newOperationFetch(o.logger, p, o.config, o.downloader, o.eventProcessor),
 		newOperationVerify(o.eventProcessor),
 		newOperationInstall(o.logger, p, o.config, o.installer, o.eventProcessor),
-		newOperationStart(o.logger, o.config, cfg, o.eventProcessor),
+		newOperationStart(o.logger, p, o.config, cfg, o.eventProcessor),
 		newOperationConfig(o.logger, o.config, cfg, o.eventProcessor),
 	}
 	return o.runFlow(p, flow)
@@ -180,7 +180,7 @@ func (o *Operator) pushConfig(p Descriptor, cfg map[string]interface{}) error {
 		flow = []operation{
 			// updates a configuration file and restarts a process
 			newOperationStop(o.logger, o.config, o.eventProcessor),
-			newOperationStart(o.logger, o.config, cfg, o.eventProcessor),
+			newOperationStart(o.logger, p, o.config, cfg, o.eventProcessor),
 		}
 	}
 
@@ -263,15 +263,6 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 }
 
 func isMonitorable(descriptor Descriptor) bool {
-	type taggable interface {
-		Tags() map[app.Tag]string
-	}
-
-	if taggable, ok := descriptor.(taggable); ok {
-		tags := taggable.Tags()
-		_, isSidecar := tags[app.TagSidecar]
-		return !isSidecar // everything is monitorable except sidecar
-	}
-
-	return false
+	isSidecar := app.IsSidecar(descriptor)
+	return !isSidecar // everything is monitorable except sidecar
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/app.go
@@ -153,7 +153,7 @@ func (a *Application) State() state.State {
 	return a.state
 }
 
-func (a *Application) watch(ctx context.Context, proc *os.Process, cfg map[string]interface{}) {
+func (a *Application) watch(ctx context.Context, p Taggable, proc *os.Process, cfg map[string]interface{}) {
 	go func() {
 		var procState *os.ProcessState
 
@@ -179,7 +179,7 @@ func (a *Application) watch(ctx context.Context, proc *os.Process, cfg map[strin
 			// it was a crash, report it async not to block
 			// process management with networking issues
 			go a.reportCrash(ctx)
-			a.Start(ctx, cfg)
+			a.Start(ctx, p, cfg)
 		}
 	}()
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/beats/beats_monitor.go
@@ -80,22 +80,30 @@ func (b *Monitor) generateLoggingPath(process, pipelineID string) string {
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *Monitor) EnrichArgs(process, pipelineID string, args []string) []string {
+func (b *Monitor) EnrichArgs(process, pipelineID string, args []string, isSidecar bool) []string {
 	appendix := make([]string, 0, 7)
 
 	monitoringEndpoint := b.generateMonitoringEndpoint(process, pipelineID)
 	if monitoringEndpoint != "" {
+		endpoint := monitoringEndpoint
+		if isSidecar {
+			endpoint += "_monitor"
+		}
 		appendix = append(appendix,
 			"-E", "http.enabled=true",
-			"-E", "http.host="+monitoringEndpoint,
+			"-E", "http.host="+endpoint,
 		)
 	}
 
 	loggingPath := b.generateLoggingPath(process, pipelineID)
 	if loggingPath != "" {
+		logFile := process
+		if isSidecar {
+			logFile += "_monitor"
+		}
 		appendix = append(appendix,
 			"-E", "logging.files.path="+loggingPath,
-			"-E", "logging.files.name="+process,
+			"-E", "logging.files.name="+logFile,
 			"-E", "logging.files.keepfiles=7",
 			"-E", "logging.files.permission=0644",
 			"-E", "logging.files.interval=1h",

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/monitor.go
@@ -18,7 +18,7 @@ type Monitor interface {
 	MetricsPathPrefixed(process, pipelineID string) string
 
 	Prepare(process, pipelineID string, uid, gid int) error
-	EnrichArgs(string, string, []string) []string
+	EnrichArgs(string, string, []string, bool) []string
 	Cleanup(process, pipelineID string) error
 	Reload(cfg *config.Config) error
 	IsMonitoringEnabled() bool

--- a/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop/noop_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/monitoring/noop/noop_monitor.go
@@ -18,7 +18,7 @@ func NewMonitor() *Monitor {
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *Monitor) EnrichArgs(_ string, _ string, args []string) []string {
+func (b *Monitor) EnrichArgs(_ string, _ string, args []string, _ bool) []string {
 	return args
 }
 

--- a/x-pack/elastic-agent/pkg/core/plugin/app/tag.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/tag.go
@@ -10,3 +10,15 @@ type Tag string
 
 // TagSidecar tags a sidecar process
 const TagSidecar = "sidecar"
+
+// Taggable is an object containing tags.
+type Taggable interface {
+	Tags() map[Tag]string
+}
+
+// IsSidecar returns true if tags contains sidecar flag.
+func IsSidecar(descriptor Taggable) bool {
+	tags := descriptor.Tags()
+	_, isSidecar := tags[TagSidecar]
+	return isSidecar
+}


### PR DESCRIPTION
Cherry-pick of PR #18723 to 7.8 branch. Original message:

## What does this PR do?

This PR differentiates beat for its purpose (normal/monitoring) and avoids monitoring output of monitoring beats. 
It does it checking special tags passed in descriptor if tag is present it redirect logs to {original_path}_monitor file/socket so it is not picked up by monitor

## Why is it important?

to lower CPU consumption and avoid publishing monitoring logs about monitored logs

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
