### PR TITLE
Cherry-pick #19354 to 7.x: Fix Istio doc link to match version of Istio

### DIFF
--- a/metricbeat/docs/modules/istio.asciidoc
+++ b/metricbeat/docs/modules/istio.asciidoc
@@ -9,14 +9,14 @@ This file is generated! See scripts/mage/docs_collector.go
 beta[]
 
 This is the Istio module. The Istio module collects metrics from the
-Istio https://istio.io/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
+Istio https://istio.io/v1.4/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
 
 The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 
 [float]
 === Compatibility
 
-The Istio module is tested with Istio 1.4
+The Istio module is tested with Istio `1.4`.
 
 
 [float]

--- a/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
@@ -1,9 +1,9 @@
 This is the Istio module. The Istio module collects metrics from the
-Istio https://istio.io/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
+Istio https://istio.io/v1.4/docs/tasks/observability/metrics/querying-metrics/#about-the-prometheus-add-on[prometheus exporters endpoints].
 
 The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
 
 [float]
 === Compatibility
 
-The Istio module is tested with Istio 1.4
+The Istio module is tested with Istio `1.4`.


### PR DESCRIPTION
Cherry-pick of PR #19354 to 7.x branch. Original message: 

## What does this PR do?
Updates Istio docs with the proper link to Istio monitoring page.

## Why is it important?
In order to point to the right version of Istio with which the module is currently compatible.