### PR TITLE
Cherry-pick #19069 to 7.8: [Filebeat][HTTPJson Input]fixes issues with mapstring against JSONObject config

### DIFF
--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -329,7 +329,7 @@ func (in *HttpjsonInput) processHTTPRequest(ctx context.Context, client *http.Cl
 					return err
 				}
 			} else {
-				v, err = common.MapStr(mm).GetValue(in.config.JSONObjects)
+				v, err = common.MapStr(obj).GetValue(in.config.JSONObjects)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Cherry-pick of PR #19069 to 7.8 branch. Original message: 

# What does this PR do?

This change resolves an error when using "json_objects_array" configuration option. Currently the feature does not work due to mm always being nil

## Why is it important?

Fixes a currently unusable feature

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

