### PR TITLE
Fix Istio doc link to match version of Istio

### DIFF
--- a/metricbeat/docs/modules/istio.asciidoc
+++ b/metricbeat/docs/modules/istio.asciidoc
@@ -16,7 +16,7 @@ The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 [float]
 === Compatibility
 
-The Istio module is tested with Istio `1.4`. This module collects metrics from Istio microservices' Prometheus exporters.
+The Istio module is tested with Istio `1.4`.
 
 
 [float]

--- a/metricbeat/docs/modules/istio.asciidoc
+++ b/metricbeat/docs/modules/istio.asciidoc
@@ -9,14 +9,14 @@ This file is generated! See scripts/mage/docs_collector.go
 beta[]
 
 This is the Istio module. The Istio module collects metrics from the
-Istio https://istio.io/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
+Istio https://istio.io/v1.4/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
 
 The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 
 [float]
 === Compatibility
 
-The Istio module is tested with Istio 1.4
+The Istio module is tested with Istio `1.4`. This module collects metrics from Istio microservices' Prometheus exporters.
 
 
 [float]

--- a/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
@@ -1,9 +1,9 @@
 This is the Istio module. The Istio module collects metrics from the
-Istio https://istio.io/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
+Istio https://istio.io/v1.4/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
 
 The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 
 [float]
 === Compatibility
 
-The Istio module is tested with Istio 1.4
+The Istio module is tested with Istio `1.4`. This module collects metrics from Istio microservices' Prometheus exporters.

--- a/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
@@ -6,4 +6,4 @@ The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 [float]
 === Compatibility
 
-The Istio module is tested with Istio `1.4`. This module collects metrics from Istio microservices' Prometheus exporters.
+The Istio module is tested with Istio `1.4`.


### PR DESCRIPTION
## What does this PR do?
Updates Istio docs with the proper link to Istio monitoring page.

## Why is it important?
In order to point to the right version of Istio with which the module is currently compatible.