### PR TITLE
[Filebeat][http_endpoint] Removing enforcement of accept header

### DIFF
--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -196,9 +196,6 @@ func (in *HttpEndpoint) validateHeader(w http.ResponseWriter, r *http.Request) (
 		return http.StatusUnsupportedMediaType, in.createErrorMessage("Wrong Content-Type header, expecting application/json")
 	}
 
-	if r.Header.Get("Accept") != "application/json" {
-		return http.StatusNotAcceptable, in.createErrorMessage("Wrong Accept header, expecting application/json")
-	}
 	return 0, ""
 }
 

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -101,24 +101,6 @@ class Test(BaseTest):
         assert r.status_code == 415
         assert r.text == '{"message": "Wrong Content-Type header, expecting application/json"}'
 
-    def test_http_endpoint_wrong_accept_header(self):
-        """
-        Test http_endpoint input with wrong accept header.
-        """
-        self.get_config()
-        filebeat = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Starting HTTP server on {}:{}".format(self.host, self.port)))
-
-        message = "somerandommessage"
-        payload = {self.prefix: message}
-        headers = {"Content-Type": "application/json", "Accept": "application/xml"}
-        r = requests.post(self.url, headers=headers, data=json.dumps(payload))
-
-        filebeat.check_kill_and_wait()
-
-        assert r.status_code == 406
-        assert r.text == '{"message": "Wrong Accept header, expecting application/json"}'
-
     def test_http_endpoint_missing_auth_value(self):
         """
         Test http_endpoint input with missing basic auth values.


### PR DESCRIPTION
For now it will break webhooks that cannot set accept headers, so removing it for now, might reintroduce it later if there is any usecases for it

## What does this PR do?

Removing accept header validation of incoming http requests for the http_endpoint module

## Why is it important?

Makes the module support more webhooks (like github)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

