### PR TITLE
Cherry-pick #18953 to 7.x: Add Okta module documentation, config cleanup, _id field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@ happened. {issue}13920[13920] {pull}18223[18223]
 - With the default configuration the cef and panw modules will no longer send the `host`
 field. You can revert this change by configuring tags for the module and omitting
 `forwarded` from the list. {issue}13920[13920] {pull}18223[18223]
+- Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]
 
 *Heartbeat*
 
@@ -193,6 +194,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix `o365.audit` failing to ingest events when ip address is surrounded by square brackets. {issue}18587[18587] {pull}18591[18591]
 - Fix Kubernetes Watcher goroutine leaks when input config is invalid and `input.reload` is enabled. {issue}18629[18629] {pull}18630[18630]
 - Fix `o365` module ignoring `var.api` settings. {pull}18948[18948]
+- Okta module now sets the Elasticsearch `_id` field to the Okta UUID value contained in each system log to minimize the possibility of duplicating events. {pull}18953[18953]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/okta.asciidoc
+++ b/filebeat/docs/modules/okta.asciidoc
@@ -12,14 +12,104 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
-This is a filebeat module for retrieving system logs from Okta (www.okta.com) via API. 
+The Okta module collects events from the
+https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
+reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta
+System Log API].
 
-:has-dashboards!:
+:fileset_ex: system
 
-This module comes with a sample dashboard. For example:
+include::../include/config-option-intro.asciidoc[]
+
+[float]
+==== `system` fileset settings
+
+The Okta System Log records system events related to your organization in order
+to provide an audit trail that can be used to understand platform activity and
+to diagnose problems. This module is implemented using the
+<<filebeat-input-httpjson,httpjson>> input and is configured to paginate through
+the logs while honoring any
+https://developer.okta.com/docs/reference/rate-limits/[rate-limiting] headers
+sent by Okta.
+
+NOTE: This module does not persist the timestamp of the last read event in
+order to facilitate resuming on restart. This feature will be coming in a future
+version. When you restart the module will read events from the beginning of the
+log. To minimize duplicates documents the module uses the event's Okta UUID
+value as the Elasticsearch `_id`.
+
+This is an example configuration for the module.
+
+[source,yaml]
+----
+- module okta
+  system:
+    var.url: https://yourOktaDomain/api/v1/logs
+    var.api_key: '00QCjAl4MlV-WPXM...0HmjFx-vbGua'
+----
+
+[float]
+===== Configuration options
+
+*`var.url`*::
+
+Specifies the URL to the Okta System Log API. Required.
++
+[source,yaml]
+----
+    var.url: https://mycompany.okta.com/api/v1/logs
+----
+
+*`var.api_key`*::
+
+Specifies the Okta API token to use in requests to the API. Required.
+The token is used in an HTTP `Authorization` header with the `SSWS` scheme.
+See https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/[
+Create an API token] for information on how to obtain a token.
++
+[source,yaml]
+----
+    var.api_key: '00QCjAl4MlV-WPXM...0HmjFx-vbGua'
+----
+
+*`var.http_client_timeout`*::
+
+Duration of the time limit on HTTP requests made by the module. Defaults to
+`60s`.
+
+*`var.interval`*::
+
+Duration between requests to the API. Defaults to `60s`.
+
+*`var.keep_original_message`*::
+
+Boolean flag indicating if the original JSON event string should be included in
+the `event.original` field. Defaults to `true`.
+
+*`var.ssl`*::
+
+Configuration options for SSL parameters like the certificate authority to use
+for HTTPS-based connections. If the `ssl` section is missing, the host CAs are
+used for HTTPS connections to Okta. See <<configuration-ssl>> for more
+information.
++
+[source,yaml]
+----
+    var.ssl:
+      supported_protocols: [TLSv1.2]
+----
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard:
 
 [role="screenshot"]
 image::./images/filebeat-okta-dashboard.png[]
+
+:has-dashboards!:
+
+:fileset_ex!:
 
 :modulename!:
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -860,17 +860,10 @@ filebeat.modules:
 - module: okta
   system:
     enabled: true
-    # API key to access Okta
-    #var.api_key
-
-    # URL of the Okta REST API
-    #var.url
-
-    # Disable SSL verification 
-    #var.ssl: |-
-    #  {
-    #    "verification_mode": "none"
-    #  }
+    # You must configure the URL with your Okta domain and provide an
+    # API token to access the logs API.
+    #var.url: https://yourOktaDomain/api/v1/logs
+    #var.api_key: 'yourApiTokenHere'
 
 #------------------------------- Osquery Module -------------------------------
 - module: osquery

--- a/x-pack/filebeat/module/okta/_meta/config.yml
+++ b/x-pack/filebeat/module/okta/_meta/config.yml
@@ -1,14 +1,7 @@
 - module: okta
   system:
     enabled: true
