### PR TITLE
Cherry-pick #19412 to 7.x: updated auditd module to use new nullcheck in set processors

### DIFF
--- a/filebeat/module/auditd/log/ingest/pipeline.yml
+++ b/filebeat/module/auditd/log/ingest/pipeline.yml
@@ -180,13 +180,15 @@ processors:
     field: event.type
     value: creation
 - set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID' && ctx.auditd.log?.vm != null"
+    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
     field: container.name
     value: "{{ auditd.log.vm }}"
+    ignore_empty_value: true
 - set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID' && ctx.auditd.log?.virt != null"
+    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
     field: container.runtime
     value: "{{ auditd.log.virt }}"
+    ignore_empty_value: true
 - rename:
     ignore_failure: true
     field: auditd.log.arch


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19412 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to elastic/beats#19407
