### PR TITLE
Cherry-pick #19346 to 7.8: Add additional time formats to decode_cef

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -276,6 +276,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for array parsing in azure-eventhub input. {pull}18585[18585]
 from being added to events by default. {pull}18159[18159]
 - Improved performance of PANW sample dashboards. {issue}19031[19031] {pull}19032[19032]
+- Add support for timezone offsets and `Z` to decode_cef timestamp parser. {pull}19346[19346]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/processors/decode_cef/cef/types.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types.go
@@ -103,18 +103,33 @@ func toMACAddress(v string) (string, error) {
 var timeLayouts = []string{
 	// MMM dd HH:mm:ss.SSS zzz
 	"Jan _2 15:04:05.000 MST",
+	"Jan _2 15:04:05.000 Z0700",
+	"Jan _2 15:04:05.000 Z07:00",
+
 	// MMM dd HH:mm:sss.SSS
 	"Jan _2 15:04:05.000",
+
 	// MMM dd HH:mm:ss zzz
 	"Jan _2 15:04:05 MST",
+	"Jan _2 15:04:05 Z0700",
+	"Jan _2 15:04:05 Z07:00",
+
 	// MMM dd HH:mm:ss
 	"Jan _2 15:04:05",
+
 	// MMM dd yyyy HH:mm:ss.SSS zzz
 	"Jan _2 2006 15:04:05.000 MST",
+	"Jan _2 2006 15:04:05.000 Z0700",
+	"Jan _2 2006 15:04:05.000 Z07:00",
+
 	// MMM dd yyyy HH:mm:ss.SSS
 	"Jan _2 2006 15:04:05.000",
+
 	// MMM dd yyyy HH:mm:ss zzz
 	"Jan _2 2006 15:04:05 MST",
+	"Jan _2 2006 15:04:05 Z0700",
+	"Jan _2 2006 15:04:05 Z07:00",
+
 	// MMM dd yyyy HH:mm:ss
 	"Jan _2 2006 15:04:05",
 }

--- a/x-pack/filebeat/processors/decode_cef/cef/types_test.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types_test.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cef
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToTimestamp(t *testing.T) {
+	var times = []string{
+		// Unix epoch in milliseconds.
+		"1322004689000",
+
+		// MMM dd HH:mm:ss.SSS zzz
+		"Jun 23 17:37:24.000 Z",
+		"Jun 23 17:37:24.000 EST",
+		"Jun 23 17:37:24.000 +05",
+		"Jun 23 17:37:24.000 +0500",
+		"Jun 23 17:37:24.000 +05:00",
+
+		// MMM dd HH:mm:sss.SSS
+		"Jun 23 17:37:24.000",
+
+		// MMM dd HH:mm:ss zzz
+		"Jun 23 17:37:24 Z",
+		"Jun 23 17:37:24 EST",
+		"Jun 23 17:37:24 +05",
+		"Jun 23 17:37:24 +0500",
+		"Jun 23 17:37:24 +05:00",
+
+		// MMM dd HH:mm:ss
+		"Jun 23 17:37:24",
+
+		// MMM dd yyyy HH:mm:ss.SSS zzz
+		"Jun 23 2020 17:37:24.000 Z",
+		"Jun 23 2020 17:37:24.000 EST",
+		"Jun 23 2020 17:37:24.000 +05",
+		"Jun 23 2020 17:37:24.000 +0500",
+		"Jun 23 2020 17:37:24.000 +05:00",
+
+		// MMM dd yyyy HH:mm:ss.SSS
+		"Jun 23 2020 17:37:24.000",
+
+		// MMM dd yyyy HH:mm:ss zzz
+		"Jun 23 2020 17:37:24 Z",
+		"Jun 23 2020 17:37:24 EST",
+		"Jun 23 2020 17:37:24 +05",
+		"Jun 23 2020 17:37:24 +0500",
+		"Jun 23 2020 17:37:24 +05:00",
+
+		// MMM dd yyyy HH:mm:ss
+		"Jun 23 2020 17:37:24",
+	}
+
+	for _, timeValue := range times {
+		_, err := toTimestamp(timeValue)
+		assert.NoError(t, err, timeValue)
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #19346 to 7.8 branch. Original message: 

## What does this PR do?

The date formats in the CEF guide describe the time formats in terms of Java's SimpleTimeFormat class.
The `zzz` specifier covers a few additional formats than what are covered by `MST` in Go's time format.
Namely on the Go side it was missing support for offsets (e.g. +04, +0400, +04:00). This change additionally
adds support for the ISO8601 `Z` time zone value (this does not strictly match the CEF guide's format).

For reference these are the Java SimpleDateFormats in the CEF guide:

MMM dd HH:mm:ss.SSS zzz
MMM dd HH:mm:sss.SSS
MMM dd HH:mm:ss zzz
MMM dd HH:mm:ss
MMM dd yyyy HH:mm:ss.SSS zzz
MMM dd yyyy HH:mm:ss.SSS
MMM dd yyyy HH:mm:ss zzz
MMM dd yyyy HH:mm:ss

## Why is it important?

It makes the decode_cef parser more closely match the CEF guide specification.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


