### PR TITLE
Cherry-pick #19427 to 7.x: updated envoyproxy module to use new nullcheck in set processors

### DIFF
--- a/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-entry.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-entry.yml
@@ -11,6 +11,7 @@ processors:
 - set:
     field: event.created
     value: '{{@timestamp}}'
+    ignore_empty_value: true
 - append:
     field: related.ip
     value: "{{source.ip}}"
@@ -36,7 +37,7 @@ processors:
 - set:
     field: '@timestamp'
     value: '{{timestamp}}'
-    if: ctx.timestamp != null
+    ignore_empty_value: true
 - remove:
     field:
     - timestamp

--- a/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-http.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-http.yml
@@ -44,6 +44,7 @@ processors:
 - set:
     field: url.domain
     value: '{{envoyproxy.authority}}'
+    ignore_empty_value: true
 - user_agent:
     field: user_agent.original
     ignore_missing: true

--- a/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-plaintext.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-plaintext.yml
@@ -80,11 +80,11 @@ processors:
 - set:
     field: destination.ip
     value: '{{destination.address}}'
-    if: ctx.destination?.address != null
+    ignore_empty_value: true
 - set:
     field: source.ip
     value: '{{source.address}}'
-    if: ctx.source?.address != null
+    ignore_empty_value: true
 on_failure:
 - set:
     field: error.message


### PR DESCRIPTION
Cherry-pick of PR #19427 to 7.x branch. Original message: 

## What does this PR do?

A new argument has been added to the set processor to replace null check values, this PR only replaces if conditions with this new argument, no new feature or changes are introduced in this PR.

## Why is it important?

Removing if conditions reduces script compilations during ingestion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Tests
All nosetests passing after change


## Related issues

Relates to #19407
