### PR TITLE
Cherry-pick #19359 to 7.x: Update compatibility note for Kubernetes module

### DIFF
--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -134,7 +134,7 @@ roleRef:
 [float]
 === Compatibility
 
-The Kubernetes module is tested with Kubernetes 1.13.x and 1.14.x
+The Kubernetes module is tested with Kubernetes 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, and 1.18.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -127,7 +127,7 @@ roleRef:
 [float]
 === Compatibility
 
-The Kubernetes module is tested with Kubernetes 1.13.x and 1.14.x
+The Kubernetes module is tested with Kubernetes 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, and 1.18.x
 
 [float]
 === Dashboard


### PR DESCRIPTION
Cherry-pick of PR #19359 to 7.x branch. Original message: 

## What does this PR do?
Updates compatibility note for Kubernetes module based on the versions we currently test on the CI at https://github.com/elastic/beats/blob/d5e9623c25c71fee4924f33633319ed462845c13/Jenkinsfile#L777
