### PR TITLE
[WIP][docs] Add platform tabs to Elastic Agent docs

### DIFF
--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -6,80 +6,14 @@ experimental[]
 
 Download and install the Agent on each system you want to monitor.
 
-//TODO: Replace with tabbed panel when the code is stable. 
-
 // tag::install-elastic-agent[]
 
 To download and install {elastic-agent}, use the commands that work with your
 system:
 
-*mac:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
-----
-
-endif::[]
-
-*linux:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
-----
-
-endif::[]
-
-*win:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-. Download the {agent} Windows zip file from the
-https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
-
-. Extract the contents of the zip file into `C:\Program Files`.
-
-. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
-
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
-
-. From the PowerShell prompt, run the following commands to install Filebeat as a
-Windows service:
-+
-[source,shell]
-----
-PS > cd 'C:\Program Files\Elastic-Agent'
-PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
-----
-
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
-
-endif::[]
+include::tab-widgets/install-linux-mac-win-widget.asciidoc[]
 
 // end::install-elastic-agent[]
 
+// Add Javascript and CSS for tabbed panels
+include::{libbeat-dir}/tab-widgets/code.asciidoc[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -27,18 +27,15 @@ generate a token. See <<ingest-management-getting-started>> for detailed steps.
 
 . Enroll the Agent:
 +
-[source,shell]
-----
-./elastic-agent enroll http://localhost:5601 $token
-----
-+
-Where `$token` is an enrollment token acquired from {fleet}.
+--
+include::tab-widgets/enroll-linux-mac-win-widget.asciidoc[]
+--
 
-To start {agent}, run:
-[source,shell]
-----
-./elastic-agent run
-----
+. Start {agent}:
++
+--
+include::tab-widgets/run-linux-mac-win-widget.asciidoc[]
+--
 
 [float]
 [[standalone-mode]]
@@ -52,16 +49,15 @@ when you restart your system.
 
 To start {agent} manually, run:
 
-[source,shell]
-----
-./elastic-agent run
-----
+include::tab-widgets/run-standalone-linux-mac-win-widget.asciidoc[]
 
-If no configuration file is specified, {agent} uses the default configuration,
-`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
-the `-c` flag to use a different configuration file.
+Use the `-c` flag to specify the configuration file. If no configuration file is
+specified, {agent} uses the default configuration, `elastic-agent.yml`, which is
+located in the same directory as {agent}.
 
 For configuration options, see <<elastic-agent-configuration>>.
 
 //<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
 
+// Add Javascript and CSS for tabbed panels
+include::{libbeat-dir}/tab-widgets/code.asciidoc[]

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll-linux-mac-win-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll-linux-mac-win-widget.asciidoc
@@ -1,0 +1,58 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Enroll">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-enroll"
+            id="mac-enroll">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-enroll"
+            id="linux-enroll"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-enroll"
+            id="win-enroll"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-enroll"
+       aria-labelledby="mac-enroll">
+++++
+
+include::enroll.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-enroll"
+       aria-labelledby="linux-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-enroll"
+       aria-labelledby="win-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
@@ -1,0 +1,36 @@
+// tag::mac[]
+[source,shell]
+----
+./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+// tag::where[]
+Where `KIBANA_URL` is the {kib} URL where {fleet} is running, and
+`ENROLLMENT_KEY` is the enrollment token acquired from {fleet}.
+// end::where[]
+
+// end::mac[]
+
+// tag::linux[]
+[source,shell]
+----
+./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where]
+// end::linux[]
+
+// tag::win[]
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select **Run As Administrator**).
+
+From the PowerShell prompt, change to the directory where you installed {agent},
+and run:
+
+[source,shell]
+----
+.\elastic-agent.exe enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where]
+// end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/install-linux-mac-win-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install-linux-mac-win-widget.asciidoc
@@ -1,0 +1,58 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-install"
+            id="mac-install">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install"
+            id="linux-install"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install"
+            id="win-install"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install"
+       aria-labelledby="mac-install">
+++++
+
+include::install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install"
+       aria-labelledby="linux-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install"
+       aria-labelledby="win-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
@@ -1,0 +1,67 @@
+// tag::mac[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
+----
+
+endif::[]
+// end::mac[]
+
+// tag::linux[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
+----
+
+endif::[]
+// end::linux[]
+
+// tag::win[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {agent} Windows zip file from the
+https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install Filebeat as a
+Windows service:
++
+[source,shell]
+----
+cd 'C:\Program Files\Elastic-Agent'
+.\install-service-elastic-agent.ps1
+----
+
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
+
+endif::[]
+// end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/run-linux-mac-win-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run-linux-mac-win-widget.asciidoc
@@ -1,0 +1,58 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Run">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-run"
+            id="mac-run">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-run"
+            id="linux-run"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-run"
+            id="win-run"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-run"
+       aria-labelledby="mac-run">
+++++
+
+include::run.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-run"
+       aria-labelledby="linux-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-run"
+       aria-labelledby="win-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/run-standalone-linux-mac-win-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run-standalone-linux-mac-win-widget.asciidoc
@@ -1,0 +1,58 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Run standalone">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-run-standalone"
+            id="mac-run-standalone">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-run-standalone"
+            id="linux-run-standalone"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-run-standalone"
+            id="win-run-standalone"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-run-standalone"
+       aria-labelledby="mac-run-standalone">
+++++
+
+include::run.asciidoc[tag=mac-standalone]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-run-standalone"
+       aria-labelledby="linux-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=linux-standalone]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-run-standalone"
+       aria-labelledby="win-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=win-standalone]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
@@ -1,0 +1,55 @@
+// tag::mac[]
+[source,shell]
+----
+./elastic-agent run
+----
+// end::mac[]
+
+// tag::mac-standalone[]
+[source,shell]
+----
+./elastic-agent -c elastic-agent-standalone.yml run
+----
+// end::mac-standalone[]
+
+// tag::linux[]
+[source,shell]
+----
+./elastic-agent run
+----
+// end::linux[]
+
+// tag::linux-standalone[]
+[source,shell]
+----
+./elastic-agent -c elastic-agent-standalone.yml run
+----
+// end::linux-standalone[]
+
+// tag::win[]
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select **Run As Administrator**).
+
+From the PowerShell prompt, change to the directory where you installed {agent},
+and run:
+
+[source,shell]
+----
+.\elastic-agent.exe run
+----
+// end::win[]
+
+// tag::win-standalone[]
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select **Run As Administrator**).
+
+From the PowerShell prompt, change to the directory where you installed {agent},
+and run:
+
+[source,shell]
+----
+.\elastic-agent.exe -c elastic-agent-standalone.yml run
+----
+// end::win-standalone[]
+
+


### PR DESCRIPTION
Adds tabbed panels for displaying platform-specific commands and info.

This PR must be merged at the same time as https://github.com/elastic/observability-docs/pull/42.

To preview this content, you'll need to pull down both PRs and run the doc build locally. 
