### PR TITLE
add functionnalitie to decode csv and some tests

### DIFF
--- a/filebeat/tests/system/header_test
+++ b/filebeat/tests/system/header_test
@@ -1,0 +1,2 @@
+column1_1,column1_2,column1_3
+column2_1,column2_2,column2_3

--- a/libbeat/processors/decode_csv_fields/decode_csv_fields.go
+++ b/libbeat/processors/decode_csv_fields/decode_csv_fields.go
@@ -18,9 +18,12 @@
 package decode_csv_fields
 
 import (
+	"bufio"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -36,6 +39,7 @@ type decodeCSVFields struct {
 	csvConfig
 	fields    map[string]string
 	separator rune
+	headers   map[string]csvHeader
 }
 
 type csvConfig struct {
@@ -45,6 +49,18 @@ type csvConfig struct {
 	OverwriteKeys    bool          `config:"overwrite_keys"`
 	FailOnError      bool          `config:"fail_on_error"`
 	Separator        string        `config:"separator"`
+	Headers          common.MapStr `config:"headers`
+}
+
+type csvHeader struct {
+	custom bool   `config:"in_file"`
+	header string `config:"string"`
+	offset int    `config:"offset"`
+	file   `config:"file"`
+}
+
+type file struct {
+	path string `config:"path"`
 }
 
 var (
@@ -60,7 +76,8 @@ func init() {
 	processors.RegisterPlugin("decode_csv_fields",
 		checks.ConfigChecked(NewDecodeCSVField,
 			checks.RequireFields("fields"),
-			checks.AllowedFields("fields", "ignore_missing", "overwrite_keys", "separator", "trim_leading_space", "overwrite_keys", "fail_on_error", "when")))
+			checks.AllowedFields("fields", "ignore_missing", "overwrite_keys", "separator", "trim_leading_space", "overwrite_keys", "fail_on_error", "when",
+				"headers", "file", "string", "offset", "path", "in_file")))
 
 	jsprocessor.RegisterPlugin("DecodeCSVField", NewDecodeCSVField)
 }
@@ -94,6 +111,70 @@ func NewDecodeCSVField(c *common.Config) (processors.Processor, error) {
 			return nil, errors.Errorf("bad destination mapping for %s: destination field must be string, not %T (got %v)", src, dstIf, dstIf)
 		}
 		f.fields[src] = dst
+	}
+	// Set headers as string -> csvHeader
+	f.headers = make(map[string]csvHeader, len(config.Headers))
+	for src, dstIf := range config.Headers {
+		var dst map[string]interface{}
+		var isString int = 0
+		var isFile int = 0
+		var isCustom int = 0
+		var isOffset bool = false
+		jsonString, _ := json.Marshal(dstIf)
+		json.Unmarshal([]byte(jsonString), &dst)
+		var toHeader csvHeader
+		if val1, found := dst["string"]; found {
+			val2, ok := val1.(string)
+			if !ok {
+				return nil, errors.Errorf("bad destination mapping for \"string\": destination field must be string, not %T (got %v)", val1, val1)
+			}
+			toHeader.header = val2
+			isString = 1
+		}
+		if val1, found := dst["offset"]; found {
+			_, err := val1.(float64)
+			val2, ok := strconv.Atoi(fmt.Sprintf("%v", val1))
+			if ok != nil || !err {
+				return nil, errors.Errorf("bad destination mapping for \"offset\": destination field must be int, got %v", val1)
+			}
+			if val2 <= 0 {
+				return nil, errors.Errorf("\"offset\" must bigger than 0 (got %v)", val2)
+			}
+			toHeader.offset = val2
+			isOffset = true
+		}
+		if val1, found := dst["in_file"]; found {
+			val2, ok := val1.(bool)
+			if !ok {
+				return nil, errors.Errorf("bad destination mapping for \"in_file\": destination field must be bool, not %T (got %v)", val1, val1)
+			}
+			if !val2 {
+				return nil, errors.Errorf("\"in_file\" must be set to true")
+			}
+			toHeader.custom = true
+			isCustom = 1
+		}
+		if val1, found := dst["file"]; found {
+			jsonString, _ = json.Marshal(val1)
+			json.Unmarshal([]byte(jsonString), &dst)
+			if val2, found := dst["path"]; found {
+				val3, ok := val2.(string)
+				if !ok {
+					return nil, errors.Errorf("bad destination mapping for \"file.path\": destination field must be string, not %T (got %v)", val2, val2)
+				}
+				toHeader.file.path = val3
+				isFile = 1
+			}
+		}
+		//can't use all configuration
+		if isString+isFile+isCustom != 1 {
+			return nil, errors.Errorf("choose one configuration : \"string\" or \"file\" or \"in_file\"")
+		}
+		//can't use string and offset
+		if isString == 1 && isOffset {
+			return nil, errors.Errorf("you cannot use \"string\" with \"offset\"")
+		}
+		f.headers[src] = toHeader
 	}
 	return f, nil
 }
@@ -143,7 +224,85 @@ func (f *decodeCSVFields) decodeCSVField(src, dest string, event *beat.Event) er
 			return errors.Errorf("target field %s already has a value. Set the overwrite_keys flag or drop/rename the field first", dest)
 		}
 	}
