### PR TITLE
[Filebeat] Check compatibility of field types in pythonIntegTest

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -548,9 +548,10 @@ class TestCase(unittest.TestCase, ComposeMixin):
             fields = []
             dictfields = []
             aliases = []
+            types = {}
 
             if doc_list is None:
-                return fields, dictfields, aliases
+                return fields, dictfields, aliases, types
 
             for field in doc_list:
 
@@ -565,14 +566,16 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     newName = field["name"]
 
                 if field.get("type") == "group":
-                    subfields, subdictfields, subaliases = extract_fields(field["fields"], newName)
+                    subfields, subdictfields, subaliases, subtypes = extract_fields(field["fields"], newName)
                     fields.extend(subfields)
                     dictfields.extend(subdictfields)
                     aliases.extend(subaliases)
+                    types.update(subtypes)
                 else:
                     fields.append(newName)
                     if field.get("type") in ["object", "geo_point"]:
                         dictfields.append(newName)
+                    types[newName] = field.get("type")
 
                 if field.get("type") == "object" and field.get("object_type") == "histogram":
                     fields.append(newName + ".values")
@@ -581,7 +584,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 if field.get("type") == "alias":
                     aliases.append(newName)
 
-            return fields, dictfields, aliases
+            return fields, dictfields, aliases, types
 
         global yaml_cache
 
@@ -607,13 +610,15 @@ class TestCase(unittest.TestCase, ComposeMixin):
             fields = []
             dictfields = []
             aliases = []
+            types = {}
 
             for item in doc:
-                subfields, subdictfields, subaliases = extract_fields(item["fields"], "")
+                subfields, subdictfields, subaliases, subtypes = extract_fields(item["fields"], "")
                 fields.extend(subfields)
                 dictfields.extend(subdictfields)
                 aliases.extend(subaliases)
-            return fields, dictfields, aliases
+                types.update(subtypes)
+            return fields, dictfields, aliases, types
 
     def flatten_object(self, obj, dict_fields, prefix=""):
         result = {}
@@ -683,10 +688,11 @@ class TestCase(unittest.TestCase, ComposeMixin):
 
     def assert_fields_are_documented(self, evt):
         """
-        Assert that all keys present in evt are documented in fields.yml.
+        Assert that all keys present in evt are documented in fields.yml and have compatible types.
         This reads from the global fields.yml, means `make collect` has to be run before the check.
         """
-        expected_fields, dict_fields, aliases = self.load_fields()
+        errors = []
+        expected_fields, dict_fields, aliases, types = self.load_fields()
         flat = self.flatten_object(evt, dict_fields)
 
         def field_pattern_match(pattern, key):
@@ -709,14 +715,38 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     return True
             return False
 
+        def has_compatible_type(field_name, value, types):
+            if field_name not in types:
+                # must be a pattern_match
+                return True
+            doc_type = types[field_name]
+            if doc_type in ['array']:
+                expected_types = (list, type(None))
+            elif doc_type in ['boolean']:
+                expected_types = (bool,)
+            elif doc_type in ['object', 'geo_point']:
+                expected_types = (dict, list, type(None))
+            elif doc_type in ['short', 'integer', 'long', 'double', 'float']:
+                expected_types = (int, float, complex, list)
+            else:
+                # everything else should be a string or array
+                expected_types = (str, list, type(None))
+            return isinstance(value, expected_types)
+
         for key in flat.keys():
             metaKey = key.startswith('@metadata.')
             # Range keys as used in 'date_range' etc will not have docs of course
             isRangeKey = key.split('.')[-1] in ['gte', 'gt', 'lte', 'lt']
             if not(is_documented(key, expected_fields) or metaKey or isRangeKey):
-                raise Exception("Key '{}' found in event is not documented!".format(key))
+                errors.append("Key '{}' found in event is not documented!".format(key))
+                next
             if is_documented(key, aliases):
-                raise Exception("Key '{}' found in event is documented as an alias!".format(key))
+                errors.append("Key '{}' found in event is documented as an alias!".format(key))
+                next
+            if not(has_compatible_type(key, flat[key], types)):
+                errors.append("Key '{}' found in event has incompatible type expected '{}' got '{}'!".format(key, types[key], type(flat[key])))
+        if len(errors) > 0:
+            raise Exception("Documentation Errors:\n{}".format('\n'.join(errors)))
 
     def get_beat_version(self):
         proc = self.start_beat(extra_args=["version"], output="version")

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -726,7 +726,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 expected_types = (bool,)
             elif doc_type in ['object', 'geo_point']:
                 expected_types = (dict, list, type(None))
-            elif doc_type in ['short', 'integer', 'long', 'double', 'float']:
+            elif doc_type in ['byte', 'short', 'integer', 'long', 'double', 'float', 'scaled_float']:
                 expected_types = (int, float, complex, list)
             else:
                 # everything else should be a string or array

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -743,7 +743,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             if is_documented(key, aliases):
                 errors.append("Key '{}' found in event is documented as an alias!".format(key))
                 next
-            if not(has_compatible_type(key, flat[key], types)):
+            if os.getenv('TESTING_FILEBEAT_TYPES', default=False) and not(has_compatible_type(key, flat[key], types)):
                 errors.append("Key '{}' found in event has incompatible type expected '{}' got '{}'!".format(key, types[key], type(flat[key])))
         if len(errors) > 0:
             raise Exception("Documentation Errors:\n{}".format('\n'.join(errors)))


### PR DESCRIPTION
## What does this PR do?
Makes sure the types documented in fields.yml is compatible
with the objects created when running the pythonIntegTest.

## Why is it important?
If the type of the data is incorrect you may not get the kind of
performance you expect, for example using string data type for a range
query.


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally
```
mage -v pythonIntegTest
```
