### PR TITLE
Cherry-pick #18956 to 7.x: Add automatic retries and exponential backoff to Filebeat httpjson input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -507,6 +507,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support for timezone offsets and `Z` to decode_cef timestamp parser. {pull}19346[19346]
 - Improve ECS categorization field mappings in traefik module. {issue}16183[16183] {pull}19379[19379]
 - Improve ECS categorization field mappings in azure module. {issue}16155[16155] {pull}19376[19376]
+- Add automatic retries and exponential backoff to httpjson input. {pull}18956[18956]
 
 *Heartbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.13.0 // indirect
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/golang-lru v0.5.2-0.20190520140433-59383c442f7d // indirect
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/insomniacslk/dhcp v0.0.0-20180716145214-633285ba52b2

--- a/go.sum
+++ b/go.sum
@@ -406,10 +406,15 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce h1:prjrVgOk2Yg6w
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874 h1:cAv7ZbSmyb1wjn6T4TIiyFCkpcfgpbcNNC3bM2srLaI=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -261,6 +261,21 @@ This specifies the field in the HTTP Header of the response that specifies the
 epoch time when the rate limit will reset.
 
 [float]
+==== `retry.max_attempts`
+
+This specifies the maximum number of retries for the retryable HTTP client. Default: 5.
+
+[float]
+==== `retry.wait_min`
+
+This specifies the minimum time to wait before a retry is attempted. Default: 1s.
+
+[float]
+==== `retry.wait_max`
+
+This specifies the maximum time to wait before a retry is attempted. Default: 60s.
+
+[float]
 ==== `ssl`
 
 This specifies SSL/TLS configuration. If the ssl section is missing, the host's

--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -29,6 +29,9 @@ type config struct {
 	NoHTTPBody           bool              `config:"no_http_body"`
 	Pagination           *Pagination       `config:"pagination"`
 	RateLimit            *RateLimit        `config:"rate_limit"`
+	RetryMax             int               `config:"retry.max_attempts"`
+	RetryWaitMin         time.Duration     `config:"retry.wait_min"`
+	RetryWaitMax         time.Duration     `config:"retry.wait_max"`
 	TLS                  *tlscommon.Config `config:"ssl"`
 	URL                  string            `config:"url" validate:"required"`
 }
@@ -95,5 +98,8 @@ func defaultConfig() config {
 	var c config
 	c.HTTPMethod = "GET"
 	c.HTTPClientTimeout = 60 * time.Second
+	c.RetryWaitMin = 1 * time.Second
+	c.RetryWaitMax = 60 * time.Second
+	c.RetryMax = 5
 	return c
 }


### PR DESCRIPTION
Cherry-pick of PR #18956 to 7.x branch. Original message: 

Add automatic retries and exponential backoff to Filebeat httpjson input. If an HTTP error is returned by the client, e.g., connection errors, or if a 500-range response code is received (except 501), then a retry is automatically invoked after a defined wait period.

go test result:

