### PR TITLE
Update supported Kafka version in doc

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -34,7 +34,7 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 [[kafka-compatibility]]
 ==== Compatibility
 
-This output works with all Kafka versions in between 0.11 and 2.1.0. Older versions
+This output works with all Kafka versions in between 0.11 and 2.2.2. Older versions
 might work as well, but are not supported.
 
 ==== Configuration options


### PR DESCRIPTION
## What does this PR do?

Updates the version of Kafka we support in the Kafka output documentation.

## Why is it important?

The version in the documentation is slightly older than the one we actually test with: https://github.com/elastic/beats/blob/43a07dac7785702129d576dc8a272b4086c84927/testing/environments/docker/kafka/Dockerfile#L7.

## Checklist

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
