### PR TITLE
[7.x] Add release highlights for 7.8 (#19289)

### DIFF
--- a/libbeat/docs/release-notes/highlights/highlights-7.8.0.asciidoc
+++ b/libbeat/docs/release-notes/highlights/highlights-7.8.0.asciidoc
@@ -7,8 +7,8 @@
 Each release of {beats} brings new features and product improvements. 
 Following are the most notable features and enhancements in 7.8.
 
-//For a complete list of related highlights, see the 
-//https://www.elastic.co/blog/elastic-observability-7-7-0-released[Observability 7.8 release blog].
+For a complete list of related highlights, see the 
+https://www.elastic.co/blog/elastic-observability-7-7-0-released[Observability 7.8 release blog].
 
 For a list of bug fixes and other changes, see the {beats}
 <<breaking-changes-7.8, Breaking Changes>> and <<release-notes, Release Notes>>.
@@ -19,12 +19,30 @@ For a list of bug fixes and other changes, see the {beats}
 // tag::notable-highlights[]
 
 //
-//[float]
-//Remove role if open source
-//[role="xpack"]
-//==== Highlight title
+[float]
+[role="xpack"]
+==== Support for monitoring Google Cloud service metrics
 
-//Description
+In this release, we've added support for monitoring Google Cloud operations
+suite (formerly Stackdriver). The new
+{metricbeat-ref}/metricbeat-metricset-googlecloud-stackdriver.html[stackdriver]
+metricset in the Google Cloud Platform module collects any service metrics from
+Google Cloud by using the `ListTimeSeries` API call.
 
+For a full list of metric types that Google Cloud monitoring supports, see the
+https://cloud.google.com/monitoring/api/metrics_gcp#gcp[Google Cloud metrics]
+documentation.
+
+[float]
+==== Specialized Linux integration
+
+To simplify Linux monitoring, we’ve introduced a new
+{metricbeat-ref}/metricbeat-module-linux.html[Linux] module that contains metrics
+exclusive to the Linux kernel and various subsystems. This is done primarily to
+avoid cluttering the System module with metricsets that are not broadly
+cross-compatible. The new Linux module currently includes these metricsets:
+{metricbeat-ref}/metricbeat-metricset-linux-pageinfo.html[pageinfo],
+{metricbeat-ref}/metricbeat-metricset-linux-ksm.html[ksm], and
+{metricbeat-ref}/metricbeat-metricset-linux-conntrack.html[conntrack].
 
 // end::notable-highlights[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add release highlights for 7.8 (#19289)