### PR TITLE
Input v2 compatibility layer

### DIFF
--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -24,13 +24,14 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/mitchellh/hashstructure"
+
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert"
-	"github.com/mitchellh/hashstructure"
 )
 
 // factory implements the cfgfile.RunnerFactory interface and wraps the

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package compat provides helpers for integrating the input/v2 API with
+// existing input based features like autodiscovery, config file reloading, or
+// filebeat modules.
+package compat
+
+import (
+	"sync"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/go-concert"
+)
+
+// factory implements the cfgfile.RunnerFactory interface and wraps the
+// v2.Loader to create cfgfile.Runner instances based on available v2 inputs.
+type factory struct {
+	log    *logp.Logger
+	info   beat.Info
+	loader *v2.Loader
+}
+
+// runner wraps a v2.Input, starting a go-routine
+// On start the runner spawns a go-routine that will call (v2.Input).Run with
+// the `sig` setup for shutdown signaling.
+// On stop the runner triggers the shutdown signal and waits until the input
+// has returned.
+type runner struct {
+	log       *logp.Logger
+	agent     *beat.Info
+	wg        sync.WaitGroup
+	sig       *concert.OnceSignaler
+	input     v2.Input
+	connector beat.PipelineConnector
+}
+
+// RunnerFactory creates a cfgfile.RunnerFactory from an input Loader that is
+// compatible with config file based input reloading, autodiscovery, and filebeat modules.
+// The RunnerFactory is can be used to integrate v2 inputs into existing Beats.
+func RunnerFactory(
+	log *logp.Logger,
+	info beat.Info,
+	loader *v2.Loader,
+) cfgfile.RunnerFactory {
+	return &factory{log: log, info: info, loader: loader}
+}
+
+func (f *factory) CheckConfig(cfg *common.Config) error {
+	_, err := f.loader.Configure(cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *factory) Create(
+	p beat.PipelineConnector,
+	config *common.Config,
+) (cfgfile.Runner, error) {
+	input, err := f.loader.Configure(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runner{
+		log:       f.log.Named(input.Name()),
+		agent:     &f.info,
+		sig:       concert.NewOnceSignaler(),
+		input:     input,
+		connector: p,
+	}, nil
+}
+
+func (r *runner) String() string { return r.input.Name() }
+
+func (r *runner) Start() {
+	log := r.log
+	name := r.input.Name()
+
+	go func() {
+		log.Infof("Input %v starting", name)
+		err := r.input.Run(
+			v2.Context{
+				ID:          "", // TODO: hmmm....
+				Agent:       *r.agent,
+				Logger:      log,
+				Cancelation: r.sig,
+			},
+			r.connector,
+		)
+		if err != nil {
+			log.Errorf("Input '%v' failed with: %+v", name, err)
+		} else {
+			log.Infof("Input '%v' stopped", name)
+		}
+	}()
+}
+
+func (r *runner) Stop() {
+	r.sig.Trigger()
+	r.wg.Wait()
+	r.log.Infof("Input '%v' stopped", r.input.Name())
+}

--- a/filebeat/input/v2/compat/compat_test.go
+++ b/filebeat/input/v2/compat/compat_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compat
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/filebeat/input/v2/internal/inputest"
+)
+
+func TestRunnerFactory_CheckConfig(t *testing.T) {
+	t.Run("does not run or test configured input", func(t *testing.T) {
+		log := logp.NewLogger("test")
+		var countConfigure, countTest, countRun int
+
+		// setup
+		plugins := inputest.SinglePlugin("test", &inputest.MockInputManager{
+			OnConfigure: func(_ *common.Config) (v2.Input, error) {
+				countConfigure++
+				return &inputest.MockInput{
+					OnTest: func(_ v2.TestContext) error { countTest++; return nil },
+					OnRun:  func(_ v2.Context, _ beat.PipelineConnector) error { countRun++; return nil },
+				}, nil
+			},
+		})
+		loader := inputest.MustNewTestLoader(t, plugins, "type", "test")
+		factory := RunnerFactory(log, beat.Info{}, loader.Loader)
+
+		// run
+		err := factory.CheckConfig(common.NewConfig())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// validate: configured an input, but do not run test or run
+		assert.Equal(t, 1, countConfigure)
+		assert.Equal(t, 0, countTest)
+		assert.Equal(t, 0, countRun)
+	})
+
+	t.Run("fail if input type is unknown to loader", func(t *testing.T) {
+		log := logp.NewLogger("test")
+		plugins := inputest.SinglePlugin("test", inputest.ConstInputManager(nil))
+		loader := inputest.MustNewTestLoader(t, plugins, "type", "")
+		factory := RunnerFactory(log, beat.Info{}, loader.Loader)
+
+		// run
+		err := factory.CheckConfig(common.MustNewConfigFrom(map[string]interface{}{
+			"type": "unknown",
+		}))
+		assert.Error(t, err)
+	})
+}
+
+func TestRunnerFactory_CreateAndRun(t *testing.T) {
+	t.Run("runner can correctly start and stop inputs", func(t *testing.T) {
+		log := logp.NewLogger("test")
+		var countRun int
+		var wg sync.WaitGroup
+		plugins := inputest.SinglePlugin("test", inputest.ConstInputManager(&inputest.MockInput{
+			OnRun: func(ctx v2.Context, _ beat.PipelineConnector) error {
+				defer wg.Done()
+				countRun++
+				<-ctx.Cancelation.Done()
+				return nil
+			},
+		}))
+		loader := inputest.MustNewTestLoader(t, plugins, "type", "test")
+		factory := RunnerFactory(log, beat.Info{}, loader.Loader)
+
+		runner, err := factory.Create(nil, common.MustNewConfigFrom(map[string]interface{}{
+			"type": "test",
+		}))
+		require.NoError(t, err)
+
+		wg.Add(1)
+		runner.Start()
+		runner.Stop()
+		wg.Wait()
+		assert.Equal(t, 1, countRun)
+	})
+
+	t.Run("fail if input type is unknown to loader", func(t *testing.T) {
+		log := logp.NewLogger("test")
+		plugins := inputest.SinglePlugin("test", inputest.ConstInputManager(nil))
+		loader := inputest.MustNewTestLoader(t, plugins, "type", "")
+		factory := RunnerFactory(log, beat.Info{}, loader.Loader)
+
+		// run
+		runner, err := factory.Create(nil, common.MustNewConfigFrom(map[string]interface{}{
+			"type": "unknown",
+		}))
+		assert.Nil(t, runner)
+		assert.Error(t, err)
+	})
+}

--- a/filebeat/input/v2/compat/composed.go
+++ b/filebeat/input/v2/compat/composed.go
@@ -32,15 +32,13 @@ type composeFactory struct {
 	fallback cfgfile.RunnerFactory
 }
 
-var _ cfgfile.RunnerFactory = composeFactory{}
-
 // Combine takes two RunnerFactory instances and creates a new RunnerFactory.
 // The new factory will first try to create an input using factory. If this operation fails fallback will be used.
 //
 // The new RunnerFactory will return the error of fallback only if factory did
 // signal that the input type is unknown via v2.ErrUnknown.
 //
-// XXX: This RunnerFactory is used for compining the v2.Loader with the
+// XXX: This RunnerFactory is used for combining the v2.Loader with the
 // existing RunnerFactory for inputs in Filebeat. The Combine function should be removed once the old RunnerFactory is removed.
 func Combine(factory, fallback cfgfile.RunnerFactory) cfgfile.RunnerFactory {
 	return composeFactory{factory: factory, fallback: fallback}

--- a/filebeat/input/v2/compat/composed.go
+++ b/filebeat/input/v2/compat/composed.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compat
+
+import (
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+// composeFactory combines to factories. Instances are created using the Combine function.
+// For each operation the configured factory will be tried first. If the
+// operation failed (for example the input type is unknown) the fallback factory is tried.
+type composeFactory struct {
+	factory  cfgfile.RunnerFactory
+	fallback cfgfile.RunnerFactory
+}
+
+var _ cfgfile.RunnerFactory = composeFactory{}
+
+// Combine takes two RunnerFactory instances and creates a new RunnerFactory.
+// The new factory will first try to create an input using factory. If this operation fails fallback will be used.
+//
+// The new RunnerFactory will return the error of fallback only if factory did
+// signal that the input type is unknown via v2.ErrUnknown.
+//
+// XXX: This RunnerFactory is used for compining the v2.Loader with the
+// existing RunnerFactory for inputs in Filebeat. The Combine function should be removed once the old RunnerFactory is removed.
+func Combine(factory, fallback cfgfile.RunnerFactory) cfgfile.RunnerFactory {
+	return composeFactory{factory: factory, fallback: fallback}
+}
+
+func (f composeFactory) CheckConfig(cfg *common.Config) error {
+	err := f.factory.CheckConfig(cfg)
+	if !v2.IsUnknownInputError(err) {
+		return err
+	}
+	return f.fallback.CheckConfig(cfg)
+}
+
+func (f composeFactory) Create(
+	p beat.PipelineConnector,
+	config *common.Config,
+) (cfgfile.Runner, error) {
+	var runner cfgfile.Runner
+	var err1, err2 error
+
+	runner, err1 = f.factory.Create(p, config)
+	if err1 == nil {
+		return runner, nil
+	}
+
+	runner, err2 = f.fallback.Create(p, config)
+	if err2 == nil {
+		return runner, nil
+	}
+
+	// return err2 only if err1 indicates that the input type is not known to f.factory
+	if v2.IsUnknownInputError(err1) {
+		return nil, err2
+	}
+	return nil, err1
+}

--- a/filebeat/input/v2/compat/composed_test.go
+++ b/filebeat/input/v2/compat/composed_test.go
@@ -1,0 +1,202 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compat
+
+import (
+	"errors"
+	"testing"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+type fakeRunnerFactory struct {
+	OnCheck  func(*common.Config) error
+	OnCreate func(beat.PipelineConnector, *common.Config) (cfgfile.Runner, error)
+}
+
+type fakeRunner struct {
+	Name    string
+	OnStart func()
+	OnStop  func()
+}
+
+func TestCombine_CheckConfig(t *testing.T) {
+	oops1 := errors.New("oops1")
+	oops2 := errors.New("oops2")
+
+	cases := map[string]struct {
+		factory, fallback cfgfile.RunnerFactory
+		want              error
+	}{
+		"success": {
+			factory:  failingRunnerFactory(nil),
+			fallback: failingRunnerFactory(nil),
+			want:     nil,
+		},
+		"fail if factory fails already": {
+			factory:  failingRunnerFactory(oops1),
+			fallback: failingRunnerFactory(oops2),
+			want:     oops1,
+		},
+		"do not fail in fallback if factory is fine": {
+			factory:  failingRunnerFactory(nil),
+			fallback: failingRunnerFactory(oops2),
+			want:     nil,
+		},
+		"ignore ErrUnknownInput and use check from fallback": {
+			factory:  failingRunnerFactory(v2.ErrUnknownInput),
+			fallback: failingRunnerFactory(oops2),
+			want:     oops2,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			factory := Combine(test.factory, test.fallback)
+			cfg := common.MustNewConfigFrom(struct{ Type string }{"test"})
+			err := factory.CheckConfig(cfg)
+			if test.want != err {
+				t.Fatalf("Failed. Want: %v, Got: %v", test.want, err)
+			}
+		})
+	}
+
+}
+
+func TestCombine_Create(t *testing.T) {
+	type validation func(*testing.T, cfgfile.Runner, error)
+
+	wantError := func(want error) validation {
+		return func(t *testing.T, _ cfgfile.Runner, got error) {
+			if want != got {
+				t.Fatalf("Wrong error. Want: %v, Got: %v", want, got)
+			}
+		}
+	}
+
+	wantRunner := func(want cfgfile.Runner) validation {
+		return func(t *testing.T, got cfgfile.Runner, err error) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != want {
+				t.Fatalf("Wrong runner. Want: %v Got: %v", want, got)
+			}
+		}
+	}
+
+	runner1 := &fakeRunner{Name: "runner1"}
+	runner2 := &fakeRunner{Name: "runner2"}
+	oops1 := errors.New("oops1")
+	oops2 := errors.New("oops2")
+
+	cases := map[string]struct {
+		factory  cfgfile.RunnerFactory
+		fallback cfgfile.RunnerFactory
+		Type     string
+		check    validation
+	}{
+		"runner exsits in factory only": {
+			factory:  constRunnerFactory(runner1),
+			fallback: failingRunnerFactory(oops2),
+			check:    wantRunner(runner1),
+		},
+		"runner exists in fallback only": {
+			factory:  failingRunnerFactory(v2.ErrUnknownInput),
+			fallback: constRunnerFactory(runner2),
+			check:    wantRunner(runner2),
+		},
+		"runner from factory has higher priority": {
+			factory:  constRunnerFactory(runner1),
+			fallback: constRunnerFactory(runner2),
+			check:    wantRunner(runner1),
+		},
+		"if both fail return error from factory": {
+			factory:  failingRunnerFactory(oops1),
+			fallback: failingRunnerFactory(oops2),
+			check:    wantError(oops1),
+		},
+		"ignore ErrUnknown": {
+			factory:  failingRunnerFactory(v2.ErrUnknownInput),
+			fallback: failingRunnerFactory(oops2),
+			check:    wantError(oops2),
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			factory := Combine(test.factory, test.fallback)
+			cfg := common.MustNewConfigFrom(struct{ Type string }{test.Type})
+			runner, err := factory.Create(nil, cfg)
+			test.check(t, runner, err)
+		})
+	}
+}
+
+// Create creates a new Runner based on the given configuration.
+func (f *fakeRunnerFactory) Create(p beat.PipelineConnector, config *common.Config) (cfgfile.Runner, error) {
+	if f.OnCreate == nil {
+		return nil, errors.New("not implemented")
+	}
+	return f.OnCreate(p, config)
+}
+
+// CheckConfig tests if a confiugation can be used to create an input. If it
+// is not possible to create an input using the configuration, an error must
+// be returned.
+func (f *fakeRunnerFactory) CheckConfig(config *common.Config) error {
+	if f.OnCheck == nil {
+		return errors.New("not implemented")
+	}
+	return f.OnCheck(config)
+}
+
+func (f *fakeRunner) String() string { return f.Name }
+func (f *fakeRunner) Start() {
+	if f.OnStart != nil {
+		f.OnStart()
+	}
+}
+
+func (f *fakeRunner) Stop() {
+	if f.OnStop != nil {
+		f.OnStop()
+	}
+}
+
+func constRunnerFactory(runner cfgfile.Runner) cfgfile.RunnerFactory {
+	return &fakeRunnerFactory{
+		OnCreate: func(_ beat.PipelineConnector, _ *common.Config) (cfgfile.Runner, error) {
+			return runner, nil
+		},
+	}
+}
+
+func failingRunnerFactory(err error) cfgfile.RunnerFactory {
+	return &fakeRunnerFactory{
+		OnCheck: func(_ *common.Config) error { return err },
+
+		OnCreate: func(_ beat.PipelineConnector, _ *common.Config) (cfgfile.Runner, error) {
+			return nil, err
+		},
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

This change introduces the input/v2/compat package, that provides a
compatibility layer for integration the input v2 API into existing beats
functionality.
The package provides a function for wrapping v2 inputs into a
cfgfile.RunnerFactory (used by autodiscovery, filebet module loading,
config file reloading, ....).

The current state of the full implementation can be seen [here](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/input/v2) and [sample inputs based on the new API](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/features/input).

The full list of changes will include:
- Introduce v2 API interfaces
- Introduce [compatibility layer](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/input/v2/compat) to integrate API with existing functionality 
- Introduce helpers for writing [stateless](https://github.com/urso/beats/blob/fb-input-v2-combined/filebeat/input/v2/input-stateless/stateless.go) inputs.
- Introduce helpers for writing [inputs that store a state](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/input/v2/input-cursor) between restarts.
- Integrate new API with [existing inputs and modules](https://github.com/urso/beats/blob/fb-input-v2-combined/filebeat/beater/filebeat.go#L301) in filebeat.

Test coverage report:

```
gocov test ./... | gocov report
ok  	github.com/elastic/beats/v7/filebeat/input/v2/compat	0.009s	coverage: 94.6% of statements

github.com/elastic/beats/v7/filebeat/input/v2/compat/composed.go composeFactory.Create		 100.00% (11/11)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 factory.CheckConfig		 100.00% (4/4)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 factory.Create			 100.00% (4/4)
github.com/elastic/beats/v7/filebeat/input/v2/compat/composed.go composeFactory.CheckConfig	 100.00% (4/4)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 runner.Stop			 100.00% (3/3)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 runner.Start			 100.00% (3/3)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 RunnerFactory			 100.00% (1/1)
github.com/elastic/beats/v7/filebeat/input/v2/compat/composed.go Combine			 100.00% (1/1)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 @99:5				 80.00% (4/5)
github.com/elastic/beats/v7/filebeat/input/v2/compat/compat.go	 runner.String			 0.00% (0/1)
github.com/elastic/beats/v7/filebeat/input/v2/compat		 --------------------------	 94.59% (35/37)
```

## Why is it important?

This PR only introduces the compatiblity layer which will allow use to use new input with existing Beats functionality, but also run new and old architecture in parallel.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#15324 