### PR TITLE
[7.8][DOCS] Describe known problem with kafka output (#19282)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.7.asciidoc
@@ -34,4 +34,11 @@ Starting in version 7.7.0, scripts that use these processors will fail. To
 resolve this problem, define the processors in your configuration instead of the
 script.
 
+[float]
+==== Known issue with Kafka output
+
+The Kafka output fails to connect when using multiple TLS brokers. We advise
+not to upgrade to {beats} 7.7.1 if you're using the Kafka output in this
+configuration.
+
 // end::notable-breaking-changes[]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [7.7] [DOCS] Describe known problem with kafka output (#19282)

NOTE: This change is necessary because users can access the 7.7 version of this topic when they are in the 7.8 docs.