### PR TITLE
S3 input: try to detect GZIPped objects

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -365,6 +365,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
 - Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
 - Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
+- The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -439,7 +439,9 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 
 	isS3ObjGzipped, err := isStreamGzipped(reader)
 	if err != nil {
-		return errors.Wrap(err, "could not determine if S3 object is gzipped")
+		err = errors.Wrap(err, "could not determine if S3 object is gzipped")
+		p.logger.Error(err)
+		return err
 	}
 
 	if isS3ObjGzipped {

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -676,6 +676,10 @@ func (c *s3Context) Inc() {
 	c.refs++
 }
 
+// isStreamGzipped determines whether the given stream of bytes (encapsulated in a buffered reader)
+// represents gzipped content or not. A buffered reader is used so the function can peek into the byte
+// stream without consuming it. This makes it convenient for code executed after this function call
+// to consume the stream if it wants.
 func isStreamGzipped(r *bufio.Reader) (bool, error) {
 	// Why 512? See https://godoc.org/net/http#DetectContentType
 	buf, err := r.Peek(512)

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -455,7 +455,7 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 		gzipReader.Close()
 	}
 
-	// Check if expand_event_list_from_field is given with document conent-type = "application/json"
+	// Check if expand_event_list_from_field is given with document content-type = "application/json"
 	if resp.ContentType != nil && *resp.ContentType == "application/json" && p.config.ExpandEventListFromField == "" {
 		err := errors.New("expand_event_list_from_field parameter is missing in config for application/json content-type file")
 		p.logger.Error(err)

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -677,6 +677,7 @@ func (c *s3Context) Inc() {
 }
 
 func isStreamGzipped(r *bufio.Reader) (bool, error) {
+	// Why 512? See https://godoc.org/net/http#DetectContentType
 	buf, err := r.Peek(512)
 	if err != nil && err != io.EOF {
 		return false, err

--- a/x-pack/filebeat/input/s3/input_test.go
+++ b/x-pack/filebeat/input/s3/input_test.go
@@ -357,6 +357,10 @@ May 28 03:03:29 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED
 			b.Bytes(),
 			true,
 		},
+		"empty": {
+			[]byte{},
+			false,
+		},
 	}
 
 	for name, test := range tests {

--- a/x-pack/filebeat/input/s3/input_test.go
+++ b/x-pack/filebeat/input/s3/input_test.go
@@ -7,12 +7,15 @@ package s3
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -326,4 +329,43 @@ func TestConvertOffsetToString(t *testing.T) {
 		assert.Equal(t, c.expectedString, output)
 	}
 
+}
+
+func TestIsStreamGzipped(t *testing.T) {
+	logBytes := []byte(`May 28 03:00:52 Shaunaks-MacBook-Pro-Work syslogd[119]: ASL Sender Statistics
+May 28 03:03:29 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing the target of a source after it has been activated; set a breakpoint on _dispatch_bug_deprecated to debug
+May 28 03:03:29 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing target queue hierarchy after xpc connection was activated; set a breakpoint on _dispatch_bug_deprecated to debug
+`)
+
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	_, err := gz.Write(logBytes)
+	require.NoError(t, err)
+
+	err = gz.Close()
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		contents []byte
+		expected bool
+	}{
+		"not_gzipped": {
+			logBytes,
+			false,
+		},
+		"gzipped": {
+			b.Bytes(),
+			true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := bufio.NewReader(bytes.NewReader(test.contents))
+			actual, err := isStreamGzipped(r)
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
 ## What does this PR do?

This PR enhances the S3 input to try harder to automatically detect GZIPped objects.

## Why is it important?

Sometimes objects returned by the S3 API are gzipped but don't come with proper headers indicating their gzipped nature. So we try different ways to auto-detect if the object is gzipped.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Follow the instructions in https://www.elastic.co/blog/getting-aws-logs-from-s3-using-filebeat-and-the-elastic-stack to setup an S3 bucket and SQS queue and configure Filebeat. When configuring Filebeat use the `console` output for easy debugging.

2. Create a sample log file.
   ```
   cat <<EOF >sample.log
   May 28 03:00:52 Shaunaks-MacBook-Pro-Work syslogd[119]: ASL Sender Statistics
   May 28 03:03:29 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing the target of a source after it has been activated; set a breakpoint on _dispatch_bug_deprecated to debug
   May 28 03:03:29 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing target queue hierarchy after xpc connection was activated; set a breakpoint on _dispatch_bug_deprecated to debug
   May 28 03:03:53 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing the target of a source after it has been activated; set a breakpoint on _dispatch_bug_deprecated to debug
   May 28 03:03:53 Shaunaks-MacBook-Pro-Work VTDecoderXPCService[57953]: DEPRECATED USE in libdispatch client: Changing target queue hierarchy after xpc connection was activated; set a breakpoint on _dispatch_bug_deprecated to debug
   EOF
   ```

3. Gzip the sample log file while keeping the original around.
   ```
   gzip --keep sample.log
   ```

4. Make a copy of the gzipped file, but remove the gzip extension to try and "fool" our S3 input.
   ```
   cp sample.log.gz sneaky.log
   ```

5. Start Filebeat
   ```
   filebeat -e
   ```

6. One by one, upload the 3 files to your S3 bucket. After each upload, check the Filebeat log to make sure there are no errors. Also make sure that the S3 input successfully generates the expected events.

## Related issues

- Resolves elastic/beats#18283
- Resolves elastic/beats#18696
