### PR TITLE
Cherry-pick #18876 to 7.x:  Agent verifies packages before using them 

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -60,6 +60,12 @@ shared:
       /etc/{{.BeatName}}/data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz:
         source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0644
+      /etc/{{.BeatName}}/data/downloads/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512:
+        source: '{{ elastic_beats_dir }}/x-pack/filebeat/build/distributions/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
+      /etc/{{.BeatName}}/data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512:
+        source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
 
 
   # MacOS pkg spec for community beats.
@@ -103,6 +109,12 @@ shared:
       /etc/{{.BeatName}}/data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz:
         source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0644
+      /etc/{{.BeatName}}/data/downloads/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512:
+        source: '{{ elastic_beats_dir }}/x-pack/filebeat/build/distributions/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
+      /etc/{{.BeatName}}/data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512:
+        source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
 
   - &agent_binary_files
     '{{.BeatName}}{{.BinaryExt}}':
@@ -137,6 +149,13 @@ shared:
       'data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz':
         source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0644
+      <<: *agent_binary_files
+      'data/downloads/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512':
+        source: '{{ elastic_beats_dir }}/x-pack/filebeat/build/distributions/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
+      'data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512':
+        source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz.sha512'
+        mode: 0644
 
   # Binary package spec (zip for windows) for community beats.
   - &agent_windows_binary_spec
@@ -154,6 +173,12 @@ shared:
         mode: 0644
       'data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip':
         source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip'
+        mode: 0644
+      'data/downloads/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip.sha512':
+        source: '{{ elastic_beats_dir }}/x-pack/filebeat/build/distributions/filebeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip.sha512'
+        mode: 0644
+      'data/downloads/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip.sha512':
+        source: '{{ elastic_beats_dir }}/x-pack/metricbeat/build/distributions/metricbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.zip.sha512'
         mode: 0644
 
   - &agent_docker_spec

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -68,3 +68,4 @@
 - Pick up version from libbeat {pull}18350[18350]
 - Use shorter hash for application differentiator {pull}18770[18770]
 - When not port are specified and the https is used fallback to 443 {pull}18844[18844]
+- Agent verifies packages before using them {pull}18876[18876]

--- a/x-pack/elastic-agent/pkg/agent/application/stream.go
+++ b/x-pack/elastic-agent/pkg/agent/application/stream.go
@@ -78,6 +78,11 @@ func newOperator(ctx context.Context, log *logger.Logger, id routingKey, config 
 	}
 
 	fetcher := downloader.NewDownloader(operatorConfig.DownloadConfig)
