### PR TITLE
[7.8] Don't send bulk structure, if empty (#18747)

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -65,7 +65,7 @@ type indexStats struct {
 		IndexTimeInMillis    int `json:"index_time_in_millis"`
 		ThrottleTimeInMillis int `json:"throttle_time_in_millis"`
 	} `json:"indexing"`
-	Bulk   bulkStats `json:"bulk"`
+	Bulk   *bulkStats `json:"bulk,omitempty"`
 	Merges struct {
 		TotalSizeInBytes int `json:"total_size_in_bytes"`
 	} `json:"merges"`


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Don't send bulk structure, if empty  (#18747)