### PR TITLE
Cherry-pick #18890 to 7.8: Add check on `<no value>` config option value for the azure input `resource_manager_endpoint` 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS categorization field mappings for nginx module. http.request.referrer only populated when nginx sets a value {issue}16174[16174] {pull}17844[17844]
 - Improve ECS field mappings in santa module. move hash.sha256 to process.hash.sha256 & move certificate fields to santa.certificate . {issue}16180[16180] {pull}17982[17982]
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
+- Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
+- Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,7 +33,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve ECS field mappings in santa module. move hash.sha256 to process.hash.sha256 & move certificate fields to santa.certificate . {issue}16180[16180] {pull}17982[17982]
 - Preserve case of http.request.method.  ECS prior to 1.6 specified normalizing to lowercase, which lost information. Affects filesets: apache/access, elasticsearch/audit, iis/access, iis/error, nginx/access, nginx/ingress_controller, aws/elb, suricata/eve, zeek/http. {issue}18154[18154] {pull}18359[18359]
 - Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
-- Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -89,7 +89,7 @@ func (a *azureInput) runWithEPH() error {
 
 func getAzureEnvironment(overrideResManager string) (azure.Environment, error) {
 	// if no overrride is set then the azure public cloud is used
-	if overrideResManager == "" {
+	if overrideResManager == "" || overrideResManager == "<no value>" {
 		return azure.PublicCloud, nil
 	}
 	if env, ok := environments[overrideResManager]; ok {

--- a/x-pack/filebeat/input/azureeventhub/eph_test.go
+++ b/x-pack/filebeat/input/azureeventhub/eph_test.go
@@ -41,4 +41,8 @@ func TestGetAzureEnvironment(t *testing.T) {
 	resMan = "http://management.invalidhybrid.com/"
 	env, err = getAzureEnvironment(resMan)
 	assert.Errorf(t, err, "invalid character 'F' looking for beginning of value")
+	resMan = "<no value>"
+	env, err = getAzureEnvironment(resMan)
+	assert.NoError(t, err)
+	assert.Equal(t, env, azure.PublicCloud)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#18890 to 7.8 branch. Original message:

## What does this PR do?

Adds a check on `<no value>` config option value for the azure input `resource_manager_endpoint`
Updates test.

## Why is it important?

Seems that after some recent changes, if a value is not set for `resource_manager_endpoint` then the value `<no value>` is sent to the input config. This needs to be checked at the input level.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Do not set a value for `resource_manager_endpoint` when running the azure module in filebeat, no events will be generated and logs will provide more information on the error regarding the azure env.



