### PR TITLE
Cherry-pick #18773 to 7.x: Tag googlepubsub docker image

### DIFF
--- a/dev-tools/mage/target/compose/compose.go
+++ b/dev-tools/mage/target/compose/compose.go
@@ -89,6 +89,11 @@ func findSupportedVersionsFiles() ([]string, error) {
 		return []string{path}, nil
 	}
 
+	if input := os.Getenv("INPUT"); len(input) > 0 {
+		path := filepath.Join("input", input, "_meta/supported-versions.yml")
+		return []string{path}, nil
+	}
+
 	return devtools.FindFilesRecursive(func(path string, _ os.FileInfo) bool {
 		return filepath.Base(path) == "supported-versions.yml"
 	})

--- a/x-pack/filebeat/docker-compose.yml
+++ b/x-pack/filebeat/docker-compose.yml
@@ -9,17 +9,11 @@ services:
       - BEAT_STRICT_PERMS=false
       - ES_HOST=elasticsearch
       - ES_PORT=9200
-      - PUBSUB_EMULATOR_HOST=googlepubsub:8432
     working_dir: /go/src/github.com/elastic/beats/x-pack/filebeat
     volumes:
       - ${PWD}/../..:/go/src/github.com/elastic/beats/
       - /var/run/docker.sock:/var/run/docker.sock
     command: make
-
-  googlepubsub:
-    build: input/googlepubsub/_meta
-    ports:
-      - 8432
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/x-pack/filebeat/input/googlepubsub/_meta/Dockerfile
+++ b/x-pack/filebeat/input/googlepubsub/_meta/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:stretch
+ARG SDK_VERSION
 
 RUN \
     apt-get update \
@@ -20,8 +21,8 @@ RUN \
 RUN \
     apt-get update \
     && apt-get install -y \
-        google-cloud-sdk \
-        google-cloud-sdk-pubsub-emulator \
+        google-cloud-sdk=${SDK_VERSION} \
+        google-cloud-sdk-pubsub-emulator=${SDK_VERSION} \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN \

--- a/x-pack/filebeat/input/googlepubsub/_meta/docker-compose.yml
+++ b/x-pack/filebeat/input/googlepubsub/_meta/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '2.3'
-
-services:
-  googlepubsub:
-    build: .
-    ports:
-      - 127.0.0.1:8432:8432

--- a/x-pack/filebeat/input/googlepubsub/_meta/supported-versions.yml
+++ b/x-pack/filebeat/input/googlepubsub/_meta/supported-versions.yml
@@ -1,0 +1,2 @@
+variants:
+  - SDK_VERSION: 293.0.0-0

--- a/x-pack/filebeat/input/googlepubsub/docker-compose.yml
+++ b/x-pack/filebeat/input/googlepubsub/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2.3'
+
+services:
+  googlepubsub:
+    image: docker.elastic.co/integrations-ci/beats-googlepubsub:emulator-${SDK_VERSION:-293.0.0-0}-1
+    build:
+      context: ./_meta
+      args:
+        SDK_VERSION: ${SDK_VERSION:-293.0.0-0}
+    ports:
+      - 8432

--- a/x-pack/filebeat/input/googlepubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/googlepubsub/pubsub_test.go
@@ -40,17 +40,19 @@ var once sync.Once
 func testSetup(t *testing.T) (*pubsub.Client, context.CancelFunc) {
 	t.Helper()
 
-	host := os.Getenv("PUBSUB_EMULATOR_HOST")
-	if host == "" {
-		t.Skip("PUBSUB_EMULATOR_HOST is not set in environment. You can start " +
-			"the emulator with \"docker-compose up\" from the _meta directory. " +
-			"The default address is PUBSUB_EMULATOR_HOST=localhost:8432")
-	}
-
+	var host string
 	if isInDockerIntegTestEnv() {
 		// We're running inside out integration test environment so
 		// make sure that that googlepubsub container is running.
-		compose.EnsureUp(t, "googlepubsub")
+		host = compose.EnsureUp(t, "googlepubsub").Host()
+		os.Setenv("PUBSUB_EMULATOR_HOST", host)
+	} else {
+		host = os.Getenv("PUBSUB_EMULATOR_HOST")
+		if host == "" {
+			t.Skip("PUBSUB_EMULATOR_HOST is not set in environment. You can start " +
+				"the emulator with \"docker-compose up\" from the _meta directory. " +
+				"The default address is PUBSUB_EMULATOR_HOST=localhost:8432")
+		}
 	}
 
 	once.Do(func() {

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -21,6 +21,8 @@ import (
 	// mage:import generate
 	_ "github.com/elastic/beats/v7/filebeat/scripts/mage/generate"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"


### PR DESCRIPTION
Cherry-pick of PR #18773 to 7.x branch. Original message: 

## What does this PR do?
    
    Add compose targets to x-pack filebeat, adding support for INPUT
    environment variable in a similar fashion to the MODULE one.
    
    Add supported-versions file to googlepubsub so this image can be built
    with `mage compose:buildSupportedVersions`. Tag the version in docker
    compose file so image can be build and reused if already exists.

    Remove googlepubsub from main docker compose file, it is not needed
    there and images defined there are always rebuilt.

## Why is it important?

This image is being built on every x-pack filebeat build, and it seems to be a quite flaky process. Tag the image so it can be pre-built and reused.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Run `mage -v goIntegTest`, googlepubsub tests should pass without being skipped.