### PR TITLE
Export Run from common listener inputsource

### DIFF
--- a/filebeat/inputsource/common/listener.go
+++ b/filebeat/inputsource/common/listener.go
@@ -80,11 +80,9 @@ func (l *Listener) Start() error {
 		return err
 	}
 
-	l.ctx, l.cancel = context.WithCancel(context.Background())
-	go func() {
-		<-l.ctx.Done()
-		l.Listener.Close()
-	}()
+	if err := l.initListen(context.Background()); err != nil {
+		return err
+	}
 
 	l.log.Info("Started listening for " + l.family.String() + " connection")
 
@@ -101,6 +99,31 @@ func (l *Listener) Start() error {
 // being received via tha io.Reader. Most clients use the splitHandler which can take a bufio.SplitFunc and parse
 // out each message into an appropriate event. The Close() of the ConnectionHandler can be used to clean up the
 // connection either by client or server based on need.
+func (l *Listener) Run(ctx context.Context) error {
+	if err := l.initListen(ctx); err != nil {
+		return err
+	}
+
+	l.wg.Add(1)
+	defer l.wg.Done()
+	l.run()
+	return nil
+}
+
+func (l *Listener) initListen(ctx context.Context) error {
+	var err error
+	l.Listener, err = l.listenerFactory()
+	if err != nil {
+		return err
+	}
+
+	l.ctx, l.cancel = ctxtool.WithFunc(ctx, func() {
+		l.Listener.Close()
+	})
+	l.log.Info("Started listening for " + l.family.String() + " connection")
+	return nil
+}
+
 func (l *Listener) run() {
 	for {
 		conn, err := l.Listener.Accept()

--- a/filebeat/inputsource/common/listener.go
+++ b/filebeat/inputsource/common/listener.go
@@ -74,17 +74,9 @@ func NewListener(family Family, location string, handlerFactory HandlerFactory, 
 
 // Start listen to the socket.
 func (l *Listener) Start() error {
-	var err error
-	l.Listener, err = l.listenerFactory()
-	if err != nil {
-		return err
-	}
-
 	if err := l.initListen(context.Background()); err != nil {
 		return err
 	}
-
-	l.log.Info("Started listening for " + l.family.String() + " connection")
 
 	l.wg.Add(1)
 	go func() {
@@ -120,11 +112,12 @@ func (l *Listener) initListen(ctx context.Context) error {
 	l.ctx, l.cancel = ctxtool.WithFunc(ctx, func() {
 		l.Listener.Close()
 	})
-	l.log.Info("Started listening for " + l.family.String() + " connection")
 	return nil
 }
 
 func (l *Listener) run() {
+	l.log.Info("Started listening for " + l.family.String() + " connection")
+
 	for {
 		conn, err := l.Listener.Accept()
 		if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

Export a Run method from the common listener inputsource. The Run method supports context.Context for cancellation, in addition to the Stop call.

## Why is it important?

Network based inputs using the v2 API require Run to be implemented.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- 


