### PR TITLE
[codeowners] for the CI specific changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,7 @@
 
 # Winlogbeat
 /x-pack/winlogbeat/ @elastic/siem
+
+# CI Specific
+/.ci/ @elastic/observablt-robots
+/Jenkinsfile @elastic/observablt-robots


### PR DESCRIPTION
## What does this PR do?

CODEOWNERS for the CI specific files

## Why is it important?

Help to communicate when there are changes in the CI.

What do you think? Will this particular ownership avoid people to contribute? Or will this help us to get notified by default when something changes in those files?