### PR TITLE
Cherry-pick #18346 to 7.x: Enable more granular control of monitoring

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@
 - Fix an issue where the checkin_frequency, jitter, and backoff options where not configurable. {pull}17843[17843]
 - Ensure that the beats uses the params prefer_v2_templates on bulk request. {pull}18318[18318]
 - Stop monitoring on config change {pull}18284[18284]
+- Enable more granular control of monitoring {pull}18346[18346]
 - Fix jq: command not found {pull}18408[18408]
 - Avoid Chown on windows {pull}18512[18512]
 - Remove fleet admin from setup script {pull}18611[18611]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -43,7 +43,7 @@ func TestGenerateSteps(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := &testMonitor{monitorLogs: tc.Config.MonitorLogs, monitorMetrics: tc.Config.MonitorMetrics}
 			operator, _ := getMonitorableTestOperator(t, "tests/scripts", m)
-			steps := operator.generateMonitoringSteps("8.0", sampleOutput, tc.Config.MonitorLogs, tc.Config.MonitorMetrics)
+			steps := operator.generateMonitoringSteps("8.0", sampleOutput)
 			if actualSteps := len(steps); actualSteps != tc.ExpectedSteps {
 				t.Fatalf("invalid number of steps, expected %v, got %v", tc.ExpectedSteps, actualSteps)
 			}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -26,6 +26,11 @@ import (
 	rconfig "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/remoteconfig/grpc"
 )
 
+const (
+	isMonitoringMetricsFlag = 1 << 0
+	isMonitoringLogsFlag    = 1 << 1
+)
+
 // Operator runs Start/Stop/Update operations
 // it is responsible for detecting reconnect to existing processes
 // based on backed up configuration
@@ -40,7 +45,7 @@ type Operator struct {
 	stateResolver  *stateresolver.StateResolver
 	eventProcessor callbackHooks
 	monitor        monitoring.Monitor
-	isMonitoring   bool
+	isMonitoring   int
 
 	apps     map[string]Application
 	appsLock sync.Mutex


### PR DESCRIPTION
Cherry-pick of PR #18346 to 7.x branch. Original message:

## What does this PR do?

Followup to #18284 where i was not happy with the form. this allows more granular control of monitoring especially when on partial failures
Instead of having true/false state of monitoring as a whole, this PR allows agent to keep per type state. As a result steps are not generated if not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #18320