### PR TITLE
Always return a non nil instrumentation object

### DIFF
--- a/libbeat/instrumentation/instrumentation.go
+++ b/libbeat/instrumentation/instrumentation.go
@@ -168,7 +168,7 @@ func initTracer(cfg Config, beatName, beatVersion string) (*instrumentation, err
 	if !cfg.IsEnabled() {
 		os.Setenv("ELASTIC_APM_ACTIVE", "false")
 		logger.Infof("APM instrumentation is disabled")
-		return nil, nil
+		return &instrumentation{}, nil
 	} else {
 		os.Setenv("ELASTIC_APM_ACTIVE", "true")
 		logger.Infof("APM instrumentation is enabled")

--- a/libbeat/instrumentation/instrumentation_test.go
+++ b/libbeat/instrumentation/instrumentation_test.go
@@ -80,3 +80,15 @@ func TestAPMTracerDisabledByDefault(t *testing.T) {
 	require.NotNil(t, tracer)
 	assert.False(t, tracer.Active())
 }
+
+func TestInstrumentationDisabled(t *testing.T) {
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		"instrumentation": map[string]interface{}{
+			"enabled": "false",
+		},
+	})
+	instrumentation, err := New(cfg, "filebeat", version.GetDefaultVersion())
+	require.NoError(t, err)
+	require.NotNil(t, instrumentation)
+
+}


### PR DESCRIPTION

## What does this PR do?

Fixes a bug when instrumentation is explicitly disabled (not commented out).

## Why is it important?

Because otherwise it panics.

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run any beat with `-E instrumentation.enabled=false`

## Related issues

Fixes up #18360 