### PR TITLE
Cherry-pick #18913 to 7.x: Fix docker image for stan

### DIFF
--- a/x-pack/metricbeat/module/stan/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/stan/_meta/Dockerfile
@@ -2,9 +2,9 @@ ARG STAN_VERSION=0.15.1
 FROM nats-streaming:$STAN_VERSION
 
 # build stage
-FROM golang:1.13-alpine AS build-env
-RUN apk --no-cache add build-base git bzr mercurial gcc
-RUN cd src && go get github.com/nats-io/stan.go/
+FROM golang:1.13-alpine3.11 AS build-env
+RUN apk --no-cache add build-base git mercurial gcc
+RUN cd src && go get -d github.com/nats-io/stan.go/
 RUN cd src/github.com/nats-io/stan.go/examples/stan-bench && git checkout tags/v0.5.2 && go build .
 
 # create an enhanced container with nc command available since nats is based


### PR DESCRIPTION
Cherry-pick of PR #18913 to 7.x branch. Original message: 

Building of docker image for stan integration tests is failing, fix it:
* Pin version of alpine (this would be enough)
* Remove dependency on bzr as doesn't seem to be needed.

Error during build was:
```
ERROR: unsatisfiable constraints:
  bzr (missing):
    required by: world[bzr]
```

We could pre-build the image, but lets fix the builds by now.