### PR TITLE
[7.x] Add basic configuration for the APM tracer (#18861)

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -52,6 +52,8 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 ==== Added
 
+- Add configuration for APM instrumentation and expose the tracer trough the Beat object. {pull}17938[17938]
+- Make the behavior of clientWorker and netClientWorker consistent when error is returned from publisher pipeline
 - Metricset generator generates beta modules by default now. {pull}10657[10657]
 - The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
 - Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -327,6 +327,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Spooling to disk creates a lockfile on each platform. {pull}15338[15338]
 - Fingerprint processor adds a new xxhash hashing algorithm {pull}15418[15418]
 - Enable DEP (Data Execution Protection) for Windows packages. {pull}15149[15149]
+- Add configuration for APM instrumentation and expose the tracer trough the Beat object. {pull}17938[17938]
 - Add document_id setting to decode_json_fields processor. {pull}15859[15859]
 - Include network information by default on add_host_metadata and add_observer_metadata. {issue}15347[15347] {pull}16077[16077]
 - Add `aws_ec2` provider for autodiscover. {issue}12518[12518] {pull}14823[14823]

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1482,6 +1482,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the auditbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of auditbeat.
+    #enabled: false
+
+    # Environment in which auditbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -187,6 +187,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the auditbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of auditbeat.
+    #enabled: false
+
+    # Environment in which auditbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2204,6 +2204,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the filebeat.
+#instrumentation:
+    # Set to true to enable instrumentation of filebeat.
+    #enabled: false
+
+    # Environment in which filebeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -212,6 +212,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the filebeat.
+#instrumentation:
+    # Set to true to enable instrumentation of filebeat.
+    #enabled: false
+
+    # Environment in which filebeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1632,6 +1632,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the heartbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of heartbeat.
+    #enabled: false
+
+    # Environment in which heartbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -163,6 +163,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the heartbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of heartbeat.
+    #enabled: false
+
+    # Environment in which heartbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1424,6 +1424,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the journalbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of journalbeat.
+    #enabled: false
+
+    # Environment in which journalbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -188,6 +188,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the journalbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of journalbeat.
+    #enabled: false
+
+    # Environment in which journalbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/libbeat/_meta/config/default.reference.yml.tmpl
+++ b/libbeat/_meta/config/default.reference.yml.tmpl
@@ -19,4 +19,5 @@
 {{template "monitoring.reference.yml.tmpl" .}}
 {{template "http.reference.yml.tmpl" .}}
 {{template "seccomp.reference.yml.tmpl" .}}
+{{template "instrumentation.reference.yml.tmpl" .}}
 {{template "migration.yml.tmpl" .}}

--- a/libbeat/_meta/config/default.short.yml.tmpl
+++ b/libbeat/_meta/config/default.short.yml.tmpl
@@ -9,4 +9,5 @@
 {{template "processors.yml.tmpl" .}}
 {{template "logging.yml.tmpl" .}}
 {{template "monitoring.yml.tmpl" .}}
+{{template "instrumentation.yml.tmpl" .}}
 {{template "migration.yml.tmpl" .}}

--- a/libbeat/_meta/config/instrumentation.reference.yml.tmpl
+++ b/libbeat/_meta/config/instrumentation.reference.yml.tmpl
@@ -1,0 +1,34 @@
+{{header "Instrumentation"}}
+
+# Instrumentation support for the {{.BeatName}}.
+#instrumentation:
+    # Set to true to enable instrumentation of {{.BeatName}}.
+    #enabled: false
+
+    # Environment in which {{.BeatName}} is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s

--- a/libbeat/_meta/config/instrumentation.yml.tmpl
+++ b/libbeat/_meta/config/instrumentation.yml.tmpl
@@ -1,0 +1,21 @@
+{{header "Instrumentation"}}
+
+# Instrumentation support for the {{.BeatName}}.
+#instrumentation:
+    # Set to true to enable instrumentation of {{.BeatName}}.
+    #enabled: false
+
+    # Environment in which {{.BeatName}} is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -19,6 +19,7 @@ package beat
 
 import (
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/keystore"
 	"github.com/elastic/beats/v7/libbeat/management"
 )
@@ -70,6 +71,8 @@ type Beat struct {
 	Manager management.Manager // manager
 
 	Keystore keystore.Keystore
+
+	Instrumentation instrumentation.Instrumentation // instrumentation holds an APM agent for capturing and reporting traces
 }
 
 // BeatConfig struct contains the basic configuration of every beat

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -33,8 +33,6 @@ import (
 	"strings"
 	"time"
 
-	"go.elastic.co/apm"
-
 	"github.com/gofrs/uuid"
 	errw "github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -52,6 +50,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/dashboards"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
+	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/keystore"
 	"github.com/elastic/beats/v7/libbeat/kibana"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -97,11 +96,12 @@ type beatConfig struct {
 	Seccomp  *common.Config `config:"seccomp"`
 
 	// beat internal components configurations
-	HTTP          *common.Config `config:"http"`
-	Path          paths.Path     `config:"path"`
-	Logging       *common.Config `config:"logging"`
-	MetricLogging *common.Config `config:"logging.metrics"`
-	Keystore      *common.Config `config:"keystore"`
+	HTTP            *common.Config         `config:"http"`
+	Path            paths.Path             `config:"path"`
+	Logging         *common.Config         `config:"logging"`
+	MetricLogging   *common.Config         `config:"logging.metrics"`
+	Keystore        *common.Config         `config:"keystore"`
+	Instrumentation instrumentation.Config `config:"instrumentation"`
 
 	// output/publishing related configurations
 	Pipeline pipeline.Config `config:",inline"`
@@ -124,7 +124,6 @@ var debugf = logp.MakeDebug("beat")
 
 func init() {
 	initRand()
-	preventDefaultTracing()
 }
 
 // initRand initializes the runtime random number generator seed using
@@ -142,16 +141,6 @@ func initRand() {
 		seed = n.Int64()
 	}
 	rand.Seed(seed)
-}
-
-func preventDefaultTracing() {
-	// By default, the APM tracer is active. We switch behaviour to not require users to have
-	// an APM Server running, making it opt-in
-	if os.Getenv("ELASTIC_APM_ACTIVE") == "" {
-		os.Setenv("ELASTIC_APM_ACTIVE", "false")
-	}
-	// we need to close the default tracer to prevent the beat sending events to localhost:8200
-	apm.DefaultTracer.Close()
 }
 
 // Run initializes and runs a Beater implementation. name is the name of the
@@ -344,18 +333,12 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 			return nil, errors.New(msg)
 		}
 	}
