### PR TITLE
Add breaking change note about logging

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -34,4 +34,19 @@ Starting in version 7.7.0, scripts that use these processors will fail. To
 resolve this problem, define the processors in your configuration instead of the
 script.
 
+[float]
+==== Systemd unit file no longer overrides logging options
+
+Prior to this release, the systemd unit file set `BEAT_LOG_OPTS=-e`, which
+caused {beats} to ignore the logging options specified in the
+configuration file.
+
+The systemd unit file no longer sets this option, and the logging settings
+specified under `logging` in the configuration now work.
+
+If you set `Environment="BEAT_LOG_OPTS=` in a previous release to work around
+this problem, remove that workaround now, and use the `logging` options in the
+configuration file to control logging behavior. For example, see
+{filebeat-ref}/configuration-logging.html[Configure logging]. 
+
 // end::notable-breaking-changes[]

--- a/libbeat/docs/shared-systemd.asciidoc
+++ b/libbeat/docs/shared-systemd.asciidoc
@@ -68,8 +68,12 @@ override to change the default options.
 | BEAT_PATH_OPTS | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
 |=======================================
 
+NOTE: You can use `BEAT_LOG_OPTS` to set debug selectors for logging. However,
+to configure logging behavior, set the logging options described in
+<<configuration-logging,Configure logging>>.
+
 To override these variables, create a drop-in unit file in the
-+/etc/systemd/system/{beatname_pkg}.service.d+ directory.
++/etc/systemd/system/{beatname_pkg}.service.d+ directory.  
 
 For example a file with the following content placed in
 +/etc/systemd/system/{beatname_pkg}.service.d/debug.conf+


### PR DESCRIPTION
Users are confused by the logging settings on systemd because in previous releases we told them to override the `BEAT_LOG_OPTS=-e` setting. Starting in 7.7, though, this causes problems because the override is no longer needed. The logging options work as expected.

This PR fixes the existing docs.

I sure wish I could put that note into a footnote on the table, but I can't because footnotes appear at the end of the page. (Opened https://github.com/elastic/docs/issues/1871 to get this changed someday.)