### PR TITLE
Cherry-pick #18972 to 7.8: Move Tomcat dashboard changelog from breaking change to added change

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -504,6 +504,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update MSSQL module to fix some SSPI authentication and add brackets to USE statements {pull}17862[17862]]
 - Remove required for region/zone and make stackdriver a metricset in googlecloud. {issue}16785[16785] {pull}18398[18398]
 - Add memory metrics into compute googlecloud. {pull}18802[18802]
+- Add new fields to HAProxy module. {issue}18523[18523]
+- Add Tomcat overview dashboard {pull}14026[14026]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #18972 to 7.8 branch. Original message: 

This is just a PR to fix changelog.