### PR TITLE
Change request for checking if ILM alias exists

### DIFF
--- a/libbeat/idxmgmt/ilm/client_handler.go
+++ b/libbeat/idxmgmt/ilm/client_handler.go
@@ -153,7 +153,7 @@ func (h *ESClientHandler) HasILMPolicy(name string) (bool, error) {
 // HasAlias queries Elasticsearch to see if alias exists. If other resource
 // with the same name exists, it returns an error.
 func (h *ESClientHandler) HasAlias(name string) (bool, error) {
-	status, b, err := h.client.Request("GET", esAliasPath+"/"+name, "", nil, nil)
+	status, b, err := h.client.Request("GET", "/"+name+esAliasPath, "", nil, nil)
 	if err != nil && status != 404 {
 		return false, wrapErrf(err, ErrRequestFailed,
 			"failed to check for alias '%v': (status=%v) %s", name, status, b)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

It changes the way libbeat queries whether an ILM rollover alias already exists or not. We want to query for a concrete alias, therefore querying `/{name}/_alias` is sufficient instead of querying `/_alias/{name}` which would also search on indices and data streams. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The current way of querying for the alias conflicts with current implementation of data stream validations.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


## How to test this PR locally
0. Create data streams in Elasticsearch, e.g. 
```
 PUT /_index_template/logs
 {
     "index_patterns": ["logs*"],
     "priority": 0,
     "data_stream": {
         "timestamp_field": "@timestamp"
     },
     "composed_of": []
 }
 
 POST logs-test-1/_doc
 {
   "name": "foo"
 }
```
1. Verify a data stream has been created `GET _data_stream/*`
2. Start any beat with ILM enabled and ensure ILM write aliases are created properly. (Without this PR this stage would fail with an error that a data stream is matched). 


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

closes elastic/beats#19029
related https://github.com/elastic/elasticsearch/issues/57712

## Use cases

Support checking whether or not an ILM alias exists while data streams exist in Elasticsearch. 

This PR does not solve a potential backwards compatibility issue of data streams with older beats versions. See https://github.com/elastic/elasticsearch/issues/57712 for more details. 

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
