### PR TITLE
Fix 15838 issue placement in CHANGELOG

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -307,6 +307,12 @@ https://github.com/elastic/beats/compare/v7.6.0...v7.6.1[View commits]
 
 - Fix timeout option of GCP functions. {issue}16282[16282] {pull}16287[16287]
 
+==== Added
+
+*Winlogbeat*
+
+- Made the event parser more lenient w.r.t. invalid event log definition version numbers. {issue}15838[15838]
+
 [[release-notes-7.6.0]]
 === Beats version 7.6.0
 https://github.com/elastic/beats/compare/v7.5.1...v7.6.0[View commits]
@@ -673,7 +679,6 @@ processing events. (CVE-2019-17596) See https://www.elastic.co/community/securit
 
 - Fill `event.provider`. {pull}13937[13937]
 - Add support for user management events to the Security module. {pull}13530[13530]
-- Made the event parser more lenient w.r.t. invalid event log definition version numbers. {issue}15838[15838]
 
 ==== Deprecated
 


### PR DESCRIPTION
Fix for https://github.com/elastic/beats/issues/15838 has first arrived in 7.6.1, not 7.5.0.

Verification: https://github.com/elastic/beats/compare/v7.6.0...v7.6.1