### PR TITLE
[7.8] Monitoring: only include X-Pack API params when appropriate (#18787)

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -61,8 +61,8 @@ const logSelector = "monitoring"
 
 var errNoMonitoring = errors.New("xpack monitoring not available")
 
-// default monitoring api parameters
-var defaultParams = map[string]string{
+// default x-pack monitoring api parameters
+var defaultXPackParams = map[string]string{
 	"system_id":          "beats",
 	"system_api_version": "7",
 }
@@ -141,13 +141,7 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 		return nil, err
 	}
 
-	params := map[string]string{}
-	for k, v := range defaultParams {
-		params[k] = v
-	}
-	for k, v := range config.Params {
-		params[k] = v
-	}
+	params := makeClientParams(config)
 
 	hosts, err := outputs.ReadHostList(cfg)
 	if err != nil {
@@ -388,4 +382,19 @@ func getClusterUUID() string {
 
 	snapshot := monitoring.CollectFlatSnapshot(elasticsearchRegistry, monitoring.Full, false)
 	return snapshot.Strings["cluster_uuid"]
+}
+
+func makeClientParams(config config) map[string]string {
+	params := map[string]string{}
+
+	if config.Format == report.FormatXPackMonitoringBulk {
+		for k, v := range defaultXPackParams {
+			params[k] = v
+		}
+	}
+	for k, v := range config.Params {
+		params[k] = v
+	}
+
+	return params
 }

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring/report"
+)
+
+func TestMakeClientParams(t *testing.T) {
+	tests := map[string]struct {
+		format   report.Format
+		params   map[string]string
+		expected map[string]string
+	}{
+		"format_bulk": {
+			report.FormatBulk,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "bar",
+			},
+		},
+		"format_xpack_monitoring_bulk": {
+			report.FormatXPackMonitoringBulk,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo":                "bar",
+				"system_id":          "beats",
+				"system_api_version": "7",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeClientParams(config{
+				Format: test.format,
+				Params: test.params,
+			})
+
+			require.Equal(t, test.expected, params)
+		})
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Monitoring: only include X-Pack API params when appropriate  (#18787)