### PR TITLE
Migrate job to build test docker images to beats repo

### DIFF
--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -1,0 +1,103 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'beats'
+    BASE_DIR = "src/github.com/elastic/beats"
+    DOCKER_REGISTRY = 'docker.elastic.co'
+    DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+    GOPATH = "${env.WORKSPACE}"
+    HOME = "${env.WORKSPACE}"
+    NOTIFY_TO = credentials('notify-to')
+    PATH = "${env.GOPATH}/bin:${env.PATH}"
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    cron '@daily'
+  }
+  parameters {
+    booleanParam(name: "RELEASE_TEST_IMAGES", defaultValue: "true", description: "If it's needed to build & push Beats' test images")
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        dir("${BASE_DIR}"){
+          git("https://github.com/elastic/beats.git")
+        }
+        script {
+          dir("${BASE_DIR}"){
+            env.GO_VERSION = readFile(".go-version").trim()
+          }
+        }
+      }
+    }
+    stage('Install dependencies') {
+      when {
+        expression { return params.RELEASE_TEST_IMAGES }
+      }
+      steps {
+        sh(label: 'Install virtualenv', script: 'pip install --user virtualenv')
+      }
+    }
+    stage('Metricbeat Test Docker images'){
+      options {
+        warnError('Metricbeat Test Docker images failed')
+      }
+      when {
+        expression { return params.RELEASE_TEST_IMAGES }
+      }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        retry(3){
+          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/metricbeat'")
+        }
+      }
+    }
+    stage('Metricbeat x-pack Test Docker images'){
+      options {
+        warnError('Metricbeat x-pack Docker images failed')
+      }
+      when {
+        expression { return params.RELEASE_TEST_IMAGES }
+      }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        retry(3){
+          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/metricbeat'")
+        }
+      }
+    }
+    stage('Filebeat x-pack Test Docker images'){
+      options {
+        warnError('Filebeat x-pack Test Docker images failed')
+      }
+      when {
+        expression { return params.RELEASE_TEST_IMAGES }
+      }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        retry(3){
+          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/filebeat'")
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/scripts/build-beats-integrations-test-images.sh
+++ b/.ci/scripts/build-beats-integrations-test-images.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+#
+# Install the given go version using the gimme script.
+#
+# Parameters:
+#   - GO_VERSION - that's the version which will be installed and enabled.
+#   - BEAT_BASE_DIR - that's the base directory of the Beat.
+#
+
+readonly GO_VERSION="${1?Please define the Go version to be used}"
+readonly BEAT_BASE_DIR="${2?Please define the location of the Beat directory}"
+
+function build_test_images() {
+    local baseDir="${1}"
+
+    cd "${baseDir}"
+    mage compose:buildSupportedVersions
+}
+
+function install_go() {
+    local goVersion="${1}"
+
+    # Install Go using the same travis approach
+    echo "Installing ${goVersion} with gimme."
+    eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${goVersion} bash)"
+}
+
+function install_mage() {
+    local baseDir="${1}"
+
+    cd "${baseDir}"
+    make mage
+}
+
+function push_test_images() {
+    local baseDir="${1}"
+
+    cd "${baseDir}"
+    mage compose:pushSupportedVersions
+}
+
+function main() {
+    install_go "${GO_VERSION}"
+    install_mage "${BEAT_BASE_DIR}"
+
+    build_test_images "${BEAT_BASE_DIR}"
+    push_test_images "${BEAT_BASE_DIR}"
+}
+
+main "$@"

--- a/.ci/scripts/build-beats-integrations-test-images.sh
+++ b/.ci/scripts/build-beats-integrations-test-images.sh
@@ -6,16 +6,16 @@ set -exo pipefail
 #
 # Parameters:
 #   - GO_VERSION - that's the version which will be installed and enabled.
-#   - BEAT_BASE_DIR - that's the base directory of the Beat.
+#   - METRICBEAT_DIR - that's the location of the metricbeat directory.
 #
 
 readonly GO_VERSION="${1?Please define the Go version to be used}"
-readonly BEAT_BASE_DIR="${2?Please define the location of the Beat directory}"
+readonly METRICBEAT_DIR="${2?Please define the location of the Metricbeat directory}"
 
 function build_test_images() {
-    local baseDir="${1}"
+    local metricbeatDir="${1}"
 
-    cd "${baseDir}"
+    cd "${metricbeatDir}"
     mage compose:buildSupportedVersions
 }
 
@@ -28,25 +28,25 @@ function install_go() {
 }
 
 function install_mage() {
-    local baseDir="${1}"
+    local metricbeatDir="${1}"
 
-    cd "${baseDir}"
+    cd "${metricbeatDir}"
     make mage
 }
 
 function push_test_images() {
-    local baseDir="${1}"
+    local metricbeatDir="${1}"
 
-    cd "${baseDir}"
+    cd "${metricbeatDir}"
     mage compose:pushSupportedVersions
 }
 
 function main() {
     install_go "${GO_VERSION}"
-    install_mage "${BEAT_BASE_DIR}"
+    install_mage "${METRICBEAT_DIR}"
 
-    build_test_images "${BEAT_BASE_DIR}"
-    push_test_images "${BEAT_BASE_DIR}"
+    build_test_images "${METRICBEAT_DIR}"
+    push_test_images "${METRICBEAT_DIR}"
 }
 
 main "$@"


### PR DESCRIPTION
## What does this PR do?

Migrate job to pre-build docker images used in integration tests to beats repository.

## Why is it important?

To have the definition of this job in the beats repository, as is related to the beats project.