### PR TITLE
Cherry-pick #19273 to 7.x: Update docker-entrypoint.elastic-agent.tmpl

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -24,7 +24,7 @@ function enroll(){
     local enrollResp
     local apiKey
 
-    if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]] && [[ ${FLEET_ENROLLMENT_TOKEN} == 1 ]]; then
+    if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]]; then
       apikey = "${FLEET_ENROLLMENT_TOKEN}"
     else
       enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19273 to 7.x branch. Original message: 

## What does this PR do?
`FLEET_ENROLLMENT_TOKEN` should not be checked to be equal to `1` since it contains token's value.

## Why is it important?
So as the startup script to honour the `FLEET_ENROLLMENT_TOKEN` env var.