### PR TITLE
Cherry-pick #19078 to 7.6: Fix crash on vsphere module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue in Jolokia module when mbean contains multiple quoted properties. {issue}17375[17375] {pull}17374[17374]
 - Fix "ID" event generator of Google Cloud module {issue}17160[17160] {pull}17608[17608]
 - Metricbeat no longer needs to be started strictly after Logstash for `logstash-xpack` module to report correct data. {issue}17261[17261] {pull}17497[17497]
+- Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
 
 *Packetbeat*
 

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -167,20 +167,20 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) error {
 			},
 		}
 
-		if vm.Summary.Runtime.Host != nil {
-			event["host.id"] = vm.Summary.Runtime.Host.Value
+		if host := vm.Summary.Runtime.Host; host != nil {
+			event["host.id"] = host.Value
+			hostSystem, err := getHostSystem(ctx, c, host.Reference())
+			if err == nil {
+				event["host.hostname"] = hostSystem.Summary.Config.Name
+			} else {
+				m.Logger().Debug(err.Error())
+			}
 		} else {
 			m.Logger().Debug("'Host', 'Runtime' or 'Summary' data not found. This is either a parsing error " +
 				"from vsphere library, an error trying to reach host/guest or incomplete information returned " +
 				"from host/guest")
 		}
 
-		hostSystem, err := getHostSystem(ctx, c, vm.Summary.Runtime.Host.Reference())
-		if err != nil {
-			m.Logger().Debug(err.Error())
-		} else {
-			event["host.hostname"] = hostSystem.Summary.Config.Name
-		}
 		// Get custom fields (attributes) values if get_custom_fields is true.
 		if m.GetCustomFields && vm.Summary.CustomValue != nil {
 			customFields := getCustomFields(vm.Summary.CustomValue, customFieldsMap)


### PR DESCRIPTION
Cherry-pick of PR #19078 to 7.6 branch. Original message: 

Host information is not always available, when it is not, some structures
are nil references. Avoid using them to retrieve additional information.

Fixes  #18996.