### PR TITLE
updated iptables module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -240,19 +240,19 @@ processors:
 - set:
     field: observer.egress.zone
     value: "{{iptables.ubiquiti.output_zone}}"
-    if: ctx?.iptables?.ubiquiti?.output_zone != null
+    ignore_empty_value: true
 - set:
     field: observer.ingress.zone
     value: "{{iptables.ubiquiti.input_zone}}"
-    if: ctx?.iptables?.ubiquiti?.input_zone != null
+    ignore_empty_value: true
 - set:
     field: rule.id
     value: "{{iptables.ubiquiti.rule_number}}"
-    if: ctx?.iptables?.ubiquiti?.rule_number != null
+    ignore_empty_value: true
 - set:
     field: rule.name
     value: "{{iptables.ubiquiti.rule_set}}"
-    if: ctx?.iptables?.ubiquiti?.rule_set != null
+    ignore_empty_value: true
 on_failure:
 - set:
     field: error.message


### PR DESCRIPTION
## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
