### PR TITLE
Update Beats to the current Sarama fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
-	github.com/Shopify/sarama => github.com/elastic/sarama v1.24.1-elastic.0.20200519143807-cbc80333a91e
+	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec
 	github.com/cucumber/godog => github.com/cucumber/godog v0.8.1
 	github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
 	github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/elastic/gosigar v0.10.5 h1:GzPQ+78RaAb4J63unidA/JavQRKrB6s8IOzN6Ib59jo=
 github.com/elastic/gosigar v0.10.5/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
-github.com/elastic/sarama v1.24.1-elastic.0.20200519143807-cbc80333a91e h1:2jm3380rkaGcosRpvtgIQrl7F5Cb99aFJYis7Y5hoJw=
-github.com/elastic/sarama v1.24.1-elastic.0.20200519143807-cbc80333a91e/go.mod h1:X690XXMxlbtN8c7xcpsENKNlbj8VClCZ2hwSOhSyNmE=
+github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec h1:rAHd7DeHIHjSzvnkl197GKh9TCWGKg/z2BBbbGOEiWI=
+github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec/go.mod h1:X690XXMxlbtN8c7xcpsENKNlbj8VClCZ2hwSOhSyNmE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
## What does this PR do?

This PR updates Beats to the current version of [Elastic's Sarama fork](https://github.com/elastic/sarama). It uses a base Sarama version of 1.26.4 with added fixes; for details of the exact Sarama state, see the [README for the current fork version](https://github.com/elastic/sarama/blob/0e7b69039eec89751dfbdf17496c639909a93547/README.md)

This PR was created by:

```
go mod edit -replace github.com/Shopify/sarama=github.com/elastic/sarama@0e7b69039eec89751dfbdf17496c639909a93547

make notice
```

targeting the following commit:

```
commit 0e7b69039eec89751dfbdf17496c639909a93547 (HEAD -> beats-fork, upstream/beats-fork)
Merge: b4d980d b47eb73
Author: Fae Charlton <fae.charlton@elastic.co>
Date:   Mon Jun 29 08:34:29 2020 -0400

    Document status and process for the Elastic fork
```