### PR TITLE
Cherry-pick #19356 to 7.x: Stream fields removed from injected configurations 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -190,16 +190,6 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 								},
 							},
 						},
-						{
-							"add_fields": map[string]interface{}{
-								"target": "stream",
-								"fields": map[string]interface{}{
-									"type":      "logs",
-									"dataset":   "agent",
-									"namespace": "default",
-								},
-							},
-						},
 					},
 				},
 			},
@@ -236,16 +226,6 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 								"fields": map[string]interface{}{
 									"type":      "metrics",
 									"name":      "agent",
-									"namespace": "default",
-								},
-							},
-						},
-						{
-							"add_fields": map[string]interface{}{
-								"target": "stream",
-								"fields": map[string]interface{}{
-									"type":      "metrics",
-									"dataset":   "agent",
 									"namespace": "default",
 								},
 							},

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
@@ -12,12 +12,6 @@ filebeat:
             type: logs
             name: generic
             namespace: default
-      - add_fields:
-          target: "stream"
-          fields:
-            type: logs
-            dataset: generic
-            namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
@@ -12,12 +12,6 @@ filebeat:
             type: logs
             name: generic
             namespace: default
-      - add_fields:
-          target: "stream"
-          fields:
-            type: logs
-            dataset: generic
-            namespace: default
 output:
   elasticsearch:
     enabled: true

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
@@ -13,12 +13,6 @@ filebeat:
             type: logs
             name: generic
             namespace: default
-      - add_fields:
-          target: "stream"
-          fields:
-            type: logs
-            dataset: generic
-            namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
@@ -14,12 +14,6 @@ filebeat:
             type: logs
             name: generic
             namespace: default
-      - add_fields:
-          target: "stream"
-          fields:
-            type: logs
-            dataset: generic
-            namespace: default
   - type: log
     paths:
       - /var/log/hello3.log
@@ -33,12 +27,6 @@ filebeat:
           fields:
             type: testtype
             name: generic
-            namespace: default
-      - add_fields:
-          target: "stream"
-          fields:
-            type: testtype
-            dataset: generic
             namespace: default
 output:
   elasticsearch:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
@@ -11,12 +11,6 @@ metricbeat:
           type: metrics
           name: docker.status
           namespace: default
-    - add_fields:
-        target: "stream"
-        fields:
-          type: metrics
-          dataset: docker.status
-          namespace: default
   - module: docker
     metricsets: [info]
     index: metrics-generic-default
@@ -27,12 +21,6 @@ metricbeat:
         fields:
           type: metrics
           name: generic
-          namespace: default
-    - add_fields:
-        target: "stream"
-        fields:
-          type: metrics
-          dataset: generic
           namespace: default
   - module: apache
     metricsets: [info]
@@ -47,12 +35,6 @@ metricbeat:
           fields:
             type: metrics
             name: generic
-            namespace: testing
-      - add_fields:
-          target: "stream"
-          fields:
-            type: metrics
-            dataset: generic
             namespace: testing
 
 output:

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -603,20 +603,6 @@ func (r *InjectStreamProcessorRule) Apply(ast *AST) error {
 
 			addFieldsMap := &Dict{value: []Node{&Key{"add_fields", processorMap}}}
 			processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, addFieldsMap)
-
-			// add this for backwards compatibility remove later
-			streamProcessorMap := &Dict{value: make([]Node, 0)}
-			streamProcessorMap.value = append(streamProcessorMap.value, &Key{name: "target", value: &StrVal{value: "stream"}})
-			streamProcessorMap.value = append(streamProcessorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
-				&Key{name: "type", value: &StrVal{value: datasetType}},
-				&Key{name: "namespace", value: &StrVal{value: namespace}},
-				&Key{name: "dataset", value: &StrVal{value: dataset}},
-			}}})
-
-			streamAddFieldsMap := &Dict{value: []Node{&Key{"add_fields", streamProcessorMap}}}
-
-			processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, streamAddFieldsMap)
-			// end of backward compatibility section
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #19356 to 7.x branch. Original message:

## What does this PR do?

Followup to #19128 removes stream.* fields from being injected into events as a add_fields processor.

## Why is it important?

Migrated to dataset.* fields

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
