### PR TITLE
Pre-build docker images used for filebeat integration testing

### DIFF
--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -62,7 +62,7 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        dir("${BASE_DIR}"){
+        dir("${HOME}/${BASE_DIR}"){
           retry(3){
             sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/metricbeat'")
           }
@@ -78,7 +78,7 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        dir("${BASE_DIR}"){
+        dir("${HOME}/${BASE_DIR}"){
           retry(3){
             sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/metricbeat'")
           }
@@ -94,7 +94,7 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        dir("${BASE_DIR}"){
+        dir("${HOME}/${BASE_DIR}"){
           retry(3){
             sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/filebeat'")
           }

--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -62,8 +62,10 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        retry(3){
-          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/metricbeat'")
+        dir("${BASE_DIR}"){
+          retry(3){
+            sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/metricbeat'")
+          }
         }
       }
     }
@@ -76,8 +78,10 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        retry(3){
-          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/metricbeat'")
+        dir("${BASE_DIR}"){
+          retry(3){
+            sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/metricbeat'")
+          }
         }
       }
     }
@@ -90,8 +94,10 @@ pipeline {
       }
       steps {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
-        retry(3){
-          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/filebeat'")
+        dir("${BASE_DIR}"){
+          retry(3){
+            sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/filebeat'")
+          }
         }
       }
     }

--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -53,9 +53,9 @@ pipeline {
         sh(label: 'Install virtualenv', script: 'pip install --user virtualenv')
       }
     }
-    stage('Release Beats Test Docker images'){
+    stage('Metricbeat Test Docker images'){
       options {
-        warnError('Release Beats Docker images failed')
+        warnError('Metricbeat Test Docker images failed')
       }
       when {
         expression { return params.RELEASE_TEST_IMAGES }
@@ -67,9 +67,9 @@ pipeline {
         }
       }
     }
-    stage('Release X-Pack Beats Test Docker images'){
+    stage('Metricbeat x-pack Test Docker images'){
       options {
-        warnError('Release X-Pack Beats Docker images failed')
+        warnError('Metricbeat x-pack Docker images failed')
       }
       when {
         expression { return params.RELEASE_TEST_IMAGES }
@@ -78,6 +78,20 @@ pipeline {
         dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
         retry(3){
           sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/metricbeat'")
+        }
+      }
+    }
+    stage('Filebeat x-pack Test Docker images'){
+      options {
+        warnError('Filebeat x-pack Test Docker images failed')
+      }
+      when {
+        expression { return params.RELEASE_TEST_IMAGES }
+      }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        retry(3){
+          sh(label: 'Build ', script: ".ci/scripts/build-beats-integrations-test-images.sh '${GO_VERSION}' '${HOME}/${BASE_DIR}/x-pack/filebeat'")
         }
       }
     }

--- a/.ci/scripts/build-beats-integrations-test-images.sh
+++ b/.ci/scripts/build-beats-integrations-test-images.sh
@@ -6,16 +6,16 @@ set -exo pipefail
 #
 # Parameters:
 #   - GO_VERSION - that's the version which will be installed and enabled.
-#   - METRICBEAT_DIR - that's the location of the metricbeat directory.
+#   - BEAT_BASE_DIR - that's the base directory of the Beat.
 #
 
 readonly GO_VERSION="${1?Please define the Go version to be used}"
-readonly METRICBEAT_DIR="${2?Please define the location of the Metricbeat directory}"
+readonly BEAT_BASE_DIR="${2?Please define the location of the Beat directory}"
 
 function build_test_images() {
-    local metricbeatDir="${1}"
+    local baseDir="${1}"
 
-    cd "${metricbeatDir}"
+    cd "${baseDir}"
     mage compose:buildSupportedVersions
 }
 
@@ -28,25 +28,25 @@ function install_go() {
 }
 
 function install_mage() {
-    local metricbeatDir="${1}"
+    local baseDir="${1}"
 
-    cd "${metricbeatDir}"
+    cd "${baseDir}"
     make mage
 }
 
 function push_test_images() {
-    local metricbeatDir="${1}"
+    local baseDir="${1}"
 
-    cd "${metricbeatDir}"
+    cd "${baseDir}"
     mage compose:pushSupportedVersions
 }
 
 function main() {
     install_go "${GO_VERSION}"
-    install_mage "${METRICBEAT_DIR}"
+    install_mage "${BEAT_BASE_DIR}"
 
-    build_test_images "${METRICBEAT_DIR}"
-    push_test_images "${METRICBEAT_DIR}"
+    build_test_images "${BEAT_BASE_DIR}"
+    push_test_images "${BEAT_BASE_DIR}"
 }
 
 main "$@"


### PR DESCRIPTION
## What does this PR do?

Pre-build docker images used for filebeat integration testing.

## Why is it important?

To reduce flakiness of tests because of having to build images.

## Related issues

- Tag googlepubsub image used in filebeat tests #18773
- Move this job to beats-ci #18785
- Enable JJBB for this job #18812