### PR TITLE
[DOC] Typo in Kerberos

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -678,7 +678,7 @@ Elasticsearch.
 
 See <<configuration-ssl>> for more information.
 
-===== `kebreros`
+===== `kerberos`
 
 Configuration options for Kerberos authentication.
 


### PR DESCRIPTION
#  What does this PR do?

Removes a typo in the docs
