### PR TITLE
Cherry-pick #19078 to 7.7: Fix crash on vsphere module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix tags_filter for cloudwatch metricset in aws. {pull}18524[18524]
 - Fix panic on `metricbeat test modules` when modules are configured in `metricbeat.modules`. {issue}18789[18789] {pull}18797[18797]
 - Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
+- Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
 
 *Packetbeat*
 

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -164,20 +164,20 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) error {
 			},
 		}
 
-		if vm.Summary.Runtime.Host != nil {
-			event["host.id"] = vm.Summary.Runtime.Host.Value
+		if host := vm.Summary.Runtime.Host; host != nil {
+			event["host.id"] = host.Value
+			hostSystem, err := getHostSystem(ctx, c, host.Reference())
+			if err == nil {
+				event["host.hostname"] = hostSystem.Summary.Config.Name
+			} else {
+				m.Logger().Debug(err.Error())
+			}
 		} else {
 			m.Logger().Debug("'Host', 'Runtime' or 'Summary' data not found. This is either a parsing error " +
 				"from vsphere library, an error trying to reach host/guest or incomplete information returned " +
 				"from host/guest")
 		}
 
-		hostSystem, err := getHostSystem(ctx, c, vm.Summary.Runtime.Host.Reference())
-		if err != nil {
-			m.Logger().Debug(err.Error())
-		} else {
-			event["host.hostname"] = hostSystem.Summary.Config.Name
-		}
 		// Get custom fields (attributes) values if get_custom_fields is true.
 		if m.GetCustomFields && vm.Summary.CustomValue != nil {
 			customFields := getCustomFields(vm.Summary.CustomValue, customFieldsMap)


### PR DESCRIPTION
Cherry-pick of PR #19078 to 7.7 branch. Original message: 

Host information is not always available, when it is not, some structures
are nil references. Avoid using them to retrieve additional information.

Fixes  #18996.