### PR TITLE
Cherry-pick #19168 to 7.x: Fix unused libbeat.config.module metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - The `monitoring.elasticsearch.api_key` value is correctly base64-encoded before being sent to the monitoring Elasticsearch cluster. {issue}18939[18939] {pull}18945[18945]
 - Fix kafka topic setting not allowing upper case characters. {pull}18854[18854] {issue}18640[18640]
 - Fix redis key setting not allowing upper case characters. {pull}18854[18854] {issue}18640[18640]
+- Fix config reload metrics (`libbeat.config.module.start/stops/running`). {pull}19168[19168]
 - Fix metrics hints builder to avoid wrong container metadata usage when port is not exposed {pull}18979[18979]
 
 *Auditbeat*

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -84,6 +84,7 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 		r.logger.Debugf("Stopping runner: %s", runner)
 		delete(r.runners, hash)
 		go runner.Stop()
+		moduleStops.Add(1)
 	}
 
 	// Start new runners
@@ -101,7 +102,14 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 		r.logger.Debugf("Starting runner: %s", runner)
 		r.runners[hash] = runner
 		runner.Start()
+		moduleStarts.Add(1)
 	}
+
+	// NOTE: This metric tracks the number of modules in the list. The true
+	// number of modules in the running state may differ because modules can
+	// stop on their own (i.e. on errors) and also when this stops a module
+	// above it is done asynchronously.
+	moduleRunning.Set(int64(len(r.runners)))
 
 	return errs.Err()
 }

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -52,7 +52,7 @@ var (
 	configReloads = monitoring.NewInt(nil, "libbeat.config.reloads")
 	moduleStarts  = monitoring.NewInt(nil, "libbeat.config.module.starts")
 	moduleStops   = monitoring.NewInt(nil, "libbeat.config.module.stops")
-	moduleRunning = monitoring.NewInt(nil, "libbeat.config.module.running")
+	moduleRunning = monitoring.NewInt(nil, "libbeat.config.module.running") // Number of modules in the runner list (not necessarily in the running state).
 )
 
 // DynamicConfig loads config files from a given path, allowing to reload new changes


### PR DESCRIPTION
Cherry-pick of PR #19168 to 7.x branch. Original message: 

## What does this PR do?

These metrics existed in the code but were unused and hence always 0.

"libbeat":{"config":{"module":{"running":0,"starts":0,"stops":0}

I updated the module reload code to increment and set the metrics when changes are applied.

## Why is it important?

If the metrics are exposed by `/stats` then they should work, otherwise they are misleading.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

I tested the metrics using Auditbeat module reloading:

```
  "libbeat": {
    "config": {
      "module": {
        "running": 1,
        "starts": 2,
        "stops": 1
      },
      "reloads": 2,
      "scans": 75
    },
```
