### PR TITLE
[Ingest Manager] Use shorter hash for application differentiator

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -63,3 +63,4 @@
 - Use nested objects so fleet can handle metadata correctly {pull}18234[18234]
 - More clear output of inspect command {pull}18405[18405]
 - Pick up version from libbeat {pull}18350[18350]
+- Use shorter hash for application differentiator {pull}18770[18770]

--- a/x-pack/elastic-agent/pkg/core/plugin/app/execution_context.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/app/execution_context.go
@@ -9,6 +9,10 @@ import (
 	"fmt"
 )
 
+const (
+	hashLen = 16
+)
+
 // ExecutionContext describes runnable binary
 type ExecutionContext struct {
 	BinaryName string
@@ -22,6 +26,9 @@ func NewExecutionContext(binaryName, version string, tags map[Tag]string) Execut
 	id := fmt.Sprintf("%s--%s", binaryName, version)
 	if len(tags) > 0 {
 		hash := fmt.Sprintf("%x", sha256.New().Sum([]byte(fmt.Sprint(tags))))
+		if len(hash) > hashLen {
+			hash = hash[:hashLen]
+		}
 		id += fmt.Sprintf("--%x", hash)
 	}
 


### PR DESCRIPTION
What does this PR do?

This PR reduces length of sha256 hash used for differentiating between apps in the same stream. 
sha256 is long and may result in some max path limits, 16 chars should be more than enough to differentiate and is safer regarding the limits. also reads better

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
