### PR TITLE
Cherry-pick #18685 to 7.x:  Download snapshot artifacts from snapshots repo

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/stream.go
+++ b/x-pack/elastic-agent/pkg/agent/application/stream.go
@@ -77,8 +77,8 @@ func newOperator(ctx context.Context, log *logger.Logger, id routingKey, config 
 		return nil, err
 	}
 
-	fetcher := downloader.NewDownloader(operatorConfig.DownloadConfig)
-	verifier, err := downloader.NewVerifier(operatorConfig.DownloadConfig)
+	fetcher := downloader.NewDownloader(log, operatorConfig.DownloadConfig)
+	verifier, err := downloader.NewVerifier(log, operatorConfig.DownloadConfig)
 	if err != nil {
 		return nil, errors.New(err, "initiating verifier")
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	gohttp "net/http"
+	"strings"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/http"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
+
+// NewDownloader creates a downloader which first checks local directory
+// and then fallbacks to remote if configured.
+func NewDownloader(config *artifact.Config) (download.Downloader, error) {
+	cfg, err := snapshotConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return http.NewDownloader(cfg), nil
+}
+
+func snapshotConfig(config *artifact.Config) (*artifact.Config, error) {
+	snapshotURI, err := snapshotURI()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect remote snapshot repo, proceeding with configured: %v", err)
+	}
+
+	return &artifact.Config{
+		OperatingSystem: config.OperatingSystem,
+		Architecture:    config.Architecture,
+		BeatsSourceURI:  snapshotURI,
+		TargetDirectory: config.TargetDirectory,
+		Timeout:         config.Timeout,
+		PgpFile:         config.PgpFile,
+		InstallPath:     config.InstallPath,
+		DropPath:        config.DropPath,
+	}, nil
+}
+
+func snapshotURI() (string, error) {
+	artifactsURI := fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s-SNAPSHOT/elastic-agent", release.Version())
+	resp, err := gohttp.Get(artifactsURI)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body := struct {
+		Packages map[string]interface{} `json:"packages"`
+	}{}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&body); err != nil {
+		return "", err
+	}
+
+	if len(body.Packages) == 0 {
+		return "", fmt.Errorf("no packages found in snapshot repo")
+	}
+
+	for k, pkg := range body.Packages {
+		pkgMap, ok := pkg.(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("content of '%s' is not a map", k)
+		}
+
+		uriVal, found := pkgMap["url"]
+		if !found {
+			return "", fmt.Errorf("item '%s' does not contain url", k)
+		}
+
+		uri, ok := uriVal.(string)
+		if !ok {
+			return "", fmt.Errorf("uri is not a string")
+		}
+
+		index := strings.Index(uri, "/elastic-agent/")
+		if index == -1 {
+			return "", fmt.Errorf("not an agent uri: '%s'", uri)
+		}
+
+		return uri[:index], nil
+	}
+
+	return "", fmt.Errorf("uri not detected")
+}

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/verifier.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package snapshot
+
+import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/http"
+)
+
+// NewVerifier creates a downloader which first checks local directory
+// and then fallbacks to remote if configured.
+func NewVerifier(config *artifact.Config, downloaders ...download.Downloader) (download.Verifier, error) {
+	cfg, err := snapshotConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return http.NewVerifier(cfg)
+}


### PR DESCRIPTION
Cherry-pick of PR #18685 to 7.x branch. Original message:

## What does this PR do?

This PR introduces new downloader which tries to detect snapshot artifact repository in case agent is built as a snapshot.
If detection fails it just does not include snapshot downloader and proceed as usual (with disk backed up by configured downloader)

## Why is it important?

More intuitive scenario when you build a snapshot without anything else and it downloads dependencies. Without this it would fail trying to download SNAPSHOT of 8.0.0 from official elastic.co  

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @111andre111 
