### PR TITLE
Encode API key as base64 in common code

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -45,6 +45,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
   fully based on Go text/template and no longer uses file concatenation to generate the config.
   Your magefile.go will require a change to adapt the devtool API. See the pull request for
   more details. {pull}18148[18148]
+- The Elasticsearch client settings expect the API key to be raw (not base64-encoded). {issue}18939[18939] {pull}18945[18945]
 
 ==== Bugfixes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -120,6 +120,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
 - Fix potential race condition in fingerprint processor. {pull}18738[18738]
 - Fixed a service restart failure under Windows. {issue}18914[18914] {pull}18916[18916]
+- The `monitoring.elasticsearch.api_key` value is correctly base64-encoded before being sent to the monitoring Elasticsearch cluster. {issue}18939[18939] {pull}18945[18945]
 
 *Auditbeat*
 

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -49,9 +49,9 @@ type Connection struct {
 	Encoder BodyEncoder
 	HTTP    esHTTPClient
 
-	encodedAPIKey string // Base64-encoded API key
-	version       common.Version
-	log           *logp.Logger
+	apiKeyAuthHeader string // Authorization HTTP request header with base64-encoded API key
+	version          common.Version
+	log              *logp.Logger
 }
 
 // ConnectionSettings are the settings needed for a Connection
@@ -167,7 +167,7 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 	}
 
 	if s.APIKey != "" {
-		conn.encodedAPIKey = base64.StdEncoding.EncodeToString([]byte(s.APIKey))
+		conn.apiKeyAuthHeader = "ApiKey " + base64.StdEncoding.EncodeToString([]byte(s.APIKey))
 	}
 
 	return &conn, nil
@@ -443,8 +443,8 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 		req.SetBasicAuth(conn.Username, conn.Password)
 	}
 
-	if conn.encodedAPIKey != "" {
-		req.Header.Add("Authorization", "ApiKey "+conn.encodedAPIKey)
+	if conn.apiKeyAuthHeader != "" {
+		req.Header.Add("Authorization", conn.apiKeyAuthHeader)
 	}
 
 	for name, value := range conn.Headers {

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -18,6 +18,7 @@
 package eslegclient
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -436,7 +437,8 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	}
 
 	if conn.APIKey != "" {
-		req.Header.Add("Authorization", "ApiKey "+conn.APIKey)
+		encoded := base64.StdEncoding.EncodeToString([]byte(conn.APIKey))
+		req.Header.Add("Authorization", "ApiKey "+encoded)
 	}
 
 	for name, value := range conn.Headers {

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -61,7 +61,7 @@ type ConnectionSettings struct {
 
 	Username string
 	Password string
-	APIKey   string
+	APIKey   string // Raw API key, NOT base64-encoded
 	Headers  map[string]string
 
 	TLS      *tlscommon.TLSConfig

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -49,8 +49,9 @@ type Connection struct {
 	Encoder BodyEncoder
 	HTTP    esHTTPClient
 
-	version common.Version
-	log     *logp.Logger
+	encodedAPIKey string // Base64-encoded API key
+	version       common.Version
+	log           *logp.Logger
 }
 
 // ConnectionSettings are the settings needed for a Connection
@@ -76,8 +77,6 @@ type ConnectionSettings struct {
 
 	Timeout         time.Duration
 	IdleConnTimeout time.Duration
-
-	encodedAPIKey string // Base64-encoded API key
 }
 
 // NewConnection returns a new Elasticsearch client
@@ -160,16 +159,18 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 		logp.Info("kerberos client created")
 	}
 
-	if s.APIKey != "" {
-		s.encodedAPIKey = base64.StdEncoding.EncodeToString([]byte(s.APIKey))
-	}
-
-	return &Connection{
+	conn := Connection{
 		ConnectionSettings: s,
 		HTTP:               httpClient,
 		Encoder:            encoder,
 		log:                logp.NewLogger("esclientleg"),
-	}, nil
+	}
+
+	if s.APIKey != "" {
+		conn.encodedAPIKey = base64.StdEncoding.EncodeToString([]byte(s.APIKey))
+	}
+
+	return &conn, nil
 }
 
 func settingsWithDefaults(s ConnectionSettings) ConnectionSettings {

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eslegclient
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIKeyEncoding(t *testing.T) {
+	apiKey := "foobar"
+	encoded := base64.StdEncoding.EncodeToString([]byte(apiKey))
+
+	conn, err := NewConnection(ConnectionSettings{
+		APIKey: apiKey,
+	})
+	require.NoError(t, err)
+
+	httpClient := newMockClient()
+	conn.HTTP = httpClient
+
+	req, err := http.NewRequest("GET", "http://fakehost/some/path", nil)
+	require.NoError(t, err)
+
+	_, _, err = conn.execHTTPRequest(req)
+	require.NoError(t, err)
+
+	require.Equal(t, "ApiKey "+encoded, httpClient.Req.Header.Get("Authorization"))
+}
+
+type mockClient struct {
+	Req *http.Request
+}
+
+func (c *mockClient) Do(req *http.Request) (*http.Response, error) {
+	c.Req = req
+
+	r := bytes.NewReader([]byte("HTTP/1.1 200 OK\n\nHello, world"))
+	return http.ReadResponse(bufio.NewReader(r), req)
+}
+
+func (c *mockClient) CloseIdleConnections() {}
+
+func newMockClient() *mockClient {
+	return &mockClient{}
+}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -19,7 +19,6 @@ package elasticsearch
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -84,7 +83,7 @@ func NewClient(
 		URL:              s.URL,
 		Username:         s.Username,
 		Password:         s.Password,
-		APIKey:           base64.StdEncoding.EncodeToString([]byte(s.APIKey)),
+		APIKey:           s.APIKey,
 		Headers:          s.Headers,
 		TLS:              s.TLS,
 		Kerberos:         s.Kerberos,

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -37,13 +37,14 @@ output.elasticsearch:
   password: "{pwd}"
 ------------------------------------------------------------------------------
 
-To use an API key to connect to {es}, use `api_key`.
+To use an API key to connect to {es}, use `api_key`. The value must be the ID of
+the API key and the API key joined by a colon.
 
 ["source","yaml",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-  api_key: "KnR6yE41RrSowb0kQ0HWoA"
+  api_key: "VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw"
 ------------------------------------------------------------------------------
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -136,8 +136,8 @@ The default value is 1.
 
 ===== `api_key`
 
-Instead of using usernames and passwords,
-you can use API keys to secure communication with {es}.
+Instead of using usernames and passwords, you can use API keys to secure communication
+with {es}. The value must be the ID of the API key and the API key joined by a colon.
 For more information, see <<beats-api-keys>>.
 
 ===== `username`


### PR DESCRIPTION
## What does this PR do?

Encodes the API key supplied to the Elasticsearch client with base64 encoding right before setting it in the `Authorization` request header.

## Why is it important?

The Elasticsearch client is shared by the Elasticsearch output as well as the Elasticsearch monitoring reporter. Rather than base64-encoding the API key in each of these places, it is better to base64-encode it within the client code itself.

In fact, prior to this PR, we were base64-encoding the key in the Elasticsearch output but not in the Elasticsearch monitoring reporter.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes elastic/beats#18939
