### PR TITLE
Cherry-pick #18980 to 7.x: [Metricbeat] Fix googlecloud dashboards

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -254,6 +254,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix panic on `metricbeat test modules` when modules are configured in `metricbeat.modules`. {issue}18789[18789] {pull}18797[18797]
 - Fix getting gcp compute instance metadata with partial zone/region in config. {pull}18757[18757]
 - Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
+- Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-compute-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-compute-overview.json
@@ -383,9 +383,9 @@
                 "metrics": [
                   {
                     "denominator": "60",
-                    "field": "googlecloud.compute.instance.uptime",
+                    "field": "googlecloud.compute.instance.uptime.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "numerator": "googlecloud.compute.instance.uptime",
+                    "numerator": "googlecloud.compute.instance.uptime.value",
                     "type": "avg",
                     "values": [
                       "60"
@@ -466,7 +466,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.instance.cpu.utilization",
+                    "field": "googlecloud.compute.instance.cpu.utilization.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -533,7 +533,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.instance.disk.read_ops_count",
+                    "field": "googlecloud.compute.instance.disk.read_ops_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -599,7 +599,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.instance.disk.write_ops_count",
+                    "field": "googlecloud.compute.instance.disk.write_ops_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -665,7 +665,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.instance.network.sent_bytes_count",
+                    "field": "googlecloud.compute.instance.network.sent_bytes_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -731,7 +731,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.instance.network.received_bytes_count",
+                    "field": "googlecloud.compute.instance.network.received_bytes_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -815,7 +815,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.firewall.dropped_bytes_count",
+                    "field": "googlecloud.compute.firewall.dropped_bytes_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -900,7 +900,7 @@
                 "line_width": "3",
                 "metrics": [
                   {
-                    "field": "googlecloud.compute.firewall.dropped_packets_count",
+                    "field": "googlecloud.compute.firewall.dropped_packets_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }

--- a/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-pubsub-overview.json
+++ b/x-pack/metricbeat/module/googlecloud/_meta/kibana/7/dashboard/Metricbeat-googlecloud-pubsub-overview.json
@@ -350,7 +350,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.oldest_unacked_message_age",
+                    "field": "googlecloud.pubsub.subscription.oldest_unacked_message_age.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "max"
                   }
@@ -421,7 +421,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.num_undelivered_messages",
+                    "field": "googlecloud.pubsub.subscription.num_undelivered_messages.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -509,7 +509,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.backlog_bytes",
+                    "field": "googlecloud.pubsub.subscription.backlog_bytes.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -587,7 +587,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.pull_request_count",
+                    "field": "googlecloud.pubsub.subscription.pull_request_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -666,7 +666,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.topic.message_sizes.bucket_options.Options.ExponentialBuckets.num_finite_buckets",
+                    "field": "googlecloud.pubsub.topic.message_sizes.bucket_options.Options.ExponentialBuckets.num_finite_buckets.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -732,7 +732,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.num_undelivered_messages",
+                    "field": "googlecloud.pubsub.subscription.num_undelivered_messages.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }
@@ -811,7 +811,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.pull_message_operation_count",
+                    "field": "googlecloud.pubsub.subscription.pull_message_operation_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "max"
                   }
@@ -890,7 +890,7 @@
                 "line_width": "2",
                 "metrics": [
                   {
-                    "field": "googlecloud.pubsub.subscription.sent_message_count",
+                    "field": "googlecloud.pubsub.subscription.sent_message_count.value",
                     "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "type": "avg"
                   }


### PR DESCRIPTION
Cherry-pick of PR #18980 to 7.x branch. Original message: 

## What does this PR do?
This PR is to fix googlecloud dashboard compute and pubsub. This is caused by changing metric names with suffix `.value`. 
For example, uptime metric name changed from `googlecloud.compute.instance.uptime.value` to `googlecloud.compute.instance.uptime.value`.

## Related issues
- Closes https://github.com/elastic/beats/issues/18962

## Screenshots
<img width="2559" alt="Screen Shot 2020-06-04 at 11 07 53 AM" src="https://user-images.githubusercontent.com/14081635/83790273-29af3280-a655-11ea-9bfa-3afc46ea3689.png">
