### PR TITLE
[7.6] [docs] Use beatname_pkg variable to resolve package name (#18423) (#18442)

### DIFF
--- a/libbeat/docs/shared-systemd.asciidoc
+++ b/libbeat/docs/shared-systemd.asciidoc
@@ -11,12 +11,12 @@ Use `systemctl` to start or stop {beatname_uc}:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl start {beatname_lc}
+systemctl start {beatname_pkg}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl stop {beatname_lc}
+systemctl stop {beatname_pkg}
 ------------------------------------------------
 
 By default, the {beatname_uc} service starts automatically when the system
@@ -24,12 +24,12 @@ boots. To enable or disable auto start use:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl enable {beatname_lc}
+systemctl enable {beatname_pkg}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl disable {beatname_lc}
+systemctl disable {beatname_pkg}
 ------------------------------------------------
 
 
@@ -39,14 +39,14 @@ To get the service status, use `systemctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl status {beatname_lc}
+systemctl status {beatname_pkg}
 ------------------------------------------------
 
 Logs are stored by default in journald. To view the Logs, use `journalctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-journalctl -u {beatname_lc}.service
+journalctl -u {beatname_pkg}.service
 ------------------------------------------------
 
 NOTE: The unit file included in the packages sets the `-e` flag by default.
@@ -68,10 +68,10 @@ override to change the default options.
 |=======================================
 
 To override these variables, create a drop-in unit file in the
-+/etc/systemd/system/{beatname_lc}.service.d+ directory.
++/etc/systemd/system/{beatname_pkg}.service.d+ directory.
 
 For example a file with the following content placed in
-+/etc/systemd/system/{beatname_lc}.service.d/debug.conf+
++/etc/systemd/system/{beatname_pkg}.service.d/debug.conf+
 would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
 
 ["source", "systemd", subs="attributes"]
@@ -95,9 +95,9 @@ the service:
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
 systemctl daemon-reload
-systemctl restart {beatname_lc}
+systemctl restart {beatname_pkg}
 ------------------------------------------------
 
 NOTE: It is recommended that you use a configuration management tool to
 include drop-in unit files. If you need to add a drop-in manually, use
-+systemctl edit {beatname_lc}.service+.
++systemctl edit {beatname_pkg}.service+.


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [docs] Use beatname_pkg variable to resolve package name (#18423) (#18442)