### PR TITLE
Auditbeat: Fixes for system/socket dataset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -128,6 +128,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
+- system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix parsing of Installed-Size field of DEB packages. {issue}16661[16661] {pull}17188[17188]
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
+- system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -178,7 +178,7 @@ type flow struct {
 	process           *process
 	local, remote     endpoint
 	complete          bool
-
+	done              bool
 	// these are automatically calculated by state from kernelTimes above
 	createdTime, lastSeenTime time.Time
 }
@@ -794,7 +794,11 @@ func (f *flow) updateWith(ref flow, s *state) {
 }
 
 func (s *state) onFlowTerminated(f *flow) {
+	if f.done {
+		return
+	}
 	s.flowLRU.remove(f)
+	f.done = true
 	// Unbind this flow from its parent
 	if parent, found := s.socks[f.sock]; found {
 		delete(parent.flows, f.remote.addr.String())

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -134,16 +135,24 @@ func TestTCPConnWithProcess(t *testing.T) {
 
 func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	const (
-		localIP            = "192.168.33.10"
-		remoteIP           = "172.19.12.13"
-		localPort          = 38842
-		remotePort         = 443
-		sock       uintptr = 0xff1234
+		localIP               = "192.168.33.10"
+		remoteIP              = "172.19.12.13"
+		localPort             = 38842
+		remotePort            = 443
+		sock          uintptr = 0xff1234
+		flowTimeout           = time.Hour
+		socketTimeout         = time.Minute * 3
+		closeTimeout          = time.Minute
 	)
-	st := makeState(nil, (*logWrapper)(t), time.Second, 0, 0, time.Second)
+	st := makeState(nil, (*logWrapper)(t), flowTimeout, socketTimeout, closeTimeout, time.Second)
+	now := time.Now()
+	st.clock = func() time.Time {
+		return now
+	}
 	lPort, rPort := be16(localPort), be16(remotePort)
 	lAddr, rAddr := ipv4(localIP), ipv4(remoteIP)
 	evs := []event{
+
 		callExecve(meta(1234, 1234, 1), []string{"/usr/bin/curl", "https://example.net/", "-o", "/tmp/site.html"}),
 		&commitCreds{Meta: meta(1234, 1234, 2), UID: 501, GID: 20, EUID: 501, EGID: 20},
 		&execveRet{Meta: meta(1234, 1234, 2), Retval: 1234},
@@ -174,7 +183,18 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 		t.Fatal(err)
 	}
 	st.ExpireOlder()
+	// Nothing expired just yet.
+	flows, err := getFlows(st.DoneFlows(), all)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Empty(t, flows)
+
 	evs = []event{
+		&clockSyncCall{
+			Meta: meta(uint32(os.Getpid()), 1235, 0),
+			Ts:   uint64(now.UnixNano()),
+		},
 		&inetReleaseCall{Meta: meta(0, 0, 15), Sock: sock},
 		&tcpV4DoRcv{
 			Meta:  meta(0, 0, 17),
@@ -185,17 +205,31 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 			RAddr: rAddr,
 			RPort: rPort,
 		},
-		&doExit{Meta: meta(1234, 1234, 18)},
+
+		&inetCreate{Meta: meta(1234, 1235, 18), Proto: 0},
+		&sockInitData{Meta: meta(1234, 1235, 19), Sock: sock + 1},
+		&tcpIPv4ConnectCall{Meta: meta(1234, 1235, 20), Sock: sock + 1, RAddr: rAddr, RPort: rPort},
+		&tcpV4DoRcv{
+			Meta:  meta(0, 0, 21),
+			Sock:  sock + 1,
+			Size:  12,
+			LAddr: lAddr,
+			LPort: lPort,
+			RAddr: rAddr,
+			RPort: rPort,
+		},
 	}
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
+	// Expire the first socket
+	now = now.Add(closeTimeout + 1)
 	st.ExpireOlder()
-	flows, err := getFlows(st.DoneFlows(), all)
+	flows, err = getFlows(st.DoneFlows(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(t, flows, 2)
+	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow 0", flow)
 	for field, expected := range map[string]interface{}{
@@ -207,8 +241,8 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 		"client.port":         localPort,
 		"destination.ip":      remoteIP,
 		"destination.port":    remotePort,
-		"destination.packets": uint64(1),
-		"destination.bytes":   uint64(12),
+		"destination.packets": uint64(2),
+		"destination.bytes":   uint64(19),
 		"server.ip":           remoteIP,
 		"server.port":         remotePort,
 		"network.direction":   "outbound",
@@ -224,10 +258,28 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 			t.Fatal("expected value not found")
 		}
 	}
+	// Wait until sock+1 expires due to inactivity. It won't be available
+	// just yet.
+	now = now.Add(socketTimeout + 1)
+	st.ExpireOlder()
+	flows, err = getFlows(st.DoneFlows(), all)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Empty(t, flows)
+
+	// Wait until the sock is closed completely.
+	now = now.Add(closeTimeout + 1)
+	st.ExpireOlder()
+	flows, err = getFlows(st.DoneFlows(), all)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, flows, 1)
+	flow = flows[0]
 
 	// we have a truncated flow with no directionality,
 	// so just report what we can
-	flow = flows[1]
 	t.Log("read flow 1", flow)
 	for field, expected := range map[string]interface{}{
 		"source.ip":         localIP,


### PR DESCRIPTION
## What does this PR do?

Fixes two problems with the system/socket dataset:

- A bug in the internal state of the socket dataset that lead to an infinite loop in systems were the kernel aggressively reuses sockets (observed in 2.6 / CentOS/RHEL 6.x).

- Socket expiration wasn't working as expected due to it using an uninitialized timestamp: Flows were expiring at every check.

Also fixes other two minor issues:
- A flow could be terminated twice by different code paths leading to wrong numFlows calculation and duplicated flows indexed.
- Decoupled the status debug log and socket cleanup into separate goroutines so that logging is still performed under high load situations.

## Why is it important?

It has been observed that the dataset would use 100% CPU and stop reporting events. During testing it was discovered that socket expiration, a new feature to prevent excessive memory usage, wasn't working as expected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

The infinite loop is easy to trigger in RHEL 6.x by running:
> nmap -n -sT 127.0.0.1 -p 1-65535
