### PR TITLE
[CI] badge for the CI jenkins build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/job/master/badge/icon)](https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/job/master/)
 [![Travis](https://travis-ci.org/elastic/beats.svg?branch=master)](https://travis-ci.org/elastic/beats)
 [![GoReportCard](http://goreportcard.com/badge/elastic/beats)](http://goreportcard.com/report/elastic/beats)
 [![codecov.io](https://codecov.io/github/elastic/beats/coverage.svg?branch=master)](https://codecov.io/github/elastic/beats?branch=master)


### PR DESCRIPTION

## What does this PR do?

Add CI Pipeline badge as stated in https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/job/master/badge/

## Why is it important?

Jenkins is now the main CI system to provide feedback

