### PR TITLE
[7.8] Update supported Kafka version in doc (#19016)

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -38,7 +38,7 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 [[kafka-compatibility]]
 ==== Compatibility
 
-This output works with all Kafka versions in between 0.11 and 2.1.0. Older versions
+This output works with all Kafka versions in between 0.11 and 2.2.2. Older versions
 might work as well, but are not supported.
 
 ==== Configuration options


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Update supported Kafka version in doc (#19016)