-    # API key to access Okta
-    #var.api_key
-
-    # URL of the Okta REST API
-    #var.url
-
-    # Disable SSL verification 
-    #var.ssl: |-
-    #  {
-    #    "verification_mode": "none"
-    #  }
+    # You must configure the URL with your Okta domain and provide an
+    # API token to access the logs API.
+    #var.url: https://yourOktaDomain/api/v1/logs
+    #var.api_key: 'yourApiTokenHere'

--- a/x-pack/filebeat/module/okta/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/okta/_meta/docs.asciidoc
@@ -7,13 +7,103 @@
 
 beta[]
 
-This is a filebeat module for retrieving system logs from Okta (www.okta.com) via API. 
+The Okta module collects events from the
+https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
+reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta
+System Log API].
 
-:has-dashboards!:
+:fileset_ex: system
 
-This module comes with a sample dashboard. For example:
+include::../include/config-option-intro.asciidoc[]
+
+[float]
+==== `system` fileset settings
+
+The Okta System Log records system events related to your organization in order
+to provide an audit trail that can be used to understand platform activity and
+to diagnose problems. This module is implemented using the
+<<filebeat-input-httpjson,httpjson>> input and is configured to paginate through
+the logs while honoring any
+https://developer.okta.com/docs/reference/rate-limits/[rate-limiting] headers
+sent by Okta.
+
+NOTE: This module does not persist the timestamp of the last read event in
+order to facilitate resuming on restart. This feature will be coming in a future
+version. When you restart the module will read events from the beginning of the
+log. To minimize duplicates documents the module uses the event's Okta UUID
+value as the Elasticsearch `_id`.
+
+This is an example configuration for the module.
+
+[source,yaml]
+----
+- module okta
+  system:
+    var.url: https://yourOktaDomain/api/v1/logs
+    var.api_key: '00QCjAl4MlV-WPXM...0HmjFx-vbGua'
+----
+
+[float]
+===== Configuration options
+
+*`var.url`*::
+
+Specifies the URL to the Okta System Log API. Required.
++
+[source,yaml]
+----
+    var.url: https://mycompany.okta.com/api/v1/logs
+----
+
+*`var.api_key`*::
+
+Specifies the Okta API token to use in requests to the API. Required.
+The token is used in an HTTP `Authorization` header with the `SSWS` scheme.
+See https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/[
+Create an API token] for information on how to obtain a token.
++
+[source,yaml]
+----
+    var.api_key: '00QCjAl4MlV-WPXM...0HmjFx-vbGua'
+----
+
+*`var.http_client_timeout`*::
+
+Duration of the time limit on HTTP requests made by the module. Defaults to
+`60s`.
+
+*`var.interval`*::
+
+Duration between requests to the API. Defaults to `60s`.
+
+*`var.keep_original_message`*::
+
+Boolean flag indicating if the original JSON event string should be included in
+the `event.original` field. Defaults to `true`.
+
+*`var.ssl`*::
+
+Configuration options for SSL parameters like the certificate authority to use
+for HTTPS-based connections. If the `ssl` section is missing, the host CAs are
+used for HTTPS connections to Okta. See <<configuration-ssl>> for more
+information.
++
+[source,yaml]
+----
+    var.ssl:
+      supported_protocols: [TLSv1.2]
+----
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard:
 
 [role="screenshot"]
 image::./images/filebeat-okta-dashboard.png[]
+
+:has-dashboards!:
+
+:fileset_ex!:
 
 :modulename!:

--- a/x-pack/filebeat/module/okta/system/config/input.yml
+++ b/x-pack/filebeat/module/okta/system/config/input.yml
@@ -1,19 +1,48 @@
 {{ if eq .input "httpjson" }}
 
 type: httpjson
+
+{{ if .api_key }}
 api_key: {{ .api_key }}
-authentication_scheme: {{.authentication_scheme}}
+{{ end }}
+
+authentication_scheme: {{ .authentication_scheme }}
+
+{{ if .http_client_timeout }}
 http_client_timeout: {{ .http_client_timeout }}
+{{ end }}
+
+{{ if .http_method }}
 http_method: {{ .http_method }}
-http_headers: {{ .http_headers }}
+{{ end }}
+
+{{ if .http_headers }}
+http_headers: {{ .http_headers | tojson }}
+{{ end }}
+
+{{ if .http_request_body }}
 http_request_body: {{ .http_request_body }}
-no_http_body: {{ .no_http_body }}
+{{ end }}
+
 interval: {{ .interval }}
+
+{{ if .json_objects_array }}
 json_objects_array: {{ .json_objects_array }}
