### PR TITLE
[Elastic Agent] Handle migration of agent_info to agent in Fleet configuration

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -73,3 +73,4 @@
 - Agent now runs the GRPC server and spawned application connect by to Agent {pull}18973[18973]
 - Rename input.type logs to logfile {pull}19360[19360]
 - Agent now installs/uninstalls Elastic Endpoint {pull}19248[19248]
+- Handle upgrade of Fleet.yml format transparently {pull}19488[19488]

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_id_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_id_test.go
@@ -1,0 +1,75 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package info
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage"
+)
+
+func TestLoadAgentInfo(t *testing.T) {
+	defer cleanupFile()
+
+	agentInfo, err := loadAgentInfo(false)
+	require.NoError(t, err)
+	assert.NotEqual(t, "", agentInfo.ID)
+	assert.Equal(t, "", agentInfo.CapID)
+}
+
+func TestLoadAgentInfoForce(t *testing.T) {
+	defer cleanupFile()
+
+	agentInfo, err := loadAgentInfo(false)
+	require.NoError(t, err)
+	assert.NotEqual(t, "", agentInfo.ID)
+	assert.Equal(t, "", agentInfo.CapID)
+
+	agentInfo2, err := loadAgentInfo(true)
+	require.NoError(t, err)
+	assert.NotEqual(t, agentInfo.ID, agentInfo2.ID)
+}
+
+func TestLoadAgentInfoUpgrade(t *testing.T) {
+	defer cleanupFile()
+
+	// write an old agent info
+	agentConfigFile := AgentConfigFile()
+	s := storage.NewEncryptedDiskStore(agentConfigFile, []byte(""))
+	id, err := generateAgentID()
+	require.NoError(t, err)
+	err = writeOldAgentInfo(s, id)
+	require.NoError(t, err)
+
+	// load agent info, will handle upgrade
+	agentInfo, err := loadAgentInfo(false)
+	require.NoError(t, err)
+	assert.Equal(t, id, agentInfo.ID)
+	assert.Equal(t, "", agentInfo.CapID)
+}
+
+func cleanupFile() {
+	os.Remove(AgentConfigFile())
+}
+
+func writeOldAgentInfo(s ioStore, id string) error {
+	configMap := make(map[string]interface{})
+	configMap[agentInfoKey] = struct {
+		ID string `json:"ID" yaml:"ID" config:"ID"`
+	}{
+		ID: id,
+	}
+
+	r, err := yamlToReader(configMap)
+	if err != nil {
+		return err
+	}
+
+	return s.Save(r)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

#19248 changed the Fleet config to use `agent.id` instead of `agent_info.ID`. This was so the configuration could match what Endpoint was expecting.

This PR handles upgrading this transparently on startup for Elastic Agent, so the agent ID will not be re-generated when upgrading to a build that includes #19243 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So the Agent ID is not regenerated when starting Agent after upgrading.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
