### PR TITLE
[Ingest Manager] When not port are specified and the https is used fallback to 443

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -66,3 +66,4 @@
 - More clear output of inspect command {pull}18405[18405]
 - Pick up version from libbeat {pull}18350[18350]
 - Use shorter hash for application differentiator {pull}18770[18770]
+- When not port are specified and the https is used fallback to 443 {pull}18844[18844]

--- a/x-pack/elastic-agent/pkg/kibana/client.go
+++ b/x-pack/elastic-agent/pkg/kibana/client.go
@@ -21,7 +21,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
-const kibanaPort = 5601
+const (
+	kibanaPort      = 5601
+	kibanaHttpsPort = 443
+)
 
 type requestFunc func(string, string, url.Values, io.Reader) (*http.Request, error)
 type wrapperFunc func(rt http.RoundTripper) (http.RoundTripper, error)
@@ -144,7 +147,12 @@ func NewWithConfig(log *logger.Logger, cfg *Config, wrapper wrapperFunc) (*Clien
 		p = p + "/"
 	}
 
-	kibanaURL, err := common.MakeURL(string(cfg.Protocol), p, cfg.Host, kibanaPort)
+	usedDefaultPort := kibanaPort
+	if cfg.Protocol == "https" {
+		usedDefaultPort = kibanaHttpsPort
+	}
+
+	kibanaURL, err := common.MakeURL(string(cfg.Protocol), p, cfg.Host, usedDefaultPort)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid Kibana endpoint")
 	}

--- a/x-pack/elastic-agent/pkg/kibana/client.go
+++ b/x-pack/elastic-agent/pkg/kibana/client.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	kibanaPort      = 5601
-	kibanaHttpsPort = 443
+	kibanaHTTPSPort = 443
 )
 
 type requestFunc func(string, string, url.Values, io.Reader) (*http.Request, error)
@@ -149,7 +149,7 @@ func NewWithConfig(log *logger.Logger, cfg *Config, wrapper wrapperFunc) (*Clien
 
 	usedDefaultPort := kibanaPort
 	if cfg.Protocol == "https" {
-		usedDefaultPort = kibanaHttpsPort
+		usedDefaultPort = kibanaHTTPSPort
 	}
 
 	kibanaURL, err := common.MakeURL(string(cfg.Protocol), p, cfg.Host, usedDefaultPort)

--- a/x-pack/elastic-agent/pkg/kibana/client_test.go
+++ b/x-pack/elastic-agent/pkg/kibana/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -30,6 +31,38 @@ func addCatchAll(mux *http.ServeMux, t *testing.T) *http.ServeMux {
 		t.Fatal("HTTP catch all handled called")
 	})
 	return mux
+}
+
+func TestPortDefaults(t *testing.T) {
+	l, err := logger.New()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		Name           string
+		URI            string
+		ExpectedPort   int
+		ExpectedScheme string
+	}{
+		{"default kibana port", "http://test.url", kibanaPort, "http"},
+		{"specified kibana port", "http://test.url:123", 123, "http"},
+		{"default kibana https port", "https://test.url", kibanaHttpsPort, "https"},
+		{"specified kibana https port", "https://test.url:123", 123, "https"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			cfg, err := NewConfigFromURL(tc.URI)
+			require.NoError(t, err)
+
+			c, err := NewWithConfig(l, cfg, nil)
+			require.NoError(t, err)
+
+			r, err := c.request("GET", "/", nil, strings.NewReader(""))
+			require.NoError(t, err)
+
+			assert.True(t, strings.HasSuffix(r.Host, fmt.Sprintf(":%d", tc.ExpectedPort)))
+			assert.Equal(t, tc.ExpectedScheme, r.URL.Scheme)
+		})
+	}
 }
 
 // - Prefix.

--- a/x-pack/elastic-agent/pkg/kibana/client_test.go
+++ b/x-pack/elastic-agent/pkg/kibana/client_test.go
@@ -43,6 +43,7 @@ func TestPortDefaults(t *testing.T) {
 		ExpectedPort   int
 		ExpectedScheme string
 	}{
+		{"no scheme uri", "test.url", kibanaPort, "http"},
 		{"default kibana port", "http://test.url", kibanaPort, "http"},
 		{"specified kibana port", "http://test.url:123", 123, "http"},
 		{"default kibana https port", "https://test.url", kibanaHTTPSPort, "https"},

--- a/x-pack/elastic-agent/pkg/kibana/client_test.go
+++ b/x-pack/elastic-agent/pkg/kibana/client_test.go
@@ -45,7 +45,7 @@ func TestPortDefaults(t *testing.T) {
 	}{
 		{"default kibana port", "http://test.url", kibanaPort, "http"},
 		{"specified kibana port", "http://test.url:123", 123, "http"},
-		{"default kibana https port", "https://test.url", kibanaHttpsPort, "https"},
+		{"default kibana https port", "https://test.url", kibanaHTTPSPort, "https"},
 		{"specified kibana https port", "https://test.url:123", 123, "https"},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
## What does this PR do?

Provides default value for kibana client when https is used but no port specified

## Why is it important?

eases up configuration and makes behavior more predictable

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
