### PR TITLE
[DOCS] Fix problems in Elastic Agent docs found during doc testing

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -1,4 +1,5 @@
 [[elastic-agent-cmd-options]]
+[role="xpack"]
 = Command line options
 
 experimental[]

--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -3,6 +3,9 @@
 
 experimental[]
 
+//REVIEWERS: There are a couple of options missing here: strict.perms and
+// path.config. Did we leave them out intentionally? 
+
 The `elastic-agent run` command provides flags that alter the behavior of an
 agent:
 

--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -4,9 +4,6 @@
 
 experimental[]
 
-//REVIEWERS: There are a couple of options missing here: strict.perms and
-// path.config. Did we leave them out intentionally? 
-
 The `elastic-agent run` command provides flags that alter the behavior of an
 agent:
 

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
@@ -1,4 +1,5 @@
 [[elastic-agent-configuration-example]]
+[role="xpack"]
 = Configuration example
 
 experimental[]

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -1,4 +1,5 @@
 [[elastic-agent-configuration]]
+[role="xpack"]
 = Configuration settings
 
 experimental[]

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -6,7 +6,7 @@ experimental[]
 
 By default {agent} runs in standalone mode to ingest system data and send it to
 a local {es} instance running on port 9200. It uses the demo credentials of the
-`elastic` user. It's also configured to monitor all {beats} managed by the agent
+`elastic` user. It's also configured to monitor all {beats} managed by the Agent
 and send the {beats} logs and metrics to the same {es) instance.
 
 To alter this behavior, configure the output and other configuration settings:

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -1,4 +1,6 @@
 [[elastic-agent-installation-configuration]]
+[role="xpack"]
+
 = Manage your {agent}s
 
 experimental[]

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -3,9 +3,11 @@
 
 experimental[]
 
+// tag::agent-install-intro[]
 {agent} is a single, unified agent that you can deploy to hosts or containers to
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the
 {beats} shippers or Endpoint required for your configuration.
+// end::agent-install-intro[]
 
 To learn how to install, configure, and run your {agent}s, see:
 

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -1,5 +1,3 @@
-:release-state: released
-
 [[elastic-agent-installation]]
 = Install {agent}
 
@@ -7,10 +5,12 @@ experimental[]
 
 Download and install the agent on each system you want to monitor.
 
+//TODO: Replace with tabbed panel when the code is stable. 
+
+// tag::install-elastic-agent[]
+
 To download and install {elastic-agent}, use the commands that work with your
 system:
-
-//TODO: Replace with tabbed panels when the code is stable (might be after 7.8).
 
 *mac:*
 
@@ -79,3 +79,6 @@ PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
 
 endif::[]
+
+// end::install-elastic-agent[]
+

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -4,7 +4,7 @@
 
 experimental[]
 
-Download and install the agent on each system you want to monitor.
+Download and install the Agent on each system you want to monitor.
 
 //TODO: Replace with tabbed panel when the code is stable. 
 

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -1,4 +1,5 @@
 [[elastic-agent-installation]]
+[role="xpack"]
 = Install {agent}
 
 experimental[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -1,4 +1,5 @@
 [[run-elastic-agent]]
+[role="xpack"]
 = Run {agent}
 
 experimental[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -7,31 +7,6 @@ experimental[]
 configure and manage the agent.
 
 [float]
-[[standalone-mode]]
-== Run in standalone mode (default)
-
-With _standalone mode_, you manually configure and manage the agent locally.
-Each agent is configured to be in standalone mode by default after installation.
-
-If {agent} is installed as an auto-starting service, it will run automatically
-when you restart your system.
-
-To start {agent} manually, run:
-
-[source,shell]
-----
-./elastic-agent run
-----
-
-If no configuration file is specified, {agent} uses the default configuration,
-`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
-the `-c` flag to use a different configuration file.
-
-For configuration options, see <<elastic-agent-configuration>>.
-
-//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
-
-[float]
 [[fleet-mode]]
 == Run in {fleet} mode
 
@@ -63,3 +38,29 @@ To start {agent}, run:
 ----
 ./elastic-agent run
 ----
+
+[float]
+[[standalone-mode]]
+== Run in standalone mode (default)
+
+With _standalone mode_, you manually configure and manage the agent locally.
+Each agent is configured to be in standalone mode by default after installation.
+
+If {agent} is installed as an auto-starting service, it will run automatically
+when you restart your system.
+
+To start {agent} manually, run:
+
+[source,shell]
+----
+./elastic-agent run
+----
+
+If no configuration file is specified, {agent} uses the default configuration,
+`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
+the `-c` flag to use a different configuration file.
+
+For configuration options, see <<elastic-agent-configuration>>.
+
+//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
+

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -5,7 +5,7 @@
 experimental[]
 
 {agent} runs in two modes: standalone or fleet. The two modes differ in how you
-configure and manage the agent.
+configure and manage the Agent.
 
 [float]
 [[fleet-mode]]
@@ -20,12 +20,12 @@ agent to {fleet}.
 
 To enroll an {agent} to {fleet}:
 
-. Stop the agent, if it's already running.
+. Stop the Agent, if it's already running.
 
 . Go the **{fleet}** tab in {ingest-manager}, and click **Enroll new agent** to
 generate a token. See <<ingest-management-getting-started>> for detailed steps.
 
-. Enroll the agent:
+. Enroll the Agent:
 +
 [source,shell]
 ----
@@ -44,7 +44,7 @@ To start {agent}, run:
 [[standalone-mode]]
 == Run in standalone mode (default)
 
-With _standalone mode_, you manually configure and manage the agent locally.
+With _standalone mode_, you manually configure and manage the Agent locally.
 Each agent is configured to be in standalone mode by default after installation.
 
 If {agent} is installed as an auto-starting service, it will run automatically

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -11,12 +11,12 @@ configure and manage the Agent.
 [[fleet-mode]]
 == Run in {fleet} mode
 
-With _fleet mode_, you manage {agent} remotely. The agent uses a trusted {kib}
-instance to retrieve configurations and report agent events. This trusted {kib}
+With _fleet mode_, you manage {agent} remotely. The Agent uses a trusted {kib}
+instance to retrieve configurations and report Agent events. This trusted {kib}
 instance must have {ingest-manager} and {fleet} enabled.
 
 To create a trusted communication channel between {agent} and {kib}, enroll the
-agent to {fleet}.
+Agent to {fleet}.
 
 To enroll an {agent} to {fleet}:
 
@@ -45,7 +45,7 @@ To start {agent}, run:
 == Run in standalone mode (default)
 
 With _standalone mode_, you manually configure and manage the Agent locally.
-Each agent is configured to be in standalone mode by default after installation.
+Each Agent is configured to be in standalone mode by default after installation.
 
 If {agent} is installed as an auto-starting service, it will run automatically
 when you restart your system.


### PR DESCRIPTION
This PR fixes issues identified by @bmorelli25 during doc testing.

This PR must be merged before https://github.com/elastic/stack-docs/pull/1194

Summary of changes:

- Add tagged regions to share content with the getting started guide
- Move description of standalone mode to appear after Fleet mode (to match order in the getting started)

Closes https://github.com/elastic/observability-dev/issues/922