### PR TITLE
Cherry-pick #19106 and #19161 to 7.x: Set ecszap version to v0.2.0 && fix lint job by updating NOTICE

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -7841,8 +7841,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: go.elastic.co/ecszap
-Version: v0.1.1
-Revision: cdd95a104193
+Version: v0.2.0
 License type (autodetected): Apache-2.0
 ./vendor/go.elastic.co/ecszap/LICENSE:
 --------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	go.elastic.co/apm v1.7.2
 	go.elastic.co/apm/module/apmelasticsearch v1.7.2
 	go.elastic.co/apm/module/apmhttp v1.7.2
-	go.elastic.co/ecszap v0.1.1-0.20200424093508-cdd95a104193
+	go.elastic.co/ecszap v0.2.0
 	go.uber.org/atomic v1.5.0
 	go.uber.org/multierr v1.3.0
 	go.uber.org/zap v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ go.elastic.co/apm/module/apmelasticsearch v1.7.2 h1:5STGHLZLSeAzxordMc+dFVKiyVtM
 go.elastic.co/apm/module/apmelasticsearch v1.7.2/go.mod h1:ZyNFuyWdt42GBZkz0SogoLzDBrBGj4orxpiUuxYeYq8=
 go.elastic.co/apm/module/apmhttp v1.7.2 h1:2mRh7SwBuEVLmJlX+hsMdcSg9xaielCLElaPn/+i34w=
 go.elastic.co/apm/module/apmhttp v1.7.2/go.mod h1:sTFWiWejnhSdZv6+dMgxGec2Nxe/ZKfHfz/xtRM+cRY=
-go.elastic.co/ecszap v0.1.1-0.20200424093508-cdd95a104193 h1:NjYJ/beChqugXSavTkH5tF6shvr/is8jdgJ331wfwT8=
-go.elastic.co/ecszap v0.1.1-0.20200424093508-cdd95a104193/go.mod h1:HTUi+QRmr3EuZMqxPX+5fyOdMNfUu5iPebgfhgsTJYQ=
+go.elastic.co/ecszap v0.2.0 h1:BSZNJ2MOIsecJ7L4ezUA+JIarx14wclqZLJm/mBj044=
+go.elastic.co/ecszap v0.2.0/go.mod h1:HTUi+QRmr3EuZMqxPX+5fyOdMNfUu5iPebgfhgsTJYQ=
 go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -857,7 +857,7 @@ go.elastic.co/apm/transport/transporttest
 go.elastic.co/apm/module/apmelasticsearch
 # go.elastic.co/apm/module/apmhttp v1.7.2
 go.elastic.co/apm/module/apmhttp
-# go.elastic.co/ecszap v0.1.1-0.20200424093508-cdd95a104193
+# go.elastic.co/ecszap v0.2.0
 go.elastic.co/ecszap
 go.elastic.co/ecszap/internal
 # go.elastic.co/fastjson v1.0.0


### PR DESCRIPTION
Backports of #19106 and #19161 to 7.x

These are being submitted together as a single PR per a request here: https://github.com/elastic/beats/pull/19106#issuecomment-644723386

