### PR TITLE
Monitoring: only include X-Pack API params when appropriate

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -141,16 +141,7 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 		return nil, err
 	}
 
-	params := map[string]string{}
-
-	if config.Format == report.FormatXPackMonitoringBulk {
-		for k, v := range defaultXPackParams {
-			params[k] = v
-		}
-	}
-	for k, v := range config.Params {
-		params[k] = v
-	}
+	params := makeClientParams(config)
 
 	hosts, err := outputs.ReadHostList(cfg)
 	if err != nil {
@@ -391,4 +382,19 @@ func getClusterUUID() string {
 
 	snapshot := monitoring.CollectFlatSnapshot(elasticsearchRegistry, monitoring.Full, false)
 	return snapshot.Strings["cluster_uuid"]
+}
+
+func makeClientParams(config config) map[string]string {
+	params := map[string]string{}
+
+	if config.Format == report.FormatXPackMonitoringBulk {
+		for k, v := range defaultXPackParams {
+			params[k] = v
+		}
+	}
+	for k, v := range config.Params {
+		params[k] = v
+	}
+
+	return params
 }

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -61,8 +61,8 @@ const logSelector = "monitoring"
 
 var errNoMonitoring = errors.New("xpack monitoring not available")
 
-// default monitoring api parameters
-var defaultParams = map[string]string{
+// default x-pack monitoring api parameters
+var defaultXPackParams = map[string]string{
 	"system_id":          "beats",
 	"system_api_version": "7",
 }
@@ -142,8 +142,11 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 	}
 
 	params := map[string]string{}
-	for k, v := range defaultParams {
-		params[k] = v
+
+	if config.Format == report.FormatXPackMonitoringBulk {
+		for k, v := range defaultXPackParams {
+			params[k] = v
+		}
 	}
 	for k, v := range config.Params {
 		params[k] = v

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring/report"
+)
+
+func TestMakeClientParams(t *testing.T) {
+	tests := map[string]struct {
+		format   report.Format
+		params   map[string]string
+		expected map[string]string
+	}{
+		"format_bulk": {
+			report.FormatBulk,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "bar",
+			},
+		},
+		"format_xpack_monitoring_bulk": {
+			report.FormatXPackMonitoringBulk,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo":                "bar",
+				"system_id":          "beats",
+				"system_api_version": "7",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeClientParams(config{
+				Format: test.format,
+				Params: test.params,
+			})
+
+			require.Equal(t, test.expected, params)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Elasticsearch monitoring reporter in libbeat to only include the `system_id` and `system_api_version` query string parameters in Elasticsearch API requests IF the Beat is sending its monitoring data to the custom X-Pack Monitoring API endpoint (`/_monitoring/bulk`).  Otherwise, these parameters are not included.

## Why is it important?

A Beat can be configured to send its monitoring data to Elasticsearch in two ways:
- using the deprecated `xpack.monitoring.*` settings. This causes the Beat to talk to the custom X-Pack Monitoring API endpoint (`/_monitoring/bulk`). This endpoint expects the `system_id` and `system_api_version` query string parameters.
- using the `monitoring.*` settings. This causes the Beat to talk to the generic Bulk API endpoint (`/_bulk`). This endpoint does not expect the `system_id` or `system_api_version` query string parameters.

It turns out that, after the fix made in #18326, the Elasticsearch monitoring reporter in libbeat was **always** sending the `system_id` and `system_api_version` query string parameters, regardless of which way a Beat was sending its monitoring data to Elasticsearch. This PR fixes this issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~ Not sure we need a CHANGELOG entry as this bug was not exposed until 7.8.0 (via #18326), which has not yet been released.

## Related issues
- Fixes #18786.