-
-	tracer, err := apm.NewTracer(b.Info.Beat, b.Info.Version)
-	if err != nil {
-		return nil, err
-	}
-
 	pipeline, err := pipeline.Load(b.Info,
 		pipeline.Monitors{
 			Metrics:   reg,
 			Telemetry: monitoring.GetNamespace("state").GetRegistry(),
 			Logger:    logp.L().Named("publisher"),
-			Tracer:    tracer,
+			Tracer:    b.Instrumentation.Tracer(),
 		},
 		b.Config.Pipeline,
 		b.processing,
@@ -453,7 +436,11 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	svc.HandleSignals(beater.Stop, cancel)
+	var stopBeat = func() {
+		b.Instrumentation.Tracer().Close()
+		beater.Stop()
+	}
+	svc.HandleSignals(stopBeat, cancel)
 
 	err = b.loadDashboards(ctx, false)
 	if err != nil {
@@ -619,6 +606,12 @@ func (b *Beat) configure(settings Settings) error {
 		// TODO: Allow the options to be more flexible for dynamic changes
 		common.OverwriteConfigOpts(configOpts(store))
 	}
+
+	instrumentation, err := instrumentation.New(cfg, b.Info.Beat, b.Info.Version)
+	if err != nil {
+		return err
+	}
+	b.Beat.Instrumentation = instrumentation
 
 	b.keystore = store
 	b.Beat.Keystore = store

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -24,10 +24,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"go.elastic.co/apm"
-
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 
 	"github.com/gofrs/uuid"
@@ -118,11 +114,4 @@ func TestEmptyMetaJson(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Unable to load meta file properly")
 	assert.NotEqual(t, uuid.Nil, b.Info.ID, "Beats UUID is not set")
-}
-
-func TestAPMTracerDisabledByDefault(t *testing.T) {
-	tracer, err := apm.NewTracer("", "")
-	require.NoError(t, err)
-	defer tracer.Close()
-	assert.False(t, tracer.Active())
 }

--- a/libbeat/common/transport/pipelistener.go
+++ b/libbeat/common/transport/pipelistener.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+)
+
+// errListenerClosed is the error returned by the Accept
+// and DialContext methods of a closed listener.
+var errListenerClosed = errors.New("listener is closed")
+
+// PipeListener is a net.PipeListener that uses net.Pipe
+// It is only relevant for the APM Server instrumentation of itself
+type PipeListener struct {
+	conns     chan net.Conn
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// NewPipeListener returns a new PipeListener.
+func NewPipeListener() *PipeListener {
+	l := &PipeListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+	return l
+}
+
+// Close closes the listener.
+// This is part of the net.PipeListener interface.
+func (l *PipeListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
+}
+
+// Addr returns the listener's network address.
+// This is part of the net.listener interface.
+//
+// The returned address's network and value are always both
+// "pipe", the same as the addresses returned by net.Pipe
+// connections.
+func (l *PipeListener) Addr() net.Addr {
+	return pipeAddr{}
+}
+
+// Accept waits for and returns the next connection to the listener.
+// This is part of the net.listener address.
+func (l *PipeListener) Accept() (net.Conn, error) {
+	select {
+	case <-l.closed:
+		return nil, errListenerClosed
+	case conn := <-l.conns:
+		return conn, nil
+	}
+}
+
+// DialContext dials a connection to the listener, blocking until
+// a paired Accept call is made, the listener is closed, or the
+// context is canceled/expired.
+func (l *PipeListener) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	client, server := net.Pipe()
+	select {
+	case <-l.closed:
+		client.Close()
+		server.Close()
+		return nil, errListenerClosed
+	case <-ctx.Done():
+		client.Close()
+		server.Close()
+		return nil, ctx.Err()
+	case l.conns <- server:
+		return client, nil
+	}
+}
+
+type pipeAddr struct{}
+
+func (pipeAddr) Network() string {
+	return "pipe"
+}
+
+func (pipeAddr) String() string {
+	return "pipe"
+}

--- a/libbeat/common/transport/pipelistener_test.go
+++ b/libbeat/common/transport/pipelistener_test.go
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package transport
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+	assert.Implements(t, new(net.Listener), l)
+}
+
+func TestAddr(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+
+	addr := l.Addr()
+	assert.NotNil(t, addr)
+	assert.Equal(t, "pipe", addr.Network())
+	assert.Equal(t, "pipe", addr.String())
+}
+
+func TestDialAccept(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+
+	clientCh := make(chan net.Conn, 1)
+	go func() {
+		defer close(clientCh)
+		client, err := l.DialContext(context.Background(), "foo", "bar")
+		if assert.NoError(t, err) {
+			clientCh <- client
+		}
+	}()
+
+	server, err := l.Accept()
+	assert.NoError(t, err)
+	client := <-clientCh
+	defer server.Close()
+	defer client.Close()
+
+	hello := []byte("hello!")
+	go client.Write(hello)
+	buf := make([]byte, len(hello))
+	_, err = server.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, string(hello), string(buf))
+}
+
+func TestAcceptClosed(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+
+	err := l.Close()
+	assert.NoError(t, err)
+	_, err = l.Accept()
+	assert.Error(t, errListenerClosed, err)
+}
+
+func TestDialClosed(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+
+	err := l.Close()
+	assert.NoError(t, err)
+	_, err = l.DialContext(context.Background(), "foo", "bar")
+	assert.Error(t, errListenerClosed, err)
+}
+
+func TestDialContextCanceled(t *testing.T) {
+	l := NewPipeListener()
+	assert.NotNil(t, l)
+	defer l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := l.DialContext(ctx, "foo", "bar")
+	assert.Error(t, context.Canceled, err)
+}

