### PR TITLE
Cherry-pick #18958 to 7.x: [Filebeat] Improve AWS cloudtrail fileset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -433,6 +433,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
 - Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
 - The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
+- Add geoip AS lookup & improve ECS categorization in aws cloudtrail fileset. {issue}18644[18644] {pull}18958[18958]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
@@ -102,6 +102,22 @@ processors:
       target_field: "source.geo"
       ignore_failure: true
       ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+        field: source.as.organization_name
+        target_field: source.as.organization.name
+        ignore_missing: true
   - user_agent:
       field: "json.userAgent"
       target_field: "user_agent"
@@ -210,20 +226,7 @@ processors:
           ctx.related.user.add(userName);
         }
 
-        ctx.event.type = 'info';
-        ctx.event.kind = 'event';
-        if (ctx.aws.cloudtrail.error_code != null || ctx.aws.cloudtrail.error_message != null) {
-            ctx.event.outcome = 'failure'
-        } else {
-            ctx.event.outcome = 'success'
-        }
 
-        if (ctx.json?.eventName == 'ConsoleLogin') {
-          ctx.event.category = 'authentication';
-          if (ctx.json?.responseElements.ConsoleLogin != null) {
-            ctx.event.outcome = Processors.lowercase(ctx.json.responseElements.ConsoleLogin);
-          }
-        }
 
         if (ctx.json?.requestParameters.userName != null) {
           addRelatedUser(ctx, ctx.json.requestParameters.userName);
@@ -262,6 +265,344 @@ processors:
           cl_map.put("additional_eventdata", aed_map);
           ctx.aws.cloudtrail.put("console_login", cl_map);
         }
+  - script:
+      lang: painless
+      ignore_failure: true
+      params:
+        AddUserToGroup:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        AssumeRole:
+          category:
+            - authentication
+          type:
+            - info
+        AttachGroupPolicy:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        AttachUserPolicy:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        ChangePassword:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        ConsoleLogin:
+          category:
+            - authentication
+          type:
+            - info
+        CreateAccessKey:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        CreateBucket:
+          category:
+            - file
+          type:
+            - creation
+        CreateGroup:
+          category:
+            - iam
+          type:
+            - group
+            - creation
+        CreateKeyPair:
+          category:
+            - iam
+          type:
+            - admin
+            - creation
+        CreateUser:
+          category:
+            - iam
+          type:
+            - user
+            - creation
+        CreateVirtualMFADevice:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeactivateMFADevice:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeleteAccessKey:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeleteBucket:
+          category:
+            - file
+          type:
+            - deletion
+        DeleteGroup:
+          category:
+            - iam
+          type:
+            - group
+            - deletion
+        DeleteGroupPolicy:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        DeleteSSHPublicKey:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeleteUser:
+          category:
+            - iam
+          type:
+            - user
+            - deletion
+        DeleteUserPermissionsBoundary:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeleteUserPolicy:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DeleteVirtualMFADevice:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        DetachGroupPolicy:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        DetachUserPolicy:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        EnableMFADevice:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        GetGroup:
+          category:
+            - iam
+          type:
+            - group
+            - info
+        GetGroupPolicy:
+          category:
+            - iam
+          type:
+            - group
+            - info
+        GetUser:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        GetUserPolicy:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListAttachedGroupPolicies:
+          category:
+            - iam
+          type:
+            - group
+            - info
+        ListAttachedUserPolicies:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListGroupsForUser:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListGroupPolicies:
+          category:
+            - iam
+          type:
+            - group
+            - info
+        ListGroups:
+          category:
+            - iam
+          type:
+            - group
+            - info
+        ListGroupsForUser:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListUserPolicies:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListUsers:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        ListUserTags:
+          category:
+            - iam
+          type:
+            - user
+            - info
+        PutGroupPolicy:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        PutUserPermissionsBoundary:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        PutUserPolicy:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        RemoveUserFromGroup:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        SetDefaultPolicyVersion:
+          category:
+            - iam
+          type:
+            - admin
+            - change
+        SetSecurityTokenServicePreferences:
+          category:
+            - iam
+          type:
+            - admin
+            - change
+        TagUser:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        UntagUser:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        UpdateAccessKey:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        UpdateAccountPasswordPolicy:
+          category:
+            - iam
+          type:
+            - admin
+            - change
+        UpdateGroup:
+          category:
+            - iam
+          type:
+            - group
+            - change
+        UpdateLoginProfile:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        UpdateRole:
+          category:
+            - iam
+          type:
+            - admin
+            - change
+        UpdateSSHPublicKey:
+          category:
+            - iam
+          type:
+            - user
+            - change
+        UpdateUser:
+          category:
+            - iam
+          type:
+            - user
+            - change
+      source: >-
+        ctx.event.kind = 'event';
+        ctx.event.type = 'info';
+
+        if (ctx.aws.cloudtrail.error_code != null || ctx.aws.cloudtrail.error_message != null) {
+            ctx.event.outcome = 'failure'
+        } else {
+            ctx.event.outcome = 'success'
+        }
+
+        if (ctx?.event?.action == null) {
+            return;
+        }
+
+        if (ctx.event.action == 'ConsoleLogin' && ctx.json?.responseElements.ConsoleLogin != null) {
+            ctx.event.outcome = Processors.lowercase(ctx.json.responseElements.ConsoleLogin);
+        }
+        
+        def hm = new HashMap(params.get(ctx.event.action));
+        hm.forEach((k, v) -> ctx.event[k] = v);
 
   - remove:
       field:

