### PR TITLE
Cherry-pick #19164 to 7.x: [CI] fail if not possible to install python3

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -20,7 +20,7 @@ where mage
 
 if not exist C:\Python38\python.exe (
     REM Install python 3.8.
-    choco install python -y -r --no-progress --version 3.8.2
+    choco install python -y -r --no-progress --version 3.8.2 || echo ERROR && exit /b
 )
 python --version
 where python


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] fail if not possible to install python3 (#19164)