### PR TITLE
Edit Elastic Agent docs

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -1,0 +1,21 @@
+[[elastic-agent-cmd-options]]
+= Command line options
+
+experimental[]
+
+The `elastic-agent run` command provides flags that alter the behavior of an
+agent:
+
+`-path.home`::
+The home directory of the {agent}. `path.home` determines the location of the
+configuration files and data directory.
+
+`-c`::
+The configuration file to load. If not specified, {agent} uses
+`{path.home}/elastic-agent.yml`.
+
+`-path.data`::
+The data directory used by {agent} to store downloaded artifacts. Also stores
+logs for any {beats} started and managed by {agent}.
++
+If not specified, {agent} uses `{path.home}/data`.

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
@@ -1,0 +1,13 @@
+[[elastic-agent-configuration-example]]
+= Configuration example
+
+experimental[]
+
+The following example shows a full list of configuration options:
+
+//REVIEWERS: I'm not sure whether this is a true statement ^^.
+
+[source,yaml]
+----
+include::elastic-agent_configuration_example.yml[]
+----

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
@@ -5,8 +5,6 @@ experimental[]
 
 The following example shows a full list of configuration options:
 
-//REVIEWERS: I'm not sure whether this is a true statement ^^.
-
 [source,yaml]
 ----
 include::elastic-agent_configuration_example.yml[]

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -83,8 +83,6 @@ collected. If neither setting is specified, monitoring is disabled. Set
 [[elastic-agent-datasource-configuration]]
 == Datasource settings
 
-//TODO: provide more context here about what a data source is and how it's used.
-
 By default {agent} collects system metrics, such as cpu, memory, network, and
 filesystem metrics, and sends them to the default output. For example:
 
@@ -109,5 +107,5 @@ datasources:
 
 If `use_output` is not specified, the `default` output is used.
 
-For more examples, see
-<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>.
+//For more examples, see
+//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>.

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -1,0 +1,113 @@
+[[elastic-agent-configuration]]
+= Configuration settings
+
+experimental[]
+
+By default {agent} runs in standalone mode to ingest system data and send it to
+a local {es} instance running on port 9200. It uses the demo credentials of the
+`elastic` user. It's also configured to monitor all {beats} managed by the agent
+and send the {beats} logs and metrics to the same {es) instance.
+
+To alter this behavior, configure the output and other configuration settings:
+
+* <<elastic-agent-output-configuration>>
+* <<elastic-agent-monitoring-configuration>>
+* <<elastic-agent-datasource-configuration>>
+
+[float]
+[[elastic-agent-output-configuration]]
+== Output settings
+
+Specify one or more outputs. Specifying multiple outputs allows you to pair
+each data source with a different output. 
+
+IMPORTANT: {agent} currently works with the {es} output only.
+
+Example output configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    username: elastic
+    password: changeme
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+-------------------------------------------------------------------------------------
+
+This example configures two outputs: `default` and  `monitoring`.
+Notice that they use different authentication methods. The first one uses a
+username and password pair, and the second one contains an API key.
+
+[NOTE]
+==============
+A default output configuration is required.
+==============
+
+[float]
+[[elastic-agent-monitoring-configuration]]
+== {beats} monitoring settings
+
+{agent} monitors {beats} by default. To disable or change monitoring 
+settings, set options under `settings.monitoring`:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+settings.monitoring:
+  # enabled turns on monitoring of running processes
+  enabled: true
+  # enables log monitoring
+  logs: true
+  # enables metrics monitoring
+  metrics: true
+  # specifies output to be used
+  use_output: monitoring
+-------------------------------------------------------------------------------------
+
+
+To disable monitoring, set `settings.monitoring.enabled` to `false`. When set to
+`false`, {beats} monitoring is turned off, and all other options in this section
+are ignored.
+
+To enable monitoring, set `settings.monitoring.enabled` to `true`. Also set the
+`logs` and `metrics` settings to control whether logs, metrics, or both are
+collected. If neither setting is specified, monitoring is disabled. Set
+`use_output` to specify the output to which monitoring events are sent.
+
+[[elastic-agent-datasource-configuration]]
+== Datasource settings
+
+//TODO: provide more context here about what a data source is and how it's used.
+
+By default {agent} collects system metrics, such as cpu, memory, network, and
+filesystem metrics, and sends them to the default output. For example:
+
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+datasources:
+  - namespace: default
+    use_output: default
+    inputs:
+      - type: system/metrics
+        streams:
+          - metricset: cpu
+            dataset: system.cpu
+          - metricset: memory
+            dataset: system.memory
+          - metricset: network
+            dataset: system.network
+          - metricset: filesystem
+            dataset: system.filesystem
+-------------------------------------------------------------------------------------
+
+If `use_output` is not specified, the `default` output is used.
+
+For more examples, see
+<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>.

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -7,19 +7,12 @@ experimental[]
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the
 {beats} shippers or Endpoint required for your configuration.
 
