### PR TITLE
Cherry-pick #19018 to 7.x: Add basic cloudfoundry integration tests

### DIFF
--- a/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
+++ b/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
@@ -1,0 +1,75 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+// +build cloudfoundry
+
+package cloudfoundry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/filebeat/channel"
+	"github.com/elastic/beats/v7/filebeat/input"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	cftest "github.com/elastic/beats/v7/x-pack/libbeat/common/cloudfoundry/test"
+)
+
+func TestInput(t *testing.T) {
+	config := common.MustNewConfigFrom(cftest.GetConfigFromEnv(t))
+
+	events := make(chan beat.Event)
+	connector := channel.ConnectorFunc(func(*common.Config, beat.ClientConfig) (channel.Outleter, error) {
+		return newOutleter(events), nil
+	})
+
+	inputCtx := input.Context{Done: make(chan struct{})}
+
+	input, err := NewInput(config, connector, inputCtx)
+	require.NoError(t, err)
+
+	go input.Run()
+	defer input.Stop()
+
+	select {
+	case e := <-events:
+		t.Logf("Event received: %+v", e)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for events")
+	}
+}
+
+type outleter struct {
+	events chan<- beat.Event
+	done   chan struct{}
+}
+
+func newOutleter(events chan<- beat.Event) *outleter {
+	return &outleter{
+		events: events,
+		done:   make(chan struct{}),
+	}
+}
+
+func (o *outleter) Close() error {
+	close(o.done)
+	return nil
+}
+
+func (o *outleter) Done() <-chan struct{} {
+	return o.done
+}
+
+func (o *outleter) OnEvent(e beat.Event) bool {
+	select {
+	case o.events <- e:
+		return true
+	default:
+		return false
+	}
+}

--- a/x-pack/libbeat/common/cloudfoundry/test/config.go
+++ b/x-pack/libbeat/common/cloudfoundry/test/config.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+func GetConfigFromEnv(t *testing.T) map[string]interface{} {
+	t.Helper()
+
+	config := map[string]interface{}{
+		"api_address":   lookupEnv(t, "CLOUDFOUNDRY_API_ADDRESS"),
+		"client_id":     lookupEnv(t, "CLOUDFOUNDRY_CLIENT_ID"),
+		"client_secret": lookupEnv(t, "CLOUDFOUNDRY_CLIENT_SECRET"),
+
+		"ssl.verification_mode": "none",
+	}
+
+	optionalConfig(config, "uaa_address", "CLOUDFOUNDRY_UAA_ADDRESS")
+	optionalConfig(config, "rlp_address", "CLOUDFOUNDRY_RLP_ADDRESS")
+	optionalConfig(config, "doppler_address", "CLOUDFOUNDRY_DOPPLER_ADDRESS")
+
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	return config
+}
+
+func lookupEnv(t *testing.T, name string) string {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		t.Errorf("Environment variable %s is not set", name)
+	}
+	return value
+}
+
+func optionalConfig(config map[string]interface{}, key string, envVar string) {
+	if value, ok := os.LookupEnv(envVar); ok {
+		config[key] = value
+	}
+}

--- a/x-pack/metricbeat/module/cloudfoundry/container/container_integration_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/container/container_integration_test.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+// +build cloudfoundry
+
+package container
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/cloudfoundry/mtest"
+)
+
+func TestFetch(t *testing.T) {
+	config := mtest.GetConfig(t, "container")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(60*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+}
+
+func TestData(t *testing.T) {
+	config := mtest.GetConfig(t, "container")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(60*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+
+	beatEvent := mbtest.StandardizeEvent(ms, events[0])
+	mbtest.WriteEventToDataJSON(t, beatEvent, "")
+}

--- a/x-pack/metricbeat/module/cloudfoundry/counter/counter_integration_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/counter/counter_integration_test.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+// +build cloudfoundry
+
+package counter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/cloudfoundry/mtest"
+)
+
+func TestFetch(t *testing.T) {
+	config := mtest.GetConfig(t, "counter")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+}
+
+func TestData(t *testing.T) {
+	config := mtest.GetConfig(t, "counter")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+
+	beatEvent := mbtest.StandardizeEvent(ms, events[0])
+	mbtest.WriteEventToDataJSON(t, beatEvent, "")
+}

--- a/x-pack/metricbeat/module/cloudfoundry/mtest/config.go
+++ b/x-pack/metricbeat/module/cloudfoundry/mtest/config.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mtest
+
+import (
+	"testing"
+
+	cftest "github.com/elastic/beats/v7/x-pack/libbeat/common/cloudfoundry/test"
+)
+
+func GetConfig(t *testing.T, metricset string) map[string]interface{} {
+	t.Helper()
+
+	config := cftest.GetConfigFromEnv(t)
+	config["module"] = "cloudfoundry"
+	config["metricsets"] = []string{metricset}
+
+	return config
+}

--- a/x-pack/metricbeat/module/cloudfoundry/value/value_integration_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/value/value_integration_test.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+// +build cloudfoundry
+
+package value
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/cloudfoundry/mtest"
+)
+
+func TestFetch(t *testing.T) {
+	config := mtest.GetConfig(t, "value")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+}
+
+func TestData(t *testing.T) {
+	config := mtest.GetConfig(t, "value")
+
+	ms := mbtest.NewPushMetricSetV2(t, config)
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
+
+	require.NotEmpty(t, events)
+
+	beatEvent := mbtest.StandardizeEvent(ms, events[0])
+	mbtest.WriteEventToDataJSON(t, beatEvent, "")
+}


### PR DESCRIPTION
Cherry-pick of PR #19018 to 7.x branch. Original message: 

## What does this PR do?

Add some basic integration tests for cloudfoundry.

By now these tests follow the approach we are following with cloud features, they need a cloud foundry deployment whose configuration is provided using environment variables, and tests are only executed if some tag is set. So they are not going to be executed in CI by now.

Instructions to have a working cloud foundry deployment will be added in a future PR.

## Why is it important?

To have some integration tests as reference before starting with further refactors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~ Instructions to have a cloud foundry deployment for development will be added in a future PR.
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

```
export CLOUDFOUNDRY_API_ADDRESS=...
export CLOUDFOUNDRY_CLIENT_ID=...
export CLOUDFOUNDRY_CLIENT_SECRET=...
go test -tags=integration,cloudfoundry ./x-pack/filebeat/input/cloudfoundry/ ./x-pack/metricbeat/module/cloudfoundry/...
```

## Related issues

- Part of elastic/beats#17539