### PR TITLE
[CI] windows pipeline

### DIFF
--- a/.ci/jobs/beats-windows-mbp.yml
+++ b/.ci/jobs/beats-windows-mbp.yml
@@ -13,6 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current          
           discover-tags: false
+          # Run MBP for the master branch and PRs
           head-filter-regex: '(master|PR-.*)'
           notification-context: 'beats-ci'
           repo: beats
@@ -28,6 +29,8 @@
             - change-request:
                 ignore-target-only-changes: false
           property-strategies:
+            # Builds for PRs won't be triggered automatically.
+            # Only the master branch will be triggered automatically. 
             - named-branches:
               - defaults:
                 - suppress-scm-triggering: true

--- a/.ci/jobs/beats-windows-mbp.yml
+++ b/.ci/jobs/beats-windows-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current          
           discover-tags: false
-          head-filter-regex: 'master'
+          head-filter-regex: '(master|PR-.*)'
           notification-context: 'beats-ci'
           repo: beats
           repo-owner: elastic
@@ -27,6 +27,15 @@
             - regular-branches: true
             - change-request:
                 ignore-target-only-changes: false
+          property-strategies:
+            - named-branches:
+              - defaults:
+                - suppress-scm-triggering: true
+              - exceptions:
+                - exception:
+                    branch-name: master
+                    properties:
+                      - suppress-scm-triggering: false
           clean:
             after: true
             before: true

--- a/.ci/windows.groovy
+++ b/.ci/windows.groovy
@@ -66,7 +66,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
         dir("${BASE_DIR}"){
-          loadConfigEnvVars()
+          //loadConfigEnvVars()
         }
         whenTrue(params.debug){
           dumpFilteredEnvironment()
@@ -75,6 +75,9 @@ pipeline {
     }
     stage('Lint'){
       options { skipDefaultCheckout() }
+      when {
+        expression { return false }
+      }
       steps {
         makeTarget("Lint", "check")
       }
@@ -91,7 +94,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_ELASTIC_AGENT_XPACK != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_ELASTIC_AGENT_XPACK != "false" && params.windowsTest
             }
           }
           steps {
@@ -103,7 +107,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_FILEBEAT != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_FILEBEAT != "false" && params.windowsTest
             }
           }
           steps {
@@ -115,7 +120,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
             }
           }
           steps {
@@ -127,7 +133,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_HEARTBEAT != "false"
+              return params.windowsTest
+              //return env.BUILD_HEARTBEAT != "false"
             }
           }
           stages {
@@ -150,7 +157,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_AUDITBEAT != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_AUDITBEAT != "false" && params.windowsTest
             }
           }
           steps {
@@ -162,7 +170,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_AUDITBEAT_XPACK != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_AUDITBEAT_XPACK != "false" && params.windowsTest
             }
           }
           steps {
@@ -174,7 +183,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_METRICBEAT != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_METRICBEAT != "false" && params.windowsTest
             }
           }
           steps {
@@ -186,7 +196,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
+              return params.windowsTest
+              //return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
             }
           }
           steps {
@@ -198,7 +209,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_WINLOGBEAT != "false"
+              return params.windowsTest
+              //return env.BUILD_WINLOGBEAT != "false"
             }
           }
           stages {
@@ -221,7 +233,8 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return params.windowsTest && env.BUILD_WINLOGBEAT_XPACK != "false"
+              return params.windowsTest
+              //return params.windowsTest && env.BUILD_WINLOGBEAT_XPACK != "false"
             }
           }
           steps {

--- a/.ci/windows.groovy
+++ b/.ci/windows.groovy
@@ -66,7 +66,9 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
         dir("${BASE_DIR}"){
-          //loadConfigEnvVars()
+          // NOTE: commented to run faster the windows pipeline.
+          //       when required then it can be enabled.
+          // loadConfigEnvVars()
         }
         whenTrue(params.debug){
           dumpFilteredEnvironment()
@@ -75,11 +77,10 @@ pipeline {
     }
     stage('Lint'){
       options { skipDefaultCheckout() }
-      when {
-        expression { return false }
-      }
       steps {
-        makeTarget("Lint", "check")
+        // NOTE: commented to run the windows pipeline a bit faster.
+        //       when required then it can be enabled.
+        // makeTarget("Lint", "check")
       }
     }
     stage('Build and Test Windows'){
@@ -95,6 +96,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_ELASTIC_AGENT_XPACK != "false" && params.windowsTest
             }
           }
@@ -108,6 +110,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_FILEBEAT != "false" && params.windowsTest
             }
           }
@@ -121,6 +124,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_FILEBEAT_XPACK != "false" && params.windowsTest
             }
           }
@@ -134,6 +138,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_HEARTBEAT != "false"
             }
           }
@@ -158,6 +163,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_AUDITBEAT != "false" && params.windowsTest
             }
           }
@@ -171,6 +177,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_AUDITBEAT_XPACK != "false" && params.windowsTest
             }
           }
@@ -184,6 +191,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_METRICBEAT != "false" && params.windowsTest
             }
           }
@@ -197,6 +205,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_METRICBEAT_XPACK != "false" && params.windowsTest
             }
           }
@@ -210,6 +219,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return env.BUILD_WINLOGBEAT != "false"
             }
           }
@@ -234,6 +244,7 @@ pipeline {
             beforeAgent true
             expression {
               return params.windowsTest
+              // NOTE: commented to run all the windows stages.
               //return params.windowsTest && env.BUILD_WINLOGBEAT_XPACK != "false"
             }
           }


### PR DESCRIPTION
## What does this PR do?

Run windows build stages always when merging to master (it does not filter if changes are related to some other beats).
Enable windows pipelines for PRs, but it won't be triggered but only the master branch.


## Why is it important?

Running a build might run nothing but the linting

Besides if we enable the MBP to monitor PRs then we will be able to test the changes for this pipeline easily rather than being blind.