### PR TITLE
Add `beta` tag/header to o365 pages.

### DIFF
--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Office 365 module
 
+beta[]
+
 This is a module for Office 365 logs received via one of the Office 365 API
 endpoints. It currently supports user, admin, system, and policy actions and
 events from Office 365 and Azure AD activity logs exposed by the Office 365


### PR DESCRIPTION
The o365 module is still in beta

