### PR TITLE
[DOCS] Add compatibility info to Kafka input doc

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -48,6 +48,12 @@ For more details on the mapping between Kafka and Event Hubs configuration
 parameters, see the
 link:https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview[Azure documentation].
 
+[[kafka-input-compatibility]]
+==== Compatibility
+
+This input works with all Kafka versions in between 0.11 and 2.1.0. Older versions
+might work as well, but are not supported.
+
 [id="{beatname_lc}-input-{type}-options"]
 ==== Configuration options
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR adds Kafka compatibility information to the Kafka input doc. This is to match what we currently have in the [Kafka output doc](https://www.elastic.co/guide/en/beats/filebeat/7.5/kafka-output.html#kafka-compatibility).

## Related issues

Closes #15199

## HTML preview

https://beats_18929.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/filebeat-input-kafka.html#kafka-input-compatibility