### PR TITLE
Cherry-pick #18991 to 7.8: Fix translate_sid's empty target field handling

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -85,6 +85,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - [Autodiscover] Check if runner is already running before starting again. {pull}18564[18564]
 - Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
 - Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
+- Fix potential race condition in fingerprint processor. {pull}18738[18738]
+- Fix the `translate_sid` processor's handling of unconfigured target fields. {issue}18990[18990] {pull}18991[18991]
 - Fixed a service restart failure under Windows. {issue}18914[18914] {pull}18916[18916]
 
 *Auditbeat*

--- a/libbeat/processors/translate_sid/translatesid.go
+++ b/libbeat/processors/translate_sid/translatesid.go
@@ -111,14 +111,20 @@ func (p *processor) translateSID(event *beat.Event) error {
 
 	// Do all operations even if one fails.
 	var errs []error
-	if _, err = event.PutValue(p.AccountNameTarget, account); err != nil {
-		errs = append(errs, err)
+	if p.AccountNameTarget != "" {
+		if _, err = event.PutValue(p.AccountNameTarget, account); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if _, err = event.PutValue(p.AccountTypeTarget, sys.SIDType(accountType).String()); err != nil {
-		errs = append(errs, err)
+	if p.AccountTypeTarget != "" {
+		if _, err = event.PutValue(p.AccountTypeTarget, sys.SIDType(accountType).String()); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if _, err = event.PutValue(p.DomainTarget, domain); err != nil {
-		errs = append(errs, err)
+	if p.DomainTarget != "" {
+		if _, err = event.PutValue(p.DomainTarget, domain); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return multierr.Combine(errs...)
 }


### PR DESCRIPTION
Cherry-pick of PR #18991 to 7.8 branch. Original message: 

## What does this PR do?

The translate_sid processor only requires one of the three target fields to be configured. It should work properly when some of the targets are not set, but it doesn't check if they are empty strings. So it ends up adding target fields that are empty strings to the event (e.g. "": "Group").

## Why is it important?

Without this fix, if some target fields were not set then the beat would produce invalid events that cannot be indexed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #18990


