### PR TITLE
Cherry-pick #18899 to 7.8: [CI] Fix permissions should not fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -753,7 +753,10 @@ def delete() {
 }
 
 def fixPermissions(location) {
-  sh(label: 'Fix permissions', script: "script/fix_permissions.sh ${location}")
+  sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+    source ./dev-tools/common.bash
+    docker_setup
+    script/fix_permissions.sh ${location}""", returnStatus: true)
 }
 
 def makeTarget(String context, String target, boolean clean = true) {


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [CI] Fix permissions should not fail (#18899)