### PR TITLE
Update go-structform to 0.0.7

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2045,7 +2045,7 @@ Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-structform
-Version: v0.0.6
+Version: v0.0.7
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-structform/LICENSE:
 --------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/elastic/go-lumber v0.1.0
 	github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595
 	github.com/elastic/go-seccomp-bpf v1.1.0
-	github.com/elastic/go-structform v0.0.6
+	github.com/elastic/go-structform v0.0.7
 	github.com/elastic/go-sysinfo v1.3.0
 	github.com/elastic/go-txfile v0.0.7
 	github.com/elastic/go-ucfg v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/elastic/go-seccomp-bpf v1.1.0 h1:jUzzDc6LyCtdolZdvL/26dad6rZ9vsc7xZ2e
 github.com/elastic/go-seccomp-bpf v1.1.0/go.mod h1:l+89Vy5BzjVcaX8USZRMOwmwwDScE+vxCFzzvQwN7T8=
 github.com/elastic/go-structform v0.0.6 h1:wqeK4LwD2NNDOoRGTImE24S6pkCDVr8+oUSIkmChzLk=
 github.com/elastic/go-structform v0.0.6/go.mod h1:QrMyP3oM9Sjk92EVGLgRaL2lKt0Qx7ZNDRWDxB6khVs=
+github.com/elastic/go-structform v0.0.7 h1:ihszOJQryNuIIHE2ZgsbiDq+agKO6V4yK0JYAI3tjzc=
+github.com/elastic/go-structform v0.0.7/go.mod h1:QrMyP3oM9Sjk92EVGLgRaL2lKt0Qx7ZNDRWDxB6khVs=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-sysinfo v1.3.0 h1:eb2XFGTMlSwG/yyU9Y8jVAYLIzU2sFzWXwo2gmetyrE=
 github.com/elastic/go-sysinfo v1.3.0/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=