+	verifier, err := downloader.NewVerifier(operatorConfig.DownloadConfig)
+	if err != nil {
+		return nil, errors.New(err, "initiating verifier")
+	}
+
 	installer, err := install.NewInstaller(operatorConfig.DownloadConfig)
 	if err != nil {
 		return nil, errors.New(err, "initiating installer")
@@ -94,6 +99,7 @@ func newOperator(ctx context.Context, log *logger.Logger, id routingKey, config 
 		id,
 		config,
 		fetcher,
+		verifier,
 		installer,
 		stateResolver,
 		r,

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -46,6 +46,7 @@ func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.
 	l := getLogger()
 
 	fetcher := &DummyDownloader{}
+	verifier := &DummyVerifier{}
 	installer := &DummyInstaller{}
 
 	stateResolver, err := stateresolver.NewStateResolver(l)
@@ -53,7 +54,7 @@ func getTestOperator(t *testing.T, installPath string) (*Operator, *operatorCfg.
 		t.Fatal(err)
 	}
 
-	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, installer, stateResolver, nil, noop.NewMonitor())
+	operator, err := NewOperator(context.Background(), l, "p1", cfg, fetcher, verifier, installer, stateResolver, nil, noop.NewMonitor())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,8 +82,7 @@ type TestConfig struct {
 	TestFile string
 }
 
-type DummyDownloader struct {
-}
+type DummyDownloader struct{}
 
 func (*DummyDownloader) Download(_ context.Context, p, v string) (string, error) {
 	return "", nil
@@ -90,8 +90,15 @@ func (*DummyDownloader) Download(_ context.Context, p, v string) (string, error)
 
 var _ download.Downloader = &DummyDownloader{}
 
-type DummyInstaller struct {
+type DummyVerifier struct{}
+
+func (*DummyVerifier) Verify(p, v string) (bool, error) {
+	return true, nil
 }
+
+var _ download.Verifier = &DummyVerifier{}
+
+type DummyInstaller struct{}
 
 func (*DummyInstaller) Install(p, v, _ string) error {
 	return nil

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -116,6 +116,7 @@ func getMonitorableTestOperator(t *testing.T, installPath string, m monitoring.M
 	l := getLogger()
 
 	fetcher := &DummyDownloader{}
+	verifier := &DummyVerifier{}
 	installer := &DummyInstaller{}
 
 	stateResolver, err := stateresolver.NewStateResolver(l)
@@ -124,7 +125,7 @@ func getMonitorableTestOperator(t *testing.T, installPath string, m monitoring.M
 	}
 	ctx := context.Background()
 
-	operator, err := NewOperator(ctx, l, "p1", cfg, fetcher, installer, stateResolver, nil, m)
+	operator, err := NewOperator(ctx, l, "p1", cfg, fetcher, verifier, installer, stateResolver, nil, m)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -51,6 +51,7 @@ type Operator struct {
 	appsLock sync.Mutex
 
 	downloader download.Downloader
+	verifier   download.Verifier
 	installer  install.Installer
 }
 
@@ -63,6 +64,7 @@ func NewOperator(
 	pipelineID string,
 	config *config.Config,
 	fetcher download.Downloader,
+	verifier download.Verifier,
 	installer install.Installer,
 	stateResolver *stateresolver.StateResolver,
 	eventProcessor callbackHooks,
@@ -87,6 +89,7 @@ func NewOperator(
 		pipelineID:     pipelineID,
 		logger:         logger,
 		downloader:     fetcher,
+		verifier:       verifier,
 		installer:      installer,
 		stateResolver:  stateResolver,
 		apps:           make(map[string]Application),
@@ -155,7 +158,7 @@ func (o *Operator) HandleConfig(cfg configrequest.Request) error {
 func (o *Operator) start(p Descriptor, cfg map[string]interface{}) (err error) {
 	flow := []operation{
 		newOperationFetch(o.logger, p, o.config, o.downloader, o.eventProcessor),
-		newOperationVerify(o.eventProcessor),
+		newOperationVerify(p, o.config, o.verifier, o.eventProcessor),
 		newOperationInstall(o.logger, p, o.config, o.installer, o.eventProcessor),
 		newOperationStart(o.logger, p, o.config, cfg, o.eventProcessor),
 		newOperationConfig(o.logger, o.config, cfg, o.eventProcessor),

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
@@ -5,11 +5,16 @@
 package fs
 
 import (
+	"bufio"
 	"bytes"
+	"crypto/sha512"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"golang.org/x/crypto/openpgp"
 
@@ -35,10 +40,6 @@ func NewVerifier(config *artifact.Config) (*Verifier, error) {
 		config: config,
 	}
 
-	if err := v.loadPGP(config.PgpFile); err != nil {
-		return nil, errors.New(err, "loading PGP")
-	}
-
 	return v, nil
 }
 
@@ -51,6 +52,63 @@ func (v *Verifier) Verify(programName, version string) (bool, error) {
 	}
 
 	fullPath := filepath.Join(v.config.TargetDirectory, filename)
+
+	return v.verifyHash(filename, fullPath)
+}
+
+func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
+	hashFilePath := fullPath + ".sha512"
+	hashFileHandler, err := os.Open(hashFilePath)
+	if err != nil {
+		return false, err
+	}
+	defer hashFileHandler.Close()
+
+	// get hash
+	// content of a file is in following format
+	// hash  filename
+	var expectedHash string
+	scanner := bufio.NewScanner(hashFileHandler)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasSuffix(line, filename) {
+			continue
+		}
+
+		expectedHash = strings.TrimSpace(strings.TrimSuffix(line, filename))
+	}
+
+	if expectedHash == "" {
+		return false, fmt.Errorf("hash for '%s' not found", filename)
+	}
+
+	// compute file hash
+	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
+	if err != nil {
+		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
+	}
+	defer fileReader.Close()
+
+	hash := sha512.New()
+	if _, err := io.Copy(hash, fileReader); err != nil {
+		return false, err
+	}
+	computedHash := fmt.Sprintf("%x", hash.Sum(nil))
+
+	return expectedHash == computedHash, nil
+}
+
+func (v *Verifier) verifyAsc(filename, fullPath string) (bool, error) {
+	var err error
+	var pgpBytesLoader sync.Once
+
+	pgpBytesLoader.Do(func() {
+		err = v.loadPGP(v.config.PgpFile)
+	})
+
+	if err != nil {
+		return false, errors.New(err, "loading PGP")
+	}
 
 	ascBytes, err := v.getPublicAsc(filename)
 	if err != nil {

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier_test.go
@@ -1,0 +1,100 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fs
+
+import (
+	"context"
+	"crypto/sha512"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+)
+
+const (
+	beatName      = "filebeat"
+	version       = "7.5.1"
+	sourcePattern = "/downloads/beats/filebeat/"
+)
+
+type testCase struct {
+	system string
+	arch   string
+}
+
+func TestVerify(t *testing.T) {
+	targetDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timeout := 30 * time.Second
+
+	config := &artifact.Config{
+		TargetDirectory: targetDir,
+		DropPath:        filepath.Join(targetDir, "drop"),
+		Timeout:         timeout,
+		OperatingSystem: "linux",
+		Architecture:    "32",
+	}
+
+	if err := prepareTestCase(beatName, version, config); err != nil {
+		t.Fatal(err)
+	}
+
+	testClient := NewDownloader(config)
+	artifact, err := testClient.Download(context.Background(), beatName, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testVerifier, err := NewVerifier(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isOk, err := testVerifier.Verify(beatName, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isOk {
+		t.Fatal("verify failed")
+	}
+
+	os.Remove(artifact)
+	os.Remove(artifact + ".sha512")
+	os.RemoveAll(config.DropPath)
+}
+
+func prepareTestCase(beatName, version string, cfg *artifact.Config) error {
+	filename, err := artifact.GetArtifactName(beatName, version, cfg.OperatingSystem, cfg.Architecture)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(cfg.DropPath, 0777); err != nil {
+		return err
+	}
+
+	content := []byte("sample content")
+	hash := sha512.Sum512(content)
+	hashContent := fmt.Sprintf("%x %s", hash, filename)
+
+	if err := ioutil.WriteFile(filepath.Join(cfg.DropPath, filename), []byte(content), 0644); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(cfg.DropPath, filename+".sha512"), []byte(hashContent), 0644)
+}

--- a/x-pack/elastic-agent/pkg/artifact/download/http/elastic_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/elastic_test.go
@@ -6,6 +6,7 @@ package http
 
 import (
 	"context"
+	"crypto/sha512"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,9 +72,6 @@ func TestDownload(t *testing.T) {
 }
 
 func TestVerify(t *testing.T) {
-	// skip so beats are not fetched from upstream, test only locally when change is made
-	t.Skip()
-
 	targetDir, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
@@ -80,6 +79,7 @@ func TestVerify(t *testing.T) {
 
 	timeout := 30 * time.Second
 	testCases := getRandomTestCases()
+	elasticClient := getElasticCoClient()
 
 	config := &artifact.Config{
 		BeatsSourceURI:  source,
@@ -93,8 +93,7 @@ func TestVerify(t *testing.T) {
 			config.OperatingSystem = testCase.system
 			config.Architecture = testCase.arch
 
-			testClient := NewDownloader(config)
-
+			testClient := NewDownloaderWithClient(config, elasticClient)
 			artifact, err := testClient.Download(context.Background(), beatName, version)
 			if err != nil {
 				t.Fatal(err)
@@ -120,6 +119,7 @@ func TestVerify(t *testing.T) {
 			}
 
 			os.Remove(artifact)
+			os.Remove(artifact + ".sha512")
 		})
 	}
 }
@@ -164,11 +164,20 @@ func getElasticCoClient() http.Client {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		packageName := r.URL.Path[len(sourcePattern):]
+		isShaReq := strings.HasSuffix(packageName, ".sha512")
+		packageName = strings.TrimSuffix(packageName, ".sha512")
+
 		if _, ok := correctValues[packageName]; !ok {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 
-		w.Write([]byte(packageName))
+		content := []byte(packageName)
+		if isShaReq {
+			hash := sha512.Sum512(content)
+			w.Write([]byte(fmt.Sprintf("%x %s", hash, packageName)))
+		} else {
+			w.Write(content)
+		}
 	})
 	server := httptest.NewServer(handler)
 

--- a/x-pack/elastic-agent/pkg/artifact/download/http/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/verifier.go
@@ -5,14 +5,18 @@
 package http
 
 import (
+	"bufio"
 	"bytes"
+	"crypto/sha512"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"strings"
+	"sync"
 
 	"golang.org/x/crypto/openpgp"
 
@@ -44,16 +48,82 @@ func NewVerifier(config *artifact.Config) (*Verifier, error) {
 		client: client,
 	}
 
-	if err := v.loadPGP(config.PgpFile); err != nil {
-		return nil, errors.New(err, "loading PGP")
-	}
-
 	return v, nil
 }
 
 // Verify checks downloaded package on preconfigured
 // location agains a key stored on elastic.co website.
 func (v *Verifier) Verify(programName, version string) (bool, error) {
+	// TODO: think about verifying asc for prepacked beats
+
+	filename, err := artifact.GetArtifactName(programName, version, v.config.OS(), v.config.Arch())
+	if err != nil {
+		return false, errors.New(err, "retrieving package name")
+	}
+
+	fullPath, err := artifact.GetArtifactPath(programName, version, v.config.OS(), v.config.Arch(), v.config.TargetDirectory)
+	if err != nil {
+		return false, errors.New(err, "retrieving package path")
+	}
+
+	return v.verifyHash(filename, fullPath)
+}
+
+func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
+	hashFilePath := fullPath + ".sha512"
+	hashFileHandler, err := os.Open(hashFilePath)
+	if err != nil {
+		return false, err
+	}
+	defer hashFileHandler.Close()
+
+	// get hash
+	// content of a file is in following format
+	// hash  filename
+	var expectedHash string
+	scanner := bufio.NewScanner(hashFileHandler)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasSuffix(line, filename) {
+			continue
+		}
+
+		expectedHash = strings.TrimSpace(strings.TrimSuffix(line, filename))
+	}
+
+	if expectedHash == "" {
+		return false, fmt.Errorf("hash for '%s' not found", filename)
+	}
+
+	// compute file hash
+	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
+	if err != nil {
+		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
+	}
+	defer fileReader.Close()
+
+	// compute file hash
+	hash := sha512.New()
+	if _, err := io.Copy(hash, fileReader); err != nil {
+		return false, err
+	}
+	computedHash := fmt.Sprintf("%x", hash.Sum(nil))
+
+	return expectedHash == computedHash, nil
+}
+
+func (v *Verifier) verifyAsc(programName, version string) (bool, error) {
+	var err error
+	var pgpBytesLoader sync.Once
+
+	pgpBytesLoader.Do(func() {
+		err = v.loadPGP(v.config.PgpFile)
+	})
+
+	if err != nil {
+		return false, errors.New(err, "loading PGP")
+	}
+
 	filename, err := artifact.GetArtifactName(programName, version, v.config.OS(), v.config.Arch())
 	if err != nil {
 		return false, errors.New(err, "retrieving package name")
@@ -92,6 +162,7 @@ func (v *Verifier) Verify(programName, version string) (bool, error) {
 	}
 
 	return true, nil
+
 }
 
 func (v *Verifier) composeURI(programName, filename string) (string, error) {


### PR DESCRIPTION
Cherry-pick of PR #18876 to 7.x branch. Original message:

## What does this PR do?

This PR enables hash verification of downloaded tar/zip packages and dont proceed with installation if package is corrupted.
In order to do that we have to include sha512 hashes while packaging.

## Why is it important?

This is important in case repo contains invalid archive or somebody tempered content of tar package.
We still need to verify signature (will be done in a followup)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #17915