### PR TITLE
Cherry-pick #18802 to 7.7: Add missing network.sent_packets_count metric into compute googlecloud

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -184,6 +184,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix storage metricset to allow config without region/zone. {issue}17623[17623] {pull}17624[17624]
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Fix tags_filter for cloudwatch metricset in aws. {pull}18524[18524]
+- Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/googlecloud/compute/manifest.yml
+++ b/x-pack/metricbeat/module/googlecloud/compute/manifest.yml
@@ -18,4 +18,5 @@ input:
         - "compute.googleapis.com/instance/network/received_bytes_count"
         - "compute.googleapis.com/instance/network/received_packets_count"
         - "compute.googleapis.com/instance/network/sent_bytes_count"
+        - "compute.googleapis.com/instance/network/sent_packets_count"
         - "compute.googleapis.com/instance/uptime"


### PR DESCRIPTION
Cherry-pick of PR #18802 to 7.7 branch. Original message:

This PR is to add 4 memory metrics(only for e2 family VMs) into googlecloud compute metricset and also added the missing network.sent_packets_count metric.

