### PR TITLE
Cherry-pick #18972 to 7.x: Move Tomcat dashboard changelog from breaking change to added change

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,7 +55,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - kubernetes.container.cpu.limit.cores and kubernetes.container.cpu.requests.cores are now floats. {issue}11975[11975]
 - Update cloudwatch metricset mapping for both metrics and dimensions. {pull}15245[15245]
 - Make use of secure port when accessing Kubelet API {pull}16063[16063]
-- Add Tomcat overview dashboard {pull}14026[14026]
 
 *Packetbeat*
 
@@ -525,6 +524,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add client address to events from http server module {pull}18336[18336]
 - Add memory metrics into compute googlecloud. {pull}18802[18802]
 - Add new fields to HAProxy module. {issue}18523[18523]
+- Add Tomcat overview dashboard {pull}14026[14026]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #18972 to 7.x branch. Original message: 

This is just a PR to fix changelog.