### PR TITLE
[7.8] [docs] Add 7.8 release highlights placeholder file (#18493)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -10,6 +10,7 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 7.x) is not recommended.
 
 See the following topics for a description of breaking changes:
+
 * <<breaking-changes-7.8>>
 
 * <<breaking-changes-7.7>>

--- a/libbeat/docs/release-notes/highlights/highlights-7.8.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.8.0.asciidoc
@@ -1,0 +1,30 @@
+[[release-highlights-7.8.0]]
+=== 7.8 release highlights
+++++
+<titleabbrev>7.8</titleabbrev>
+++++
+
+Each release of {beats} brings new features and product improvements. 
+Following are the most notable features and enhancements in 7.8.
+
+//For a complete list of related highlights, see the 
+//https://www.elastic.co/blog/elastic-observability-7-7-0-released[Observability 7.8 release blog].
+
+For a list of bug fixes and other changes, see the {beats}
+<<breaking-changes-7.8, Breaking Changes>> and <<release-notes, Release Notes>>.
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+
+//
+//[float]
+//Remove role if open source
+//[role="xpack"]
+//==== Highlight title
+
+//Description
+
+
+// end::notable-highlights[]

--- a/libbeat/docs/release-notes/highlights/highlights.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights.asciidoc
@@ -4,6 +4,8 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-7.8.0>>
+
 * <<release-highlights-7.7.0>>
 
 * <<release-highlights-7.6.0>>
@@ -19,6 +21,8 @@ full list, see <<release-notes>> and <<breaking-changes>>.
 * <<release-highlights-7.1.0>>
 
 * <<release-highlights-7.0.0>>
+
+include::highlights-7.8.0.asciidoc[]
 
 include::highlights-7.7.0.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [docs] Add 7.8 release highlights placeholder file (#18493)