### PR TITLE
updated elasticsearch module to use new nullcheck in set processors

### DIFF
--- a/filebeat/module/elasticsearch/audit/ingest/pipeline-json.yml
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline-json.yml
@@ -57,13 +57,12 @@ processors:
     field: url.query
     path: elasticsearch.audit
 - set:
-    if: ctx.elasticsearch.audit?.url?.path != null && ctx.elasticsearch.audit?.url?.query
-      == null
+    if: ctx.elasticsearch.audit?.url?.query == null
     field: url.original
     value: '{{elasticsearch.audit.url.path}}'
+    ignore_empty_value: true
 - set:
-    if: ctx.elasticsearch.audit?.url?.path != null && ctx.elasticsearch.audit?.url?.query
-      != null
+    if: ctx.elasticsearch.audit?.url?.path != null && ctx.elasticsearch.audit?.url?.query != null
     field: url.original
     value: '{{elasticsearch.audit.url.path}}?{{elasticsearch.audit.url.query}}'
 - remove:

--- a/filebeat/module/elasticsearch/audit/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline.yml
@@ -43,11 +43,11 @@ processors:
 - set:
     field: host.id
     value: "{{elasticsearch.node.id}}"
-    if: "ctx?.elasticsearch?.node?.id != null"
+    ignore_empty_value: true
 - set:
     field: host.name
     value: "{{elasticsearch.node.name}}"
-    if: "ctx?.elasticsearch?.node?.name != null"
+    ignore_empty_value: true
 - append:
     field: related.user
     value: "{{user.name}}"

--- a/filebeat/module/elasticsearch/deprecation/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/deprecation/ingest/pipeline.yml
@@ -27,11 +27,11 @@ processors:
 - set:
     field: host.id
     value: "{{elasticsearch.node.id}}"
-    if: "ctx?.elasticsearch?.node?.id != null"
+    ignore_empty_value: true
 - set:
     field: host.name
     value: "{{elasticsearch.node.name}}"
-    if: "ctx?.elasticsearch?.node?.name != null"
+    ignore_empty_value: true
 - remove:
     field:
     - elasticsearch.deprecation.timestamp

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.yml
@@ -67,11 +67,11 @@ processors:
 - set:
     field: host.name
     value: "{{elasticsearch.node.name}}"
-    if: "ctx?.elasticsearch?.node?.name != null"
+    ignore_empty_value: true
 - set:
     field: host.id
     value: "{{elasticsearch.node.id}}"
-    if: "ctx?.elasticsearch?.node?.id != null"
+    ignore_empty_value: true
 - remove:
     field:
     - elasticsearch.server.gc.collection_duration.time

--- a/filebeat/module/elasticsearch/slowlog/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/slowlog/ingest/pipeline.yml
@@ -49,11 +49,11 @@ processors:
 - set:
     field: host.name
     value: "{{elasticsearch.node.name}}"
-    if: "ctx?.elasticsearch?.node?.name != null"
+    ignore_empty_value: true
 - set:
     field: host.id
     value: "{{elasticsearch.node.id}}"
-    if: "ctx?.elasticsearch?.node?.id != null"
+    ignore_empty_value: true
 - remove:
     field:
     - first_char


### PR DESCRIPTION
## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
