### PR TITLE
Cherry-pick #19432 to 7.x: [CI] Move jobs to the beats repository

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -22,15 +22,21 @@ pipeline {
     disableConcurrentBuilds()
   }
   triggers {
-    issueCommentTrigger('(?i)^\\/packaging$')
     upstream('Beats/beats-beats-mbp/7.x')
+    issueCommentTrigger('(?i)^\\/packag[ing|e]$')
   }
   parameters {
-    booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')
+    booleanParam(name: 'macos', defaultValue: true, description: 'Allow macOS stages.')
     booleanParam(name: 'linux', defaultValue: true, description: 'Allow linux stages.')
   }
   stages {
     stage('Checkout') {
+      when {
+        beforeAgent true
+        not {
+          triggeredBy 'SCMTrigger'
+        }
+      }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -40,6 +46,12 @@ pipeline {
       }
     }
     stage('Build Packages'){
+      when {
+        beforeAgent true
+        not {
+          triggeredBy 'SCMTrigger'
+        }
+      }
       matrix {
         axes {
           axis {
@@ -92,12 +104,14 @@ pipeline {
               ].join(' ')
             }
             steps {
-              release()
-              pushCIDockerImages()
+              withGithubNotify(context: "Packaging ${BEATS_FOLDER}") {
+                release()
+                pushCIDockerImages()
+              }
             }
           }
           stage('Package Mac OS'){
-            agent { label 'macosx' }
+            agent { label 'macosx-10.12' }
             options { skipDefaultCheckout() }
             when {
               beforeAgent true


### PR DESCRIPTION
Cherry-pick #19432 

## What does this PR do?

* Packaging job changes:
  * Send a GitHub check per Beat packaging
  * Ignore SCMTrigger to create the first execution and capture the GitHub messages
  * Enable MacOS build 
  * Use the Mac can sign 
  * Allow to trigger the job with the following GitHub messages: 
    * `/packaging` 
    * `/package`
* ~~Move jobs from the infra repo to this repo~~

## Why is it important?

The packaging job was not triggered with a comment correctly, now you do not need to execute it manually one time 
before using the GitHub comments. 
We move the jobs from the infra repo to our repo to give us more independence.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

closes to https://github.com/elastic/beats/issues/19399