### PR TITLE
Cherry-pick #19133 to 7.x: Disable host.* fields by default for Fortinet module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   `forwarded` from the list. {issue}13920[13920]
 * Cisco {pull}18753[18753]
 * CrowdStrike {pull}19132[19132]
+* Fortinet {pull}19133[19133]
 * iptables {pull}18756[18756]
 * Checkpoint {pull}18754[18754]
 * Netflow {pull}19087[19087]

--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -58,6 +58,12 @@ Set to 0.0.0.0 to bind to all available interfaces.
 
 The port to listen for syslog traffic. Defaults to 9004.
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[fortinet-firewall, forwarded]`.
+
 [float]
 ==== Fortinet ECS fields
 

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -53,6 +53,12 @@ Set to 0.0.0.0 to bind to all available interfaces.
 
 The port to listen for syslog traffic. Defaults to 9004.
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Defaults to `[fortinet-firewall, forwarded]`.
+
 [float]
 ==== Fortinet ECS fields
 

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -20,7 +20,8 @@ exclude_files: [".gz$"]
 
 {{ end }}
 
-tags: {{.tags}}
+tags: {{.tags | tojson}}
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
   - add_locale: ~

--- a/x-pack/filebeat/module/fortinet/firewall/manifest.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/manifest.yml
@@ -4,7 +4,7 @@ var:
   - name: syslog_host
     default: localhost
   - name: tags
-    default: [fortinet-firewall]
+    default: [fortinet-firewall, forwarded]
   - name: syslog_port
     default: 9004
   - name: input

--- a/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
@@ -68,7 +68,8 @@
         "source.user.group.name": "elasticgroup",
         "source.user.name": "elasticuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ],
         "url.domain": "elastic.co",
         "url.path": "/config/"
@@ -140,7 +141,8 @@
         "source.packets": 0,
         "source.port": 60899,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -212,7 +214,8 @@
         "source.user.group.name": "elasticgroup",
         "source.user.name": "elasticuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ],
         "url.domain": "elastic.co",
         "url.path": "/"
@@ -284,7 +287,8 @@
         "source.user.group.name": "elasticgroup",
         "source.user.name": "elasticuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ],
         "tls.client.server_name": "test.elastic.co",
         "url.domain": "elastic.co",
@@ -357,7 +361,8 @@
         "source.user.group.name": "elasticgroup",
         "source.user.name": "elasticuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ],
         "tls.client.server_name": "test.elastic.co",
         "url.domain": "elastic.co",
@@ -428,7 +433,8 @@
         "source.ip": "192.168.2.1",
         "source.port": 53430,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -497,7 +503,8 @@
         "source.ip": "192.168.2.1",
         "source.port": 53430,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -567,7 +574,8 @@
         "source.user.group.name": "elasticgroup",
         "source.user.name": "elasticuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ],
         "url.domain": "elastic.no",
         "url.path": "/"
@@ -637,7 +645,8 @@
         "source.ip": "192.168.2.1",
         "source.port": 54438,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -696,7 +705,8 @@
         "source.ip": "192.168.2.1",
         "source.port": 54788,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -760,7 +770,8 @@
         "source.user.group.name": "elasticgroup2",
         "source.user.name": "elasticuser2",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -805,7 +816,8 @@
         "source.ip": "10.10.10.10",
         "source.user.name": "elasticouser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -868,7 +880,8 @@
         "source.ip": "8.8.8.8",
         "source.port": 500,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -935,7 +948,8 @@
         "source.ip": "9.9.9.9",
         "source.port": 500,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -979,7 +993,8 @@
         "rule.description": "System performance statistics",
         "service.type": "fortinet",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1025,7 +1040,8 @@
         "source.ip": "10.10.10.10",
         "source.user.name": "elastiiiuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1090,7 +1106,8 @@
         "source.ip": "7.6.3.4",
         "source.port": 500,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1118,7 +1135,8 @@
         "rule.description": "FortiSandbox AV database updated",
         "service.type": "fortinet",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1158,7 +1176,8 @@
         "service.type": "fortinet",
         "source.user.name": "elastico",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1206,7 +1225,8 @@
         "rule.description": "SSL VPN new connection",
         "service.type": "fortinet",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1260,7 +1280,8 @@
         "source.user.group.name": "somegroup",
         "source.user.name": "someuser",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1305,7 +1326,8 @@
         "source.ip": "192.168.1.1",
         "source.user.name": "elasticadmin",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1334,7 +1356,8 @@
         "rule.description": "FortiCloud server connected",
         "service.type": "fortinet",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1364,7 +1387,8 @@
         "rule.description": "FortiCloud server disconnected",
         "service.type": "fortinet",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1431,7 +1455,8 @@
         "source.ip": "192.168.1.6",
         "source.port": 53438,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1518,7 +1543,8 @@
         "source.packets": 723417,
         "source.port": 6000,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1593,7 +1619,8 @@
         "source.ip": "2001:4860:4860::8888",
         "source.packets": 4,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1668,7 +1695,8 @@
         "source.ip": "9.7.7.7",
         "source.packets": 0,
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     },
     {
@@ -1734,7 +1762,8 @@
         "source.port": 62493,
         "source.user.name": "elasticsuper",
         "tags": [
-            "fortinet-firewall"
+            "fortinet-firewall",
+            "forwarded"
         ]
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #19133 to 7.x branch. Original message: 

## What does this PR do?

For the Fortinet module when data is forwarded to Filebeat from another host/device (this is most of the time) you don't want Filebeat to add `host`. So by default this modules add a `forwarded` tag to events. If you configure the module to not include the `forwarded` tag (e.g. `var.tags: [my_tag]`) then Filebeat will add the `host.*` fields.

## Why is it important?

We want Filebeat to follow Elastic Common Schema. And setting host with the correct value is part of that. By setting (or not setting host) we can better interpret events. Without this change the Filebeat host is being attributed as the source of Checkpoint firewall events.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates: #13920