--- a/vendor/github.com/elastic/go-structform/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-structform/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.0.7]
+
+### Fixed
+
+- Fix potential use after free in string and []byte conversions. (PR #21)
+
 ## [0.0.6]
 
 ### Added
@@ -54,7 +60,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix invalid pointer indirections in struct to array/map.
 
-[Unreleased]: https://github.com/elastic/go-structform/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/elastic/go-structform/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/elastic/go-structform/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/elastic/go-structform/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/elastic/go-structform/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/elastic/go-structform/compare/v0.0.3...v0.0.4

--- a/vendor/github.com/elastic/go-structform/README.md
+++ b/vendor/github.com/elastic/go-structform/README.md
@@ -1,0 +1,184 @@
+# Go-Structform - Structured Formatters
+
+go-structform provides capabilities for serializing, desirializing, and
+transcoding structured data efficiently and generically.
+
+The top-level package provides the common layer by which serializers and
+deserializers interact with each other. Serializers convert the input into a
+stream of events by calling methods on the
+[Visitor](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#Visitor)
+interfaces. The Deserializers implement the Visitor interface to convert the
+stream of events into the target structure.
+
+A type implementing the `Visitor` interface, but forwards calls to another
+visitor is called a Transformer or Filter. Transformers/Filters can manipulate
+the data stream or create/collect errors if some wanted validation fails.
+
+## Examples
+
+Transcode a stream of JSON objects into a stream of CBOR objects:
+
+```
+func TranscodeJSON2CBOR(out io.Writer, in io.Reader) (int64, error) {
+	bytesCount, err := json.ParseReader(in, cborl.NewVisitor(out))
+	return bytesCount, err
+}
+```
+
+Parse a stream of JSON objects:
+
+```
+	var in io.Reader = ...
+	visitor, _ := gotype.NewUnfolder(nil)
+	dec := json.NewDecoder(in, 2048, visitor)
+	for {
+		var to interface{}
+		visitor.SetTarget(&to)
+		if err := dec.Next(); err != nil {
+			return err
+		}
+
+		// process `to`
+	}
+```
+
+Encode a channel of go `map[string]interface{}` to a stream of cbor objects:
+
+```
+	var out io.Writer = ...
+	var objects chan map[string]interface{} = ...
+
+	visitor := cborl.NewVisitor(out)
+	it, _ := gotype.NewIterator(visitor)
+	for _, obj := range objects {
+		if err := it.Fold(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+```
+
+Convert between go types:
+
+```
+	var to map[string]int
+	visitor, _ := gotype.NewUnfolder(&to)
+	it, _ := gotype.NewIterator(visitor)
+
+	st := struct {
+		A int    `struct:"a"`
+		B string `struct:",omit"`
+	}{A: 1, B: "hello"}
+	if err := it.Fold(st); err != nil {
+		return err
+	}
+
+	// to == map[string]int{"a": 1}
+```
+
+Use custom folder and unfolder for existing go types:
+
+```
+type durationUnfolder struct {
+	gotype.BaseUnfoldState // Use BaseUnfoldState to create errors for methods not implemented
+	to                     *time.Duration
+}
+
+func foldDuration(in *time.Duration, v structform.ExtVisitor) error {
+	return v.OnString(in.String())
+}
+
+func unfoldDuration(to *time.Duration) gotype.UnfoldState {
+	return &durationUnfolder{to: to}
+}
+
+type durationUnfolder struct {
+	gotype.BaseUnfoldState // Use BaseUnfoldState to create errors for methods not implemented
+	to                     *time.Duration
+}
+
+func (u *durationUnfolder) OnString(_ gotype.UnfoldCtx, str string) error {
+	d, err := time.ParseDuration(str)
+	if err == nil {
+		*u.to = d
+	}
+	return err
+}
+
+
+...
+
+
+	visitor, _ := gotype.NewUnfolder(nil, gotype.Unfolders(
+		unfoldDuration,
+	))
+	it, _ := gotype.NewIterator(visitor, gotype.Folders(
+		foldDuration,
+	))
+
+	// store duration in temporary value
+	var tmp interface{}
+	visitor.SetTarget(&tmp)
+	it.Fold(5 * time.Minute)
+
+	// restore duration from temporary value
+	var dur time.Duration
+	visitor.SetTarget(&dur)
+	it.Fold(tmp)
+
+	// dur == 5 * time.Minute
+```
+
+## Data Model
+
+The data model describes by which data types Serializers and Deserializers
+interact. In this sense the data model provides a simplified type system, that supports a subset of
+serializable go types (for example channels or function pointers can not be serialized).
+
+Go-structform provides a simplified, common data model via the [Visitor](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#Visitor) interface.
+
+### Types
+
+- **primitives** (See [ValueVisitor](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#ValueVisitor) interface):  `Bool`, `Byte`, `String`, `Int`, `Int8/16/32/64`, `Uint`, `Uint8/16/32/64`, `Float32`, `Float64`, untyped `Nil`
+- **compound**: objects ([ObjectVisitor](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#ObjectVisitor)), arrays ([ArrayVisitor](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#ArrayVisitor))
+
+## Extended Data Model
+
+The extended data model provides support for similar types to the `Visitor`
+interface, but provides a number of optimizations, allowing users to pass a set
+of common go values directly without having to serialize and deserialize those
+values.
+
+The extended data model is provided by the
+[`ExtVisitor`](https://pkg.go.dev/github.com/elastic/go-structform?tab=doc#ExtVisitor)
+interface.
+
+All features in the Extended Data Model can be seamlessly converted to the Data
+Model provided by the `Visitor interface.
+
+Deserializers supporting the Extended Data Model must always implement the
+common Data Model as is required by the `Visitor` interface.
+
+Serializers wanting to interact with the Extended Data Model should still
+accept the `Visitor` interface only and use `EnsureExtVisitor` in order to create an `ExtVisitor`.
+`EnsureExtVisitor` wraps the `Visitor` if necessarry, allowing the `Visitor` to
+implement only a subset of features in the Extended Data Model.
+
+- **extended primitives**: The Visitor adds support for `[]byte` values as
+  strings. The value must be consumed immediately or copied, as the buffer is
+  not guaranteed to be stable.
+- **slices**: The visitor adds support for slice types, for each supported
+  primitive type. For example `[]int8/16/32/64` can be passed as is.
+- **map**: The visitor adds support for `map[string]T` types, for each
+  supported primitive type. For example `map[string]int8/16/32/64`.
+
+
+## Data Formats
+
+- JSON: the `json` package provides a JSON parser and JSON serializer. The serializer implements a subset of `ExtVisitor`.
+- UBJSON: the `ubjson` packages provides a parser and serializer for Universal Binary JSON.
+- CBOR: the `cborl` package supports a compatible subset of CBOR (for example object keys must be strings).
+- Go Types: the `gotype` package provides a `Folder` to convert go values into
+  a stream of events and an `Unfolder` to apply a stream of events to go
+  values.

--- a/vendor/github.com/elastic/go-structform/internal/unsafe/unsafe.go
+++ b/vendor/github.com/elastic/go-structform/internal/unsafe/unsafe.go
@@ -19,6 +19,7 @@ package unsafe
 
 import (
 	"reflect"
+	"runtime"
 	"unsafe"
 )
 
@@ -27,17 +28,23 @@ type emptyInterface struct {
 	word unsafe.Pointer
 }
 
-func Str2Bytes(s string) []byte {
+func Str2Bytes(s string) (b []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{Data: sh.Data, Len: sh.Len, Cap: sh.Len}
-	b := *(*[]byte)(unsafe.Pointer(&bh))
-	return b
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return
 }
 
-func Bytes2Str(b []byte) string {
+func Bytes2Str(b []byte) (s string) {
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{Data: bh.Data, Len: bh.Len}
-	return *((*string)(unsafe.Pointer(&sh)))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	sh.Data = bh.Data
+	sh.Len = bh.Len
+	runtime.KeepAlive(b)
+	return
 }
 
 // IfcValuePtr extracts the underlying values pointer from an empty interface{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -459,7 +459,7 @@ github.com/elastic/go-perf
 # github.com/elastic/go-seccomp-bpf v1.1.0
 github.com/elastic/go-seccomp-bpf
 github.com/elastic/go-seccomp-bpf/arch
-# github.com/elastic/go-structform v0.0.6
+# github.com/elastic/go-structform v0.0.7
 github.com/elastic/go-structform
 github.com/elastic/go-structform/cborl
 github.com/elastic/go-structform/gotype


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Update Dependency

## What does this PR do?

Update go-structform dependency to 0.0.7

## Why is it important?

Version 0.0.7 fixes a potential use after free issue when encoding to JSON. The way events are encoded Beats should not really be affected by this, as Beats hold on to the original structures until after ACK. Still, we should update potential critical fixes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