-pagination: {{ .pagination }}
-rate_limit: {{ .rate_limit }}
+{{ end }}
+
+no_http_body: {{ .no_http_body }}
+
+pagination: {{ .pagination | tojson }}
+
+rate_limit: {{ .rate_limit | tojson }}
+
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
+{{ if .url }}
 url: {{ .url }}
-ssl: {{ .ssl }}
+{{ end }}
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/okta/system/manifest.yml
+++ b/x-pack/filebeat/module/okta/system/manifest.yml
@@ -4,50 +4,33 @@ var:
   - name: input
     default: httpjson
   - name: api_key
-    default: ""
   - name: authentication_scheme
     default: "SSWS"
   - name: http_client_timeout
-    default: 60
   - name: http_method
-    default: GET
   - name: http_headers
-    default: |-
-      {}
   - name: http_request_body
-    default: |-
-      {}
-  - name: no_http_body
-    default: true
   - name: interval
-    default: 60
+    default: 60s
   - name: json_objects_array
-    default: ""
   - name: keep_original_message
     default: true
+  - name: no_http_body
+    default: true
   - name: pagination
-    default: |-
-      {
-        "enabled": true,
-        "header": {
-          "field_name": "Link",
-          "regex_pattern": "<([^>]+)>; *rel=\"next\"(?:,|$)"
-        },
-      }
+    default:
+      header:
+        field_name: Link
+        regex_pattern: '<([^>]+)>; *rel="next"(?:,|$)'
   - name: rate_limit
-    default: |-
-      {
-        "limit": "X-Rate-Limit-Limit",
-        "remaining": "X-Rate-Limit-Remaining",
-        "reset": "X-Rate-Limit-Reset"
-      }
-  - name: url
-    default: ""
+    default:
+      limit: X-Rate-Limit-Limit
+      remaining: X-Rate-Limit-Remaining
+      reset: X-Rate-Limit-Reset
   - name: ssl
-    default: |-
-      {}
   - name: tags
     default: [forwarded]
+  - name: url
 
 input: config/input.yml
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/modules.d/okta.yml.disabled
+++ b/x-pack/filebeat/modules.d/okta.yml.disabled
@@ -4,14 +4,7 @@
 - module: okta
   system:
     enabled: true
-    # API key to access Okta
-    #var.api_key
-
-    # URL of the Okta REST API
-    #var.url
-
-    # Disable SSL verification 
-    #var.ssl: |-
-    #  {
-    #    "verification_mode": "none"
-    #  }
+    # You must configure the URL with your Okta domain and provide an
+    # API token to access the logs API.
+    #var.url: https://yourOktaDomain/api/v1/logs
+    #var.api_key: 'yourApiTokenHere'


### PR DESCRIPTION
Cherry-pick of PR #18953 to 7.x branch. Original message: 

## What does this PR do?

This add documentation for the Okta module. It contains descriptions of the
configuration options and general information about the module.

I fixed an issue with the module where it was not setting the `_id` field for Elasticsearch events.

I also did some cleanup to the pipeline.js (indentation, semi-colons, strict equality checks).

The module's manifest was updated to not duplicate httpjson's default values.

The module was accepting configuration as JSON strings for some parameters (`http_headers`, `http_request_body`, `pagination`, `rate_limit`, `ssl`) which is inconsistent with how other parts of Beats are configured so I removed this. Now these options expect regular YAML objects for values. None of these options are required to use the module so the impact to users should be minimal.

## Why is it important?

Documentation is required for users to know how to use the module.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

I ran the module against the Okta API to test. You'll note that the `@metadata._id` field is now set which libbeat will use when writing the data to Elasticsearch.

