### PR TITLE
Cherry-pick #18738 to 7.x: Improve thread safety of fingerprint processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - [Autodiscover] Check if runner is already running before starting again. {pull}18564[18564]
 - Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
 - Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
+- Fix potential race condition in fingerprint processor. {pull}18738[18738]
 
 *Auditbeat*
 

--- a/libbeat/processors/fingerprint/fingerprint.go
+++ b/libbeat/processors/fingerprint/fingerprint.go
@@ -19,7 +19,6 @@ package fingerprint
 
 import (
 	"fmt"
-	"hash"
 	"io"
 	"time"
 
@@ -39,7 +38,7 @@ const processorName = "fingerprint"
 type fingerprint struct {
 	config Config
 	fields []string
-	hash   hash.Hash
+	hash   hashMethod
 }
 
 // New constructs a new fingerprint processor.
@@ -49,12 +48,15 @@ func New(cfg *common.Config) (processors.Processor, error) {
 		return nil, makeErrConfigUnpack(err)
 	}
 
-	fields := common.MakeStringSet(config.Fields...)
+	// The fields array must be sorted, to guarantee that we always
+	// get the same hash for a similar set of configured keys.
+	// The call `ToSlice` always returns a sorted slice.
+	fields := common.MakeStringSet(config.Fields...).ToSlice()
 
 	p := &fingerprint{
 		config: config,
-		hash:   config.Method(),
-		fields: fields.ToSlice(),
+		hash:   config.Method,
+		fields: fields,
 	}
 
 	return p, nil
@@ -62,8 +64,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 
 // Run enriches the given event with fingerprint information
 func (p *fingerprint) Run(event *beat.Event) (*beat.Event, error) {
-	hashFn := p.hash
-	hashFn.Reset()
+	hashFn := p.hash()
 
 	err := p.writeFields(hashFn, event.Fields)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #18738 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

Remove the reuse of the hash function between runs in the hash processor.

Running the benchmarks seems to suggest that we don't create any extra
allocations with this change (tested with go1.13):

```
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/elastic/beats/v7/libbeat/processors/fingerprint
BenchmarkHashMethods/sha384-4         	1000000000	         0.123 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashMethods/sha512-4         	1000000000	         0.125 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashMethods/xxhash-4         	1000000000	         0.0539 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashMethods/md5-4            	1000000000	         0.0925 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashMethods/sha1-4           	1000000000	         0.112 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashMethods/sha256-4         	1000000000	         0.134 ns/op	       0 B/op	       0 allocs/op
```

## Why is it important?

The fingerprint processor used to reuse state between calls, but not
being threadsafe means that the processor might get into an invalid
state if it is used by multiple go-routines by accident, creating
invalid, non-reproducible hash values. This change does not reuse the
hash state between runs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- elastic/beats#18542 


