### PR TITLE
[7.7] [DOCS] Add output.console to Functionbeat doc and Functionbeat reference file (#18965)

### DIFF
--- a/libbeat/outputs/console/docs/console.asciidoc
+++ b/libbeat/outputs/console/docs/console.asciidoc
@@ -7,6 +7,13 @@
 
 The Console output writes events in JSON format to stdout.
 
+WARNING: The Console output should be used only for debugging issues as it can produce a large amount of logging data. 
+
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the console output by adding `output.console`.
+
+Example configuration:
+
 [source,yaml]
 ------------------------------------------------------------------------------
 output.console:

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -20,8 +20,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :no_kafka_output:
 :no_redis_output:
 :no_file_output:
-:no_console_output:
-:no_codec:
 :requires_xpack:
 :serverless:
 :mac_os:

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -896,7 +896,23 @@ output.elasticsearch:
   # timing out. The default is 30s.
   #timeout: 30s
 
-#================================= Paths ======================================
+
+
+
+# ------------------------------- Console Output -------------------------------
+#output.console:
+  # Boolean flag to enable or disable the output module.
+  #enabled: true
+
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty-print JSON event
+    #pretty: false
+
+    # Configure escaping HTML symbols in strings.
+    #escape_html: false
+
+# =================================== Paths ====================================
 
 # The home path for the Functionbeat installation. This is the default base path
 # for all other path settings and for miscellaneous files that come with the

--- a/x-pack/functionbeat/scripts/mage/config.go
+++ b/x-pack/functionbeat/scripts/mage/config.go
@@ -10,21 +10,13 @@ import (
 
 // XPackConfigFileParams returns the configuration of sample and reference configuration data.
 func XPackConfigFileParams() devtools.ConfigFileParams {
-	return devtools.ConfigFileParams{
-		ShortParts: []string{
-			devtools.OSSBeatDir("_meta/beat.yml"),
-			devtools.LibbeatDir("_meta/config.yml.tmpl"),
-		},
-		ReferenceParts: []string{
-			devtools.OSSBeatDir("_meta/beat.reference.yml"),
-			devtools.LibbeatDir("_meta/config.reference.yml.tmpl"),
-		},
-		ExtraVars: map[string]interface{}{
-			"ExcludeConsole":             true,
-			"ExcludeFileOutput":          true,
-			"ExcludeKafka":               true,
-			"ExcludeRedis":               true,
-			"UseDockerMetadataProcessor": false,
-		},
+	p := devtools.DefaultConfigFileParams()
+	p.Templates = append(p.Templates, "_meta/config/*.tmpl")
+	p.ExtraVars = map[string]interface{}{
+		"ExcludeConsole":             false,
+		"ExcludeFileOutput":          true,
+		"ExcludeKafka":               true,
+		"ExcludeRedis":               true,
+		"UseDockerMetadataProcessor": false,
 	}
 }


### PR DESCRIPTION
Backports the following commits to 7.7:
 - [DOCS] Add output.console to Functionbeat doc and Functionbeat reference file (#18965)