-//REVIEWERS: Maybe we shouldn't mention Endpoint yet ^^. WDYT?
-
-//REVIEWERS: Moved this up because I think it's important to highlight this up
-//front. It's covered in more detail later.
-
 To learn how to install, configure, and run your {agent}s, see:
 
 * <<elastic-agent-installation>>
 * <<run-elastic-agent>>
 * <<elastic-agent-cmd-options>>
 * <<elastic-agent-configuration>>
-
-//TODO: More these to the index.asciidoc for Ingest Management Guide?
 
 include::install-elastic-agent.asciidoc[leveloffset=+1]
 
@@ -29,4 +22,4 @@ include::elastic-agent-command-line.asciidoc[leveloffset=+1]
 
 include::elastic-agent-configuration.asciidoc[leveloffset=+1]
 
-include::elastic-agent-configuration-example.asciidoc[leveloffset=+1]
+//include::elastic-agent-configuration-example.asciidoc[leveloffset=+1]

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -1,242 +1,32 @@
 [[elastic-agent-installation-configuration]]
-== Get started with {beatname_uc}
+= Manage your {agent}s
 
-++++
-<titleabbrev>Get started</titleabbrev>
-++++
+experimental[]
 
-Elastic Agent is a single, unified agent that you can deploy to hosts or containers to collect data and send it to the {stack}. Behind the scenes, Elastic Agent runs the {beats} shippers or Endpoint required for your configuration.
+{agent} is a single, unified agent that you can deploy to hosts or containers to
+collect data and send it to the {stack}. Behind the scenes, {agent} runs the
+{beats} shippers or Endpoint required for your configuration.
+
+//REVIEWERS: Maybe we shouldn't mention Endpoint yet ^^. WDYT?
+
+//REVIEWERS: Moved this up because I think it's important to highlight this up
+//front. It's covered in more detail later.
+
+To learn how to install, configure, and run your {agent}s, see:
 
 * <<elastic-agent-installation>>
-* <<elastic-agent-execution-modes>>
+* <<run-elastic-agent>>
 * <<elastic-agent-cmd-options>>
 * <<elastic-agent-configuration>>
 
-[[elastic-agent-installation]]
-== Install Elastic Agent
+//TODO: More these to the index.asciidoc for Ingest Management Guide?
 
-=== Step 1: Unpack archive
+include::install-elastic-agent.asciidoc[leveloffset=+1]
 
+include::run-elastic-agent.asciidoc[leveloffset=+1]
 
-[[mac]]
-*mac:*
+include::elastic-agent-command-line.asciidoc[leveloffset=+1]
 
-ifeval::["{release-state}"=="unreleased"]
+include::elastic-agent-configuration.asciidoc[leveloffset=+1]
 
