### PR TITLE
Cherry-pick #19424 to 7.x: updated aws module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
@@ -84,6 +84,7 @@ processors:
       field: "event.action"
       value: "{{json.eventName}}"
       ignore_failure: true
+      ignore_empty_value: true
   - rename:
       field: "json.awsRegion"
       target_field: "cloud.region"

--- a/x-pack/filebeat/module/aws/elb/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/elb/ingest/pipeline.yml
@@ -128,9 +128,9 @@ processors:
       value: failure
 
   - set:
-      if: "ctx?.aws?.elb?.trace_id != null"
       field: tracing.trace.id
       value: "{{aws.elb.trace_id}}"
+      ignore_empty_value: true
 
   - split:
       field: '_tmp.actions_executed'
@@ -146,6 +146,7 @@ processors:
   - set:
       field: 'event.end'
       value: '{{ @timestamp }}'
+      ignore_empty_value: true
 
   - geoip:
       field: 'source.ip'
@@ -174,7 +175,7 @@ processors:
   - set:
       field: tls.cipher
       value: '{{aws.elb.ssl_cipher}}'
-      if: ctx.aws?.elb?.ssl_cipher != null
+      ignore_empty_value: true
 
   - script:
       lang: painless

--- a/x-pack/filebeat/module/aws/s3access/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/s3access/ingest/pipeline.yml
@@ -37,9 +37,9 @@ processors:
         - "dd/MMM/yyyy:H:m:s Z"
 
   - set:
-      if: "ctx?.aws?.s3access?.remote_ip != null"
       field: client.ip
       value: "{{aws.s3access.remote_ip}}"
+      ignore_empty_value: true
 
   - append:
       if: "ctx?.aws?.s3access?.remote_ip != null"
@@ -47,9 +47,9 @@ processors:
       value: "{{aws.s3access.remote_ip}}"
 
   - set:
-      if: "ctx?.aws?.s3access?.remote_ip != null"
       field: client.address
       value: "{{aws.s3access.remote_ip}}"
+      ignore_empty_value: true
 
   - geoip:
       if: "ctx?.aws?.s3access?.remote_ip != null"
@@ -57,24 +57,24 @@ processors:
       target_field: geo
 
   - set:
-      if: "ctx?.aws?.s3access?.requester != null"
       field: client.user.id
       value: "{{aws.s3access.requester}}"
+      ignore_empty_value: true
 
   - set:
-      if: "ctx?.aws?.s3access?.request_id != null"
       field: event.id
       value: "{{aws.s3access.request_id}}"
+      ignore_empty_value: true
 
   - set:
-      if: "ctx?.aws?.s3access?.operation != null"
       field: event.action
       value: "{{aws.s3access.operation}}"
+      ignore_empty_value: true
 
   - set:
-      if: "ctx?.aws?.s3access?.http_status != null"
       field: http.response.status_code
       value: "{{aws.s3access.http_status}}"
+      ignore_empty_value: true
 
   - convert:
       if: "ctx?.http?.response?.status_code != null"
@@ -87,9 +87,9 @@ processors:
       value: failure
 
   - set:
-      if: "ctx?.aws?.s3access?.error_code != null"
       field: event.code
       value: "{{aws.s3access.error_code}}"
+      ignore_empty_value: true
 
   - set:
       if: "ctx?.aws?.s3access?.error_code == null"
@@ -97,14 +97,14 @@ processors:
       value: success
 
   - set:
-      if: "ctx?.aws?.s3access?.total_time != null"
       field: event.duration
       value: "{{aws.s3access.total_time}}"
+      ignore_empty_value: true
 
   - set:
-      if: "ctx?.aws?.s3access?.referrer != null"
       field: http.request.referrer
       value: "{{aws.s3access.referrer}}"
+      ignore_empty_value: true
 
   - user_agent:
       if: "ctx?.aws?.s3access?.user_agent != null"
@@ -113,7 +113,7 @@ processors:
   - set:
       field: tls.cipher
       value: '{{aws.s3access.cipher_suite}}'
-      if: ctx.aws?.s3access?.cipher_suite != null
+      ignore_empty_value: true
 
   - script:
       lang: painless

--- a/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
@@ -84,14 +84,15 @@ processors:
       value: aws
 
   - set:
-      if: "ctx?.aws?.vpcflow?.account_id != null"
       field: cloud.account.id
       value: "{{aws.vpcflow.account_id}}"
+      ignore_empty_value: true
 
   - set:
-      if: "ctx?.aws?.vpcflow?.instance_id != null && ctx.aws.vpcflow.instance_id != '-'"
+      if: "ctx.aws.vpcflow.instance_id != '-'"
       field: cloud.instance.id
       value: "{{aws.vpcflow.instance_id}}"
+      ignore_empty_value: true
 
   - set:
       field: event.kind


### PR DESCRIPTION
Cherry-pick of PR #19424 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
