### PR TITLE
Update modules-dev-guide.asciidoc

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -488,4 +488,4 @@ locally for a specific module, using the following procedure under Filebeat dire
 . Create python env: `make python-env`
 . Source python env: `./build/python-env/bin/activate`
 . Create the testing binary: `make filebeat.test`
-. Run the test, ie: `GENERATE=1 INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=nginx nosetests tests/system/test_modules.py`
+. Run the test, ie: `./filebeat.test GENERATE=1 INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=nginx nosetests tests/system/test_modules.py`


### PR DESCRIPTION
The current beats filebeat module development documentation mentions how to run tests but leaves out the executable to be used.

- Enhancement

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