-	if _, err = event.PutValue(dest, record); err != nil {
+	if _, exist := f.Headers[src]; exist == false {
+		if _, err = event.PutValue(dest, record); err != nil {
+			return errors.Wrapf(err, "failed setting field %s", dest)
+		}
+		return nil
+	}
+
+	firstLine := ""
+	head, _ := f.headers[src]
+	if len(head.header) > 0 {
+		//header in .yml
+		firstLine = head.header
+	} else {
+		strPath := ""
+		if len(head.file.path) > 0 {
+			//header in file conf
+			strPath = head.file.path
+		} else {
+			//header in current file
+			//get path file and open file
+			path, err := event.GetValue("log.file.path")
+			if err != nil {
+				return errors.Errorf("could not fetch value for field log.file.path")
+			}
+			strPath = fmt.Sprintf("%v", path)
+		}
+		//if doesn't give offset, set to default 1
+		if head.offset == 0 {
+			head.offset = 1
+		}
+		file, err := os.Open(strPath)
+		if err != nil {
+			return errors.Errorf("could not open file : %v", strPath)
+		}
+		defer file.Close()
+
+		//read header in file
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() && head.offset > 0 {
+			firstLine = scanner.Text()
+			head.offset--
+			if err := scanner.Err(); err != nil {
+				return errors.Errorf("error from scanner.Text() in read file")
+			}
+		}
+		if head.offset != 0 {
+			return errors.Errorf("error: offset too large")
+		}
+	}
+	if text == firstLine {
+		return nil
+	}
+	//get header record
+	reader = csv.NewReader(strings.NewReader(firstLine))
+	reader.Comma = f.separator
+	reader.TrimLeadingSpace = f.TrimLeadingSpace
+	reader.LazyQuotes = true
+	headcsv, err := reader.Read()
+	if err != nil {
+		return errors.Errorf("error decoding header")
+	}
+	//check length header and record
+	if len(headcsv) != len(record) {
+		return errors.Errorf("number of header and line are different, given %v headers, needed %v", len(headcsv), len(record))
+	}
+	//create map object
+	mymap := make(map[string]string)
+	for i := 0; i < len(headcsv); i++ {
+		if headcsv[i] == "" {
+			headcsv[i] = fmt.Sprintf("%v", i)
+		}
+		if record[i] == "" {
+			record[i] = fmt.Sprintf("%v", i)
+		}
+		mymap[headcsv[i]] = record[i]
+	}
+
+	//put result in fields dest
+	if _, err = event.PutValue(dest, mymap); err != nil {
 		return errors.Wrapf(err, "failed setting field %s", dest)
 	}
 	return nil

--- a/libbeat/processors/decode_csv_fields/header_test
+++ b/libbeat/processors/decode_csv_fields/header_test
@@ -1,0 +1,3 @@
+col1_1,col1_2
+col2_1,col2_2
+col3_1,col3_2


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Enhancement
## What does this PR do?
This PR add functionality in decode_csv_fields processor.  
It offers the possibility to combine the headers with the corresponding column in the csv file.  
Headers can be given : either in the configuration file * filebeat.yml *, either from a conf file or either from the current file (first line) : 
```
processors:
  - decode_csv_fields:
      fields:
        message: decoded.csv
      separator: ","
      headers:
        - message:
            in_file: true
            string: [string]
            offset: [number]
            file:
              path: [string]
```
- in_file : get the headers in the current file (in "log.file.path")
- string : give the headers as string, separated by the separator
- file.path : give path of conf file where to get headers. Can be use with offset to set the line of the headers

If **headers** fields is not given, the processor works like the current version of decode_csv_fields

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Allows to combine the headers of a csv file with the column, make json field for elasticsearch to avoid using for example pipeline ingests
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally
- go test :
```
cd github.com/elastic/beats/libbeat/processors/decode_csv_fields
go test -v
```
- python test (with python3.8 and virtualenv, requirements : jinja2, docker-compose, pyyaml, nose ) : 
```
cd github.com/elastic/beats/filebeat
make filebeat.test
pip3 install virtualenv
virtualenv -p /usr/bin/python3.8 venv
source venv/bin/activate
pip3 install jinja2 docker-compose pyyaml nose
INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false nosetests -v -s tests/system/test_processors.py
```
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- relates [#19385](https://github.com/elastic/beats/issues/19385)

## Use cases
Here is the content of my log : 
```
firstname,lastname
chris,paul
baptiste,jean
```
The conf of filebeat.yml : 
```
processors:
  - decode_csv_fields:
      fields:
        message: csv
      separator: ";"
      headers:
        - message:
            in_file: true
```
Output desired : 
```
"firstname": "chris",
"lastname": "paul"

"firstname": "baptiste",
"lastname": "jean"
```
<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots
![1](https://user-images.githubusercontent.com/40337958/86156834-d66eb980-bb06-11ea-8f24-615a7b85e374.png)
![2](https://user-images.githubusercontent.com/40337958/86156904-eb4b4d00-bb06-11ea-8044-e366e2d5369f.png)

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->