### PR TITLE
Flag rabbitmq module as x-pack in documentation

### DIFF
--- a/filebeat/docs/modules/rabbitmq.asciidoc
+++ b/filebeat/docs/modules/rabbitmq.asciidoc
@@ -3,6 +3,8 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[filebeat-module-rabbitmq]]
+[role="xpack"]
+
 :modulename: rabbitmq
 :has-dashboards: false
 


### PR DESCRIPTION
## What does this PR do?

Flag the RabbitMQ module as x-pack in the documentation.

## Why is it important?

It's in the [x-pack modules](https://github.com/elastic/beats/tree/master/x-pack/filebeat/module) but not in the [oss modules](https://github.com/elastic/beats/tree/master/filebeat/module). Documentation does not say so.


## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~