### PR TITLE
fix: ignore target changes on scans

### DIFF
--- a/.ci/jobs/apm-beats-update.yml
+++ b/.ci/jobs/apm-beats-update.yml
@@ -44,7 +44,7 @@
                 regex: '8\.\d+'
                 case-sensitive: true
         - change-request:
-            ignore-target-only-changes: false
+            ignore-target-only-changes: true
         clean:
             after: true
             before: true

--- a/.ci/jobs/beats-windows-mbp.yml
+++ b/.ci/jobs/beats-windows-mbp.yml
@@ -1,7 +1,7 @@
 ---
 - job:
     name: Beats/beats-windows-mbp
-    display-name: Beats Pipeline for Windows 
+    display-name: Beats Pipeline for Windows
     description: Jenkins pipeline for the Beats project running on windows agents.
     view: Beats
     project-type: multibranch
@@ -11,7 +11,7 @@
           branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
-          discover-pr-origin: merge-current          
+          discover-pr-origin: merge-current
           discover-tags: false
           # Run MBP for the master branch and PRs
           head-filter-regex: '(master|PR-.*)'
@@ -27,10 +27,10 @@
                 ignore-tags-newer-than: -1
             - regular-branches: true
             - change-request:
-                ignore-target-only-changes: false
+                ignore-target-only-changes: true
           property-strategies:
             # Builds for PRs won't be triggered automatically.
-            # Only the master branch will be triggered automatically. 
+            # Only the master branch will be triggered automatically.
             named-branches:
               defaults:
                 - suppress-scm-triggering: true

--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -34,7 +34,7 @@
             ignore-tags-older-than: -1
             ignore-tags-newer-than: -1
         - change-request:
-            ignore-target-only-changes: false
+            ignore-target-only-changes: true
         - named-branches:
             - exact-name:
                 name: 'master'

--- a/.ci/jobs/golang-crossbuild-mbp.yml
+++ b/.ci/jobs/golang-crossbuild-mbp.yml
@@ -11,7 +11,7 @@
           branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
-          discover-pr-origin: merge-current          
+          discover-pr-origin: merge-current
           discover-tags: true
           notification-context: 'beats-ci'
           repo: golang-crossbuild
@@ -25,7 +25,7 @@
                 ignore-tags-newer-than: -1
             - regular-branches: true
             - change-request:
-                ignore-target-only-changes: false
+                ignore-target-only-changes: true
           clean:
             after: true
             before: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -23,7 +23,7 @@
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:
           - tags:
-              ignore-tags-older-than: -1
+              ignore-tags-older-than: 30
               ignore-tags-newer-than: -1
           - named-branches:
               - exact-name:
@@ -36,7 +36,7 @@
                   regex: '8\.\d+'
                   case-sensitive: true
           - change-request:
-              ignore-target-only-changes: false
+              ignore-target-only-changes: true
           clean:
               after: true
               before: true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

It changes the behavior to build PRs when Jenkins makes a scan, instead of trigger all PRs if the target branch has changed, the builds are only triggered if there's changes in the PR and we did not test them.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

With the amount of PRs and branches that this repo has built all PRs on changes in the master is not an option, we would use all the resources we have and we block the real builds we need to make.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
