### PR TITLE
Cherry-pick #18994 to 7.8: Fix typo in remote_write documentation

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -1,5 +1,5 @@
 This is the remote_write metricset of the module prometheus. This metricset can receive metrics from a Prometheus server that
-has configureed https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write[remote_write] setting accordingly, for instance:
+has configured https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write[remote_write] setting accordingly, for instance:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of PR #18994 to 7.8 branch. Original message: 

Fix typo in remote_write metricset documentation.