### PR TITLE
Cherry-pick #18935 to 7.8: [Filebeat] Add missing beta label to O365 docs

### DIFF
--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Office 365 module
 
+beta[]
+
 This is a module for Office 365 logs received via one of the Office 365 API
 endpoints. It currently supports user, admin, system, and policy actions and
 events from Office 365 and Azure AD activity logs exposed by the Office 365

--- a/x-pack/filebeat/module/o365/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/o365/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Office 365 module
 
+beta[]
+
 This is a module for Office 365 logs received via one of the Office 365 API
 endpoints. It currently supports user, admin, system, and policy actions and
 events from Office 365 and Azure AD activity logs exposed by the Office 365


### PR DESCRIPTION
Cherry-pick of PR #18935 to 7.8 branch. Original message: 

## What does this PR do?

The Beat logs that the module is beta if used, but the docs were missing the label.

## Why is it important?

The code and the docs were not aligned on the beta label.