--- a/libbeat/instrumentation/instrumentation.go
+++ b/libbeat/instrumentation/instrumentation.go
@@ -1,0 +1,244 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instrumentation
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"go.elastic.co/apm"
+	apmtransport "go.elastic.co/apm/transport"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/transport"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func init() {
+	// we need to close the default tracer to prevent the beat sending events to localhost:8200
+	apm.DefaultTracer.Close()
+}
+
+// Instrumentation is an interface that can return an APM tracer a net.listener
+type Instrumentation interface {
+	Tracer() *apm.Tracer
+	Listener() net.Listener
+}
+
+type instrumentation struct {
+	tracer   *apm.Tracer
+	listener net.Listener
+}
+
+// Tracer returns the configured tracer
+// If there is not configured tracer, it returns the DefaultTracer, which is always disabled
+func (t *instrumentation) Tracer() *apm.Tracer {
+	if t.tracer == nil {
+		return apm.DefaultTracer
+	}
+	return t.tracer
+}
+
+// Listener is only relevant for APM Server sending tracing data to itself
+// APM Server needs this listener to create an ad-hoc tracing server
+func (t *instrumentation) Listener() net.Listener {
+	return t.listener
+}
+
+// Config holds config information about self instrumenting the APM Server
+type Config struct {
+	Enabled     *bool           `config:"enabled"`
+	Environment *string         `config:"environment"`
+	Hosts       urls            `config:"hosts"`
+	Profiling   ProfilingConfig `config:"profiling"`
+	APIKey      string          `config:"api_key"`
+	SecretToken string          `config:"secret_token"`
+}
+
+type urls []*url.URL
+
+func (u *urls) Unpack(c interface{}) error {
+	if c == nil {
+		return nil
+	}
+	hosts, ok := c.([]interface{})
+	if !ok {
+		return fmt.Errorf("hosts must be a list, got: %#v", c)
+	}
+
+	nu := make(urls, len(hosts))
+	for i, host := range hosts {
+		h, ok := host.(string)
+		if !ok {
+			return fmt.Errorf("host must be a string, got: %#v", host)
+		}
+		url, err := url.Parse(h)
+		if err != nil {
+			return err
+		}
+		nu[i] = url
+	}
+	*u = nu
+
+	return nil
+}
+
+// ProfilingConfig holds config information about self profiling the APM Server
+type ProfilingConfig struct {
+	CPU  *CPUProfiling  `config:"cpu"`
+	Heap *HeapProfiling `config:"heap"`
+}
+
+// CPUProfiling holds config information about CPU profiling of the APM Server
+type CPUProfiling struct {
+	Enabled  bool          `config:"enabled"`
+	Interval time.Duration `config:"interval" validate:"positive"`
+	Duration time.Duration `config:"duration" validate:"positive"`
+}
+
+// IsEnabled indicates whether instrumentation is enabled
+func (c *Config) IsEnabled() bool {
+	return c != nil && c.Enabled != nil && *c.Enabled
+}
+
+// IsEnabled indicates whether CPU profiling is enabled
+func (p *CPUProfiling) IsEnabled() bool {
+	return p != nil && p.Enabled
+}
+
+// IsEnabled indicates whether heap profiling is enabled
+func (p *HeapProfiling) IsEnabled() bool {
+	return p != nil && p.Enabled
+}
+
+// HeapProfiling holds config information about heap profiling of the APM Server
+type HeapProfiling struct {
+	Enabled  bool          `config:"enabled"`
+	Interval time.Duration `config:"interval" validate:"positive"`
+}
+
+// New configures and returns an instrumentation object for tracing
+func New(cfg *common.Config, beatName, beatVersion string) (Instrumentation, error) {
+	if !cfg.HasField("instrumentation") {
+		return &instrumentation{}, nil
+	}
+
+	instrConfig, err := cfg.Child("instrumentation", -1)
+	if err != nil {
+		return &instrumentation{}, nil
+	}
+
+	config := Config{}
+
+	if instrConfig == nil {
+		instrConfig = common.NewConfig()
+	}
+	err = instrConfig.Unpack(&config)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not create tracer, err: %v", err)
+	}
+
+	return initTracer(config, beatName, beatVersion)
+}
+
+func initTracer(cfg Config, beatName, beatVersion string) (*instrumentation, error) {
+
+	logger := logp.NewLogger("tracing")
+
+	if !cfg.IsEnabled() {
+		os.Setenv("ELASTIC_APM_ACTIVE", "false")
+		logger.Infof("APM instrumentation is disabled")
+		return nil, nil
+	} else {
+		os.Setenv("ELASTIC_APM_ACTIVE", "true")
+		logger.Infof("APM instrumentation is enabled")
+	}
+
+	if cfg.Profiling.CPU.IsEnabled() {
+		interval := cfg.Profiling.CPU.Interval
+		duration := cfg.Profiling.CPU.Duration
+		logger.Infof("CPU profiling: every %s for %s", interval, duration)
+		os.Setenv("ELASTIC_APM_CPU_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
+		os.Setenv("ELASTIC_APM_CPU_PROFILE_DURATION", fmt.Sprintf("%dms", int(duration.Seconds()*1000)))
+	}
+	if cfg.Profiling.Heap.IsEnabled() {
+		interval := cfg.Profiling.Heap.Interval
+		logger.Infof("Heap profiling: every %s", interval)
+		os.Setenv("ELASTIC_APM_HEAP_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
+	}
+
+	var tracerTransport apmtransport.Transport
+	var tracerListener net.Listener
+
+	if cfg.Hosts == nil {
+		pipeListener := transport.NewPipeListener()
+		pipeTransport, err := apmtransport.NewHTTPTransport()
+		if err != nil {
+			return nil, err
+		}
+		pipeTransport.SetServerURL(&url.URL{Scheme: "http", Host: "localhost:8200"})
+		pipeTransport.Client.Transport = &http.Transport{
+			DialContext:     pipeListener.DialContext,
+			MaxIdleConns:    100,
+			IdleConnTimeout: 90 * time.Second,
+		}
+		tracerTransport = pipeTransport
+		// the traceListener will allow APM Server to create an ad-hoc server for tracing
+		tracerListener = pipeListener
+
+	} else {
+		t, err := apmtransport.NewHTTPTransport()
+		if err != nil {
+			return nil, err
+		}
+		if len(cfg.Hosts) > 0 {
+			t.SetServerURL(cfg.Hosts...)
+		}
+		if cfg.APIKey != "" {
+			t.SetAPIKey(cfg.APIKey)
+		} else {
+			t.SetSecretToken(cfg.SecretToken)
+		}
+		tracerTransport = t
+	}
+
+	var environment string
+	if cfg.Environment != nil {
+		environment = *cfg.Environment
+	}
+	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName:        beatName,
+		ServiceVersion:     beatVersion,
+		ServiceEnvironment: environment,
+		Transport:          tracerTransport,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tracer.SetLogger(logger)
+	return &instrumentation{
+		tracer:   tracer,
+		listener: tracerListener,
+	}, nil
+}

--- a/libbeat/instrumentation/instrumentation_test.go
+++ b/libbeat/instrumentation/instrumentation_test.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/version"
+)
+
+func TestInstrumentationConfig(t *testing.T) {
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		"instrumentation": map[string]interface{}{
+			"enabled": "true",
+		},
+	})
+	instrumentation, err := New(cfg, "my-beat", version.GetDefaultVersion())
+	require.NoError(t, err)
+
+	tracer := instrumentation.Tracer()
+	defer tracer.Close()
+	assert.True(t, tracer.Active())
+	assert.NotNil(t, instrumentation.Listener())
+}
+
+func TestInstrumentationConfigExplicitHosts(t *testing.T) {
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		"instrumentation": map[string]interface{}{
+			"enabled": "true",
+			"hosts":   []string{"localhost:8200"},
+		},
+	},
+	)
+	instrumentation, err := New(cfg, "my-beat", version.GetDefaultVersion())
+	require.NoError(t, err)
+	tracer := instrumentation.Tracer()
+	defer tracer.Close()
+	assert.True(t, tracer.Active())
+	assert.Nil(t, instrumentation.Listener())
+}
+
+func TestInstrumentationConfigListener(t *testing.T) {
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		"instrumentation": map[string]interface{}{
+			"enabled": "true",
+		},
+	})
+	instrumentation, err := New(cfg, "apm-server", version.GetDefaultVersion())
+	require.NoError(t, err)
+
+	tracer := instrumentation.Tracer()
+	defer tracer.Close()
+	assert.True(t, tracer.Active())
+	assert.NotNil(t, instrumentation.Listener())
+}
+
+func TestAPMTracerDisabledByDefault(t *testing.T) {
+	instrumentation, err := New(common.NewConfig(), "beat", "8.0")
+	require.NoError(t, err)
+	tracer := instrumentation.Tracer()
+	require.NotNil(t, tracer)
+	assert.False(t, tracer.Active())
+}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2248,6 +2248,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the metricbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of metricbeat.
+    #enabled: false
+
+    # Environment in which metricbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -160,6 +160,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the metricbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of metricbeat.
+    #enabled: false
+
+    # Environment in which metricbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1908,6 +1908,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the packetbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of packetbeat.
+    #enabled: false
+
+    # Environment in which packetbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -240,6 +240,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the packetbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of packetbeat.
+    #enabled: false
+
+    # Environment in which packetbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1404,6 +1404,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the winlogbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of winlogbeat.
+    #enabled: false
+
+    # Environment in which winlogbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -171,6 +171,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the winlogbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of winlogbeat.
+    #enabled: false
+
+    # Environment in which winlogbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1538,6 +1538,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the auditbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of auditbeat.
+    #enabled: false
+
+    # Environment in which auditbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -214,6 +214,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the auditbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of auditbeat.
+    #enabled: false
+
+    # Environment in which auditbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2945,6 +2945,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the filebeat.
+#instrumentation:
+    # Set to true to enable instrumentation of filebeat.
+    #enabled: false
+
+    # Environment in which filebeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -212,6 +212,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the filebeat.
+#instrumentation:
+    # Set to true to enable instrumentation of filebeat.
+    #enabled: false
+
+    # Environment in which filebeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1408,6 +1408,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the functionbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of functionbeat.
+    #enabled: false
+
+    # Environment in which functionbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -476,6 +476,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the functionbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of functionbeat.
+    #enabled: false
+
+    # Environment in which functionbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2681,6 +2681,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the metricbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of metricbeat.
+    #enabled: false
+
+    # Environment in which metricbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -160,6 +160,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the metricbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of metricbeat.
+    #enabled: false
+
+    # Environment in which metricbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1447,6 +1447,41 @@ logging.files:
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.
 #seccomp.enabled: true
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the winlogbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of winlogbeat.
+    #enabled: false
+
+    # Environment in which winlogbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+    # Enable profiling of the server, recording profile samples as events.
+    #
+    # This feature is experimental.
+    #profiling:
+        #cpu:
+            # Set to true to enable CPU profiling.
+            #enabled: false
+            #interval: 60s
+            #duration: 10s
+        #heap:
+            # Set to true to enable heap profiling.
+            #enabled: false
+            #interval: 60s
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -214,6 +214,28 @@ processors:
 # uncomment the following line.
 #monitoring.elasticsearch:
 
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the winlogbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of winlogbeat.
+    #enabled: false
+
+    # Environment in which winlogbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+    # APM Server hosts to report instrumentation results to.
+    #hosts:
+    #  - http://localhost:8200
+
+    # API Key for the APM Server(s).
+    # If api_key is set then secret_token will be ignored.
+    #api_key:
+
+    # Secret token for the APM Server(s).
+    #secret_token:
+
+
 # ================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add basic configuration for the APM tracer (#18861)