### PR TITLE
Cherry-pick #19413 to 7.x: updated kibana module to use new nullcheck in set processors

### DIFF
--- a/filebeat/module/kibana/log/ingest/pipeline.yml
+++ b/filebeat/module/kibana/log/ingest/pipeline.yml
@@ -70,7 +70,7 @@ processors:
 - set:
     field: source.ip
     value: '{{source.address}}'
-    if: ctx.source?.address != null
+    ignore_empty_value: true
 - rename:
     field: kibana.log.meta.req.url
     target_field: url.original


### PR DESCRIPTION
Cherry-pick of PR #19413 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
