### PR TITLE
Cherry-pick #19246 to 7.x: [Filebeat][httpjson] Add split_events_by config setting

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -66,6 +66,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Adds check on `<no value>` config option value for the azure input `resource_manager_endpoint`. {pull}18890[18890]
 - Okta module now requires objects instead of JSON strings for the `http_headers`, `http_request_body`, `pagination`, `rate_limit`, and `ssl` variables. {pull}18953[18953]
 - Adds oauth support for httpjson input. {issue}18415[18415] {pull}18892[18892]
+- Adds `split_events_by` option to httpjson input. {pull}19246[19246]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -179,6 +179,73 @@ The config needs to specify `events` as the `json_objects_array` value.
 ----
 
 [float]
+==== `split_events_by`
+
+If the response body contains a JSON object containing an array then this option
+specifies the key containing that array. Each object in that array will generate
+an event, but will maintain the common fields of the document as well.
+
+["source","json",subs="attributes"]
+----
+{
+  "time": "2020-06-02 23:22:32 UTC",
+  "user": "Bob",
+  "events": [
+    {
+      "timestamp": "2020-05-02 11:10:03 UTC",
+      "event": {
+        "category": "authorization"
+      }
+    },
+    {
+      "timestamp": "2020-05-05 13:03:11 UTC",
+      "event": {
+        "category": "authorization"
+      }
+    }
+  ]
+}
+----
+
+The config needs to specify `events` as the `split_events_by` value.
+
+["source","yaml",subs="attributes"]
+----
+- type: httpjson
+  split_events_by: events
+----
+
+And will output the following events:
+
+["source","json",subs="attributes"]
+----
+[
+  {
+    "time": "2020-06-02 23:22:32 UTC",
+    "user": "Bob",
+    "events": {
+      "timestamp": "2020-05-02 11:10:03 UTC",
+      "event": {
+        "category": "authorization"
+      }
+    }
+  },
+  {
+    "time": "2020-06-02 23:22:32 UTC",
+    "user": "Bob",
+    "events": {
+      "timestamp": "2020-05-05 13:03:11 UTC",
+      "event": {
+        "category": "authorization"
+      }
+    }
+  }
+]
+----
+
+It can be used in combination with `json_objects_array`, which will look for the field inside each element.
+
+[float]
 ==== `no_http_body`
 
 Force HTTP requests to be sent with an empty HTTP body. Defaults to `false`.

--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -26,6 +26,7 @@ type config struct {
 	HTTPRequestBody      common.MapStr     `config:"http_request_body"`
 	Interval             time.Duration     `config:"interval"`
 	JSONObjects          string            `config:"json_objects_array"`
+	SplitEventsBy        string            `config:"split_events_by"`
 	NoHTTPBody           bool              `config:"no_http_body"`
 	Pagination           *Pagination       `config:"pagination"`
 	RateLimit            *RateLimit        `config:"rate_limit"`

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -181,24 +181,61 @@ func (in *HttpjsonInput) createHTTPRequest(ctx context.Context, ri *RequestInfo)
 
 // processEventArray publishes an event for each object contained in the array. It returns the last object in the array and an error if any.
 func (in *HttpjsonInput) processEventArray(events []interface{}) (map[string]interface{}, error) {
-	var m map[string]interface{}
+	var last map[string]interface{}
 	for _, t := range events {
 		switch v := t.(type) {
 		case map[string]interface{}:
-			m = v
-			d, err := json.Marshal(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to marshal %+v", v)
-			}
-			ok := in.outlet.OnEvent(makeEvent(string(d)))
-			if !ok {
-				return nil, errors.New("function OnEvent returned false")
+			for _, e := range in.splitEvent(v) {
+				last = e
+				d, err := json.Marshal(e)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to marshal %+v", e)
+				}
+				ok := in.outlet.OnEvent(makeEvent(string(d)))
+				if !ok {
+					return nil, errors.New("function OnEvent returned false")
+				}
 			}
 		default:
 			return nil, errors.Errorf("expected only JSON objects in the array but got a %T", v)
 		}
 	}
-	return m, nil
+	return last, nil
+}
+
+func (in *HttpjsonInput) splitEvent(event map[string]interface{}) []map[string]interface{} {
+	m := common.MapStr(event)
+
+	hasSplitKey, _ := m.HasKey(in.config.SplitEventsBy)
+	if in.config.SplitEventsBy == "" || !hasSplitKey {
+		return []map[string]interface{}{event}
+	}
+
+	splitOnIfc, _ := m.GetValue(in.config.SplitEventsBy)
+	splitOn, ok := splitOnIfc.([]interface{})
+	// if not an array or is empty, we do nothing
+	if !ok || len(splitOn) == 0 {
+		return []map[string]interface{}{event}
+	}
+
+	var events []map[string]interface{}
+	for _, split := range splitOn {
+		s, ok := split.(map[string]interface{})
+		// if not an object, we do nothing
+		if !ok {
+			return []map[string]interface{}{event}
+		}
+
+		mm := m.Clone()
+		_, err := mm.Put(in.config.SplitEventsBy, s)
+		if err != nil {
+			return []map[string]interface{}{event}
+		}
+
+		events = append(events, mm)
+	}
+
+	return events
 }
 
 // getNextLinkFromHeader retrieves the next URL for pagination from the HTTP Header of the response


### PR DESCRIPTION
Cherry-pick of PR #19246 to 7.x branch. Original message: 

## What does this PR do?

Adds a `split_events_by` setting to the `httpjson` input to allow similar mechanics as the `split` filter for logstash.

## Why is it important?

There are many use cases where a list of elements is passed as an API response, and we want to create each of them to a single event.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

