### PR TITLE
[libbeat] Verify that a separator exists after a greedy delimiter on the dissect tokenizer

### DIFF
--- a/libbeat/processors/dissect/dissect_test.go
+++ b/libbeat/processors/dissect/dissect_test.go
@@ -39,6 +39,16 @@ func TestEmptyString(t *testing.T) {
 	assert.Equal(t, errEmpty, err)
 }
 
+func TestInvalidTokenizer(t *testing.T) {
+	const (
+		pattern = "%{id} %{function-\u003e}%{server}"
+		message = `00000043 ViewReceive machine-321    `
+	)
+
+	_, err := New(pattern)
+	assert.Equal(t, errInvalidTokenizer, err)
+}
+
 // JSON tags are used to create a common test file for the `logstash-filter-dissect` and the
 // beat implementation.
 type dissectTest struct {

--- a/libbeat/processors/dissect/parser.go
+++ b/libbeat/processors/dissect/parser.go
@@ -74,6 +74,10 @@ func newParser(tokenizer string) (*parser, error) {
 	// Some delimiters also need information about their surrounding for decision.
 	for i := 0; i < len(delimiters); i++ {
 		if i+1 < len(delimiters) {
+			// If the current delimiter is greedy verify that there is a delimiter before the next field
+			if delimiters[i].IsGreedy() && (i+1 < len(matches)) && (matches[i][1] == matches[i+1][3]) {
+				return nil, errInvalidTokenizer
+			}
 			delimiters[i].SetNext(delimiters[i+1])
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

If a delimiter is set as greedy and there is no separator before the next field (as in):

```
"%{id} %{function->}%{server}"
```

the `extract` method goes into an infinite loop, consuming a lot of CPU and limiting the performance of the filebeat instance.

This PR adds a validation when the parser is created from the tokenizer string (on the `newParser` function), specifically where the delimiters are chained together. 

If no separator is found after the greedy delimiter an `errInvalidTokenizer` is returned.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Fixes an edge case in the dissect processor with the tokenizer string provided in the configuration. Initially found in https://github.com/jorgelbg/dissect-tester/issues/10. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

A test case was added to the `dissect_test.go` file.