### PR TITLE
Cherry-pick #18844 to 7.x: When not port are specified and the https is used fa…

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -67,3 +67,4 @@
 - More clear output of inspect command {pull}18405[18405]
 - Pick up version from libbeat {pull}18350[18350]
 - Use shorter hash for application differentiator {pull}18770[18770]
+- When not port are specified and the https is used fallback to 443 {pull}18844[18844]

--- a/x-pack/elastic-agent/pkg/kibana/client.go
+++ b/x-pack/elastic-agent/pkg/kibana/client.go
@@ -21,7 +21,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
-const kibanaPort = 5601
+const (
+	kibanaPort      = 5601
+	kibanaHTTPSPort = 443
+)
 
 type requestFunc func(string, string, url.Values, io.Reader) (*http.Request, error)
 type wrapperFunc func(rt http.RoundTripper) (http.RoundTripper, error)
@@ -144,7 +147,12 @@ func NewWithConfig(log *logger.Logger, cfg *Config, wrapper wrapperFunc) (*Clien
 		p = p + "/"
 	}
 
-	kibanaURL, err := common.MakeURL(string(cfg.Protocol), p, cfg.Host, kibanaPort)
+	usedDefaultPort := kibanaPort
+	if cfg.Protocol == "https" {
+		usedDefaultPort = kibanaHTTPSPort
+	}
+
+	kibanaURL, err := common.MakeURL(string(cfg.Protocol), p, cfg.Host, usedDefaultPort)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid Kibana endpoint")
 	}


### PR DESCRIPTION
Cherry-pick of PR #18844 to 7.x branch. Original message:

## What does this PR do?

Provides default value for kibana client when https is used but no port specified

## Why is it important?

eases up configuration and makes behavior more predictable

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
