### PR TITLE
[CI] Fix permissions in MacOSX agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -765,7 +765,10 @@ def delete() {
 }
 
 def fixPermissions(location) {
-  sh(label: 'Fix permissions', script: "script/fix_permissions.sh ${location}")
+  sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+    source ./dev-tools/common.bash
+    docker_setup
+    script/fix_permissions.sh ${location}""")
 }
 
 def makeTarget(String context, String target, boolean clean = true) {


### PR DESCRIPTION
## What does this PR do?

A cornercase when cleaning the workspace of the static MacOSX workers and there was a test error. Therefore, the workspace might not be healthy enough to be tidied up. 

![image](https://user-images.githubusercontent.com/2871786/83258749-c2a20180-a1ae-11ea-9347-35716145fe9e.png)

## Why is it important?

Avoid any misleading when the deleteDir() fails in the GH PR comments.

## Screenshots

- MacOSX

![image](https://user-images.githubusercontent.com/2871786/83262698-570f6280-a1b5-11ea-9bde-2ac0445a5c65.png)

- Linux

![image](https://user-images.githubusercontent.com/2871786/83262740-642c5180-a1b5-11ea-928a-c2638b3b5a16.png)

