### PR TITLE
libbeat/beat: add ClientConfig.WaitCloseChan

### DIFF
--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -48,11 +48,17 @@ type ClientConfig struct {
 
 	CloseRef CloseRef
 
-	// WaitClose sets the maximum duration to wait on ACK, if client still has events
-	// active non-acknowledged events in the publisher pipeline.
-	// WaitClose is only effective if one of ACKCount, ACKEvents and ACKLastEvents
-	// is configured
+	// WaitClose holds a channel which controls the blocking behaviour of Close.
+	// If WaitClose is greater than zero, then Close will block until all events
+	// in the publisher pipeline have been acknowledged, WaitClose elapses, or
+	// (if non-nil) WaitCloseChan is signalled.
 	WaitClose time.Duration
+
+	// WaitCloseChan holds a channel which controls the blocking behaviour of Close.
+	// If WaitCloseChan is non-nil, then Close will block until all events in the
+	// publisher pipeline have been acknowledged, the channel is signalled, or
+	// (if specified) WaitClose elapses.
+	WaitCloseChan <-chan struct{}
 
 	// Configure ACK callback.
 	ACKHandler ACKer

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -271,7 +271,7 @@ func (w *clientCloseWaiter) signalClose() {
 		return
 	}
 
-	w.closing.Store(false)
+	w.closing.Store(true)
 	if w.events.Load() == 0 {
 		w.finishClose()
 		return

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -21,11 +21,14 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 )
 
@@ -110,6 +113,145 @@ func TestClient(t *testing.T) {
 				test.close(client, cancel)
 				wg.Wait()
 			})
+		}
+	})
+}
+
+func TestClientWaitClose(t *testing.T) {
+	routinesChecker := resources.NewGoroutinesChecker()
+	defer routinesChecker.Check(t)
+
+	makePipeline := func(settings Settings, qu queue.Queue) *Pipeline {
+		p, err := New(beat.Info{},
+			Monitors{},
+			func(queue.ACKListener) (queue.Queue, error) { return qu, nil },
+			outputs.Group{},
+			settings,
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		return p
+	}
+	if testing.Verbose() {
+		logp.TestingSetup()
+	}
+
+	q := memqueue.NewQueue(logp.L(), memqueue.Settings{Events: 1})
+	pipeline := makePipeline(Settings{}, q)
+	defer pipeline.Close()
+
+	t.Run("WaitCloseChan blocks", func(t *testing.T) {
+		for name, waitCloseTimeout := range map[string]time.Duration{
+			"without timeout": 0,
+			"with timeout":    time.Minute,
+		} {
+			t.Run(name, func(t *testing.T) {
+				waitCloseChan := make(chan struct{})
+				client, err := pipeline.ConnectWith(beat.ClientConfig{
+					WaitCloseChan: waitCloseChan,
+					WaitClose:     waitCloseTimeout,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer client.Close()
+
+				// Send an event which never gets acknowledged.
+				client.Publish(beat.Event{})
+
+				closed := make(chan struct{})
+				go func() {
+					defer close(closed)
+					client.Close()
+				}()
+
+				select {
+				case <-closed:
+					t.Fatal("expected Close to wait for event acknowledgement")
+				case <-time.After(100 * time.Millisecond):
+				}
+
+				close(waitCloseChan)
+				select {
+				case <-closed:
+				case <-time.After(10 * time.Second):
+					t.Fatal("expected Close to stop waiting after WaitCloseChan signalled")
+				}
+			})
+		}
+	})
+
+	t.Run("WaitClose blocks", func(t *testing.T) {
+		for name, waitCloseChan := range map[string]<-chan struct{}{
+			"without channel": nil,
+			"with channel":    make(chan struct{}),
+		} {
+			t.Run(name, func(t *testing.T) {
+				client, err := pipeline.ConnectWith(beat.ClientConfig{
+					WaitCloseChan: waitCloseChan,
+					WaitClose:     500 * time.Millisecond,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer client.Close()
+
+				// Send an event which never gets acknowledged.
+				client.Publish(beat.Event{})
+
+				closed := make(chan struct{})
+				go func() {
+					defer close(closed)
+					client.Close()
+				}()
+
+				select {
+				case <-closed:
+					t.Fatal("expected Close to wait for event acknowledgement")
+				case <-time.After(100 * time.Millisecond):
+				}
+
+				select {
+				case <-closed:
+				case <-time.After(10 * time.Second):
+					t.Fatal("expected Close to stop waiting after WaitClose elapses")
+				}
+			})
+		}
+	})
+
+	t.Run("ACKing events unblocks", func(t *testing.T) {
+		client, err := pipeline.ConnectWith(beat.ClientConfig{
+			WaitCloseChan: make(chan struct{}),
+			WaitClose:     time.Minute,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+
+		// Send an event which gets acknowledged immediately.
+		client.Publish(beat.Event{})
+		output := newMockClient(func(batch publisher.Batch) error {
+			batch.ACK()
+			return nil
+		})
+		defer output.Close()
+		pipeline.output.Set(outputs.Group{Clients: []outputs.Client{output}})
+		defer pipeline.output.Set(outputs.Group{})
+
+		closed := make(chan struct{})
+		go func() {
+			defer close(closed)
+			client.Close()
+		}()
+
+		select {
+		case <-closed:
+		case <-time.After(10 * time.Second):
+			t.Fatal("expected Close to stop waiting after event acknowledgement")
 		}
 	})
 }

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -266,15 +266,15 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 		canDrop = true
 	}
 
-	waitClose := cfg.WaitClose
+	waitCloseTimeout := cfg.WaitClose
 	reportEvents := p.waitCloser != nil
 
 	switch p.waitCloseMode {
 	case NoWaitOnClose:
 
 	case WaitOnClientClose:
-		if waitClose <= 0 {
-			waitClose = p.waitCloseTimeout
+		if waitCloseTimeout <= 0 {
+			waitCloseTimeout = p.waitCloseTimeout
 		}
 	}
 
@@ -311,8 +311,8 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	var waiter *clientCloseWaiter
-	if waitClose > 0 {
-		waiter = newClientCloseWaiter(waitClose)
+	if waitCloseTimeout > 0 || cfg.WaitCloseChan != nil {
+		waiter = newClientCloseWaiter(waitCloseTimeout, cfg.WaitCloseChan)
 	}
 
 	if waiter != nil {


### PR DESCRIPTION
## What does this PR do?

This PR adds a `ClientConfig.WaitCloseChan` channel which, if signalled/closed, will interrupt `Client.Close`. Setting either `ClientConfig.WaitClose` (duration) or `Client.WaitCloseChan` (channel) will cause the client to wait for enqueued events to be acknowledged, or for one of the wait conditions to be satisfied.

## Why is it important?

Users of `pipeline.Client` may wish to block for a limited amount of time while closing the client. Currently there is a single means of achieving this: setting `WaitClose` when creating the client. This means the wait time cannot be dynamically adjusted.

In APM Server we have a "shutdown timeout" configuration, which is intended to cover all operations during shutdown: graceful HTTP server shutdown, flushing internal event queues, and finally closing the pipeline.Client. The operations leading up to closing the client may take a non-negligible amount of time, so conceptually we need to adjust the `WaitClose` time while closing, by subtracting the amount of time taken so far from the configured shutdown timeout.

We can achieve this by creating a cancellable context and passing its Done channel in as WaitCloseChan; then cancelling it with a timer started at the beginning of the APM Server's shutdown sequence.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

https://github.com/elastic/apm-server/issues/3789