### PR TITLE
PostgreSQL Filebeat: Define fields.epr.yml

### DIFF
--- a/filebeat/module/postgresql/log/_meta/fields.epr.yml
+++ b/filebeat/module/postgresql/log/_meta/fields.epr.yml
@@ -1,0 +1,13 @@
+- name: event.kind
+  type: keyword
+  description: Event kind (e.g. event)
+- name: event.category
+  type: keyword
+  description: Event category (e.g. database)
+- name: event.code
+  type: keyword
+  description: Identification code for this event
+- name: event.type
+  type: keyword
+  description: Event severity (e.g. info, error)
+


### PR DESCRIPTION
This PR defines additional fields referenced in the ingest pipeline.

The file is used by the `import-beats` script to include them in integration packages.