### PR TITLE
Cherry-pick #19430 to 7.x: updated cisco module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -304,6 +304,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338001'"
       field: "server.domain"
       value: "{{source.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338002'"
       field: "message"
@@ -312,6 +313,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338002'"
       field: "server.domain"
       value: "{{destination.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338003'"
       field: "message"
@@ -328,6 +330,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338005'"
       field: "server.domain"
       value: "{{source.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338006'"
       field: "message"
@@ -336,6 +339,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338006'"
       field: "server.domain"
       value: "{{destination.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338007'"
       field: "message"
@@ -352,6 +356,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338101'"
       field: "server.domain"
       value: "{{source.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338102'"
       field: "message"
@@ -360,6 +365,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338102'"
       field: "server.domain"
       value: "{{destination.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338103'"
       field: "message"
@@ -376,6 +382,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338201'"
       field: "server.domain"
       value: "{{source.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338202'"
       field: "message"
@@ -384,6 +391,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338202'"
       field: "server.domain"
       value: "{{destination.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338203'"
       field: "message"
@@ -392,6 +400,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338203'"
       field: "server.domain"
       value: "{{source.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338204'"
       field: "message"
@@ -400,6 +409,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338204'"
       field: "server.domain"
       value: "{{destination.domain}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "message"
@@ -408,18 +418,22 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.address"
       value: "{{destination.address}}"
+      ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.port"
       value: "{{destination.port}}"
+      ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.address"
       value: "{{source.address}}"
+      ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.port"
       value: "{{source.port}}"
+      ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '734001'"
       field: "message"
@@ -957,7 +971,7 @@ processors:
   - set:
       field: "_temp_.duration_hms"
       value: "{{event.duration}}"
-      if: "ctx.event?.duration != null"
+      ignore_empty_value: true
 
   #
   # Process the flow duration "hh:mm:ss" present in some messages
@@ -1230,19 +1244,23 @@ processors:
   - set:
       field: source.nat.ip
       value: "{{_temp_.cisco.mapped_source_ip}}"
-      if: "ctx._temp_.cisco.mapped_source_ip != null && (ctx._temp_.cisco.mapped_source_ip != ctx.source.ip || ctx._temp_.cisco.mapped_source_port != ctx.source.port)"
+      if: "(ctx?._temp_?.cisco?.mapped_source_ip != ctx?.source?.ip || ctx?._temp_?.cisco?.mapped_source_port != ctx?.source?.port)"
+      ignore_empty_value: true
   - set:
       field: source.nat.port
       value: "{{_temp_.cisco.mapped_source_port}}"
-      if: "ctx._temp_.cisco.mapped_source_port != null && (ctx._temp_.cisco.mapped_source_ip != ctx.source.ip || ctx._temp_.cisco.mapped_source_port != ctx.source.port)"
+      if: "(ctx?._temp_?.cisco.mapped_source_ip != ctx?.source?.ip || ctx?._temp_?.cisco?.mapped_source_port != ctx?.source?.port)"
+      ignore_empty_value: true
   - set:
       field: destination.nat.ip
       value: "{{_temp_.cisco.mapped_destination_ip}}"
-      if: "ctx._temp_.cisco.mapped_destination_ip != null && (ctx._temp_.cisco.mapped_destination_ip != ctx.destination.ip || ctx._temp_.cisco.mapped_destination_port != ctx.destination.port)"
+      if: "(ctx?._temp_?.cisco.mapped_destination_ip != ctx?.destination?.ip || ctx?._temp_?.cisco?.mapped_destination_port != ctx?.destination?.port)"
+      ignore_empty_value: true
   - set:
       field: destination.nat.port
       value: "{{_temp_.cisco.mapped_destination_port}}"
-      if: "ctx._temp_.cisco.mapped_destination_port != null && (ctx._temp_.cisco.mapped_destination_ip != ctx.destination.ip || ctx._temp_.cisco.mapped_destination_port != ctx.destination.port)"
+      if: "(ctx?._temp_?.cisco?.mapped_destination_ip != ctx?.destination?.ip || ctx?._temp_?.cisco?.mapped_destination_port != ctx?.destination?.port)"
+      ignore_empty_value: true
 
   #
   # Populate ECS event.code


### PR DESCRIPTION
Cherry-pick of PR #19430 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