--- a/x-pack/filebeat/module/aws/cloudtrail/test/add-user-to-group-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/add-user-to-group-json.log-expected.json
@@ -11,13 +11,19 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-2",
         "event.action": "AddUserToGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.kind": "event",
         "event.module": "aws",
         "event.original": "{\"eventVersion\":\"1.0\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EX_PRINCIPAL_ID\",\"arn\":\"arn:aws:iam::123456789012:user/Alice\",\"accountId\":\"123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2014-03-25T18:45:11Z\"}}},\"eventTime\":\"2014-03-25T21:08:14Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"AddUserToGroup\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"AWSConsole\",\"requestParameters\":{\"userName\":\"Bob\",\"groupName\":\"admin\"},\"responseElements\":null}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/assume-role-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/assume-role-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "111111111111",
         "cloud.region": "us-east-2",
         "event.action": "AssumeRole",
+        "event.category": [
+            "authentication"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "1917948f-3042-46ec-98e2-62865EXAMPLE",
         "event.kind": "event",
@@ -21,12 +24,16 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROAIN5ATK5U7KEXAMPLE:JohnRole1\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/JohnDoe/JohnRole1\",\"accountId\":\"111111111111\",\"accessKeyId\":\"AKIAI44QH8DHBEXAMPLE\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2019-10-02T21:50:54Z\"},\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROAIN5ATK5U7KEXAMPLE\",\"arn\":\"arn:aws:iam::111111111111:role/JohnRole1\",\"accountId\":\"111111111111\",\"userName\":\"JohnDoe\"}}},\"eventTime\":\"2019-10-02T22:12:29Z\",\"eventSource\":\"sts.amazonaws.com\",\"eventName\":\"AssumeRole\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"123.145.67.89\",\"userAgent\":\"aws-cli/1.16.248 Python/3.4.7 Linux/4.9.184-0.1.ac.235.83.329.metal1.x86_64 botocore/1.12.239\",\"requestParameters\":{\"incomingTransitiveTags\":{\"Department\":\"Engineering\"},\"tags\":[{\"value\":\"johndoe@example.com\",\"key\":\"Email\"},{\"value\":\"12345\",\"key\":\"CostCenter\"}],\"roleArn\":\"arn:aws:iam::111111111111:role/JohnRole2\",\"roleSessionName\":\"Role2WithTags\",\"transitiveTagKeys\":[\"Email\",\"CostCenter\"],\"durationSeconds\":3600},\"responseElements\":{\"credentials\":{\"accessKeyId\":\"ASIAWHOJDLGPOEXAMPLE\",\"expiration\":\"Oct 2, 2019 11:12:29 PM\",\"sessionToken\":\"AgoJb3JpZ2luX2VjEB4aCXVzLXdlc3QtMSJHMEXAMPLETOKEN+//rJb8Lo30mFc5MlhFCEbubZvEj0wHB/mDMwIgSEe9gk/Zjr09tZV7F1HDTMhmEXAMPLETOKEN/iEJ/rkqngII9///////////ARABGgw0MjgzMDc4NjM5NjYiDLZjZFKwP4qxQG5sFCryASO4UPz5qE97wPPH1eLMvs7CgSDBSWfonmRTCfokm2FN1+hWUdQQH6adjbbrVLFL8c3jSsBhQ383AvxpwK5YRuDE1AI/+C+WKFZb701eiv9J5La2EXAMPLETOKEN/c7S5Iro1WUJ0q3Cxuo/8HUoSxVhQHM7zF7mWWLhXLEQ52ivL+F6q5dpXu4aTFedpMfnJa8JtkWwG9x1Axj0Ypy2ok8v5unpQGWych1vwdvj6ez1Dm8Xg1+qIzXILiEXAMPLETOKEN/vQGqu8H+nxp3kabcrtOvTFTvxX6vsc8OGwUfHhzAfYGEXAMPLETOKEN/L6v1yMM3B1OwFOrQBno1HEjf1oNI8RnQiMNFdUOtwYj7HUZIOCZmjfN8PPHq77N7GJl9lzvIZKQA0Owcjg+mc78zHCj8y0siY8C96paEXAMPLETOKEN/E3cpksxWdgs91HRzJWScjN2+r2LTGjYhyPqcmFzzo2mCE7mBNEXAMPLETOKEN/oJy+2o83YNW5tOiDmczgDzJZ4UKR84yGYOMfSnF4XcEJrDgAJ3OJFwmTcTQICAlSwLEXAMPLETOKEN\"},\"assumedRoleUser\":{\"assumedRoleId\":\"AROAIFR7WHDTSOYQYHFUE:Role2WithTags\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/test-role/Role2WithTags\"}},\"requestID\":\"b96b0e4e-e561-11e9-8b3f-7b396EXAMPLE\",\"eventID\":\"1917948f-3042-46ec-98e2-62865EXAMPLE\",\"resources\":[{\"ARN\":\"arn:aws:iam::111122223333:role/JohnRole2\",\"accountId\":\"111111111111\",\"type\":\"AWS::IAM::Role\"}],\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"111111111111\"}",
         "event.outcome": "success",
         "event.provider": "sts.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "info"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
         "service.type": "aws",
         "source.address": "123.145.67.89",
+        "source.as.number": 4837,
+        "source.as.organization.name": "CHINA UNICOM China169 Backbone",
         "source.geo.continent_name": "Asia",
         "source.geo.country_iso_code": "CN",
         "source.geo.location.lat": 29.5569,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/change-password-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/change-password-json.log-expected.json
@@ -12,6 +12,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "ChangePassword",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-b92f-48bb-8c4c-efeEXAMPLE",
         "event.kind": "event",
@@ -19,7 +22,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T00:09:33Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ChangePassword\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"errorCode\":\"AccessDeniedException\",\"errorMessage\":\"An unknown error occurred\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"EXAMPLE-5204-4fed-9c60-9c6EXAMPLE\",\"eventID\":\"EXAMPLE-b92f-48bb-8c4c-efeEXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "failure",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -44,6 +50,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "ChangePassword",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-35a7-4c25-9fc7-EXAMPLE",
         "event.kind": "event",
@@ -51,7 +60,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T00:03:36Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ChangePassword\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"EXAMPLE-5c16-4eda-9724-EXAMPLE\",\"eventID\":\"EXAMPLE-35a7-4c25-9fc7-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 720,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/console-login-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/console-login-json.log-expected.json
@@ -12,7 +12,9 @@
         "cloud.account.id": "111122223333",
         "cloud.region": "us-east-2",
         "event.action": "ConsoleLogin",
-        "event.category": "authentication",
+        "event.category": [
+            "authentication"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "3fcfb182-98f8-4744-bd45-10aEXAMPLE",
         "event.kind": "event",
@@ -20,7 +22,9 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDACKCEVSQ6C2EXAMPLE\",\"arn\":\"arn:aws:iam::111122223333:user/JohnDoe\",\"accountId\":\"111122223333\",\"userName\":\"JohnDoe\"},\"eventTime\":\"2014-07-16T15:49:27Z\",\"eventSource\":\"signin.amazonaws.com\",\"eventName\":\"ConsoleLogin\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"192.0.2.110\",\"userAgent\":\"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko/20100101 Firefox/24.0\",\"requestParameters\":null,\"responseElements\":{\"ConsoleLogin\":\"Success\"},\"additionalEventData\":{\"MobileVersion\":\"No\",\"LoginTo\":\"https://console.aws.amazon.com/s3/\",\"MFAUsed\":\"No\"},\"eventID\":\"3fcfb182-98f8-4744-bd45-10aEXAMPLE\"}",
         "event.outcome": "success",
         "event.provider": "signin.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "info"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -51,7 +55,9 @@
         "cloud.account.id": "111122223333",
         "cloud.region": "us-east-2",
         "event.action": "ConsoleLogin",
-        "event.category": "authentication",
+        "event.category": [
+            "authentication"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "11ea990b-4678-4bcd-8fbe-625EXAMPLE",
         "event.kind": "event",
@@ -59,7 +65,9 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDACKCEVSQ6C2EXAMPLE\",\"arn\":\"arn:aws:iam::111122223333:user/JaneDoe\",\"accountId\":\"111122223333\",\"userName\":\"JaneDoe\"},\"eventTime\":\"2014-07-08T17:35:27Z\",\"eventSource\":\"signin.amazonaws.com\",\"eventName\":\"ConsoleLogin\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"192.0.2.100\",\"userAgent\":\"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko/20100101 Firefox/24.0\",\"errorMessage\":\"Failed authentication\",\"requestParameters\":null,\"responseElements\":{\"ConsoleLogin\":\"Failure\"},\"additionalEventData\":{\"MobileVersion\":\"No\",\"LoginTo\":\"https://console.aws.amazon.com/sns\",\"MFAUsed\":\"No\"},\"eventID\":\"11ea990b-4678-4bcd-8fbe-625EXAMPLE\"}",
         "event.outcome": "failure",
         "event.provider": "signin.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "info"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 658,
@@ -96,7 +104,9 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-2",
         "event.action": "ConsoleLogin",
-        "event.category": "authentication",
+        "event.category": [
+            "authentication"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "11ea990b-4678-4bcd-8fbe-625EXAMPLE",
         "event.kind": "event",
@@ -104,7 +114,9 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROAIDPPEZS35WEXAMPLE:AssumedRoleSessionName\",\"arn\":\"arn:aws:sts::123456789012:assumed-role/RoleToBeAssumed/MySessionName\",\"accountId\":\"123456789012\",\"accessKeyId\":\"AKIAIOSFODNN7EXAMPLE\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"20131102T010628Z\"}},\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROAIDPPEZS35WEXAMPLE\",\"arn\":\"arn:aws:iam::123456789012:role/RoleToBeAssumed\",\"accountId\":\"123456789012\",\"userName\":\"RoleToBeAssumed\"}},\"eventTime\":\"2014-07-08T17:35:27Z\",\"eventSource\":\"signin.amazonaws.com\",\"eventName\":\"ConsoleLogin\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"192.0.2.100\",\"userAgent\":\"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko/20100101 Firefox/24.0\",\"errorMessage\":\"Failed authentication\",\"requestParameters\":null,\"responseElements\":{\"ConsoleLogin\":\"Failure\"},\"additionalEventData\":{\"MobileVersion\":\"No\",\"LoginTo\":\"https://console.aws.amazon.com/sns\",\"MFAUsed\":\"No\"},\"eventID\":\"11ea990b-4678-4bcd-8fbe-625EXAMPLE\"}",
         "event.outcome": "failure",
         "event.provider": "signin.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "info"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 1355,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/create-access-key-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/create-access-key-json.log-expected.json
@@ -15,6 +15,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "CreateAccessKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-3cab-40f8-938b-EXAMPLE",
         "event.kind": "event",
@@ -22,7 +25,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-08T15:12:16Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-08T20:43:06Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"CreateAccessKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"userName\":\"Bob\"},\"responseElements\":{\"accessKey\":{\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"status\":\"Active\",\"userName\":\"Bob\",\"createDate\":\"Jan 8, 2020 8:43:06 PM\"}},\"requestID\":\"EXAMPLE-823a-48dc-8fa9-EXAMPLE\",\"eventID\":\"EXAMPLE-3cab-40f8-938b-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/create-group-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/create-group-json.log-expected.json
@@ -15,6 +15,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "CreateGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-37ec-425a-a7ef-EXAMPLE",
         "event.kind": "event",
@@ -22,7 +25,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-08T15:12:16Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-09T01:48:44Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"CreateGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"groupName\":\"TEST-GROUP\"},\"responseElements\":{\"group\":{\"createDate\":\"Jan 9, 2020 1:48:44 AM\",\"path\":\"/\",\"arn\":\"arn:aws:iam::0123456789012:group/TEST-GROUP\",\"groupName\":\"TEST-GROUP\",\"groupId\":\"EXAMPLE_ID\"}},\"requestID\":\"EXAMPLE-769d-4a61-b731-EXAMPLE\",\"eventID\":\"EXAMPLE-37ec-425a-a7ef-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "creation"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -49,6 +55,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "CreateGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-09c6-4745-af70-EXAMPLE",
         "event.kind": "event",
@@ -56,7 +65,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T02:22:03Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"CreateGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"errorCode\":\"EntityAlreadyExistsException\",\"errorMessage\":\"Group with name TEST-GROUP already exists.\",\"requestParameters\":{\"groupName\":\"TEST-GROUP\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-c8ae-44dc-8114-EXAMPLE\",\"eventID\":\"EXAMPLE-09c6-4745-af70-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "failure",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "creation"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 903,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/create-key-pair-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/create-key-pair-json.log-expected.json
@@ -12,18 +12,26 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-2",
         "event.action": "CreateKeyPair",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.kind": "event",
         "event.module": "aws",
         "event.original": "{\"eventVersion\":\"1.0\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EX_PRINCIPAL_ID\",\"arn\":\"arn:aws:iam::123456789012:user/Alice\",\"accountId\":\"123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2014-03-06T15:15:06Z\"}}},\"eventTime\":\"2014-03-06T17:10:34Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"CreateKeyPair\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"72.21.198.64\",\"userAgent\":\"EC2ConsoleBackend, aws-sdk-java/Linux/x.xx.fleetxen Java_HotSpot(TM)_64-Bit_Server_VM/xx\",\"requestParameters\":{\"keyName\":\"mykeypair\"},\"responseElements\":{\"keyName\":\"mykeypair\",\"keyFingerprint\":\"30:1d:46:d0:5b:ad:7e:1b:b6:70:62:8b:ff:38:b5:e9:ab:5d:b8:21\",\"keyMaterial\":\"<sensitiveDataRemoved>\"}}",
         "event.outcome": "success",
         "event.provider": "ec2.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "admin",
+            "creation"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
         "service.type": "aws",
         "source.address": "72.21.198.64",
+        "source.as.number": 16509,
+        "source.as.organization.name": "Amazon.com, Inc.",
         "source.geo.city_name": "Ashburn",
         "source.geo.continent_name": "North America",
         "source.geo.country_iso_code": "US",

--- a/x-pack/filebeat/module/aws/cloudtrail/test/create-user-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/create-user-json.log-expected.json
@@ -10,13 +10,19 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-2",
         "event.action": "CreateUser",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.kind": "event",
         "event.module": "aws",
         "event.original": "{\"eventVersion\":\"1.0\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EX_PRINCIPAL_ID\",\"arn\":\"arn:aws:iam::123456789012:user/Alice\",\"accountId\":\"123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\"},\"eventTime\":\"2014-03-24T21:11:59Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"CreateUser\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.3.2 Python/2.7.5 Windows/7\",\"requestParameters\":{\"userName\":\"Bob\"},\"responseElements\":{\"user\":{\"createDate\":\"Mar 24, 2014 9:11:59 PM\",\"userName\":\"Bob\",\"arn\":\"arn:aws:iam::123456789012:user/Bob\",\"path\":\"/\",\"userId\":\"EXAMPLEUSERID\"}}}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "creation"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/create-virtual-mfa-device-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/create-virtual-mfa-device-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "CreateVirtualMFADevice",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-351c-472a-b089-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2019-11-27T15:07:22Z\"}}},\"eventTime\":\"2019-11-27T15:10:15Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"CreateVirtualMFADevice\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"virtualMFADeviceName\":\"Alice\",\"path\":\"/\"},\"responseElements\":{\"virtualMFADevice\":{\"serialNumber\":\"arn:aws:iam::0123456789012:mfa/Alice\"}},\"requestID\":\"EXAMPLE-303b-4b0e-a8c7-EXAMPLE\",\"eventID\":\"EXAMPLE-351c-472a-b089-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/deactivate-mfa-device-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/deactivate-mfa-device-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeactivateMFADevice",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-1889-416b-ace9-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-09T16:36:17Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T00:34:02Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeactivateMFADevice\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"userName\":\"Alice\",\"serialNumber\":\"arn:aws:iam::0123456789012:mfa/Alice\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-801a-4624-8fa0-EXAMPLE\",\"eventID\":\"EXAMPLE-1889-416b-ace9-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-access-key-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-access-key-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteAccessKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-0698-46bd-998d-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-08T15:12:16Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-08T19:09:36Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteAccessKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"userName\":\"Bob\",\"accessKeyId\":\"EXAMPLE_ID\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-3bea-41fa-a0b4-EXAMPLE\",\"eventID\":\"EXAMPLE-0698-46bd-998d-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-bucket-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-bucket-json.log-expected.json
@@ -13,6 +13,9 @@
         "cloud.account.id": "777788889999",
         "cloud.region": "us-east-2",
         "event.action": "DeleteBucket",
+        "event.category": [
+            "file"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "dEXAMPLE-265a-41e0-9352-4401bEXAMPLE",
         "event.kind": "event",
@@ -20,7 +23,9 @@
         "event.original": "{\"eventVersion\":\"1.04\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AIDAQRSTUVWXYZEXAMPLE:devdsk\",\"arn\":\"arn:aws:sts::777788889999:assumed-role/AssumeNothing/devdsk\",\"accountId\":\"777788889999\",\"accessKeyId\":\"AKIAQRSTUVWXYZEXAMPLE\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2016-11-14T17:25:26Z\"},\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AIDAQRSTUVWXYZEXAMPLE\",\"arn\":\"arn:aws:iam::777788889999:role/AssumeNothing\",\"accountId\":\"777788889999\",\"userName\":\"AssumeNothing\"}}},\"eventTime\":\"2016-11-14T17:25:45Z\",\"eventSource\":\"s3.amazonaws.com\",\"eventName\":\"DeleteBucket\",\"awsRegion\":\"us-east-2\",\"sourceIPAddress\":\"192.0.2.1\",\"userAgent\":\"[aws-cli/1.11.10 Python/2.7.8 Linux/3.2.45-0.6.wd.865.49.315.metal1.x86_64 botocore/1.4.67]\",\"requestParameters\":{\"bucketName\":\"my-test-bucket-cross-account\"},\"responseElements\":null,\"requestID\":\"EXAMPLE463D56D4C\",\"eventID\":\"dEXAMPLE-265a-41e0-9352-4401bEXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"777788889999\"}",
         "event.outcome": "success",
         "event.provider": "s3.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "deletion"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-group-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-group-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-cbc2-4cc3-8bbc-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-08T15:12:16Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-09T02:25:44Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"groupName\":\"TEST-GROUP\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-66cb-4775-a203-EXAMPLE\",\"eventID\":\"EXAMPLE-cbc2-4cc3-8bbc-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "deletion"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -48,6 +54,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-5aa2-4b5f-a52a-EXAMPLE",
         "event.kind": "event",
@@ -55,7 +64,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_PRINCIPLE\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T02:25:11Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"errorCode\":\"DeleteConflictException\",\"errorMessage\":\"Cannot delete entity, must detach all policies first.\",\"requestParameters\":{\"groupName\":\"TEST-GROUP\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-2a3c-4a94-b24f-EXAMPLE\",\"eventID\":\"EXAMPLE-5aa2-4b5f-a52a-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "failure",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "deletion"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 747,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-ssh-public-key-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-ssh-public-key-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteSSHPublicKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-72ff-4d4f-9a8d-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T16:07:08Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteSSHPublicKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"sSHPublicKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Bob\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-7b34-44ae-a22f-EXAMPLE\",\"eventID\":\"EXAMPLE-72ff-4d4f-9a8d-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-user-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-user-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteUser",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "b89eb34b-8fcb-4cba-8439-d4EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EX_PRINCIPAL_ID\",\"arn\":\"arn:aws:iam::123456789012:user/Alice\",\"accountId\":\"123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-03T15:26:38Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-03T15:50:52Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteUser\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"userName\":\"Bob\"},\"responseElements\":null,\"requestID\":\"0e794d53-cdb5-4f7d-b7db-5EXAMPLE\",\"eventID\":\"b89eb34b-8fcb-4cba-8439-d4EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "deletion"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/delete-virtual-mfa-device-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/delete-virtual-mfa-device-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "DeleteVirtualMFADevice",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-f8e6-4d5f-8525-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-09T16:36:17Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T00:34:02Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"DeleteVirtualMFADevice\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"serialNumber\":\"arn:aws:iam::0123456789012:mfa/Alice\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-af91-4d1a-aaf2-EXAMPLE\",\"eventID\":\"EXAMPLE-f8e6-4d5f-8525-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/enable-mfa-device-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/enable-mfa-device-json.log-expected.json
@@ -13,6 +13,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "EnableMFADevice",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-3fdc-4b2a-9885-EXAMPLE",
         "event.kind": "event",
@@ -20,7 +23,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2019-11-27T15:07:22Z\"}}},\"eventTime\":\"2019-11-27T15:11:09Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"EnableMFADevice\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"userName\":\"Bob\",\"serialNumber\":\"arn:aws:iam::0123456789012:mfa/Bob\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-adea-490a-a806-EXAMPLE\",\"eventID\":\"EXAMPLE-3fdc-4b2a-9885-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/remove-user-from-group-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/remove-user-from-group-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "RemoveUserFromGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-6e8b-431a-94f4-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-06T14:36:28Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-06T15:19:50Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"RemoveUserFromGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"groupName\":\"Admin\",\"userName\":\"Bob\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-0bf0-47be-bc80-EXAMPLE\",\"eventID\":\"EXAMPLE-6e8b-431a-94f4-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-access-key-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-access-key-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateAccessKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-0ef0-42cd-8551-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T15:01:23Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateAccessKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"status\":\"Inactive\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Bob\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-7d0c-45f4-b25b-EXAMPLE\",\"eventID\":\"EXAMPLE-0ef0-42cd-8551-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-accout-password-policy-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-accout-password-policy-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateAccountPasswordPolicy",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-91f9-49f3-948c-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T18:05:33Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateAccountPasswordPolicy\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"requireLowercaseCharacters\":true,\"requireSymbols\":true,\"requireNumbers\":true,\"minimumPasswordLength\":12,\"requireUppercaseCharacters\":true,\"allowUsersToChangePassword\":true},\"responseElements\":null,\"requestID\":\"EXAMPLE-5ebf-4bc3-a349-EXAMPLE\",\"eventID\":\"EXAMPLE-91f9-49f3-948c-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "admin",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-group-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-group-json.log-expected.json
@@ -11,6 +11,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-c3aa-487b-b05e-EXAMPLE",
         "event.kind": "event",
@@ -18,7 +21,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T02:23:11Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"requestParameters\":{\"newGroupName\":\"TEST-GROUP2\",\"groupName\":\"TEST-GROUP\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-c22d-4fca-b40a-EXAMPLE\",\"eventID\":\"EXAMPLE-c3aa-487b-b05e-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -46,6 +52,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateGroup",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-6a0b-475c-b5db-EXAMPLE",
         "event.kind": "event",
@@ -53,7 +62,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"0123456789012\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-09T02:24:35Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"errorCode\":\"EntityAlreadyExistsException\",\"errorMessage\":\"Group with name TEST-GROUP already exists.\",\"requestParameters\":{\"newGroupName\":\"TEST-GROUP\",\"groupName\":\"TEST-GROUP2\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-f673-4ce7-8529-EXAMPLE\",\"eventID\":\"EXAMPLE-6a0b-475c-b5db-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "failure",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "group",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 683,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-login-profile-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-login-profile-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateLoginProfile",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-c3b6-4498-b818-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T18:25:42Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateLoginProfile\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"userName\":\"Bob\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-0dc6-447a-8859-EXAMPLE\",\"eventID\":\"EXAMPLE-c3b6-4498-b818-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-ssh-public-key-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-ssh-public-key-json.log-expected.json
@@ -14,6 +14,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateSSHPublicKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-5c88-4652-9ee9-EXAMPLE",
         "event.kind": "event",
@@ -21,7 +24,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T16:06:54Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateSSHPublicKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"status\":\"Inactive\",\"userName\":\"Bob\",\"sSHPublicKeyId\":\"EXAMPLE_KEY_ID\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-32f3-4a92-82e1-EXAMPLE\",\"eventID\":\"EXAMPLE-5c88-4652-9ee9-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,
@@ -52,6 +58,9 @@
         "cloud.account.id": "0123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateSSHPublicKey",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "EXAMPLE-5c88-4652-9ee9-EXAMPLE",
         "event.kind": "event",
@@ -59,7 +68,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EXAMPLE_ID\",\"arn\":\"arn:aws:iam::0123456789012:user/Alice\",\"accountId\":\"0123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"true\",\"creationDate\":\"2020-01-10T14:38:30Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2020-01-10T16:06:54Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateSSHPublicKey\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"status\":\"Inactive\",\"userName\":\"Bob\",\"sSHPublicKeyId\":\"EXAMPLE_KEY_ID\"},\"responseElements\":null,\"requestID\":\"EXAMPLE-32f3-4a92-82e1-EXAMPLE\",\"eventID\":\"EXAMPLE-5c88-4652-9ee9-EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"0123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 800,

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-trail-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-trail-json.log-expected.json
@@ -26,6 +26,8 @@
         "log.offset": 0,
         "service.type": "aws",
         "source.address": "205.251.233.182",
+        "source.as.number": 16509,
+        "source.as.organization.name": "Amazon.com, Inc.",
         "source.geo.city_name": "Boardman",
         "source.geo.continent_name": "North America",
         "source.geo.country_iso_code": "US",

--- a/x-pack/filebeat/module/aws/cloudtrail/test/update-user-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/update-user-json.log-expected.json
@@ -11,6 +11,9 @@
         "cloud.account.id": "123456789012",
         "cloud.region": "us-east-1",
         "event.action": "UpdateUser",
+        "event.category": [
+            "iam"
+        ],
         "event.dataset": "aws.cloudtrail",
         "event.id": "9150d546-3564-4262-8e62-110EXAMPLE",
         "event.kind": "event",
@@ -18,7 +21,10 @@
         "event.original": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"EX_PRINCIPAL_ID\",\"arn\":\"arn:aws:iam::123456789012:user/Alice\",\"accountId\":\"123456789012\",\"accessKeyId\":\"EXAMPLE_KEY_ID\",\"userName\":\"Alice\"},\"eventTime\":\"2020-01-08T20:53:12Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"UpdateUser\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"127.0.0.1\",\"userAgent\":\"aws-cli/1.16.310 Python/3.8.1 Darwin/18.7.0 botocore/1.13.46\",\"requestParameters\":{\"userName\":\"Bob\",\"newUserName\":\"Robert\"},\"responseElements\":null,\"requestID\":\"3a6b3260-739d-465e-9406-bcEXAMPLE\",\"eventID\":\"9150d546-3564-4262-8e62-110EXAMPLE\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789012\"}",
         "event.outcome": "success",
         "event.provider": "iam.amazonaws.com",
-        "event.type": "info",
+        "event.type": [
+            "user",
+            "change"
+        ],
         "fileset.name": "cloudtrail",
         "input.type": "log",
         "log.offset": 0,


### PR DESCRIPTION
Cherry-pick of PR #18958 to 7.x branch. Original message: 

## What does this PR do?
Changes to AWS cloudtrail fileset, specifically:

- adds geoip AS lookup on source.ip
- improve mappings event.category
- improve mappings for event.type

## Why is it important?
- geoip AS is used for detections
- having correct mappings for event.category & event.type improves detections

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```
TESTING_FILEBEAT_MODULES=aws TESTING_FILEBEAT_FILESETS=cloudtrail mage -v pythonIntegTest
```

## Related issues
- Closes #18644

