### PR TITLE
Cherry-pick #19032 to 7.8: Improve performance of PANW module dashboards

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -262,6 +262,14 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dashboard for Google Cloud Audit and AWS CloudTrail. {pull}17379[17379]
 - Add support for array parsing in azure-eventhub input. {pull}18585[18585]
 from being added to events by default. {pull}18159[18159]
+- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
+- The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
+- Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
+- Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
+- Improve ECS categorization field mappings in cisco module. {issue}16028[16028] {pull}18537[18537]
+- The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
+- Add geoip AS lookup & improve ECS categorization in aws cloudtrail fileset. {issue}18644[18644] {pull}18958[18958]
+- Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -262,13 +262,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dashboard for Google Cloud Audit and AWS CloudTrail. {pull}17379[17379]
 - Add support for array parsing in azure-eventhub input. {pull}18585[18585]
 from being added to events by default. {pull}18159[18159]
-- Added `observer.vendor`, `observer.product`, and `observer.type` to PANW module events. {pull}18223[18223]
-- The `logstash` module can now automatically detect the log file format (JSON or plaintext) and process it accordingly. {issue}9964[9964] {pull}18095[18095]
-- Improve ECS categorization field mappings in envoyproxy module. {issue}16161[16161] {pull}18395[18395]
-- Improve ECS categorization field mappings in coredns module. {issue}16159[16159] {pull}18424[18424]
-- Improve ECS categorization field mappings in cisco module. {issue}16028[16028] {pull}18537[18537]
-- The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
-- Add geoip AS lookup & improve ECS categorization in aws cloudtrail fileset. {issue}18644[18644] {pull}18958[18958]
 - Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
 
 *Heartbeat*

--- a/x-pack/filebeat/module/panw/_meta/kibana/7/dashboard/Filebeat-panw-network-overview.json
+++ b/x-pack/filebeat/module/panw/_meta/kibana/7/dashboard/Filebeat-panw-network-overview.json
@@ -1075,7 +1075,7 @@
             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
             "query": {
               "language": "kuery",
-              "query": "panw.panos:* and event.category: \"network_traffic\""
+              "query": "event.dataset: \"panw.panos\" and event.category: \"network_traffic\""
             },
             "version": true
           }

--- a/x-pack/filebeat/module/panw/_meta/kibana/7/dashboard/Filebeat-panw-threat-overview.json
+++ b/x-pack/filebeat/module/panw/_meta/kibana/7/dashboard/Filebeat-panw-threat-overview.json
@@ -764,7 +764,7 @@
             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
             "query": {
               "language": "kuery",
-              "query": "panw.panos:* and event.category: \"security_threat\""
+              "query": "event.dataset: \"panw.panos\" and event.category: \"security_threat\""
             },
             "version": true
           }


### PR DESCRIPTION
Cherry-pick of PR #19032 to 7.8 branch. Original message: 

A saved search was using `panw.panos: *` as to filter for data from the
dataset, instead of the more efficient `event.dataset: panw.panos`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #19031 