### PR TITLE
[CI] required a step in the windows pipeline

### DIFF
--- a/.ci/jobs/beats-windows-mbp.yml
+++ b/.ci/jobs/beats-windows-mbp.yml
@@ -31,14 +31,14 @@
           property-strategies:
             # Builds for PRs won't be triggered automatically.
             # Only the master branch will be triggered automatically. 
-            - named-branches:
+            named-branches:
               - defaults:
                 - suppress-scm-triggering: true
               - exceptions:
                 - exception:
-                    branch-name: master
-                    properties:
-                      - suppress-scm-triggering: false
+                  branch-name: master
+                  properties:
+                    - suppress-scm-triggering: false
           clean:
             after: true
             before: true

--- a/.ci/windows.groovy
+++ b/.ci/windows.groovy
@@ -81,6 +81,7 @@ pipeline {
         // NOTE: commented to run the windows pipeline a bit faster.
         //       when required then it can be enabled.
         // makeTarget("Lint", "check")
+        echo 'SKIPPED'
       }
     }
     stage('Build and Test Windows'){


### PR DESCRIPTION
The MBP will catch this errors now :)

## What does this PR do?

Fix a typo

## Why is it important?

`MBP@master` is now broken
