### PR TITLE
Additional context around the max_retention

### DIFF
--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -189,7 +189,8 @@ endpoints.
 
 The maximum data retention period to support. `168h` by default. {beatname_uc}
 will fetch all retained data for a tenant when run for the first time. The
-default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Only increase it if your tenant has a longer retention period.
+default is 7 days, which matches the standard period that Microsoft will keep the
+logs before deleting them. Only increase it if your tenant has a longer retention period.
 
 *`var.api.poll_interval`*::
 

--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -189,7 +189,7 @@ endpoints.
 
 The maximum data retention period to support. `168h` by default. {beatname_uc}
 will fetch all retained data for a tenant when run for the first time. The
-default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Only increase it if your tenant has a different retention period.
+default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Only increase it if your tenant has a longer retention period.
 
 *`var.api.poll_interval`*::
 

--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -189,7 +189,7 @@ endpoints.
 
 The maximum data retention period to support. `168h` by default. {beatname_uc}
 will fetch all retained data for a tenant when run for the first time. The
-default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Adjust it only if your tenant has a different retention period.
+default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Only increase it if your tenant has a different retention period.
 
 *`var.api.poll_interval`*::
 

--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -189,7 +189,7 @@ endpoints.
 
 The maximum data retention period to support. `168h` by default. {beatname_uc}
 will fetch all retained data for a tenant when run for the first time. The
-default is 7 days. Adjust it if your tenant has a different retention period.
+default is 7 days, which matches the standard period that Microsoft will keep the logs before deleting them. Adjust it only if your tenant has a different retention period.
 
 *`var.api.poll_interval`*::
 

--- a/x-pack/filebeat/module/o365/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/o365/_meta/docs.asciidoc
@@ -184,7 +184,8 @@ endpoints.
 
 The maximum data retention period to support. `168h` by default. {beatname_uc}
 will fetch all retained data for a tenant when run for the first time. The
-default is 7 days. Adjust it if your tenant has a different retention period.
+default is 7 days, which matches the standard period that Microsoft will keep the
+logs before deleting them. Only increase it if your tenant has a longer retention period.
 
 *`var.api.poll_interval`*::
 


### PR DESCRIPTION
I think it would be good to get some extra information around the max_retention setting, to make it clear that unless the tenant itself has a longer retention period, then 7 days is going to be all that you can fetch

Follow-on from investigation behind  https://github.com/elastic/beats/pull/18948 
