### PR TITLE
Allow host.* fields to be disabled in Suricata module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 * iptables {pull}18756[18756]
 * Checkpoint {pull}18754[18754]
 * Netflow {pull}19087[19087]
+* Suricata {pull}19107[19107] (`forwarded` tag is not included by default)
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
 - Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
 - Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -45,6 +45,12 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[suricata]`.
+
 [float]
 === Example dashboard
 

--- a/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
@@ -40,6 +40,12 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[suricata]`.
+
 [float]
 === Example dashboard
 

--- a/x-pack/filebeat/module/suricata/eve/config/eve.yml
+++ b/x-pack/filebeat/module/suricata/eve/config/eve.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
   - rename:

--- a/x-pack/filebeat/module/suricata/eve/manifest.yml
+++ b/x-pack/filebeat/module/suricata/eve/manifest.yml
@@ -13,8 +13,6 @@ var:
   - name: community_id
     default: true
 
-  # - name: nested_ecs
-  #   default: false
 ingest_pipeline: ingest/pipeline.yml
 input: config/eve.yml
 


### PR DESCRIPTION
## What does this PR do?

If `forwarded` as configured as a tag (e.g. `var.tags: [forwarded]`) for the Suricata module then Filebeat will not add `host` fields to events. This is for use cases where Suricata is analyzing forwarded data (like from a network tap or mirror port).

## Why is it important?

We want Filebeat to follow Elastic Common Schema. And setting host with the correct value is part of that. By setting (or not setting host) we can better interpret events. Without this change the Filebeat host is being attributed as the source even if data was received over a network tap or mirror port.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates: #13920