### PR TITLE
Cherry-pick #18818 to 7.8: Use indexers and matchers in config when defaults are enabled

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Gives monitoring reporter hosts, if configured, total precedence over corresponding output hosts. {issue}17937[17937] {pull}17991[17991]
 - [Autodiscover] Check if runner is already running before starting again. {pull}18564[18564]
 - Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
+- Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -127,4 +128,104 @@ func TestAnnotatorWithNoKubernetesAvailable(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, intialEventMap, event.Fields)
+}
+
+// TestNewProcessorConfigDefaultIndexers validates the behaviour of default indexers and
+// matchers settings
+func TestNewProcessorConfigDefaultIndexers(t *testing.T) {
+	emptyRegister := NewRegister()
+	registerWithDefaults := NewRegister()
+	registerWithDefaults.AddDefaultIndexerConfig("ip_port", *common.NewConfig())
+	registerWithDefaults.AddDefaultMatcherConfig("field_format", *common.MustNewConfigFrom(map[string]interface{}{
+		"format": "%{[destination.ip]}:%{[destination.port]}",
+	}))
+
+	configWithIndexersAndMatchers := common.MustNewConfigFrom(map[string]interface{}{
+		"indexers": []map[string]interface{}{
+			{
+				"container": map[string]interface{}{},
+			},
+		},
+		"matchers": []map[string]interface{}{
+			{
+				"fields": map[string]interface{}{
+					"lookup_fields": []string{"container.id"},
+				},
+			},
+		},
+	})
+	configOverrideDefaults := common.MustNewConfigFrom(map[string]interface{}{
+		"default_indexers.enabled": "false",
+		"default_matchers.enabled": "false",
+	})
+	require.NoError(t, configOverrideDefaults.Merge(configWithIndexersAndMatchers))
+
+	cases := map[string]struct {
+		register         *Register
+		config           *common.Config
+		expectedMatchers []string
+		expectedIndexers []string
+	}{
+		"no matchers": {
+			register: emptyRegister,
+			config:   common.NewConfig(),
+		},
+		"one configured indexer and matcher": {
+			register:         emptyRegister,
+			config:           configWithIndexersAndMatchers,
+			expectedIndexers: []string{"container"},
+			expectedMatchers: []string{"fields"},
+		},
+		"default indexers and matchers": {
+			register:         registerWithDefaults,
+			config:           common.NewConfig(),
+			expectedIndexers: []string{"ip_port"},
+			expectedMatchers: []string{"field_format"},
+		},
+		"default indexers and matchers, don't use indexers": {
+			register: registerWithDefaults,
+			config: common.MustNewConfigFrom(map[string]interface{}{
+				"default_indexers.enabled": "false",
+			}),
+			expectedMatchers: []string{"field_format"},
+		},
+		"default indexers and matchers, don't use matchers": {
+			register: registerWithDefaults,
+			config: common.MustNewConfigFrom(map[string]interface{}{
+				"default_matchers.enabled": "false",
+			}),
+			expectedIndexers: []string{"ip_port"},
+		},
+		"one configured indexer and matcher and defaults, configured should come first": {
+			register:         registerWithDefaults,
+			config:           configWithIndexersAndMatchers,
+			expectedIndexers: []string{"container", "ip_port"},
+			expectedMatchers: []string{"fields", "field_format"},
+		},
+		"override defaults": {
+			register:         registerWithDefaults,
+			config:           configOverrideDefaults,
+			expectedIndexers: []string{"container"},
+			expectedMatchers: []string{"fields"},
+		},
+	}
+
+	names := func(plugins PluginConfig) []string {
+		var ns []string
+		for _, plugin := range plugins {
+			for name := range plugin {
+				ns = append(ns, name)
+			}
+		}
+		return ns
+	}
+
+	for title, c := range cases {
+		t.Run(title, func(t *testing.T) {
+			config, err := newProcessorConfig(c.config, c.register)
+			require.NoError(t, err)
+			assert.Equal(t, c.expectedMatchers, names(config.Matchers), "expected matchers")
+			assert.Equal(t, c.expectedIndexers, names(config.Indexers), "expected indexers")
+		})
+	}
 }


### PR DESCRIPTION
Cherry-pick of PR #18818 to 7.8 branch. Original message: 

Before 7.7.0, indexers and matchers defined in `add_kubernetes_metadata`
configuration were used even when defaults were not disabled. Revert to
this behaviour and add tests to avoid changing it unexpectedly in the
future.

Reverts part of #16979, fixes #18481.