### PR TITLE
Cherry-pick #19421 to 7.x: updated fortinet module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -30,7 +30,7 @@ processors:
 - set:
     field: event.timezone
     value: "{{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
+    ignore_empty_value: true
 - set:
     field: _temp.time
     value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}} {{fortinet.firewall.tz}}"

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/traffic.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/traffic.yml
@@ -6,7 +6,7 @@ processors:
 - set:
     field: event.action
     value: "{{fortinet.firewall.action}}"
-    if: "ctx.fortinet?.firewall?.action != null"
+    ignore_empty_value: true
 - set:
     field: event.outcome
     value: success


### PR DESCRIPTION
Cherry-pick of PR #19421 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
