### PR TITLE
Cherry-pick #18967 to 7.x: Moved from stream to dataset 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -70,3 +70,4 @@
 - When not port are specified and the https is used fallback to 443 {pull}18844[18844]
 - Change monitoring defaults for agent {pull}18927[18927]
 - Agent verifies packages before using them {pull}18876[18876]
+- Change stream.* to dataset.* fields {pull}18967[18967]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -180,7 +180,17 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 					"paths": paths,
 					"index": "logs-agent-default",
 					"processors": []map[string]interface{}{
-						map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"target": "dataset",
+								"fields": map[string]interface{}{
+									"type":      "logs",
+									"name":      "agent",
+									"namespace": "default",
+								},
+							},
+						},
+						{
 							"add_fields": map[string]interface{}{
 								"target": "stream",
 								"fields": map[string]interface{}{
@@ -220,7 +230,17 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 					"hosts":      hosts,
 					"index":      "metrics-agent-default",
 					"processors": []map[string]interface{}{
-						map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"target": "dataset",
+								"fields": map[string]interface{}{
+									"type":      "metrics",
+									"name":      "agent",
+									"namespace": "default",
+								},
+							},
+						},
+						{
 							"add_fields": map[string]interface{}{
 								"target": "stream",
 								"fields": map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
@@ -8,6 +8,12 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "dataset"
+          fields:
+            type: logs
+            name: generic
+            namespace: default
+      - add_fields:
           target: "stream"
           fields:
             type: logs

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
@@ -8,6 +8,12 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "dataset"
+          fields:
+            type: logs
+            name: generic
+            namespace: default
+      - add_fields:
           target: "stream"
           fields:
             type: logs

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
@@ -9,6 +9,12 @@ filebeat:
     index: logs-generic-default
     processors:
       - add_fields:
+          target: "dataset"
+          fields:
+            type: logs
+            name: generic
+            namespace: default
+      - add_fields:
           target: "stream"
           fields:
             type: logs

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
@@ -10,6 +10,12 @@ filebeat:
       var: value
     processors:
       - add_fields:
+          target: "dataset"
+          fields:
+            type: logs
+            name: generic
+            namespace: default
+      - add_fields:
           target: "stream"
           fields:
             type: logs

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
@@ -6,6 +6,12 @@ metricbeat:
     hosts: ["http://127.0.0.1:8080"]
     processors:
     - add_fields:
+        target: "dataset"
+        fields:
+          type: metrics
+          name: docker.status
+          namespace: default
+    - add_fields:
         target: "stream"
         fields:
           type: metrics
@@ -16,6 +22,12 @@ metricbeat:
     index: metrics-generic-default
     hosts: ["http://127.0.0.1:8080"]
     processors:
+    - add_fields:
+        target: "dataset"
+        fields:
+          type: metrics
+          name: generic
+          namespace: default
     - add_fields:
         target: "stream"
         fields:
@@ -31,11 +43,18 @@ metricbeat:
           fields:
             should_be: first
       - add_fields:
+          target: "dataset"
+          fields:
+            type: metrics
+            name: generic
+            namespace: testing
+      - add_fields:
           target: "stream"
           fields:
             type: metrics
             dataset: generic
             namespace: testing
+
 output:
   elasticsearch:
     hosts: [127.0.0.1:9200, 127.0.0.1:9300]

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -628,15 +628,29 @@ func (r *InjectStreamProcessorRule) Apply(ast *AST) error {
 				}
 
 				processorMap := &Dict{value: make([]Node, 0)}
-				processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "stream"}})
+				processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "dataset"}})
 				processorMap.value = append(processorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
+					&Key{name: "type", value: &StrVal{value: r.Type}},
+					&Key{name: "namespace", value: &StrVal{value: namespace}},
+					&Key{name: "name", value: &StrVal{value: dataset}},
+				}}})
+
+				addFieldsMap := &Dict{value: []Node{&Key{"add_fields", processorMap}}}
+				processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, addFieldsMap)
+
+				// add this for backwards compatibility remove later
+				streamProcessorMap := &Dict{value: make([]Node, 0)}
+				streamProcessorMap.value = append(streamProcessorMap.value, &Key{name: "target", value: &StrVal{value: "stream"}})
+				streamProcessorMap.value = append(streamProcessorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
 					&Key{name: "type", value: &StrVal{value: r.Type}},
 					&Key{name: "namespace", value: &StrVal{value: namespace}},
 					&Key{name: "dataset", value: &StrVal{value: dataset}},
 				}}})
 
-				addFieldsMap := &Dict{value: []Node{&Key{"add_fields", processorMap}}}
-				processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, addFieldsMap)
+				streamAddFieldsMap := &Dict{value: []Node{&Key{"add_fields", streamProcessorMap}}}
+
+				processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, streamAddFieldsMap)
+				// end of backward compatibility section
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #18967 to 7.x branch. Original message:

## What does this PR do?

Changes injected processor to events so it enriches them with dataset.* instead of stream.*

## Why is it important?

https://github.com/elastic/package-registry/issues/491

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

As draft until we are ready and in sync to merge

Fixes: https://github.com/elastic/package-registry/issues/491
Fixes: https://github.com/elastic/beats/issues/18826

cc @ruflin 