### PR TITLE
Cherry-pick #19052 to 7.x: Fix incorrect usage of hints builder when exposed port is a substring of the hint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -281,6 +281,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
 - Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 - Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
+- Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
 
 *Packetbeat*
 

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -290,6 +290,45 @@ func TestGenerateHints(t *testing.T) {
 				"enabled":    true,
 			},
 		},
+		{
+			message: "Module, namespace, host hint shouldn't return when port isn't the same has hint",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 80,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "${data.host}:8080",
+					},
+				},
+			},
+			len: 0,
+		},
+		{
+			message: "Non http URLs with valid host port combination should return a valid config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 3306,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "tcp(${data.host}:3306)/",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module":     "mockmoduledefaults",
+				"namespace":  "test",
+				"metricsets": []string{"default"},
+				"hosts":      []interface{}{"tcp(1.2.3.4:3306)/"},
+				"timeout":    "3s",
+				"period":     "1m",
+				"enabled":    true,
+			},
+		},
 	}
 	for _, test := range tests {
 		mockRegister := mb.NewRegister()


### PR DESCRIPTION
Cherry-pick of PR #19052 to 7.x branch. Original message: 

Type of change - Bug

## What does this PR do?

This PR makes sure that if a user exposes port `80` and has `8080` on the metric hint, then we dont use that port to do the autodiscover as the port could be exposed on another container

## Why is it important?

This is important as this impacts what container metadata gets appended to the metric. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

## Related issues


## Use cases


