### PR TITLE
Cherry-pick #19324 to 7.x: Fix bash syntax error in agent docker entrypoint

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -25,7 +25,7 @@ function enroll(){
     local apiKey
 
     if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]]; then
-      apikey = "${FLEET_ENROLLMENT_TOKEN}"
+      apikey="${FLEET_ENROLLMENT_TOKEN}"
     else
       enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \
         -H 'Content-Type: application/json' \


### PR DESCRIPTION
Cherry-pick of PR #19324 to 7.x branch. Original message: 

## What does this PR do?

This minor change fixes the following syntax error:
`/usr/local/bin/docker-entrypoint: line 27: apikey: command not found`