### PR TITLE
Fix fmt issue on Cloudfoundry

### DIFF
--- a/x-pack/filebeat/input/cloudfoundry/input.go
+++ b/x-pack/filebeat/input/cloudfoundry/input.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input"
-	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/logp"


### PR DESCRIPTION
## What does this PR do?
Fixes lint error not caught at https://github.com/elastic/beats/pull/19125.
https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats-beats-mbp/detail/PR-19125/9/pipeline#step-317-log-207

## Why is it important?
To make CI happy again.
