### PR TITLE
Cherry-pick #18979 to 7.x: Fix metrics hints builder to avoid wrong container metadata usage when port is not exposed

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -146,6 +146,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - The `monitoring.elasticsearch.api_key` value is correctly base64-encoded before being sent to the monitoring Elasticsearch cluster. {issue}18939[18939] {pull}18945[18945]
 - Fix kafka topic setting not allowing upper case characters. {pull}18854[18854] {issue}18640[18640]
 - Fix redis key setting not allowing upper case characters. {pull}18854[18854] {issue}18640[18640]
+- Fix metrics hints builder to avoid wrong container metadata usage when port is not exposed {pull}18979[18979]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -392,6 +392,7 @@ func TestEmitEvent(t *testing.T) {
 			Expected: bus.Event{
 				"start":    true,
 				"host":     "127.0.0.1",
+				"port":     0,
 				"id":       cid,
 				"provider": UUID,
 				"kubernetes": common.MapStr{
@@ -525,6 +526,7 @@ func TestEmitEvent(t *testing.T) {
 				"stop":     true,
 				"host":     "",
 				"id":       cid,
+				"port":     0,
 				"provider": UUID,
 				"kubernetes": common.MapStr{
 					"container": common.MapStr{
@@ -593,6 +595,7 @@ func TestEmitEvent(t *testing.T) {
 			Expected: bus.Event{
 				"stop":     true,
 				"host":     "127.0.0.1",
+				"port":     0,
 				"id":       cid,
 				"provider": UUID,
 				"kubernetes": common.MapStr{

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/bus"
 	"github.com/elastic/beats/v7/libbeat/keystore"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -267,6 +268,21 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
+			message: "Module with data.host defined and a zero port should not return a config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 0,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "${data.host}:9090",
+					},
+				},
+			},
+			len: 0,
+		},
+		{
 			message: "Module, namespace, host hint should return valid config",
 			event: bus.Event{
 				"host": "1.2.3.4",
@@ -340,6 +356,7 @@ func TestGenerateHints(t *testing.T) {
 		m := metricHints{
 			Key:      defaultConfig().Key,
 			Registry: mockRegister,
+			logger:   logp.NewLogger("hints.builder"),
 		}
 		cfgs := m.CreateConfig(test.event)
 		assert.Equal(t, len(cfgs), test.len)
@@ -413,6 +430,7 @@ func TestGenerateHintsDoesNotAccessGlobalKeystore(t *testing.T) {
 		m := metricHints{
 			Key:      defaultConfig().Key,
 			Registry: mockRegister,
+			logger:   logp.NewLogger("hints.builder"),
 		}
 		cfgs := m.CreateConfig(test.event)
 		assert.Equal(t, len(cfgs), test.len)


### PR DESCRIPTION
Cherry-pick of PR #18979 to 7.x branch. Original message: 

Type of PR

- Enhancement

## What does this PR do?

I have enhanced the emitEvent to generate a pod level event with no port. The hints builder checks to see if there is a port or not. If not then it uses the pod level metadata to monitor `data.host:<port>` annotations. This ensures that we dont use the wrong container metadata to start up a metricbeat module or do it multiple times as well.

## Why is it important?

The way that things exist today is that when ports arent exposed, the container meta is non-deterministic  

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally


## Related issues

- 

## Use cases



## Screenshots


## Logs

 Fixes: https://github.com/elastic/beats/issues/12011

Co-Authored-By: Vijay Samuel <vjsamuel@ebay.com>