### PR TITLE
[dev-tools] Script to find recent top committers for a module

### DIFF
--- a/dev-tools/module_committers
+++ b/dev-tools/module_committers
@@ -9,6 +9,42 @@ set -euo pipefail
 # module_devs <module name, partial ok>
 #
 
+find_beat_dirs() {
+  find $beats_base_dir -type d -iname \*beat -maxdepth 2 | grep -v libbeat
+}
+
+find_module_dirs() {
+  beat_dirs="$1"
+  module_name="$2"
+
+  module_dirs=""
+  for beat_dir in $beat_dirs; do
+    if [ -d "$beat_dir/module" ]; then
+        module_dirs=$module_dirs" "$(find $beat_dir/module -type d -depth 1)
+    fi
+  done
+
+  found_dirs=""
+  for module_dir in $module_dirs; do
+      module=$(echo $module_dir | awk -F\/ '{ print $NF}')
+      if [[ "$module" == *"$module_name"* ]]; then
+          found_dirs=$found_dirs" "$module_dir
+      fi
+  done
+
+  echo "$found_dirs"
+}
+
+print_recent_top_committers() {
+  module_dirs="$1"
+  for module_dir in $module_dirs; do
+    echo "Found matching $module_dir:"
+    cd $module_dir
+    echo "  Recent top committers:"
+    git log --since="one year ago" --pretty=format:"%an" -- . | sort | uniq -c | sort -nr | head -3 | awk '{$1 = ""; print "  -"$0}'
+  done
+}
+
 module_name="$1"
 if [ -z "$module_name" ]; then
     echo "Usage: module_devs <module name>"
@@ -17,26 +53,6 @@ fi
 
 beats_base_dir=$(cd $(dirname $BASH_SOURCE)/..; pwd)
 
-beat_dirs=$(find $beats_base_dir -type d -iname \*beat -maxdepth 2 | grep -v libbeat)
-
-module_dirs=""
-for beat_dir in $beat_dirs; do
-    if [ -d "$beat_dir/module" ]; then
-        module_dirs=$module_dirs" "$(find $beat_dir/module -type d -depth 1)
-    fi
-done
-
-found_dirs=""
-for module_dir in $module_dirs; do
-    module=$(echo $module_dir | awk -F\/ '{ print $NF}')
-    if [[ "$module" == *"$module_name"* ]]; then
-        found_dirs=$found_dirs" "$module_dir
-    fi
-done
-
-for found_dir in $found_dirs; do
-    echo "Found matching $found_dir:"
-    cd $found_dir
-    echo "  Recent top committers:"
-    git log --since="one year ago" --pretty=format:"%an" -- . | sort | uniq -c | sort -nr | head -3 | awk '{$1 = ""; print "  -"$0}'
-done
+beat_dirs=$(find_beat_dirs)
+module_dirs=$(find_module_dirs "$beat_dirs" "$module_name")
+print_recent_top_committers "$module_dirs"

--- a/dev-tools/module_committers
+++ b/dev-tools/module_committers
@@ -36,7 +36,7 @@ done
 
 for found_dir in $found_dirs; do
     echo "Found matching $found_dir:"
-    cd $base_dir/$found_dir
+    cd $found_dir
     echo "  Recent top committers:"
     git log --since="one year ago" --pretty=format:"%an" -- . | sort | uniq -c | sort -nr | head -3 | awk '{$1 = ""; print "  -"$0}'
 done

--- a/dev-tools/module_committers
+++ b/dev-tools/module_committers
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# Finds modules matching given string and prints out their recent top committers.
+#
+# Usage:
+# module_devs <module name, partial ok>
+#
+
+module_name="$1"
+if [ -z "$module_name" ]; then
+    echo "Usage: module_devs <module name>"
+    exit 1
+fi
+
+beats_base_dir=$(cd $(dirname $BASH_SOURCE)/..; pwd)
+
+beat_dirs=$(find $beats_base_dir -type d -iname \*beat -maxdepth 2 | grep -v libbeat)
+
+module_dirs=""
+for beat_dir in $beat_dirs; do
+    if [ -d "$beat_dir/module" ]; then
+        module_dirs=$module_dirs" "$(find $beat_dir/module -type d -depth 1)
+    fi
+done
+
+found_dirs=""
+for module_dir in $module_dirs; do
+    module=$(echo $module_dir | awk -F\/ '{ print $NF}')
+    if [[ "$module" == *"$module_name"* ]]; then
+        found_dirs=$found_dirs" "$module_dir
+    fi
+done
+
+for found_dir in $found_dirs; do
+    echo "Found matching $found_dir:"
+    cd $base_dir/$found_dir
+    echo "  Recent top committers:"
+    git log --since="one year ago" --pretty=format:"%an" -- . | sort | uniq -c | sort -nr | head -3 | awk '{$1 = ""; print "  -"$0}'
+done

--- a/dev-tools/module_committers
+++ b/dev-tools/module_committers
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 #
 # Finds modules matching given string and prints out their recent top committers.
 #


### PR DESCRIPTION
## What does this PR do?

Adds a script, `dev-tools/module_committers` that finds a given module and lists out recent (within last year) top (3) committers for it.

### Sample usages

#### Exact module name
```
$ ./dev-tools/module_committers o365                                                                                                                                                  
Found matching /Users/shaunak/go/src/github.com/elastic/beats/x-pack/filebeat/module/o365:
  Recent top committers:
  - Andrew Kroh
  - Adrian Serrano
  - Lee Hinman
```

#### Partial module name
```
$ ./dev-tools/module_committers 36
Found matching /Users/shaunak/go/src/github.com/elastic/beats/x-pack/filebeat/module/o365:
  Recent top committers:
  - Andrew Kroh
  - Adrian Serrano
  - Lee Hinman
```

#### Matching from multiple beats
```
$ ./dev-tools/module_committers kibana
Found matching /Users/shaunak/go/src/github.com/elastic/beats/metricbeat/module/kibana:
  Recent top committers:
  - Jaime Soriano Pastor
  - Shaunak Kashyap
  - Pablo Mercado
Found matching /Users/shaunak/go/src/github.com/elastic/beats/filebeat/module/kibana:
  Recent top committers:
  - Lee Hinman
  - Noémi Ványi
  - DeDe Morton
```

## Why is it important?

It can be useful when trying to figure out who might know most about a module, particularly when triaging issues/PRs while on community duty or while handling tricky discuss posts or SDHs.
