### PR TITLE
Cherry-pick #18766 to 7.x: [CI|K8s] Fix k8s tests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -978,8 +978,8 @@ def k8sTest(versions){
           withBeatsEnv(false) {
             sh(label: "Install kind", script: ".ci/scripts/install-kind.sh")
             sh(label: "Install kubectl", script: ".ci/scripts/install-kubectl.sh")
-            sh(label: "Integration tests", script: "MODULE=kubernetes make -C metricbeat integration-tests")
             sh(label: "Setup kind", script: ".ci/scripts/kind-setup.sh")
+            sh(label: "Integration tests", script: "MODULE=kubernetes make -C metricbeat integration-tests")
             sh(label: "Deploy to kubernetes",script: "make -C deploy/kubernetes test")
             sh(label: 'Delete cluster', script: 'kind delete cluster')
           }


### PR DESCRIPTION
Cherry-pick of PR #18766 to 7.x branch. Original message: 

This PR fixes k8s testing job which has been failing: https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats-beats-mbp/detail/PR-18766/4/pipeline/1324/#step-1599-log-1

Changes:
1. Run k8s integration tests after `kind` cluster is created
2. Verify that `KUBECONFIG` or `KUBE_CONFIG` paths exist before using. If those files do not exist then create a cluster.

@blakerouse let me know what you think and/or if I'm missing something.

cc: @jsoriano 