### PR TITLE
Cherry-pick #19375 to 7.x: [Filebeat] Pass-thru other panw.panos log types

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -513,6 +513,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add new mode to multiline reader to aggregate constant number of lines {pull}18352[18352]
 - Explicitly set ECS version in all Filebeat modules. {pull}19198[19198]
 - Add awscloudwatch input. {pull}19025[19025]
+- Add automatic retries and exponential backoff to httpjson input. {pull}18956[18956]
+- Changed the panw module to pass through (rather than drop) message types other than threat and traffic. {issue}16815[16815] {pull}19375[19375]
 - Add support for timezone offsets and `Z` to decode_cef timestamp parser. {pull}19346[19346]
 - Improve ECS categorization field mappings in traefik module. {issue}16183[16183] {pull}19379[19379]
 - Improve ECS categorization field mappings in azure module. {issue}16155[16155] {pull}19376[19376]

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -197,8 +197,6 @@ processors:
        - intrusion_detection
        - network
      if: 'ctx?._temp_?.message_type == "THREAT"'
- - drop:
-     if: 'ctx?.event?.category == null'
  - append:
      field: event.type
      value: allowed

--- a/x-pack/filebeat/module/panw/panos/test/pan_inc_other.log-expected.json
+++ b/x-pack/filebeat/module/panw/panos/test/pan_inc_other.log-expected.json
@@ -1,5 +1,665 @@
 [
     {
+        "@timestamp": "2012-02-25T00:51:50.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 0,
+        "log.original": "Mar 25 23:58:57 1,2013/03/25 23:58:57,1606001116,CONFIG,0,0,2012/02/25 00:51:50,192.168.0.2,,set,admin,Web,Succeeded, config shared local-user-database user  badguy,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:53:22.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 171,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:53:22,192.168.0.2,,set,admin,Web,Succeeded, config mgt-config users  badguy,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:53:40.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 327,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:53:40,192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:53:53.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 454,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:53:53,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:53:56.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 650,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,vpn,0,2012/02/25 00:53:56,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:54:16.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 837,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:54:16,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:54:16.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1033,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,ras,0,2012/02/25 00:54:16,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:57:17.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1226,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:57:17,192.168.0.2,,edit,badguy,Web,Succeeded, vsys  vsys1 profiles url-filtering  monzyspolicy,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:57:36.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1401,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:57:36,192.168.0.2,,commit,badguy,Web,Submitted,,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:57:49.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1529,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:57:49,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:57:52.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1725,
+        "log.original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,vpn,0,2012/02/25 00:57:52,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:58:12.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 1912,
+        "log.original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,routing,0,2012/02/25 00:58:12,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:58:12.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2108,
+        "log.original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,vpn,0,2012/02/25 00:58:12,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:58:12.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2295,
+        "log.original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,ras,0,2012/02/25 00:58:12,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:58:14.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2488,
+        "log.original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,general,1,2012/02/25 00:58:14,,unknown,,0,0,general,informational,Config installed,909,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-02-25T00:59:36.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2635,
+        "log.original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,general,0,2012/02/25 00:59:36,,general,,0,0,general,informational,Log type config cleared by user badguy ,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "1606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:11:57.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2803,
+        "log.original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,general,1,2012/04/10 03:11:57,,unknown,,0,0,general,informational,Config installed,884,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:11:56.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 2951,
+        "log.original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,ras,0,2012/04/10 03:11:56,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:11:56.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 3145,
+        "log.original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,vpn,0,2012/04/10 03:11:56,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:11:56.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 3333,
+        "log.original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,routing,0,2012/04/10 03:11:56,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:06:11.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 3530,
+        "log.original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,ras,0,2012/04/10 03:06:11,,rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-10T03:06:00.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 3724,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,routing,0,2012/04/10 03:06:00,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:02:53.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 3921,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,general,1,2012/04/09 09:02:53,,unknown,,0,0,general,informational,Config installed,840,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:02:52.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 4069,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,ras,0,2012/04/09 09:02:52,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:02:52.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 4263,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,vpn,0,2012/04/09 09:02:52,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:02:52.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 4451,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,routing,0,2012/04/09 09:02:52,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:00:55.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 4648,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,ras,0,2012/04/09 09:00:55,,rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:00:52.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 4842,
+        "log.original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,vpn,0,2012/04/09 09:00:52,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:00:35.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 5030,
+        "log.original": "Mar 25 23:59:32 1,2013/03/25 23:59:32,01606001116,CONFIG,0,0,2012/04/09 09:00:35,192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T09:00:20.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 5158,
+        "log.original": "Mar 25 23:59:32 1,2013/03/25 23:59:32,01606001116,CONFIG,0,0,2012/04/09 09:00:20,192.168.0.2,,edit,admin,Web,Succeeded, vsys  vsys1 profiles data-objects  PII,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T03:21:53.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 5323,
+        "log.original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,general,1,2012/04/09 03:21:53,,unknown,,0,0,general,informational,Config installed,821,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T03:21:53.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 5471,
+        "log.original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,ras,0,2012/04/09 03:21:53,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2012-04-09T03:21:53.000-02:00",
+        "event.dataset": "panw.panos",
+        "event.module": "panw",
+        "event.outcome": "success",
+        "event.timezone": "-02:00",
+        "fileset.name": "panos",
+        "input.type": "log",
+        "log.offset": 5665,
+        "log.original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,vpn,0,2012/04/09 03:21:53,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
+        "observer.product": "PAN-OS",
+        "observer.serial_number": "01606001116",
+        "observer.type": "firewall",
+        "observer.vendor": "Palo Alto Networks",
+        "service.type": "panw",
+        "tags": [
+            "pan-os",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2012-04-10T04:39:56.000-02:00",
         "client.bytes": 78,
         "client.ip": "192.168.0.2",


### PR DESCRIPTION
Cherry-pick of PR #19375 to 7.x branch. Original message: 


## What does this PR do?

This removes the drop processor from the ingest node pipeline that drops events other than THREAT and TRAFFIC.
This way we can retain the other log data but don't necessarily handle the parsing of it.

## Why is it important?

We want to keep data from panos even if the messages are not explicitly handled by the module. The data may not have all the ECS mappings, but at least it won't be lost. https://github.com/elastic/beats/issues/15603 tracks adding parsing support for additional message types.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/16815

