### PR TITLE
Cherry-pick #19459 to 7.x: [Filebeat] Fix reference leak in TCP and Unix socket inputs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -231,6 +231,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix date and timestamp formats for fortigate module {pull}19316[19316]
 - Add missing `default_field: false` to aws filesets fields.yml. {pull}19568[19568]
 - Fix tls mapping in suricata module {issue}19492[19492] {pull}19494[19494]
+- Fix memory leak in tcp and unix input sources. {pull}19459[19459]
 
 *Heartbeat*
 

--- a/filebeat/inputsource/common/listener.go
+++ b/filebeat/inputsource/common/listener.go
@@ -78,6 +78,14 @@ func (l *Listener) Start() error {
 		return err
 	}
 
+	l.ctx, l.cancel = context.WithCancel(context.Background())
+	go func() {
+		<-l.ctx.Done()
+		l.Listener.Close()
+	}()
+
+	l.log.Info("Started listening for " + l.family.String() + " connection")
+
 	l.wg.Add(1)
 	go func() {
 		defer l.wg.Done()


### PR DESCRIPTION
Cherry-pick of PR #19459 to 7.x branch. Original message: 


## What does this PR do?

The tcp and unix input sources were leaking references causing a memory leak.
When an accepted connection ended inputsource/common.Closer was
supposed to delete the pointer that it held to the connection, but due to a code
error `delete` was being called on the wrong map.

## Why is it important?

This fixes a memory leak with the tcp and unix inputs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
