### PR TITLE
Cherry-pick #19535 to 7.x: Use Go install for getting goimports 

### DIFF
--- a/dev-tools/mage/fmt.go
+++ b/dev-tools/mage/fmt.go
@@ -74,8 +74,8 @@ func GoImports() error {
 			return err
 		}
 	} else {
-		if err := gotool.Get(
-			gotool.Get.Package(filepath.Join(GoImportsImportPath)),
+		if err := gotool.Install(
+			gotool.Install.Package(filepath.Join(GoImportsImportPath)),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry-pick of PR #19535 to 7.x branch. Original message:

## What does this PR do?

ATM when we run go get goimports on CI it modifies go.mod to include latest (daily) version of `x/tools`
this causes lint to break and results in PR bringing `x/tools` version up to date in PR fixes

## Why is it important?

To avoid failures like this:
```
diff --git a/go.mod b/go.mod
index 552b28cbb4..f4867e4d91 100644
--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
        golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
        golang.org/x/text v0.3.2
        golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-       golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f
+       golang.org/x/tools v0.0.0-20200630154851-b2d8b0336632
        google.golang.org/api v0.15.0
        google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb
        google.golang.org/grpc v1.29.1
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
