### PR TITLE
[yum] Clear cached data and add retry loop

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -5,10 +5,8 @@
 FROM {{ .from }}
 
 # Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
-RUN yum -y --setopt=tsflags=nodocs update && \
-    yum install epel-release -y && \
-    yum install jq -y && \
-    yum clean all
+RUN for iter in {1..10}; do yum update --setopt=tsflags=nodocs -y && yum install --setopt=tsflags=nodocs -y epel-release &&  yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
+RUN for iter in {1..10}; do yum update -y && yum install -y jq &&  yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
 
 LABEL \
   org.label-schema.build-date="{{ date }}" \


### PR DESCRIPTION
## What does this PR do?

This commit makes the yum commands more robust by:

- clearing the cache after the install command is finished
- adding a retry loop so that the installation is retried in case of transient network issues

This is inspired by what the Elasticsearch team is doing for building the Elasticsearch Docker image
- https://github.com/elastic/dockerfiles/blob/a5749cb11d8b38491c40efa476c576ab60a3a9f8/elasticsearch/Dockerfile#L16

## Why is it important?

Without this fix, the Unified Release Process can't complete any Stack/Solution snapshots or staging builds because of the following error:

```
"[Errno -1] repomd.xml does not match metalink for epel"
```

This is related to this  https://serverfault.com/questions/1021273/yum-install-jq-is-failing-intermittently-on-centos7

@andrewkroh  I don't know how to test it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

