### PR TITLE
[CI] fail if not possible to install python3

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -20,7 +20,7 @@ where mage
 
 if not exist C:\Python38\python.exe (
     REM Install python 3.8.
-    choco install python -y -r --no-progress --version 3.8.2
+    choco install python -y -r --no-progress --version 3.8.2 || echo ERROR && exit /b
 )
 python --version
 where python


### PR DESCRIPTION
## What does this PR do?

Script didn't fail when the python installation with choco failed.

## Why is it important?

To be able to retry before running the tests.

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/84520516-9a94c100-accb-11ea-839e-d6d79ac1ad1d.png)


## Logs

```
[2020-06-12T14:58:26.130Z] By installing you accept licenses for the packages.
[2020-06-12T15:23:03.350Z] python not installed. An error occurred during installation:
[2020-06-12T15:23:03.350Z]  Unable to read package from path 'python3.3.8.2.nupkg'.
[2020-06-12T15:23:03.350Z] python package files install completed. Performing other installation steps.
[2020-06-12T15:23:03.350Z] The install of python was NOT successful.
[2020-06-12T15:23:03.350Z] python not installed. An error occurred during installation:
[2020-06-12T15:23:03.350Z]  Unable to read package from path 'python3.3.8.2.nupkg'.
[2020-06-12T15:23:03.350Z] 
[2020-06-12T15:23:03.350Z] Chocolatey installed 0/1 packages. 1 packages failed.
[2020-06-12T15:23:03.350Z]  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
[2020-06-12T15:23:03.350Z] 
[2020-06-12T15:23:03.350Z] Failures
[2020-06-12T15:23:03.350Z]  - python (exited 1) - python not installed. An error occurred during installation:
[2020-06-12T15:23:03.350Z]  Unable to read package from path 'python3.3.8.2.nupkg'.
[2020-06-12T15:23:03.350Z] 
[2020-06-12T15:23:03.350Z] C:\Users\jenkins\workspace\Beats_beats-beats-mbp_PR-18695\src\github.com\elastic\beats>python --version 
[2020-06-12T15:23:03.350Z] Python 2.7.16
[2020-06-12T15:23:03.350Z] 
[2020-06-12T15:23:03.350Z] C:\Users\jenkins\workspace\Beats_beats-beats-mbp_PR-18695\src\github.com\elastic\beats>where python 
[2020-06-12T15:23:03.350Z] C:\Python27\python.exe
```

See [build log](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats-beats-mbp%2FPR-18695/detail/PR-18695/20/pipeline/426#step-1935-log-79)