### PR TITLE
Update add_docker_metadata docs on socket issues

### DIFF
--- a/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
+++ b/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
@@ -29,6 +29,12 @@ To avoid privilege issues, you may also need to add `--user=root` to the
 `docker run` flags. Because the user must be part of the docker group in order
 to access `/var/run/docker.sock`, root access is required if {beatname_uc} is
 running as non-root inside the container.
+
+If Docker daemon is restarted the mounted socket will become invalid and metadata
+will stop working, in these situations there are two options:
+
+ - Restart {beatname_uc} every time Docker is restarted
+ - Mount the entire `/var/run` directory (instead of just the socket)
 =====
 
 [source,yaml]


### PR DESCRIPTION
Docker socket can become stale when Docker is restarted, this PR adds
info about that situation and how to deal with it

Closes https://github.com/elastic/beats/issues/19323