### PR TITLE
[Winlogbeat] Fix issue with missing module fields in index template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -230,7 +230,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
-- Fix invalid IP addresses in DNS query results from Sysmon data. {issue}18432[18432] {pull}18436{18436}
+- Fix invalid IP addresses in DNS query results from Sysmon data. {issue}18432[18432] {pull}18436[18436]
+- Fields from Winlogbeat modules were not being included in index templates and patterns. {pull}18983[18983]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/cmd/root.go
+++ b/x-pack/winlogbeat/cmd/root.go
@@ -7,6 +7,9 @@ package cmd
 import (
 	"github.com/elastic/beats/v7/winlogbeat/cmd"
 	xpackcmd "github.com/elastic/beats/v7/x-pack/libbeat/cmd"
+
+	// Register fields.
+	_ "github.com/elastic/beats/v7/x-pack/winlogbeat/include"
 )
 
 // Name of this beat.

--- a/x-pack/winlogbeat/main.go
+++ b/x-pack/winlogbeat/main.go
@@ -7,8 +7,6 @@ package main
 import (
 	"os"
 
-	_ "github.com/elastic/beats/v7/winlogbeat/include"
-
 	"github.com/elastic/beats/v7/x-pack/winlogbeat/cmd"
 )
 


### PR DESCRIPTION
## What does this PR do?

The fields.go files were not being imported for the Winlogbeat modules so they were absent from the index template.

## Why is it important?

To avoid dynamic mappings for fields that we already defined in fields.yml.

