### PR TITLE
[CI] Fix permissions should not fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -798,7 +798,7 @@ def fixPermissions(location) {
   sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
     source ./dev-tools/common.bash
     docker_setup
-    script/fix_permissions.sh ${location}""")
+    script/fix_permissions.sh ${location}""", returnStatus: true)
 }
 
 def makeTarget(String context, String target, boolean clean = true) {


### PR DESCRIPTION
## What does this PR do?

Since https://github.com/elastic/beats/pull/18847 was merged there are some errors when fixing the permissions in some MacOSX. This particular step should not fail the build as it's just intended to help with the cleaning up of the workspaces in the static workers.
 
## Why is it important?

Avoid any misleading with steps that are not required to catch the error.

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/83532897-d5864000-a4e6-11ea-9c86-162ad3183edb.png)

![image](https://user-images.githubusercontent.com/2871786/83532952-e46cf280-a4e6-11ea-9872-af2c621aaa75.png)
