### PR TITLE
Fix tags for coredns/envoyproxy

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 * Checkpoint {pull}18754[18754]
 * Netflow {pull}19087[19087]
 * Suricata {pull}19107[19107] (`forwarded` tag is not included by default)
+* CoreDNS {pull}19134[19134] (`forwarded` tag is not included by default)
+* Envoy Proxy {pull}19134[19134] (`forwarded` tag is not included by default)
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
 - Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
 - Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]

--- a/x-pack/filebeat/module/coredns/log/config/coredns.yml
+++ b/x-pack/filebeat/module/coredns/log/config/coredns.yml
@@ -3,7 +3,8 @@ paths:
 {{ range $i, $path := .paths }}
   - {{$path}}
 {{ end }}
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:
   - add_fields:
       target: ''

--- a/x-pack/filebeat/module/envoyproxy/log/config/envoyproxy.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/config/envoyproxy.yml
@@ -3,7 +3,8 @@ paths:
 {{ range $i, $path := .paths }}
   - {{$path}}
 {{ end }}
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:
   - add_fields:
       target: ''


### PR DESCRIPTION
## What does this PR do?
When `{{ .tags }}` is evaluated in the module config it not written in the correct format.
This fixes that issue and also conditionally enables `publisher_pipeline.disable_host`
based on whether tags contains `forwarded` to be consistent with every other module
that allows for `var.tags` to be set (relates: #13920).

For example (https://play.golang.org/p/LUr-X94msd1):

    var.tags: [foo, bar]

will be written into the config as

    tags: [foo bar]

which is a single value array containing the string "foo bar" rather than two tags.

## Why is it important?

If a user specified more than one tag in a module config then they would not have had the expect tags in their events.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #13920