### PR TITLE
Cherry-pick #18878 to 7.x: [Filebeat] Remove references to non-existent Zeek signatures fileset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/beats/compare/v7.5.0...v7.5.1[View commits]
 - Change iis url path grok pattern from URIPATH to NOTSPACE. {issue}12710[12710] {pull}13225[13225] {issue}7951[7951] {pull}13378[13378] {pull}14754[14754]
 - Fix azure filesets test files. {issue}14185[14185] {pull}14235[14235]
 - Update Logstash module's Grok patterns to support Logstash 7.4 logs. {pull}14743[14743]
+- Remove references to non-existent Zeek `signatures` fileset. {pull}18878[18878]
 
 *Metricbeat*
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1020,8 +1020,6 @@ filebeat.modules:
     enabled: true
   rfb:
     enabled: true
-  signatures:
-    enabled: true
   sip:
     enabled: true
   smb_cmd:

--- a/x-pack/filebeat/module/zeek/_meta/config.yml
+++ b/x-pack/filebeat/module/zeek/_meta/config.yml
@@ -43,8 +43,6 @@
     enabled: true
   rfb:
     enabled: true
-  signatures:
-    enabled: true
   sip:
     enabled: true
   smb_cmd:

--- a/x-pack/filebeat/modules.d/zeek.yml.disabled
+++ b/x-pack/filebeat/modules.d/zeek.yml.disabled
@@ -46,8 +46,6 @@
     enabled: true
   rfb:
     enabled: true
-  signatures:
-    enabled: true
   sip:
     enabled: true
   smb_cmd:


### PR DESCRIPTION
Cherry-pick of PR #18878 to 7.x branch. Original message: 

## What does this PR do?
In #13683, a `signatures` fileset is enabled, but it did not exist. This removes
it from the module.d/zeek.yml config file so that the module can start.

In #12812 there was a signatures fileset but that PR never merged. Perhaps
the fileset from that closed PR can be brought into master.

## Why is it important?

The module doesn't start under the default config because of the missing fileset.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #18868

