### PR TITLE
adding support for epoch in seconds

### DIFF
--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -68,6 +68,7 @@ processors:
     target_field: event.start
     formats:
     - UNIX_MS
+    - UNIX
     timezone: "{{fortinet.firewall.tz}}"
     if: "ctx.fortinet?.firewall?.tz != null"
 - date:
@@ -75,6 +76,7 @@ processors:
     target_field: event.start
     formats:
     - UNIX_MS
+    - UNIX
     if: "ctx.fortinet?.firewall?.tz == null"
 - rename:
     field: fortinet.firewall.devname

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -68,16 +68,27 @@ processors:
     target_field: event.start
     formats:
     - UNIX_MS
+    timezone: "{{fortinet.firewall.tz}}"
+    if: "ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+- date:
+    field: fortinet.firewall.eventtime
+    target_field: event.start
+    formats:
     - UNIX
     timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
+    if: "ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
 - date:
     field: fortinet.firewall.eventtime
     target_field: event.start
     formats:
     - UNIX_MS
+    if: "ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+- date:
+    field: fortinet.firewall.eventtime
+    target_field: event.start
+    formats:
     - UNIX
-    if: "ctx.fortinet?.firewall?.tz == null"
+    if: "ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
 - rename:
     field: fortinet.firewall.devname
     target_field: observer.name

--- a/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
@@ -95,7 +95,7 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "1970-01-19T10:29:21.368Z",
+        "event.start": "2020-06-24T01:16:08.000Z",
         "event.timezone": "-02:00",
         "event.type": [
             "connection",
@@ -313,7 +313,7 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "1970-01-19T06:09:48.391-04:00",
+        "event.start": "2020-06-10T07:26:31.000-04:00",
         "event.timezone": "-0400",
         "event.type": [
             "allowed"


### PR DESCRIPTION
## What does this PR do?

Certain versions of fortinet handles the eventtime field in seconds instead of milliseconds, added support for that datetime format

## Why is it important?

Adds support for certain fields that can be calculated incorrectly on certain versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

