### PR TITLE
Cherry-pick #19426 to 7.x: updated cef module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/cef/log/ingest/fp-pipeline.yml
+++ b/x-pack/filebeat/module/cef/log/ingest/fp-pipeline.yml
@@ -6,22 +6,22 @@ processors:
   - set:
       field: rule.id
       value: "{{cef.extensions.deviceCustomString1}}"
-      if: "ctx.cef?.extensions?.deviceCustomString1 != null"
+      ignore_empty_value: true
 
   # cs2 is natRuleID
   - set:
       field: rule.id
       value: "{{cef.extensions.deviceCustomString2}}"
-      if: "ctx.cef?.extensions?.deviceCustomString2 != null"
+      ignore_empty_value: true
 
   # cs3 is VulnerabilityReference
   - set:
       field: vulnerability.reference
       value: "{{cef.extensions.deviceCustomString3}}"
-      if: "ctx.cef?.extensions?.deviceCustomString3 != null"
+      ignore_empty_value: true
 
   # cs4 is virusID
   - set:
       field: cef.forcepoint.virus_id
       value: "{{cef.extensions.deviceCustomString4}}"
-      if: "ctx.cef?.extensions?.deviceCustomString4 != null"
+      ignore_empty_value: true


### PR DESCRIPTION
Cherry-pick of PR #19426 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
