### PR TITLE
[Ingest Manager] Fix install service script for windows

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -144,7 +144,7 @@ shared:
     files:
       <<: *agent_binary_files
       install-service-{{.BeatName}}.ps1:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service.ps1.tmpl'
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service-elastic-agent.ps1.tmpl'
         mode: 0755
       uninstall-service-{{.BeatName}}.ps1:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/uninstall-service.ps1.tmpl'

--- a/dev-tools/packaging/templates/windows/install-service-elastic-agent.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service-elastic-agent.ps1.tmpl
@@ -1,0 +1,20 @@
+# Delete and stop the service if it already exists.
+if (Get-Service {{.BeatName}} -ErrorAction SilentlyContinue) {
+  $service = Get-WmiObject -Class Win32_Service -Filter "name='{{.BeatName}}'"
+  $service.StopService()
+  Start-Sleep -s 1
+  $service.delete()
+}
+
+$workdir = Split-Path $MyInvocation.MyCommand.Path
+
+# Create the new service.
+New-Service -name {{.BeatName}} `
+  -displayName {{.BeatName | title}} `
+  -binaryPathName "`"$workdir\{{.BeatName}}.exe`" --path.home `"$workdir`" --path.data  `"$workdir\data`" run"
+
+# Attempt to set the service to delayed start using sc config.
+Try {
+  Start-Process -FilePath sc.exe -ArgumentList 'config {{.BeatName}} start= delayed-auto'
+}
+Catch { Write-Host -f red "An error occured setting the service to delayed start." }

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@
 - Clean action store after enrolling to new configuration {pull}18656[18656]
 - Avoid watching monitor logs {pull}18723[18723]
 - Guard against empty stream.datasource and namespace {pull}18769[18769]
+- Fix install service script for windows {pull}18814[18814]
 
 ==== New features
 


### PR DESCRIPTION
## What does this PR do?

Agent was using beat version of install service script for windows but the way how agent is started is different. 
This PR aligns script with the agent command syntax

## Why is it important?

To enable agent be installed on windows as a service

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #18811