### PR TITLE
Cherry-pick #19390 to 7.x: Removed unwanted Println's 

### DIFF
--- a/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
@@ -112,7 +112,7 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 			errors.TypeNetwork,
 			errors.M(errors.MetaKeyURI, cp))
 	}
-	fmt.Println(string(rs))
+
 	if err := checkinResponse.Validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick of PR #19390 to 7.x branch. Original message:

## What does this PR do?

removes debug messages

## Why is it important?

to not leak any sensitive information

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
