### PR TITLE
Cherry-pick #19221 to 7.8: [Metricbeat] Remove dedot for AWS tag value

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -165,9 +165,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
 - Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 - Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
-- Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
-- Stop counterCache only when already started {pull}19103[19103]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -165,6 +165,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add missing network.sent_packets_count metric into compute metricset in googlecloud module. {pull}18802[18802]
 - Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 - Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
+- Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
+- Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
+- Stop counterCache only when already started {pull}19103[19103]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -607,9 +607,10 @@ func insertTags(events map[string]mb.Event, identifier string, resourceTagMap ma
 	for _, v := range subIdentifiers {
 		tags := resourceTagMap[v]
 		if len(tags) != 0 {
-			// By default, replace dot "." using underscore "_" for tag keys and values
+			// By default, replace dot "." using underscore "_" for tag keys.
+			// Note: tag values are not dedotted.
 			for _, tag := range tags {
-				events[identifier].RootFields.Put("aws.tags."+common.DeDot(*tag.Key), common.DeDot(*tag.Value))
+				events[identifier].RootFields.Put("aws.tags."+common.DeDot(*tag.Key), *tag.Value)
 			}
 			continue
 		}

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -197,9 +197,10 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 					}
 				}
 
-				// By default, replace dot "." using under bar "_" for tag keys and values
+				// By default, replace dot "." using underscore "_" for tag keys.
+				// Note: tag values are not dedotted.
 				for _, tag := range tags {
-					events[instanceID].ModuleFields.Put("tags."+common.DeDot(*tag.Key), common.DeDot(*tag.Value))
+					events[instanceID].ModuleFields.Put("tags."+common.DeDot(*tag.Key), *tag.Value)
 				}
 
 				machineType, err := instanceOutput[instanceID].InstanceType.MarshalValue()

--- a/x-pack/metricbeat/module/aws/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/rds/rds.go
@@ -207,11 +207,12 @@ func (m *MetricSet) getDBInstancesPerRegion(svc rdsiface.ClientAPI) ([]string, m
 		}
 
 		for _, tag := range outputListTags.TagList {
-			// By default, replace dot "." using under bar "_" for tag keys and values
+			// By default, replace dot "." using underscore "_" for tag keys.
+			// Note: tag values are not dedotted.
 			dbDetails.tags = append(dbDetails.tags,
 				aws.Tag{
 					Key:   common.DeDot(*tag.Key),
-					Value: common.DeDot(*tag.Value),
+					Value: *tag.Value,
 				})
 		}
 		dbDetailsMap[*dbInstance.DBInstanceIdentifier] = dbDetails

--- a/x-pack/metricbeat/module/aws/rds/rds_test.go
+++ b/x-pack/metricbeat/module/aws/rds/rds_test.go
@@ -146,7 +146,7 @@ func TestGetDBInstancesPerRegion(t *testing.T) {
 		dbIdentifier:       dbInstanceIdentifier,
 		dbStatus:           dbInstanceStatus,
 		tags: []aws.Tag{
-			{Key: "dept_name", Value: "eng_software"},
+			{Key: "dept_name", Value: "eng.software"},
 			{Key: "created-by", Value: "foo"},
 		},
 	}
@@ -177,7 +177,7 @@ func TestGetDBInstancesPerRegionWithTagsFilter(t *testing.T) {
 		dbIdentifier:       dbInstanceIdentifier,
 		dbStatus:           dbInstanceStatus,
 		tags: []aws.Tag{
-			{Key: "dept_name", Value: "eng_software"},
+			{Key: "dept_name", Value: "eng.software"},
 			{Key: "created-by", Value: "foo"},
 		},
 	}
@@ -208,7 +208,7 @@ func TestGetDBInstancesPerRegionWithDotInTag(t *testing.T) {
 		dbIdentifier:       dbInstanceIdentifier,
 		dbStatus:           dbInstanceStatus,
 		tags: []aws.Tag{
-			{Key: "dept_name", Value: "eng_software"},
+			{Key: "dept_name", Value: "eng.software"},
 			{Key: "created-by", Value: "foo"},
 		},
 	}


### PR DESCRIPTION
Cherry-pick of PR #19221 to 7.8 branch. Original message: 

## What does this PR do?
This PR is to remove dedotting when collecting AWS tag value. Only tag keys are dedotted, but keep tag values to be the original. 

## Why is it important?
For some use cases, tags value may contain dot, such as IPv4 address. There is no need to dedot when storing into ES in json event field value.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes https://github.com/elastic/beats/issues/19112

## Screenshots
This is before and after comparison for tag value:
<img width="1306" alt="Screen Shot 2020-06-16 at 11 00 22 AM" src="https://user-images.githubusercontent.com/14081635/84804874-9a910b80-afc0-11ea-802d-a266ec14a737.png">


