### PR TITLE
Add ignore old file truncate configuration 

### DIFF
--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -68,6 +68,7 @@ var (
 			CloseRenamed:  false,
 			CloseEOF:      false,
 			CloseTimeout:  0,
+			IgnoreOldFileTruncate: true,
 		},
 	}
 )
@@ -123,6 +124,7 @@ type LogConfig struct {
 	CloseRenamed  bool          `config:"close_renamed"`
 	CloseEOF      bool          `config:"close_eof"`
 	CloseTimeout  time.Duration `config:"close_timeout" validate:"min=0"`
+	IgnoreOldFileTruncate bool `config:"ignore_old_file_truncate"`
 }
 
 // Contains available scan options

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -68,7 +68,7 @@ var (
 			CloseRenamed:  false,
 			CloseEOF:      false,
 			CloseTimeout:  0,
-			IgnoreOldFileTruncate: true,
+			IgnoreOldFileTruncate: false,
 		},
 	}
 )

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -529,6 +529,16 @@ func (p *Input) harvestExistingFile(newState file.State, oldState file.State) {
 
 	// File size was reduced -> truncated file
 	if oldState.Finished && newState.Fileinfo.Size() < oldState.Offset {
+		if p.config.IgnoreOldFileTruncate {
+			logp.Info("Old file was truncated, ignore_old_file_truncate: true, file: %s, new offset: %d , old offset: %d", newState.Source , newState.Fileinfo.Size() , oldState.Offset )
+            		oldState.Offset = newState.Fileinfo.Size()
+            		err := p.updateState(oldState)
+            		if err != nil {
+                		logp.Err("File truncate update file: %s state error: %s", newState.Source, err)
+            		}
+            		return
+        	}
+		
 		logp.Debug("input", "Old file was truncated. Starting from the beginning: %s, offset: %d, new size: %d ", newState.Source, newState.Offset, newState.Fileinfo.Size())
 		err := p.startHarvester(newState, 0)
 		if err != nil {


### PR DESCRIPTION
- Enhancement

## What does this PR do?

prevent Harvester read again from offset 0 when truncate old file.

## Why is it important?

when deleting old large log file, we use truncate to delete it slowly, ignore_old_file_truncate configuration can prevent Harvester read again from offset 0

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Use cases

`
filebeat.inputs:


- enabled: true
  encoding: "utf-8"
  exclude_files: []
  fields:
    ip: "172.27.236.101"
    topic: "fb-2xxxxxxxx"
  ignore_older: "12h"
  ignore_old_file_truncate: true
  paths:
  - "/data/unipay/log/log_data_water.log*"
  tail_files: true
  type: "log"
`


## Logs

2020-06-11T14:17:37.077+0800	INFO	log/input.go:531	Old file was truncated, ignore_old_file_truncate: true, file: /data/log/log_data_water.log.2020-06-09.66, new offset: 337642394 , old offset: 531628954
2020-06-11T14:17:47.078+0800	INFO	log/input.go:531	Old file was truncated, ignore_old_file_truncate: true, file: /data/log/log_data_water.log.2020-06-09.66, new offset: 138412954 , old offset: 337642394
2020-06-11T14:17:57.080+0800	INFO	log/input.go:531	Old file was truncated, ignore_old_file_truncate: true, file: /data/log/log_data_water.log.2020-06-09.66, new offset: 0 , old offset: 138412954
2020-06-11T14:20:07.094+0800	INFO	log/harvester.go:297	Harvester started for file: /data/log/log_data_water.log.2020-06-09.66
2020-06-11T14:25:12.099+0800	INFO	log/harvester.go:324	File is inactive: /data/log/log_data_water.log.2020-06-09.66. Closing because close_inactive of 5m0s reached.
