### PR TITLE
[CI] Move jobs to the beats repository

### DIFF
--- a/.ci/jobs/apm-beats-update.yml
+++ b/.ci/jobs/apm-beats-update.yml
@@ -1,8 +1,7 @@
 - job:
-    name: 'apm-beats-update'
+    name: Beats/apm-beats-update
     display-name: 'APM Server Beats update'
     description: 'Check if the Beats lib update works on the APM server master branch'
-    folder: 'Beats'
     view: Beats
     concurrent: true
     project-type: multibranch
@@ -35,7 +34,7 @@
             ignore-tags-older-than: -1
             ignore-tags-newer-than: -1
         - named-branches:
-            - exact-name: 
+            - exact-name:
                 name: 'master'
                 case-sensitive: true
             - regex-name:

--- a/.ci/jobs/apm-beats-update.yml
+++ b/.ci/jobs/apm-beats-update.yml
@@ -1,0 +1,63 @@
+- job:
+    name: 'apm-beats-update'
+    display-name: 'APM Server Beats update'
+    description: 'Check if the Beats lib update works on the APM server master branch'
+    folder: 'Beats'
+    view: Beats
+    concurrent: true
+    project-type: multibranch
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true
+    number-to-keep: 10
+    days-to-keep: 30
+    script-path: '.ci/apm-beats-update.groovy'
+    triggers: []
+    wrappers: []
+    scm:
+    - github:
+        branch-discovery: 'no-pr'
+        discover-pr-forks-strategy: 'merge-current'
+        discover-pr-forks-trust: 'permission'
+        discover-pr-origin: 'merge-current'
+        discover-tags: true
+        disable-pr-notifications: true
+        notification-context: 'apm-beats-update'
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
+        repo: 'beats'
+        repo-owner: 'elastic'
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - named-branches:
+            - exact-name: 
+                name: 'master'
+                case-sensitive: true
+            - regex-name:
+                regex: '7\.[x789]'
+                case-sensitive: true
+            - regex-name:
+                regex: '8\.\d+'
+                case-sensitive: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+            after: true
+            before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: true

--- a/.ci/jobs/beats-test-infra.yml
+++ b/.ci/jobs/beats-test-infra.yml
@@ -1,0 +1,23 @@
+---
+- job:
+    name: 'beats-test-infra'
+    display-name: 'Beats test infra'
+    description: 'Pipeline to run the test infra'
+    folder: 'Beats'
+    view: Beats
+    project-type: pipeline
+    pipeline-scm:
+        script-path: .ci/validateWorkersBeatsCi.groovy
+        scm:
+        - git:
+            url: git@github.com:elastic/apm-pipeline-library.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/apm-test-pipeline.git
+            branches:
+                - master
+    triggers:
+        - timed: 'H H(3-4) * * 1-5'

--- a/.ci/jobs/beats-test-infra.yml
+++ b/.ci/jobs/beats-test-infra.yml
@@ -1,9 +1,8 @@
 ---
 - job:
-    name: 'beats-test-infra'
+    name: Beats/beats-test-infra
     display-name: 'Beats test infra'
     description: 'Pipeline to run the test infra'
-    folder: 'Beats'
     view: Beats
     project-type: pipeline
     pipeline-scm:

--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -1,0 +1,62 @@
+---
+- job:
+    name: Beats/beats
+    display-name: 'Beats (replacement)'
+    description: 'Beats Main Pipeline'
+    view: Beats
+    concurrent: true
+    project-type: multibranch
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true
+    number-to-keep: 10
+    days-to-keep: 30
+    script-path: 'Jenkinsfile'
+    triggers: []
+    wrappers: []
+    scm:
+    - github:
+        branch-discovery: 'no-pr'
+        discover-pr-forks-strategy: 'merge-current'
+        discover-pr-forks-trust: 'permission'
+        discover-pr-origin: 'merge-current'
+        discover-tags: true
+        notification-context: "beats-ci"
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
+        repo: 'beats'
+        repo-owner: 'elastic'
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - change-request:
+            ignore-target-only-changes: false
+        - named-branches:
+            - exact-name:
+                name: 'master'
+                case-sensitive: true
+            - regex-name:
+                regex: '7\.[x789]'
+                case-sensitive: true
+            - regex-name:
+                regex: '8\.\d+'
+                case-sensitive: true
+        clean:
+            after: true
+            before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: true

