### PR TITLE
Flatten BuildConfigFromFlags to avoid warning logs on k8s client creation

### DIFF
--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -26,7 +26,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -49,7 +51,7 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 		kubeconfig = getKubeConfigEnvironmentVariable()
 	}
 
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	cfg, err := buildConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build kube config due to error: %+v", err)
 	}
@@ -60,6 +62,23 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 	}
 
 	return client, nil
+}
+
+// buildConfig is a helper function that builds configs from a kubeconfig filepath.
+// If neither masterUrl or kubeconfigPath are passed in we fallback to inClusterConfig.
+// If inClusterConfig fails, we fallback to the default config.
+// This is copy of `clientcmd.BuildConfigFromFlags` of `client-go` but without the annoying
+// klog messages that are not possible to be disabled.
+func buildConfig(kubeconfigPath string) (*restclient.Config, error) {
+	if kubeconfigPath == "" {
+		kubeconfig, err := restclient.InClusterConfig()
+		if err == nil {
+			return kubeconfig, nil
+		}
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}}).ClientConfig()
 }
 
 // IsInCluster takes a kubeconfig file path as input and deduces if Beats is running in cluster or not,

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -65,9 +65,9 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 }
 
 // buildConfig is a helper function that builds configs from a kubeconfig filepath.
-// If neither masterUrl or kubeconfigPath are passed in we fallback to inClusterConfig.
+// If kubeconfigPath is not passed in we fallback to inClusterConfig.
 // If inClusterConfig fails, we fallback to the default config.
-// This is copy of `clientcmd.BuildConfigFromFlags` of `client-go` but without the annoying
+// This is a copy of `clientcmd.BuildConfigFromFlags` of `client-go` but without the annoying
 // klog messages that are not possible to be disabled.
 func buildConfig(kubeconfigPath string) (*restclient.Config, error) {
 	if kubeconfigPath == "" {


### PR DESCRIPTION
## What does this PR do?
This PR fixes https://github.com/elastic/beats/issues/18961, by implementing client configuration creation on Beats side in order to avoid the annoying warning logs of `client-go`. 

This happens by replacing https://github.com/elastic/beats/blob/0ef20cc5cbe2142650c7cf21c2aeacc401adc9bc/libbeat/common/kubernetes/util.go#L52 call with a call to a method of ours which implements the same logic without the logging.

## Why is it important?
In order to avoid the annoying warning logs of `client-go`.

Closes https://github.com/elastic/beats/issues/18961