```
=== RUN   TestProviderCanonical
--- PASS: TestProviderCanonical (0.00s)
=== RUN   TestGetProviderIsCanonical
--- PASS: TestGetProviderIsCanonical (0.00s)
=== RUN   TestIsEnabled
--- PASS: TestIsEnabled (0.00s)
=== RUN   TestGetTokenURL
--- PASS: TestGetTokenURL (0.00s)
=== RUN   TestGetTokenURLWithAzure
--- PASS: TestGetTokenURLWithAzure (0.00s)
=== RUN   TestGetEndpointParams
--- PASS: TestGetEndpointParams (0.00s)
=== RUN   TestGetEndpointParamsWithAzure
--- PASS: TestGetEndpointParamsWithAzure (0.00s)
=== RUN   TestConfigValidationCase1
--- PASS: TestConfigValidationCase1 (0.00s)
=== RUN   TestConfigValidationCase2
--- PASS: TestConfigValidationCase2 (0.00s)
=== RUN   TestConfigValidationCase3
--- PASS: TestConfigValidationCase3 (0.00s)
=== RUN   TestConfigValidationCase4
--- PASS: TestConfigValidationCase4 (0.00s)
=== RUN   TestConfigValidationCase5
--- PASS: TestConfigValidationCase5 (0.00s)
=== RUN   TestConfigValidationCase6
--- PASS: TestConfigValidationCase6 (0.00s)
=== RUN   TestConfigValidationCase7
--- PASS: TestConfigValidationCase7 (0.00s)
=== RUN   TestConfigOauth2Validation
=== RUN   TestConfigOauth2Validation/can't_set_oauth2_and_api_key_together
=== RUN   TestConfigOauth2Validation/can_set_oauth2_and_api_key_together_if_oauth2_is_disabled
=== RUN   TestConfigOauth2Validation/can't_set_oauth2_and_authentication_scheme
=== RUN   TestConfigOauth2Validation/token_url_and_client_credentials_must_be_set
=== RUN   TestConfigOauth2Validation/must_fail_with_an_unknown_provider
=== RUN   TestConfigOauth2Validation/azure_must_have_either_tenant_id_or_token_url
=== RUN   TestConfigOauth2Validation/azure_must_have_only_one_of_token_url_and_tenant_id
=== RUN   TestConfigOauth2Validation/azure_must_have_client_credentials_set
=== RUN   TestConfigOauth2Validation/azure_config_is_valid
=== RUN   TestConfigOauth2Validation/google_can't_have_token_url_or_client_credentials_set
=== RUN   TestConfigOauth2Validation/google_must_fail_if_no_ADC_available
=== RUN   TestConfigOauth2Validation/google_must_fail_if_credentials_file_not_found
=== RUN   TestConfigOauth2Validation/google_must_fail_if_ADC_is_wrongly_set
=== RUN   TestConfigOauth2Validation/google_must_work_if_ADC_is_set_up
=== RUN   TestConfigOauth2Validation/google_must_work_if_credentials_file_is_correct
=== RUN   TestConfigOauth2Validation/google_must_work_if_jwt_file_is_correct
=== RUN   TestConfigOauth2Validation/google_must_work_if_credentials_json_is_correct
=== RUN   TestConfigOauth2Validation/google_must_fail_if_credentials_json_is_not_a_valid_JSON
=== RUN   TestConfigOauth2Validation/google_must_fail_if_the_provided_credentials_file_is_not_a_valid_JSON
--- PASS: TestConfigOauth2Validation (0.00s)
    --- PASS: TestConfigOauth2Validation/can't_set_oauth2_and_api_key_together (0.00s)
    --- PASS: TestConfigOauth2Validation/can_set_oauth2_and_api_key_together_if_oauth2_is_disabled (0.00s)
    --- PASS: TestConfigOauth2Validation/can't_set_oauth2_and_authentication_scheme (0.00s)
    --- PASS: TestConfigOauth2Validation/token_url_and_client_credentials_must_be_set (0.00s)
    --- PASS: TestConfigOauth2Validation/must_fail_with_an_unknown_provider (0.00s)
    --- PASS: TestConfigOauth2Validation/azure_must_have_either_tenant_id_or_token_url (0.00s)
    --- PASS: TestConfigOauth2Validation/azure_must_have_only_one_of_token_url_and_tenant_id (0.00s)
    --- PASS: TestConfigOauth2Validation/azure_must_have_client_credentials_set (0.00s)
    --- PASS: TestConfigOauth2Validation/azure_config_is_valid (0.00s)
    --- PASS: TestConfigOauth2Validation/google_can't_have_token_url_or_client_credentials_set (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_fail_if_no_ADC_available (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_fail_if_credentials_file_not_found (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_fail_if_ADC_is_wrongly_set (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_work_if_ADC_is_set_up (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_work_if_credentials_file_is_correct (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_work_if_jwt_file_is_correct (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_work_if_credentials_json_is_correct (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_fail_if_credentials_json_is_not_a_valid_JSON (0.00s)
    --- PASS: TestConfigOauth2Validation/google_must_fail_if_the_provided_credentials_file_is_not_a_valid_JSON (0.00s)
=== RUN   TestGetNextLinkFromHeader
--- PASS: TestGetNextLinkFromHeader (0.00s)
=== RUN   TestCreateRequestInfoFromBody
--- PASS: TestCreateRequestInfoFromBody (0.00s)
=== RUN   TestGetRateLimitCase1
--- PASS: TestGetRateLimitCase1 (0.00s)
=== RUN   TestGetRateLimitCase2
--- PASS: TestGetRateLimitCase2 (0.00s)
=== RUN   TestGetRateLimitCase3
--- PASS: TestGetRateLimitCase3 (0.00s)
=== RUN   TestGET
2020-06-16T20:53:14.947-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53858"}
2020-06-16T20:53:14.947-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53858
--- PASS: TestGET (0.00s)
=== RUN   TestGetHTTPS
2020-06-16T20:53:14.948-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53860"}
2020-06-16T20:53:14.948-0700	WARN	[tls]	tlscommon/tls_config.go:83	SSL/TLS verifications disabled.
2020-06-16T20:53:14.948-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53860
--- PASS: TestGetHTTPS (0.00s)
=== RUN   TestRateLimitRetry
2020-06-16T20:53:14.949-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53862"}
2020-06-16T20:53:14.949-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53862
2020-06-16T20:53:14.949-0700	DEBUG	[httpjson]	httpjson/input.go:325	HTTP request failed	{"url": "http://127.0.0.1:53862", "http.response.status_code": 429, "http.response.body": ""}
2020-06-16T20:53:14.949-0700	DEBUG	[httpjson]	httpjson/input.go:262	Rate Limit: No need to apply rate limit.	{"url": "http://127.0.0.1:53862"}
2020-06-16T20:53:14.949-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53862
--- PASS: TestRateLimitRetry (0.00s)
=== RUN   TestErrorRetry
2020-06-16T20:53:14.950-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53865"}
2020-06-16T20:53:14.950-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53865
2020-06-16T20:53:14.950-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:600	[DEBUG] GET http://127.0.0.1:53865 (status: 506): retrying in 1s (5 left)
2020-06-16T20:53:15.951-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:600	[DEBUG] GET http://127.0.0.1:53865 (status: 508): retrying in 2s (4 left)
--- PASS: TestErrorRetry (3.01s)
=== RUN   TestArrayResponse
2020-06-16T20:53:17.955-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53900"}
2020-06-16T20:53:17.956-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53900
--- PASS: TestArrayResponse (0.00s)
=== RUN   TestPOST
2020-06-16T20:53:17.957-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53902"}
2020-06-16T20:53:17.957-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] POST http://127.0.0.1:53902
--- PASS: TestPOST (0.00s)
=== RUN   TestRepeatedPOST
2020-06-16T20:53:17.958-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53904"}
2020-06-16T20:53:17.958-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] POST http://127.0.0.1:53904
2020-06-16T20:53:20.963-0700	INFO	[httpjson]	httpjson/input.go:438	Process another repeated request.	{"url": "http://127.0.0.1:53904"}
2020-06-16T20:53:20.963-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] POST http://127.0.0.1:53904
2020-06-16T20:53:23.962-0700	INFO	[httpjson]	httpjson/input.go:438	Process another repeated request.	{"url": "http://127.0.0.1:53904"}
2020-06-16T20:53:23.962-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] POST http://127.0.0.1:53904
2020-06-16T20:53:23.963-0700	INFO	[httpjson]	httpjson/input.go:435	Context done.	{"url": "http://127.0.0.1:53904"}
--- PASS: TestRepeatedPOST (6.01s)
=== RUN   TestRunStop
2020-06-16T20:53:23.963-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53970"}
2020-06-16T20:53:23.963-0700	INFO	[httpjson]	httpjson/input.go:133	httpjson input worker has started.	{"url": "http://127.0.0.1:53970"}
2020-06-16T20:53:23.963-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53970
2020-06-16T20:53:23.963-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:551	[ERR] GET http://127.0.0.1:53970 request failed: Get http://127.0.0.1:53970: context canceled
2020-06-16T20:53:23.963-0700	ERROR	[httpjson]	httpjson/input.go:138	failed to execute http client.Do: Get http://127.0.0.1:53970: context canceled	{"url": "http://127.0.0.1:53970"}
2020-06-16T20:53:23.963-0700	INFO	[httpjson]	httpjson/input.go:139	httpjson input worker has stopped.	{"url": "http://127.0.0.1:53970"}
--- PASS: TestRunStop (0.00s)
=== RUN   TestOAuth2
2020-06-16T20:53:23.963-0700	INFO	[httpjson]	httpjson/input.go:123	Initialized httpjson input.	{"url": "http://127.0.0.1:53972"}
2020-06-16T20:53:23.964-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] POST http://127.0.0.1:53971
2020-06-16T20:53:23.964-0700	DEBUG	[httpjson.retryablehttp]	go-retryablehttp@v0.6.6/client.go:502	[DEBUG] GET http://127.0.0.1:53972
--- PASS: TestOAuth2 (0.00s)
PASS
ok  	github.com/elastic/beats/v7/x-pack/filebeat/input/httpjson	9.214s
(base)
```