--- a/.ci/jobs/folders.yml
+++ b/.ci/jobs/folders.yml
@@ -1,0 +1,5 @@
+---
+#https://docs.openstack.org/infra/jenkins-job-builder/project_folder.html
+- job:
+    name: Beats
+    project-type: folder

--- a/.ci/jobs/folders.yml
+++ b/.ci/jobs/folders.yml
@@ -2,4 +2,5 @@
 #https://docs.openstack.org/infra/jenkins-job-builder/project_folder.html
 - job:
     name: Beats
+    description: Beats
     project-type: folder

--- a/.ci/jobs/packagin.yml
+++ b/.ci/jobs/packagin.yml
@@ -1,0 +1,53 @@
+---
+- job:
+    name: apm-shared/packaging
+    display-name: Beats Packaging
+    description: Make the packages for beats and publish them on a GCS bucket.
+    view: Beats
+    project-type: multibranch
+    script-path: .ci/packaging.groovy
+    scm:
+      - github:
+          branch-discovery: 'no-pr'
+          discover-pr-forks-strategy: 'merge-current'
+          discover-pr-forks-trust: 'permission'
+          discover-pr-origin: 'merge-current'
+          discover-tags: true
+          disable-pr-notifications: false
+          notification-context: 'beats-packaging'
+          repo: 'beats'
+          repo-owner: 'elastic'
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+          - tags:
+              ignore-tags-older-than: -1
+              ignore-tags-newer-than: -1
+          - named-branches:
+              - exact-name:
+                  name: 'master'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '7\.[x789]'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '8\.\d+'
+                  case-sensitive: true
+          - change-request:
+              ignore-target-only-changes: false
+          clean:
+              after: true
+              before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: apm-shared/packaging
+    name: Beats/packaging
     display-name: Beats Packaging
     description: Make the packages for beats and publish them on a GCS bucket.
     view: Beats

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -22,15 +22,21 @@ pipeline {
     disableConcurrentBuilds()
   }
   triggers {
-    issueCommentTrigger('(?i)^\\/packaging$')
+    issueCommentTrigger('(?i)^\\/packag[ing|e]$')
     upstream('Beats/beats-beats-mbp/master')
   }
   parameters {
-    booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')
+    booleanParam(name: 'macos', defaultValue: true, description: 'Allow macOS stages.')
     booleanParam(name: 'linux', defaultValue: true, description: 'Allow linux stages.')
   }
   stages {
     stage('Checkout') {
+      when {
+        beforeAgent true
+        not {
+          triggeredBy 'SCMTrigger'
+        }
+      }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -40,6 +46,12 @@ pipeline {
       }
     }
     stage('Build Packages'){
+      when {
+        beforeAgent true
+        not {
+          triggeredBy 'SCMTrigger'
+        }
+      }
       matrix {
         axes {
           axis {
@@ -97,7 +109,7 @@ pipeline {
             }
           }
           stage('Package Mac OS'){
-            agent { label 'macosx' }
+            agent { label 'macosx-10.12' }
             options { skipDefaultCheckout() }
             when {
               beforeAgent true

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -104,8 +104,10 @@ pipeline {
               ].join(' ')
             }
             steps {
-              release()
-              pushCIDockerImages()
+              withGithubNotify(context: "Packaging ${BEATS_FOLDER}") {
+                release()
+                pushCIDockerImages()
+              }
             }
           }
           stage('Package Mac OS'){


### PR DESCRIPTION
## What does this PR do?

* Packaging job changes:
  * Send a GitHub check per Beat packaging
  * Ignore SCMTrigger to create the first execution and capture the GitHub messages
  * Enable MacOS build 
  * Use the Mac can sign 
  * Allow to trigger the job with the following GitHub messages: 
    * `/packaging` 
    * `/package`
* Move jobs from the infra repo to this repo

## Why is it important?

The packaging job was not triggered with a comment correctly, now you do not need to execute it manually one time 
before using the GitHub comments. 
We move the jobs from the infra repo to our repo to give us more independence.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

closes to https://github.com/elastic/beats/issues/19399