### PR TITLE
[7.8] Add compatibility info (#18929)

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -48,6 +48,12 @@ For more details on the mapping between Kafka and Event Hubs configuration
 parameters, see the
 link:https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview[Azure documentation].
 
+[[kafka-input-compatibility]]
+==== Compatibility
+
+This input works with all Kafka versions in between 0.11 and 2.1.0. Older versions
+might work as well, but are not supported.
+
 [id="{beatname_lc}-input-{type}-options"]
 ==== Configuration options
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Add compatibility info (#18929)