### PR TITLE
Cherry-pick #19420 to 7.x: updated suricata module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.yml
@@ -30,9 +30,10 @@ processors:
         }
       ignore_failure: true
   - set:
-      if: "ctx?.destination?.domain != null && ctx?.network?.protocol == 'http'"
+      if: "ctx?.network?.protocol == 'http'"
       field: url.domain
       value: '{{destination.domain}}'
+      ignore_empty_value: true
   - grok:
       field: suricata.eve.http.url
       patterns:
@@ -73,15 +74,15 @@ processors:
   - set:
       field: rule.category
       value: "{{suricata.eve.alert.category}}"
-      if: "ctx?.suricata?.eve?.alert?.category != null"
+      ignore_empty_value: true
   - set:
       field: rule.id
       value: "{{suricata.eve.alert.signature_id}}"
-      if: "ctx?.suricata?.eve?.alert?.signature_id != null"
+      ignore_empty_value: true
   - set:
       field: rule.name
       value: "{{suricata.eve.alert.signature}}"
-      if: "ctx?.suricata?.eve?.alert?.signature != null"
+      ignore_empty_value: true
   - set:
       field: suricata.eve.alert.action
       value: denied


### PR DESCRIPTION
Cherry-pick of PR #19420 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
