### PR TITLE
Cherry-pick #19110 to 7.x: [Filebeat] Update input docs

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -99,3 +99,5 @@ include::inputs/input-syslog.asciidoc[]
 include::inputs/input-tcp.asciidoc[]
 
 include::inputs/input-udp.asciidoc[]
+
+include::inputs/input-unix.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -8,7 +8,7 @@
 === s3 input
 
 ++++
-<titleabbrev>s3</titleabbrev>
+<titleabbrev>S3</titleabbrev>
 ++++
 
 beta[]

--- a/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
@@ -6,7 +6,7 @@
 === Azure eventhub input
 
 ++++
-<titleabbrev>Azure eventhub</titleabbrev>
+<titleabbrev>Azure Event Hub</titleabbrev>
 ++++
 
 Users can make use of the `azure-eventhub` input in order to read messages from an azure eventhub.


### PR DESCRIPTION
Cherry-pick of PR #19110 to 7.x branch. Original message: 

## What does this PR do?

Include unix input.
Change s3 to S3.
Change "Azure eventhub" to "Azure Event Hub".

## Why is it important?

The docs were missing for the unix input.

## Screenshots

Before
<img width="358" alt="inputs-before" src="https://user-images.githubusercontent.com/4565752/84284639-763db680-ab0a-11ea-8793-1c8cb5c9f766.png">
After
<img width="363" alt="inputs-after" src="https://user-images.githubusercontent.com/4565752/84284636-763db680-ab0a-11ea-975d-46b1ec787e19.png">

