### PR TITLE
Cherry-pick #19174 to 7.x: [Functionbeat] Add ECS categorization fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -580,6 +580,7 @@ field. You can revert this change by configuring tags for the module and omittin
 
 - Add monitoring info about triggered functions. {pull}14876[14876]
 - Add Google Cloud Platform support. {pull}13598[13598]
+- Add basic ECS categorization and `cloud` fields. {pull}19174[19174]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
@@ -31,6 +31,12 @@ func CloudwatchLogs(request events.CloudwatchLogsData) []beat.Event {
 		events[idx] = beat.Event{
 			Timestamp: time.Unix(0, logEvent.Timestamp*1000000),
 			Fields: common.MapStr{
+				"event": common.MapStr{
+					"kind": "event",
+				},
+				"cloud": common.MapStr{
+					"provider": "aws",
+				},
 				"message":              logEvent.Message,
 				"id":                   logEvent.ID,
 				"owner":                request.Owner,
@@ -50,6 +56,19 @@ func APIGatewayProxyRequest(request events.APIGatewayProxyRequest) beat.Event {
 	return beat.Event{
 		Timestamp: time.Now(),
 		Fields: common.MapStr{
+			"event": common.MapStr{
+				"kind":     "event",
+				"category": []string{"network"},
+				"type":     []string{"connection", "protocol"},
+			},
+			"cloud": common.MapStr{
+				"provider":   "aws",
+				"account.id": request.RequestContext.AccountID,
+			},
+			"network": common.MapStr{
+				"transport": "tcp",
+				"protocol":  "http",
+			},
 			"resource":          request.Resource,
 			"path":              request.Path,
 			"method":            request.HTTPMethod,
@@ -70,6 +89,13 @@ func KinesisEvent(request events.KinesisEvent) []beat.Event {
 		events[idx] = beat.Event{
 			Timestamp: time.Now(),
 			Fields: common.MapStr{
+				"event": common.MapStr{
+					"kind": "event",
+				},
+				"cloud": common.MapStr{
+					"provider": "aws",
+					"region":   record.AwsRegion,
+				},
 				"event_id":                record.EventID,
 				"event_name":              record.EventName,
 				"event_source":            record.EventSource,
@@ -93,6 +119,13 @@ func CloudwatchKinesisEvent(request events.KinesisEvent, base64Encoded, compress
 	var evts []beat.Event
 	for _, record := range request.Records {
 		envelopeFields := common.MapStr{
+			"event": common.MapStr{
+				"kind": "event",
+			},
+			"cloud": common.MapStr{
+				"provider": "aws",
+				"region":   record.AwsRegion,
+			},
 			"event_id":                record.EventID,
 			"event_name":              record.EventName,
 			"event_source":            record.EventSource,
@@ -157,6 +190,13 @@ func SQS(request events.SQSEvent) []beat.Event {
 		events[idx] = beat.Event{
 			Timestamp: time.Now(),
 			Fields: common.MapStr{
+				"event": common.MapStr{
+					"kind": "event",
+				},
+				"cloud": common.MapStr{
+					"provider": "aws",
+					"region":   record.AWSRegion,
+				},
 				"message_id":       record.MessageId,
 				"receipt_handle":   record.ReceiptHandle,
 				"message":          record.Body,

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
@@ -40,6 +40,12 @@ func TestCloudwatch(t *testing.T) {
 	expectedEvent := beat.Event{
 		Timestamp: expectedTime,
 		Fields: common.MapStr{
+			"event": common.MapStr{
+				"kind": "event",
+			},
+			"cloud": common.MapStr{
+				"provider": "aws",
+			},
 			"message":              "my interesting message",
 			"id":                   "1234567890123456789",
 			"owner":                "me",
@@ -79,6 +85,13 @@ func TestKinesis(t *testing.T) {
 	assert.Equal(t, 1, len(events))
 
 	fields := common.MapStr{
+		"cloud": common.MapStr{
+			"provider": "aws",
+			"region":   "us-east-1",
+		},
+		"event": common.MapStr{
+			"kind": "event",
+		},
 		"event_id":                "1234",
 		"event_name":              "connect",
 		"event_source":            "web",
@@ -130,6 +143,13 @@ ciJ9XX0=`),
 	assert.Equal(t, 3, len(events))
 
 	envelopeFields := common.MapStr{
+		"cloud": common.MapStr{
+			"provider": "aws",
+			"region":   "us-east-1",
+		},
+		"event": common.MapStr{
+			"kind": "event",
+		},
 		"event_id":                "1234",
 		"event_name":              "connect",
 		"event_source":            "web",

--- a/x-pack/functionbeat/provider/gcp/gcp/transformer.go
+++ b/x-pack/functionbeat/provider/gcp/gcp/transformer.go
@@ -29,6 +29,12 @@ func transformPubSub(mData *metadata.Metadata, msg pubsub.Message) (beat.Event, 
 	return beat.Event{
 		Timestamp: mData.Timestamp,
 		Fields: common.MapStr{
+			"event": common.MapStr{
+				"kind": "event",
+			},
+			"cloud": common.MapStr{
+				"provider": "gcp",
+			},
 			"read_timestamp": time.Now(),
 			"message":        string(msg.Data),
 			"attributes":     msg.Attributes,
@@ -48,6 +54,14 @@ func transformStorage(mData *metadata.Metadata, evt StorageEvent) (beat.Event, e
 	return beat.Event{
 		Timestamp: mData.Timestamp,
 		Fields: common.MapStr{
+			"event": common.MapStr{
+				"kind":     "event",
+				"category": []string{"file"},
+				"type":     []string{"info"},
+			},
+			"cloud": common.MapStr{
+				"provider": "gcp",
+			},
 			"read_timestamp": time.Now(),
 			"id":             mData.EventID,
 			"resource": common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #19174 to 7.x branch. Original message: 

## What does this PR do?

Adds ECS categorization fields and some basic ECS fields that were missing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/18268
