### PR TITLE
Cherry-pick #19087 to 7.x: Disable host.* fields by default for netflow module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   `forwarded` from the list. {issue}13920[13920]
 * Cisco {pull}18753[18753]
 * Checkpoint {pull}18754[18754]
+* Netflow {pull}19087[19087]
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
 - With the default configuration the cloud modules (aws, azure, googlecloud, o365, okta)
 will no longer send the `host` field that contains information about the host Filebeat is

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -72,6 +72,12 @@ details.
 monitor sequence numbers in the Netflow packets to detect an Exporting Process
 reset. See <<filebeat-input-netflow,netflow input>> for details.
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[forwarded]`.
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -67,6 +67,12 @@ details.
 monitor sequence numbers in the Netflow packets to detect an Exporting Process
 reset. See <<filebeat-input-netflow,netflow input>> for details.
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[forwarded]`.
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -24,6 +24,9 @@ custom_definitions:
 detect_sequence_reset: {{.detect_sequence_reset}}
 {{end}}
 
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
+
 processors:
   - add_fields:
       target: ''

--- a/x-pack/filebeat/module/netflow/log/manifest.yml
+++ b/x-pack/filebeat/module/netflow/log/manifest.yml
@@ -15,6 +15,8 @@ var:
   - name: timeout
   - name: custom_definitions
   - name: detect_sequence_reset
+  - name: tags
+    default: [forwarded]
 ingest_pipeline: ingest/pipeline.yml
 input: config/netflow.yml
 


### PR DESCRIPTION
Cherry-pick of PR #19087 to 7.x branch. Original message: 

## What does this PR do?

For the netflow module when data is forwarded to Filebeat from another host/device you don't want Filebeat to add `host`. So by default this modules add a `forwarded` tag to events. If you configure the module to not include the `forwarded` tag (e.g. `var.tags: [my_tag]`) then Filebeat will add the `host.*` fields.

## Why is it important?

We want Filebeat to follow Elastic Common Schema. And setting host with the correct value is part of that. By setting (or not setting host) we can better interpret events. Without this change the Filebeat host is being attributed as the source even if data was received over netflow from another host.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates: #13920