### PR TITLE
ci: enable JJBB

### DIFF
--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -27,7 +27,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    cron '@daily'
+    cron 'H H(0-5) * * 1-5'
   }
   parameters {
     booleanParam(name: "RELEASE_TEST_IMAGES", defaultValue: "true", description: "If it's needed to build & push Beats' test images")

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,20 @@
+  
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: beats-ci
+
+##### JOB DEFAULTS
+
+- job:
+    logrotate:
+      numToKeep: 20
+    node: linux
+    concurrent: true
+    publishers:
+      - email:
+          recipients: infra-root+build@elastic.co
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true

--- a/.ci/jobs/package-registry.yml
+++ b/.ci/jobs/package-registry.yml
@@ -1,0 +1,23 @@
+---
+---
+- job:
+    name: Beats/build-it-docker-images
+    display-name: ITs Docker images
+    description: Job to pre-build docker images used in integration tests.
+    view: Beats
+    project-type: pipeline
+    pipeline-scm:
+      script-path: .ci/build-docker-images.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/beats.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/beats.git
+            branches:
+              - 'master'
+    triggers:
+      - timed: 'H H(0-5) * * 1-5'


### PR DESCRIPTION
Job for pre-buiid ITs Docker images

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

* Enable JJB for the creation of Jobs in Jenkins
* Create a new job to pre-build ITs Docker images, and set the schedule on a range from 0 to 5:00 AM from Monday to Friday.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Move the Jenkins Job definition to JJBB give us more autonomy.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

related to https://github.com/elastic/beats/pull/18785