```json
{
  "@timestamp": "2020-06-03T18:10:38.118Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.0.0",
    "pipeline": "filebeat-8.0.0-okta-system-pipeline",
    "_id": "870da4d0-a5c5-11ea-a40a-5d8cbb5cdb88"
  },
  "input": {
    "type": "httpjson"
  },
  "fileset": {
    "name": "system"
  },
  "client": {
    "user": {
      "full_name": "Andrew Kroh",
      "id": "00ue26zi9EdhopJgw4x6"
    },
    "geo": {
      "region_name": "Virginia",
      "country_name": "United States",
      "location": {
        "lat": 38.9637,
        "lon": -77.6099
      },
      "city_name": "Aldie"
    },
    "ip": "198.51.100.1",
    "as": {
      "number": 701,
      "organization": {
        "name": "verizon"
      }
    },
    "domain": "verizon.net"
  },
  "user_agent": {
    "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:76.0) Gecko/20100101 Firefox/76.0"
  },
  "source": {
    "ip": "198.51.100.1",
    "domain": "verizon.net",
    "user": {
      "full_name": "Andrew Kroh",
      "id": "00ue26zi9EdhopJgw4x6"
    }
  },
  "ecs": {
    "version": "1.5.0"
  },
  "event": {
    "category": [
      "authentication"
    ],
    "action": "system.api_token.create",
    "id": "870da4d0-a5c5-11ea-a40a-5d8cbb5cdb88",
    "kind": "event",
    "module": "okta",
    "dataset": "okta.system",
    "original": "{\"actor\":{\"alternateId\":\"id-okta@test.com\",\"detailEntry\":null,\"displayName\":\"Andrew Kroh\",\"id\":\"00ue26zi9EdhopJgw4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102NKlIOnToQGGOboI6cpvgYQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Aldie\",\"country\":\"United States\",\"geolocation\":{\"lat\":38.9637,\"lon\":-77.6099},\"postalCode\":\"20105\",\"state\":\"Virginia\"},\"id\":null,\"ipAddress\":\"198.51.100.1\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:76.0) Gecko/20100101 Firefox/76.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"requestId\":\"XtfnnhZLAtrLPbdLtrp-4AAABw4\",\"requestUri\":\"/api/internal/tokens\",\"threatSuspected\":\"false\",\"url\":\"/api/internal/tokens?expand=user\"}},\"displayMessage\":\"Create API token\",\"eventType\":\"system.api_token.create\",\"legacyEventType\":\"api.token.create\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-06-03T18:10:38.118Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Aldie\",\"country\":\"United States\",\"geolocation\":{\"lat\":38.9637,\"lon\":-77.6099},\"postalCode\":\"20105\",\"state\":\"Virginia\"},\"ip\":\"198.51.100.1\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":701,\"asOrg\":\"verizon\",\"domain\":\"verizon.net\",\"isProxy\":false,\"isp\":\"mci communications services  inc. d/b/a verizon business\"},\"severity\":\"INFO\",\"target\":[{\"alternateId\":\"unknown\",\"detailEntry\":null,\"displayName\":\"filebeat\",\"id\":\"00Tt0pmrpvAs7CHYL4x5\",\"type\":\"Token\"}],\"transaction\":{\"detail\":{},\"id\":\"XtfnnhZLAtrLPbdLtrp-4AAABw4\",\"type\":\"WEB\"},\"uuid\":\"870da4d0-a5c5-11ea-a40a-5d8cbb5cdb88\",\"version\":\"0\"}",
    "type": [
      "access"
    ],
    "outcome": "success",
    "created": "2020-06-03T18:12:23.908Z"
  },
  "okta": {
    "event_type": "system.api_token.create",
    "client": {
      "device": "Computer",
      "ip": "198.51.100.1",
      "user_agent": {
        "os": "Mac OS X",
        "raw_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:76.0) Gecko/20100101 Firefox/76.0",
        "browser": "FIREFOX"
      },
      "zone": "null"
    },
    "authentication_context": {
      "external_session_id": "102NKlIOnToQGGOboI6cpvgYQ",
      "authentication_step": 0
    },
    "display_message": "Create API token",
    "uuid": "870da4d0-a5c5-11ea-a40a-5d8cbb5cdb88",
    "actor": {
      "display_name": "Andrew Kroh",
      "id": "00ue26zi9EdhopJgw4x6",
      "type": "User",
      "alternate_id": "id-okta@test.com"
    },
    "outcome": {
      "result": "SUCCESS"
    },
    "target": [
      {
        "type": "Token",
        "alternate_id": "unknown",
        "display_name": "filebeat",
        "id": "00Tt0pmrpvAs7CHYL4x5"
      }
    ],
    "transaction": {
      "id": "XtfnnhZLAtrLPbdLtrp-4AAABw4",
      "type": "WEB"
    },
    "debug_context": {
      "debug_data": {
        "request_id": "XtfnnhZLAtrLPbdLtrp-4AAABw4",
        "request_uri": "/api/internal/tokens",
        "threat_suspected": "false",
        "url": "/api/internal/tokens?expand=user"
      }
    },
    "security_context": {
      "as": {
        "number": 701,
        "organization": {
          "name": "verizon"
        }
      },
      "domain": "verizon.net",
      "is_proxy": false,
      "isp": "mci communications services  inc. d/b/a verizon business"
    }
  },
  "tags": [
    "forwarded"
  ],
  "service": {
    "type": "okta"
  },
  "agent": {
    "ephemeral_id": "9cd78eb3-acb9-4da6-95a3-7484450a5ad9",
    "id": "1ee8bc3e-9e78-4384-b771-a5655904db72",
    "name": "mac15.example.com",
    "type": "filebeat",
    "version": "8.0.0"
  },
  "related": {
    "user": "Andrew Kroh",
    "ip": "198.51.100.1"
  }
}
```