### PR TITLE
Use correct attribute to resolve apm overview links

### DIFF
--- a/libbeat/docs/shared/obs-apps.asciidoc
+++ b/libbeat/docs/shared/obs-apps.asciidoc
@@ -22,7 +22,7 @@ ifeval::["{beatname_lc}"!="heartbeat"]
 |{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat}]
 |Uptime information
 endif::[]
-|{apm-get-started-ref}/index.html[APM]
+|{apm-overview-ref-v}/index.html[APM]
 |Application performance metrics
 ifeval::["{beatname_lc}"!="auditbeat"]
 |{auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat}]


### PR DESCRIPTION
`apm-overview-ref-v` is the preferred attribute to use for versioned links.