### PR TITLE
Cherry-pick #18882 to 7.x: Add better handling for Kubernetes Update and Delete watcher events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,6 +141,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix `keystore add` hanging under Windows. {issue}18649[18649] {pull}18654[18654]
 - Fix regression in `add_kubernetes_metadata`, so configured `indexers` and `matchers` are used if defaults are not disabled. {issue}18481[18481] {pull}18818[18818]
 - Fix potential race condition in fingerprint processor. {pull}18738[18738]
+- Add better handling for Kubernetes Update and Delete watcher events. {pull}18882[18882]
 - Fix the `translate_sid` processor's handling of unconfigured target fields. {issue}18990[18990] {pull}18991[18991]
 - Fixed a service restart failure under Windows. {issue}18914[18914] {pull}18916[18916]
 - The `monitoring.elasticsearch.api_key` value is correctly base64-encoded before being sent to the monitoring Elasticsearch cluster. {issue}18939[18939] {pull}18945[18945]

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -206,7 +206,9 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 
 		err = a.factory.CheckConfig(config)
 		if err != nil {
-			a.logger.Error(errors.Wrap(err, fmt.Sprintf("Auto discover config check failed for config '%s', won't start runner", common.DebugString(config, true))))
+			a.logger.Error(errors.Wrap(err, fmt.Sprintf(
+				"Auto discover config check failed for config '%s', won't start runner",
+				common.DebugString(config, true))))
 			continue
 		}
 

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -69,8 +69,9 @@ type WatchOptions struct {
 }
 
 type item struct {
-	object interface{}
-	state  string
+	object    interface{}
+	objectRaw interface{}
+	state     string
 }
 
 type watcher struct {
@@ -175,8 +176,7 @@ func (w *watcher) enqueue(obj interface{}, state string) {
 	if err != nil {
 		return
 	}
-
-	w.queue.Add(&item{key, state})
+	w.queue.Add(&item{key, obj, state})
 }
 
 // process gets the top of the work queue and processes the object that is received.
@@ -204,6 +204,11 @@ func (w *watcher) process(ctx context.Context) bool {
 			return nil
 		}
 		if !exists {
+			if entry.state == delete {
+				w.logger.Debugf("Object %+v was not found in the store, deleting anyway!", key)
+				// delete anyway in order to clean states
+				w.handler.OnDelete(entry.objectRaw)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
Cherry-pick of PR #18882 to 7.x branch. Original message: 

Improvements for https://github.com/elastic/beats/issues/11834 described on https://github.com/elastic/beats/issues/11834#issuecomment-636909429

Changes:
1. ~~Retry on configCheck failures in order to cover stop/start events.~~
1. Ignore `Update` events when status of Pod is `Pending`.
2. Emit `delete` anyway` even if the obj cannot be found in the `store` at https://github.com/elastic/beats/blob/95626b8f1690344312c0831ab2bdcbccffe4d089/libbeat/common/kubernetes/watcher.go#L202, so as to ensure that states are cleaned anyway.  