### PR TITLE
Cherry-pick #19275 to 7.8: Add librpm.so.9 to the names dlopen searches

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
+- system/package: Fix librpm loading on Fedora 31/32. {pull}NNNN[NNNN]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -207,11 +207,13 @@ func (lib *librpm) close() error {
 func openLibrpm() (*librpm, error) {
 	var librpmNames = []string{
 		"librpm.so",   // with rpm-devel installed
-		"librpm.so.8", // Fedora 29
+		"librpm.so.9", // Fedora 31/32
+		"librpm.so.8", // Fedora 29/30
 		"librpm.so.3", // CentOS 7
 		"librpm.so.1", // CentOS 6
 
 		// Following for completeness, but not explicitly tested
+		"librpm.so.10",
 		"librpm.so.7",
 		"librpm.so.6",
 		"librpm.so.5",


### PR DESCRIPTION
Cherry-pick of PR #19275 to 7.8 branch. Original message: 


## What does this PR do?

Fedora 31 and 32 use librpm.so.9, but Auditbeat's system/package dataset doesn't try to load
this version of the library.



## Why is it important?

It makes the system/package dataset work on newer Fedora releases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #19253