-Version {version} of {beatname_uc} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes,callouts"]
-------------------------------------------------
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
-------------------------------------------------
-
-endif::[]
-
-[[linux]]
-*linux:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {beatname_uc} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes,callouts"]
-------------------------------------------------
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
-------------------------------------------------
-
-endif::[]
-
-[[win]]
-*win:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {beatname_uc} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-. Download the Elastic Agent Windows zip file from the
-https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
-
-. Extract the contents of the zip file into `C:\Program Files`.
-
-. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
-
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
-
-. From the PowerShell prompt, run the following commands to install Filebeat as a
-Windows service:
-+
-[source,shell]
-----------------------------------------------------------------------
-PS > cd 'C:\Program Files\Elastic-Agent'
-PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
-----------------------------------------------------------------------
-
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
-
-endif::[]
-
-=== Step 2: Run Elastic Agent
-
-If Elastic Agent is not installed as an auto-starting service, start it manually:
-
-
-[source,shell]
-----------------------------------------------------------------------
-$ ./elastic-agent run
-----------------------------------------------------------------------
-
-[[elastic-agent-execution-modes]]
-== Execution modes
-
-Elastic Agent runs in two modes: standalone or fleet. The two modes differ in how you configure and manage the agent.
-[float]
-=== Standalone mode
-
-With _standalone mode_, you manually configure and manage the agent locally. Each agent is configured to be in standalone mode by default after installation.
-At startup, Elastic Agent reads the configuration file specified by the `-c` argument or uses the default configuration, `elastic-agent.yml`, which is located in the same directory as the agent.
-
-For configuration options see `elastic-agent_configuration_example.yml`
-
-=== Fleet mode
-
-With _fleet mode_, you manage Elastic Agent remotely. The agent uses a trusted {kib} instance to retrieve configurations and report agent events. This trusted {kib} instance must have Ingest Manager and Fleet enabled.
-
-To create a trusted communication channel between Elastic Agent and {kib}, you enroll the agent to Fleet.
-
-To enroll an Elastic Agent to Fleet:
-
-
-. Stop the agent.
-
-. Enroll the agent:
-+
-[source,shell]
-----------------------------------------------------------------------
-$ ./elastic-agent http://localhost:5601 $token
-----------------------------------------------------------------------
-+
-`$token` is an enrollment token acquired from Fleet.
-
-[[elastic-agent-cmd-options]]
-== Command line options
-
-The `elastic-agent run` command provides flags that alter the behavior of an agent.
-
-==== `-path.home`
-
-The home directory of the Elastic Agent. `path.home` determines the location of the configuration files and data directory.
-
-==== `-c`
-
-The configuration file to load.
-If not specified, Elastic Agent uses `{path.home}/elastic-agent.yml`.
-
-
-==== `-path.data`
-
-The data directory used by Elastic Agent to store downloaded artifacts. Also stores logs for any Beats started and managed by Elastic Agent.
-
-If not specified, Elastic Agent uses `{path.home}/data`.
-
-[[elastic-agent-configuration]]
-== Configure Elastic Agent
-
-By default Elastic Agent runs in standalone mode to ingest system data and send it to a local {es} instance running on port 9200. It uses the demo credentials of the `elastic` user. It's also configured to monitor all Beats managed by the agent and send the Beats logs and metrics to the same {es) instance.
-
-To alter this behavior, configure the output.
-
-=== Configure the output
-
-Elastic Agent enables definition of multiple outputs where each data source can be paired with different output.
-
-At the moment Elastic Agent works only with Elasticsearch output.
-Sample configuration can look like the example below:
-
-[source,yaml]
--------------------------------------------------------------------------------------
-outputs:
-  default:
-    type: elasticsearch
-    hosts: [127.0.0.1:9200]
-    username: elastic
-    password: changeme
-
-  monitoring:
-    type: elasticsearch
-    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
-    hosts: ["localhost:9200"]
-    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
--------------------------------------------------------------------------------------
-
-This example configures two outputs: `default` and  `monitoring`.
-Notice that they use different authentication methods. The first one uses a username and password pair, and the second one contains an api key.
-
-[NOTE]
-==============
-A default output configuration is required.
-==============
-
-=== Configure Beats monitoring
-
-Elastic Agent is monitoring _Beats_ by default. To disable or change monitoring settings, set options under `settings.monitoring`:
-
-[source,yaml]
--------------------------------------------------------------------------------------
-settings.monitoring:
-  # enabled turns on monitoring of running processes
-  enabled: true
-  # enables log monitoring
-  logs: true
-  # enables metrics monitoring
-  metrics: true
-  # specifies output to be used
-  use_output: monitoring
--------------------------------------------------------------------------------------
-
-
-To disable monitoring, set `settings.monitoring.enabled` to `false`. When set to `false`, Beats monitoring is turned off, and all other options in this section are ignored.
-To enable monitoring, set `settings.monitoring.enabled` to `true`. Also set the `logs` and `metrics` settings to control whether logs, metrics, or both are collected. If neither setting is specified, monitoring is disabled.
-
-
-Set `use_output` to specify the output to which monitoring events are sent.
-
-=== Specify data sources
-
-By default Elastic Agent collects system metrics, such as cpu, memory, network, and filesystem metrics, and sends them to the default output. For example:
-
-
-[source,yaml]
--------------------------------------------------------------------------------------
-datasources:
-  - namespace: default
-    use_output: default
-    inputs:
-      - type: system/metrics
-        streams:
-          - metricset: cpu
-            dataset: system.cpu
-          - metricset: memory
-            dataset: system.memory
-          - metricset: network
-            dataset: system.network
-          - metricset: filesystem
-            dataset: system.filesystem
--------------------------------------------------------------------------------------
-
-If `use_output` is not specified, the `default` output is used.
-
-For more examples, see `elastic-agent_configuration_example.yml`
+include::elastic-agent-configuration-example.asciidoc[leveloffset=+1]

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -1,0 +1,81 @@
+:release-state: released
+
+[[elastic-agent-installation]]
+= Install {agent}
+
+experimental[]
+
+Download and install the agent on each system you want to monitor.
+
+To download and install {elastic-agent}, use the commands that work with your
+system:
+
+//TODO: Replace with tabbed panels when the code is stable (might be after 7.8).
+
+*mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
+----
+
+endif::[]
+
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
+----
+
+endif::[]
+
+*win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {agent} Windows zip file from the
+https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install Filebeat as a
+Windows service:
++
+[source,shell]
+----
+PS > cd 'C:\Program Files\Elastic-Agent'
+PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
+----
+
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
+
+endif::[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -27,10 +27,9 @@ If no configuration file is specified, {agent} uses the default configuration,
 `elastic-agent.yml`, which is located in the same directory as {agent}. Specify
 the `-c` flag to use a different configuration file.
 
-For configuration options, see:
+For configuration options, see <<elastic-agent-configuration>>.
 
-* <<elastic-agent-configuration>>
-* <<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
+//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
 
 [float]
 [[fleet-mode]]
@@ -39,8 +38,6 @@ For configuration options, see:
 With _fleet mode_, you manage {agent} remotely. The agent uses a trusted {kib}
 instance to retrieve configurations and report agent events. This trusted {kib}
 instance must have {ingest-manager} and {fleet} enabled.
-
-//TODO: Add links to topics about Ingest Manager.
 
 To create a trusted communication channel between {agent} and {kib}, enroll the
 agent to {fleet}.

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -1,0 +1,68 @@
+[[run-elastic-agent]]
+= Run {agent}
+
+experimental[]
+
+{agent} runs in two modes: standalone or fleet. The two modes differ in how you
+configure and manage the agent.
+
+[float]
+[[standalone-mode]]
+== Run in standalone mode (default)
+
+With _standalone mode_, you manually configure and manage the agent locally.
+Each agent is configured to be in standalone mode by default after installation.
+
+If {agent} is installed as an auto-starting service, it will run automatically
+when you restart your system.
+
+To start {agent} manually, run:
+
+[source,shell]
+----
+./elastic-agent run
+----
+
+If no configuration file is specified, {agent} uses the default configuration,
+`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
+the `-c` flag to use a different configuration file.
+
+For configuration options, see:
+
+* <<elastic-agent-configuration>>
+* <<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
+
+[float]
+[[fleet-mode]]
+== Run in {fleet} mode
+
+With _fleet mode_, you manage {agent} remotely. The agent uses a trusted {kib}
+instance to retrieve configurations and report agent events. This trusted {kib}
+instance must have {ingest-manager} and {fleet} enabled.
+
+//TODO: Add links to topics about Ingest Manager.
+
+To create a trusted communication channel between {agent} and {kib}, enroll the
+agent to {fleet}.
+
+To enroll an {agent} to {fleet}:
+
+. Stop the agent, if it's already running.
+
+. Go the **{fleet}** tab in {ingest-manager}, and click **Enroll new agent** to
+generate a token. See <<ingest-management-getting-started>> for detailed steps.
+
+. Enroll the agent:
++
+[source,shell]
+----
+./elastic-agent enroll http://localhost:5601 $token
+----
++
+Where `$token` is an enrollment token acquired from {fleet}.
+
+To start {agent}, run:
+[source,shell]
+----
+./elastic-agent run
+----


### PR DESCRIPTION
Summary of changes:
- Break content into separate files so that there is a one to one mapping between the source and html file.
- Clean up asciidoc coding
- Change heading levels because we want to control nesting from the TOC rather than section levels (makes it easier to move content around and contributors don't need to worry about heading levels).
- More edits...moved some things around to improve the flow of ideas.
- Changed the name of the top-level container because I think it's weird to have two getting started guides in the same doc.

Here's what the TOC looks like when this is hooked into the nav (agent will resolve to Elastic Agent):

![image](https://user-images.githubusercontent.com/14206422/84445432-e0348980-abf8-11ea-94bf-7aa7c7ca1d01.png)

