### PR TITLE
Cherry-pick #18872 to 7.x: Revert "Allow the Docker image to be run with a random user id (#12905)"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -314,7 +314,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Kerberos support to Elasticsearch output. {pull}17927[17927]
 - Add support for fixed length extraction in `dissect` processor. {pull}17191[17191]
 - Update RPM packages contained in Beat Docker images. {issue}17035[17035]
-- Change ownership of files in docker images so they can be used in secured environments. {pull}12905[12905]
 - Add TLS support to Kerberos authentication in Elasticsearch. {pull}18607[18607]
 - Upgrade k8s.io/client-go and k8s keystore tests. {pull}18817[18817]
 

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -186,13 +186,8 @@ func checkDocker(t *testing.T, file string) {
 	checkDockerEntryPoint(t, p, info)
 	checkDockerLabels(t, p, info, file)
 	checkDockerUser(t, p, info, *rootUserContainer)
-
-	// The configuration file in the Docker image is expected to be readable and writable by any user who belongs to
-	// the root group. This is done in order to allow the docker image to run on secured Kubernetes environment where
-	// the user ID used to run a container can't be known in advance.
-	checkConfigPermissionsWithMode(t, p, os.FileMode(0660))
-	checkManifestPermissionsWithMode(t, p, os.FileMode(0660))
-
+	checkConfigPermissionsWithMode(t, p, os.FileMode(0640))
+	checkManifestPermissionsWithMode(t, p, os.FileMode(0640))
 	checkModulesPresent(t, "", p)
 	checkModulesDPresent(t, "", p)
 }

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -30,10 +30,10 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint
 RUN groupadd --gid 1000 {{ .BeatName }}
 
 RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
-    chown -R root:root {{ $beatHome }} && \
-    find {{ $beatHome }} -type d -exec chmod 0770 {} \; && \
-    find {{ $beatHome }} -type f -exec chmod 0660 {} \; && \
-    chmod 0770 {{ $beatBinary }} && \
+    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
+    find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
+    find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
+    chmod 0750 {{ $beatBinary }} && \
 {{- if .linux_capabilities }}
     setcap {{ .linux_capabilities }} {{ $beatBinary }} && \
 {{- end }}
@@ -43,7 +43,7 @@ RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
     chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
 
 {{- if ne .user "root" }}
-RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
+RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
 {{- end }}
 USER {{ .user }}
 


### PR DESCRIPTION
Cherry-pick of PR #18872 to 7.x branch. Original message: 

This reverts commits 9dbdc1579f350d3beaff156b78a365e3a200e2cd and 3eac5f7b69a5627dfd9e241c1916988c1c602760.

Reverts #12905.
To be continued in #18871.

Fixes #18858.
