### PR TITLE
[7.8] S3 input: try to detect GZIPped objects (#18764)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,6 +256,18 @@ from being added to events by default. {pull}18159[18159]
 - Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
 - Add event.ingested for CrowdStrike module {pull}20138[20138]
 - Add support for additional fields and FirewallMatchEvent type events in CrowdStrike module {pull}20138[20138]
+- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
+- The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
+- Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
+- Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
+- The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
+
+*Heartbeat*
+
+
+*Heartbeat*
+
+*Journalbeat*
 
 *Metricbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,18 +256,7 @@ from being added to events by default. {pull}18159[18159]
 - Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
 - Add event.ingested for CrowdStrike module {pull}20138[20138]
 - Add support for additional fields and FirewallMatchEvent type events in CrowdStrike module {pull}20138[20138]
-- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
-- The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
-- Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
-- Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
 - The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
-
-*Heartbeat*
-
-
-*Heartbeat*
-
-*Journalbeat*
 
 *Metricbeat*
 


### PR DESCRIPTION
⚠️ Do not backport until `7.8` is pointing to `7.8.2`. This is because the changes in this PR need to go through manual testing, which will only happen next for `7.9`. ⚠️ 

Backports the following commits to 7.8:
 - S3 input: try to detect GZIPped objects  (#18764)