### PR TITLE
Cherry-pick #19149 to 7.8: [Filebeat] Fix Cisco ASA dissect pattern for 313008 & 313009

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `googlecloud.audit` pipeline to only take in fields that are explicitly defined by the dataset. {issue}18465[18465] {pull}18472[18472]
 - Fix a rate limit related issue in httpjson input for Okta module. {issue}18530[18530] {pull}18534[18534]
 - Fix tls mapping in suricata module {issue}19492[19492] {pull}19494[19494]
+- Fix Cisco ASA dissect pattern for 313008 & 313009 messages. {pull}19149[19149]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
@@ -3,3 +3,5 @@ Apr 17 2020 14:00:31 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny icmp src Inside:10.12
 Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group "acl_dmz" [0xe3afb522, 0x0]
 Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\Elastic) dst Outside:10.123.123.123/57621 by access-group "Inside_access_in" [0x0, 0x0]
 Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123
+Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1
+Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
@@ -148,5 +148,66 @@
         "tags": [
             "cisco-asa"
         ]
+    },
+    {
+        "cisco.asa.icmp_code": 0,
+        "cisco.asa.icmp_type": 134,
+        "cisco.asa.message_id": "313008",
+        "cisco.asa.source_interface": "ISP1",
+        "event.action": "firewall-rule",
+        "event.code": 313008,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1",
+        "event.outcome": "deny",
+        "event.severity": 3,
+        "event.timezone": "-02:00",
+        "fileset.name": "asa",
+        "host.hostname": "SNL-ASA-VPN-A01",
+        "input.type": "log",
+        "log.level": "error",
+        "log.offset": 853,
+        "network.iana_number": 58,
+        "network.transport": "ipv6-icmp",
+        "service.type": "cisco",
+        "source.address": "fe80::1ff:fe23:4567:890a",
+        "source.ip": "fe80::1ff:fe23:4567:890a",
+        "tags": [
+            "cisco-asa"
+        ]
+    },
+    {
+        "cisco.asa.destination_interface": "identity",
+        "cisco.asa.icmp_code": 9,
+        "cisco.asa.mapped_destination_ip": "10.12.31.51",
+        "cisco.asa.mapped_destination_port": 0,
+        "cisco.asa.mapped_source_ip": "10.255.0.206",
+        "cisco.asa.mapped_source_port": 8795,
+        "cisco.asa.message_id": "313009",
+        "cisco.asa.source_interface": "Inside",
+        "destination.address": "10.12.31.51",
+        "destination.ip": "10.12.31.51",
+        "destination.port": 0,
+        "event.action": "firewall-rule",
+        "event.code": 313009,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8",
+        "event.outcome": "deny",
+        "event.severity": 4,
+        "event.timezone": "-02:00",
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.level": "warning",
+        "log.offset": 989,
+        "network.iana_number": 1,
+        "network.transport": "icmp",
+        "service.type": "cisco",
+        "source.address": "10.255.0.206",
+        "source.ip": "10.255.0.206",
+        "source.port": 8795,
+        "tags": [
+            "cisco-asa"
+        ]
     }
 ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -289,11 +289,11 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313008'"
       field: "message"
-      pattern: "%{event.outcome} %{network.transport} type=%{_temp_.cisco.icmp_type} , code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "%{event.outcome} %{network.transport} type=%{_temp_.cisco.icmp_type}, code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313009'"
       field: "message"
-      pattern: "%{event.outcome} invalid %{network.transport} code %{_temp_.cisco.icmp_code} , for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}"
+      pattern: "%{event.outcome} invalid %{network.transport} code %{_temp_.cisco.icmp_code}, for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
       field: "message"


### PR DESCRIPTION
Cherry-pick of PR #19149 to 7.8 branch. Original message: 

## What does this PR do?

Corrects parsing errors for message IDs 313008 & 313009 that have space after comma that lead to 'Unable to find match for dissect pattern' error.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
