### PR TITLE
[7.8] [DOCS] Minor change to wording for known issues (#19276)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.8.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.8.asciidoc
@@ -12,7 +12,7 @@
 
 //tag::notable-breaking-changes[]
 [float]
-==== Known problem with Kafka output
+==== Known issue with Kafka output
 
 The Kafka output fails to connect when using multiple TLS brokers. We advise
 not to upgrade to {beats} 7.8.0 if you're using the Kafka output in this

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -6,7 +6,7 @@
 ++++
 
 [IMPORTANT]
-.Known problem in version 7.8.0
+.Known issue in version 7.8.0
 ====
 The Kafka output fails to connect when using multiple TLS brokers. We advise
 not to upgrade to {beatname_uc} 7.8.0 if you're using the Kafka output in this


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Minor change to wording for known issues (#19276)