### PR TITLE
Cherry-pick #18948 to 7.x: Filebeat: Fix o365 module issues

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -184,6 +184,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed ingestion of some Cisco ASA and FTD messages when a hostname was used instead of an IP for NAT fields. {issue}14034[14034] {pull}18376[18376]
 - Fix `o365.audit` failing to ingest events when ip address is surrounded by square brackets. {issue}18587[18587] {pull}18591[18591]
 - Fix Kubernetes Watcher goroutine leaks when input config is invalid and `input.reload` is enabled. {issue}18629[18629] {pull}18630[18630]
+- Fix `o365` module ignoring `var.api` settings. {pull}18948[18948]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -852,7 +852,7 @@ filebeat.modules:
     #   authentication_endpoint: "https://login.microsoftonline.us/"
     #   resource: "https://manage.office365.us"
     #
-    #   max_retention: 7d
+    #   max_retention: 168h
     #   max_requests_per_minute: 2000
     #   poll_interval: 3m
 

--- a/x-pack/filebeat/input/o365audit/state.go
+++ b/x-pack/filebeat/input/o365audit/state.go
@@ -114,10 +114,7 @@ func (s *stateStorage) Load(key stream) (cursor, error) {
 	}
 	cur, err := s.persister.Load(key)
 	if err != nil {
-		if err != errStateNotFound {
-			return cur, err
-		}
-		cur = newCursor(key, time.Time{})
+		return newCursor(key, time.Time{}), err
 	}
 	return cur, s.saveUnsafe(cur)
 }

--- a/x-pack/filebeat/input/o365audit/state_test.go
+++ b/x-pack/filebeat/input/o365audit/state_test.go
@@ -21,18 +21,14 @@ func TestNoopState(t *testing.T) {
 	t.Run("new state", func(t *testing.T) {
 		st := newStateStorage(noopPersister{})
 		cur, err := st.Load(myStream)
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		assert.Equal(t, errStateNotFound, err)
 		empty := newCursor(myStream, time.Time{})
 		assert.Equal(t, empty, cur)
 	})
 	t.Run("update state", func(t *testing.T) {
 		st := newStateStorage(noopPersister{})
 		cur, err := st.Load(myStream)
-		if !assert.NoError(t, err) {
-			t.Fatal(err)
-		}
+		assert.Equal(t, errStateNotFound, err)
 		advanced := cur.TryAdvance(content{
 			Type:       tn,
 			ID:         "1234",

--- a/x-pack/filebeat/module/o365/_meta/config.yml
+++ b/x-pack/filebeat/module/o365/_meta/config.yml
@@ -40,6 +40,6 @@
     #   authentication_endpoint: "https://login.microsoftonline.us/"
     #   resource: "https://manage.office365.us"
     #
-    #   max_retention: 7d
+    #   max_retention: 168h
     #   max_requests_per_minute: 2000
     #   poll_interval: 3m

--- a/x-pack/filebeat/module/o365/audit/config/input.yml
+++ b/x-pack/filebeat/module/o365/audit/config/input.yml
@@ -19,7 +19,10 @@ content_type:
 {{ end }}
 {{ end }}
 {{ if .api }}
-api: {{.api | tojson }}
+api:
+{{ range $k, $v := .api }}
+  {{ $k }}: {{ $v -}}
+{{ end }}
 {{ end }}
 
 {{ else if eq .input "file" }}

--- a/x-pack/filebeat/module/o365/audit/config/input.yml
+++ b/x-pack/filebeat/module/o365/audit/config/input.yml
@@ -19,10 +19,7 @@ content_type:
 {{ end }}
 {{ end }}
 {{ if .api }}
-api:
-{{ range $k, $v := .api }}
- - {{ $k }}: {{ $v -}}
-{{ end }}
+api: {{.api | tojson }}
 {{ end }}
 
 {{ else if eq .input "file" }}
@@ -49,6 +46,7 @@ processors:
         - 2006-01-02T15:04:05
 {{ end }}
   - script:
+      when.has_fields: ['o365audit']
       lang: javascript
       id: o365audit_script
       file: ${path.home}/module/o365/audit/config/pipeline.js

--- a/x-pack/filebeat/module/o365/audit/config/pipeline.js
+++ b/x-pack/filebeat/module/o365/audit/config/pipeline.js
@@ -729,7 +729,10 @@ function AuditProcessor(tenant_names, debug) {
         tokenizer: '[%{_ip}]:%{port}',
         field: 'client.address',
         target_prefix: 'client',
-        'when.contains.client.address': ']:',
+        'when.and': [
+            {'not.has_fields': ['client._ip', 'client.port']},
+            {'contains.client.address': ']:'},
+        ],
     }));
     builder.Add("extractClientIPv4Port", new processor.Dissect({
         tokenizer: '%{_ip}:%{port}',

--- a/x-pack/filebeat/modules.d/o365.yml.disabled
+++ b/x-pack/filebeat/modules.d/o365.yml.disabled
@@ -43,6 +43,6 @@
     #   authentication_endpoint: "https://login.microsoftonline.us/"
     #   resource: "https://manage.office365.us"
     #
-    #   max_retention: 7d
+    #   max_retention: 168h
     #   max_requests_per_minute: 2000
     #   poll_interval: 3m


### PR DESCRIPTION
Cherry-pick of PR #18948 to 7.x branch. Original message: 

Assorted fixes to the o365 module:

- Mark module as beta in docs.
- get rid of data-loss error on startup: Bad error handling around saved-state loading (unimplemented) caused a data-loss warning on startup instead of a less scary info message:

```diff
- [ERROR] Error loading saved state. Will fetch all retained events. Depending on max_retention, this can cause event loss or duplication.
+ [INFO] No saved state found. Will fetch events for the last 168h.
```

- Avoid passing API errors to the JS pipeline

Ingestion pipeline errors from o365audit input need not to go through the JS pipeline, it'll add more errors and noise.

- Prevent dissect error about overriding client.port

- Fix how API settings are passed to the o365 input

Passing low-level API settings between module and input was broken.

- Document max_period using the right units.

The sample conf will use `7d` which is not valid as hours is the largest supported unit.