### PR TITLE
[7.x] Encode API key as base64 in common code (#18945)

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -42,6 +42,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
   Your magefile.go will require a change to adapt the devtool API. See the pull request for
   more details. {pull}18148[18148]
 - Introduce APM libbeat instrumentation. `Publish` method on `Client` interface now takes a Context as first argument. {pull}17938[17938]
+- The Elasticsearch client settings expect the API key to be raw (not base64-encoded). {issue}18939[18939] {pull}18945[18945]
 
 ==== Bugfixes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -124,6 +124,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
 - Fix potential race condition in fingerprint processor. {pull}18738[18738]
 - Fixed a service restart failure under Windows. {issue}18914[18914] {pull}18916[18916]
+- The `monitoring.elasticsearch.api_key` value is correctly base64-encoded before being sent to the monitoring Elasticsearch cluster. {issue}18939[18939] {pull}18945[18945]
 
 *Auditbeat*
 

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eslegclient
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIKeyEncoding(t *testing.T) {
+	apiKey := "foobar"
+	encoded := base64.StdEncoding.EncodeToString([]byte(apiKey))
+
+	conn, err := NewConnection(ConnectionSettings{
+		APIKey: apiKey,
+	})
+	require.NoError(t, err)
+
+	httpClient := newMockClient()
+	conn.HTTP = httpClient
+
+	req, err := http.NewRequest("GET", "http://fakehost/some/path", nil)
+	require.NoError(t, err)
+
+	_, _, err = conn.execHTTPRequest(req)
+	require.NoError(t, err)
+
+	require.Equal(t, "ApiKey "+encoded, httpClient.Req.Header.Get("Authorization"))
+}
+
+type mockClient struct {
+	Req *http.Request
+}
+
+func (c *mockClient) Do(req *http.Request) (*http.Response, error) {
+	c.Req = req
+
+	r := bytes.NewReader([]byte("HTTP/1.1 200 OK\n\nHello, world"))
+	return http.ReadResponse(bufio.NewReader(r), req)
+}
+
+func (c *mockClient) CloseIdleConnections() {}
+
+func newMockClient() *mockClient {
+	return &mockClient{}
+}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -19,7 +19,6 @@ package elasticsearch
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -84,7 +83,7 @@ func NewClient(
 		URL:              s.URL,
 		Username:         s.Username,
 		Password:         s.Password,
-		APIKey:           base64.StdEncoding.EncodeToString([]byte(s.APIKey)),
+		APIKey:           s.APIKey,
 		Headers:          s.Headers,
 		TLS:              s.TLS,
 		Kerberos:         s.Kerberos,

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -37,13 +37,14 @@ output.elasticsearch:
   password: "{pwd}"
 ------------------------------------------------------------------------------
 
-To use an API key to connect to {es}, use `api_key`.
+To use an API key to connect to {es}, use `api_key`. The value must be the ID of
+the API key and the API key joined by a colon.
 
 ["source","yaml",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-  api_key: "KnR6yE41RrSowb0kQ0HWoA"
+  api_key: "VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw"
 ------------------------------------------------------------------------------
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.
@@ -135,8 +136,8 @@ The default value is 1.
 
 ===== `api_key`
 
-Instead of using usernames and passwords,
-you can use API keys to secure communication with {es}.
+Instead of using usernames and passwords, you can use API keys to secure communication
+with {es}. The value must be the ID of the API key and the API key joined by a colon.
 For more information, see <<beats-api-keys>>.
 
 ===== `username`


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Encode API key as base64 in common code  (#18945)