### PR TITLE
Cherry-pick #19423 to 7.x: [MetricBeat] add param `aws_partition` to support aws-cn, aws-us-gov regions

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -302,6 +302,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
 - Stop counterCache only when already started {pull}19103[19103]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
+- Add param `aws_partition` to support aws-cn, aws-us-gov regions. {issue}18850[18850] {pull}19423[19423]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -302,7 +302,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
 - Stop counterCache only when already started {pull}19103[19103]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
-- Add param `aws_partition` to support aws-cn, aws-us-gov regions. {issue}18850[18850] {pull}19423[19423]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
 
 *Packetbeat*
@@ -595,6 +594,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add dashboards for googlecloud load balancing metricset. {pull}18369[18369]
 - Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add support for v1 consumer API in Cloud Foundry module, use it by default. {pull}19268[19268]
+- Add param `aws_partition` to support aws-cn, aws-us-gov regions. {issue}18850[18850] {pull}19423[19423]
 
 *Packetbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f
+	golang.org/x/tools v0.0.0-20200630154851-b2d8b0336632
 	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb
 	google.golang.org/grpc v1.29.1

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -24,6 +24,7 @@ type ConfigAWS struct {
 	SharedCredentialFile string `config:"shared_credential_file"`
 	Endpoint             string `config:"endpoint"`
 	RoleArn              string `config:"role_arn"`
+	AWSPartition         string `config:"aws_partition"`
 }
 
 // GetAWSCredentials function gets aws credentials from the config.

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -11,6 +11,7 @@ To configure AWS credentials, either put the credentials into the {beatname_uc} 
 * *shared_credential_file*: directory of the shared credentials file.
 * *endpoint*: URL of the entry point for an AWS web service.
 * *role_arn*: AWS IAM Role to assume.
+* *aws_partition*: AWS region parttion name, value is one of `aws, aws-cn, aws-us-gov`, default is `aws`.
 
 [float]
 ==== Supported Formats

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -93,8 +93,16 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	base.Logger().Debug("Metricset level config for period: ", metricSet.Period)
 	base.Logger().Debug("Metricset level config for tags filter: ", metricSet.TagsFilter)
 
-	// Get IAM account name
-	awsConfig.Region = "us-east-1"
+	// Get IAM account name, set region by aws_partition, default is aws global partition
+	// refer https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+	switch config.AWSConfig.AWSPartition {
+	case "aws-cn":
+		awsConfig.Region = "cn-north-1"
+	case "aws-us-gov":
+		awsConfig.Region = "us-gov-east-1"
+	default:
+		awsConfig.Region = "us-east-1"
+	}
 	svcIam := iam.New(awscommon.EnrichAWSConfigWithEndpoint(
 		config.AWSConfig.Endpoint, "iam", "", awsConfig))
 	req := svcIam.ListAccountAliasesRequest(&iam.ListAccountAliasesInput{})


### PR DESCRIPTION
Cherry-pick of PR #19423 to 7.x branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->


## What does this PR do?

This PR is to add a parameter `aws_partition` for metricbeat aws cloudwatch module, so metricbeat can support aws china and aws us-gov account.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Because there are three partitions ` aws, aws-cn, aws-us-gov` of aws regions,  now metricbeat can only support aws global region, here is a hardcode. 


https://github.com/elastic/beats/blob/5ba7026f81afcdf9a2d745eb248d2711d901673e/x-pack/metricbeat/module/aws/aws.go#L95-L100

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. add `aws_partition` param in aws module config 

```
metricbeat.modules:
  - module: aws
    aws_partition: aws-cn
    period: 300s
    access_key_id: 
    secret_access_key:
```
2. run metricbeat , open debug log, then you can see it can retrive metrics from correct regions



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->

-  Closes elastic/beats#18850

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

* no side affect
* user can use metricbeat to get metrics from aws china and aws us-gov account except aws global account


## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

aws global account, set `aws_partition: aws ` in aws module config  or remove the param

![image](https://user-images.githubusercontent.com/12824991/85829385-13f8dd00-b7bd-11ea-8bbe-002f4de59325.png)

 aws china account, set `aws_partition: aws-cn ` in aws module config 

![image](https://user-images.githubusercontent.com/12824991/85829463-40acf480-b7bd-11ea-9ab5-536e79992325.png)



