### PR TITLE
Cherry-pick #18890 to 7.x: Add check on `<no value>` config option value for the azure input `resource_manager_endpoint`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,7 @@ happened. {issue}13920[13920] {pull}18223[18223]
 - With the default configuration the cef and panw modules will no longer send the `host`
 field. You can revert this change by configuring tags for the module and omitting
 `forwarded` from the list. {issue}13920[13920] {pull}18223[18223]
+- Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
 - Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]
 - Adds oauth support for httpjson input. {issue}18415[18415] {pull}18892[18892]
 

--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -89,7 +89,7 @@ func (a *azureInput) runWithEPH() error {
 
 func getAzureEnvironment(overrideResManager string) (azure.Environment, error) {
 	// if no overrride is set then the azure public cloud is used
-	if overrideResManager == "" {
+	if overrideResManager == "" || overrideResManager == "<no value>" {
 		return azure.PublicCloud, nil
 	}
 	if env, ok := environments[overrideResManager]; ok {

--- a/x-pack/filebeat/input/azureeventhub/eph_test.go
+++ b/x-pack/filebeat/input/azureeventhub/eph_test.go
@@ -41,4 +41,8 @@ func TestGetAzureEnvironment(t *testing.T) {
 	resMan = "http://management.invalidhybrid.com/"
 	env, err = getAzureEnvironment(resMan)
 	assert.Errorf(t, err, "invalid character 'F' looking for beginning of value")
+	resMan = "<no value>"
+	env, err = getAzureEnvironment(resMan)
+	assert.NoError(t, err)
+	assert.Equal(t, env, azure.PublicCloud)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#18890 to 7.x branch. Original message:

## What does this PR do?

Adds a check on `<no value>` config option value for the azure input `resource_manager_endpoint`
Updates test.

## Why is it important?

Seems that after some recent changes, if a value is not set for `resource_manager_endpoint` then the value `<no value>` is sent to the input config. This needs to be checked at the input level.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Do not set a value for `resource_manager_endpoint` when running the azure module in filebeat, no events will be generated and logs will provide more information on the error regarding the azure env.



