### PR TITLE
Allow host.* fields to be disabled in Zeek module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 * iptables {pull}18756[18756]
 * Checkpoint {pull}18754[18754]
 * Netflow {pull}19087[19087]
+* Zeek {pull}19113[19113] (`forwarded` tag is not included by default)
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
 - Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
 - Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]

--- a/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
+++ b/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/connection/config/connection.yml
+++ b/x-pack/filebeat/module/zeek/connection/config/connection.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/dns/config/dns.yml
+++ b/x-pack/filebeat/module/zeek/dns/config/dns.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
   - rename:

--- a/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
+++ b/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/files/config/files.yml
+++ b/x-pack/filebeat/module/zeek/files/config/files.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
+++ b/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/http/config/http.yml
+++ b/x-pack/filebeat/module/zeek/http/config/http.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 
@@ -62,7 +63,7 @@ processors:
 
         - from: "zeek.http.password"
           to: "url.password"
-        
+
         - from: "zeek.http.user_agent"
           to: "user_agent.original"
 

--- a/x-pack/filebeat/module/zeek/intel/config/intel.yml
+++ b/x-pack/filebeat/module/zeek/intel/config/intel.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
   - rename:

--- a/x-pack/filebeat/module/zeek/irc/config/irc.yml
+++ b/x-pack/filebeat/module/zeek/irc/config/irc.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
+++ b/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
+++ b/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
+++ b/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/pe/config/pe.yml
+++ b/x-pack/filebeat/module/zeek/pe/config/pe.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/radius/config/radius.yml
+++ b/x-pack/filebeat/module/zeek/radius/config/radius.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
+++ b/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
+++ b/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/sip/config/sip.yml
+++ b/x-pack/filebeat/module/zeek/sip/config/sip.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
+++ b/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
+++ b/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/socks/config/socks.yml
+++ b/x-pack/filebeat/module/zeek/socks/config/socks.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
+++ b/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
+++ b/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/stats/config/stats.yml
+++ b/x-pack/filebeat/module/zeek/stats/config/stats.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
+++ b/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
+++ b/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
+++ b/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/weird/config/weird.yml
+++ b/x-pack/filebeat/module/zeek/weird/config/weird.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 

--- a/x-pack/filebeat/module/zeek/x509/config/x509.yml
+++ b/x-pack/filebeat/module/zeek/x509/config/x509.yml
@@ -4,7 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 json.keys_under_root: false
 


### PR DESCRIPTION
## What does this PR do?

If `forwarded` as configured as a tag (e.g. `var.tags: [forwarded]`) for the Zeek module then Filebeat will not add `host` fields to events. This is for use cases where Zeek is analyzing forwarded data (like from a network tap or mirror port).

## Why is it important?

We want Filebeat to follow Elastic Common Schema. And setting host with the correct value is part of that. By setting (or not setting host) we can better interpret events. Without this change the Filebeat host is being attributed as the source even if data was received over a network tap or mirror port.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates: #13920