### PR TITLE
fixes #19088 urldecode for nginx access url.original and nginx error …

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -386,6 +386,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The s3 input can now automatically detect gzipped objects. {issue}18283[18283] {pull}18764[18764]
 - Add geoip AS lookup & improve ECS categorization in aws cloudtrail fileset. {issue}18644[18644] {pull}18958[18958]
 - Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
+- Added urldecode for nginx access url.original and nginx error message {issue}19088[19088]
 
 *Heartbeat*
 

--- a/filebeat/module/nginx/access/ingest/pipeline.yml
+++ b/filebeat/module/nginx/access/ingest/pipeline.yml
@@ -158,6 +158,11 @@ processors:
     field: related.user
     value: "{{user.name}}"
     if: "ctx?.user?.name != null"
+- urldecode:
+    field: url.original
+    target_field: url.original
+    ignore_missing: true
+    ignore_failure: true
 on_failure:
 - set:
     field: error.message

--- a/filebeat/module/nginx/error/ingest/pipeline.yml
+++ b/filebeat/module/nginx/error/ingest/pipeline.yml
@@ -45,6 +45,11 @@ processors:
 - append:
     field: event.type
     value: error
+- urldecode:
+    field: message
+    target_field: message
+    ignore_missing: true
+    ignore_failure: true
 on_failure:
 - set:
     field: error.message


### PR DESCRIPTION
Type of change: 
- Enhancement

## What does this PR do?

This PR adds `urldecode` processor to filebeat nginx module pipelines (both access and error).

## Why is it important?

Nginx logs encode URLs and they are hard to read as is.
With urldecode processor logs are much easier to read. See few examples in the #19088  

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` ~~or `CHANGELOG-developer.next.asciidoc`~~.

## How to test this PR locally

This PR can be tested by using Filebeat with nginx module

## Related issues

- Closes elastic/beats#19088

## Screenshots

![Screen Shot 2020-06-09 at 10 08 24 PM](https://user-images.githubusercontent.com/6293679/84229390-4eb10480-aa9e-11ea-9138-407dc6394e6b.jpg)
