### PR TITLE
Cherry-pick #18552 to 7.x: [libbeat] Remove global loggers from plugin and mock

### DIFF
--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -34,13 +34,15 @@ var Name = "mockbeat"
 var Settings = instance.Settings{Name: Name, Version: Version, HasDashboards: true}
 
 type Mockbeat struct {
-	done chan struct{}
+	done   chan struct{}
+	logger *logp.Logger
 }
 
 // Creates beater
 func New(b *beat.Beat, _ *common.Config) (beat.Beater, error) {
 	return &Mockbeat{
-		done: make(chan struct{}),
+		done:   make(chan struct{}),
+		logger: logp.NewLogger("mock"),
 	}, nil
 }
 
@@ -76,7 +78,7 @@ func (mb *Mockbeat) Run(b *beat.Beat) error {
 }
 
 func (mb *Mockbeat) Stop() {
-	logp.Info("Mockbeat Stop")
+	mb.logger.Info("Mockbeat Stop")
 
 	close(mb.done)
 }

--- a/libbeat/plugin/cli.go
+++ b/libbeat/plugin/cli.go
@@ -29,7 +29,8 @@ import (
 )
 
 type pluginList struct {
-	paths []string
+	paths  []string
+	logger *logp.Logger
 }
 
 func (p *pluginList) String() string {
@@ -39,7 +40,7 @@ func (p *pluginList) String() string {
 func (p *pluginList) Set(v string) error {
 	for _, path := range p.paths {
 		if path == v {
-			logp.Warn("%s is already a registered plugin", path)
+			p.logger.Warnf("%s is already a registered plugin", path)
 			return nil
 		}
 	}
@@ -47,7 +48,9 @@ func (p *pluginList) Set(v string) error {
 	return nil
 }
 
-var plugins = &pluginList{}
+var plugins = &pluginList{
+	logger: logp.NewLogger("cli"),
+}
 
 func init() {
 	flag.Var(plugins, "plugin", "Load additional plugins")
@@ -59,7 +62,7 @@ func Initialize() error {
 	}
 
 	for _, path := range plugins.paths {
-		logp.Info("loading plugin bundle: %v", path)
+		plugins.logger.Infof("loading plugin bundle: %v", path)
 
 		if err := LoadPlugins(path); err != nil {
 			return err


### PR DESCRIPTION
Cherry-pick of PR #18552 to 7.x branch. Original message: 

This PR is to remove global loggers for libbeat/plugin/cli.
Please see elastic/beats#15699 for the meta-issue and more details.