### PR TITLE
updated coredns module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/coredns/log/ingest/pipeline-entry.yml
+++ b/x-pack/filebeat/module/coredns/log/ingest/pipeline-entry.yml
@@ -34,7 +34,7 @@ processors:
   - set:
       field: source.ip
       value: "{{source.address}}"
-      if: ctx.source?.address != null
+      ignore_empty_value: true
   - convert:
       field: source.port
       type: integer
@@ -73,25 +73,25 @@ processors:
   # namespace to avoid introducing breaking change. This should be removed
   # for 8.0.0. Additionally coredns.dnssec_ok can be removed.
   - set:
-      if: ctx.dns?.id != null
       field: coredns.id
       value: '{{dns.id}}'
+      ignore_empty_value: true
   - set:
-      if: ctx.dns?.question?.class != null
       field: coredns.query.class
       value: '{{dns.question.class}}'
+      ignore_empty_value: true
   - set:
-      if: ctx.dns?.question?.name != null
       field: coredns.query.name
       value: '{{dns.question.name}}'
+      ignore_empty_value: true
   - set:
-      if: ctx.dns?.question?.type != null
       field: coredns.query.type
       value: '{{dns.question.type}}'
+      ignore_empty_value: true
   - set:
-      if: ctx.dns?.response_code != null
       field: coredns.response.code
       value: '{{dns.response_code}}'
+      ignore_empty_value: true
   - script:
       if: ctx.dns?.header_flags != null
       lang: painless


### PR DESCRIPTION
## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
