### PR TITLE
Cherry-pick #19490 #19559 to 7.x: ci: disable upstream trigger on PRs for the packaging job

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -7,6 +7,7 @@ pipeline {
   environment {
     BASE_DIR = 'src/github.com/elastic/beats'
     JOB_GCS_BUCKET = 'beats-ci-artifacts'
+    JOB_GCS_BUCKET_STASH = 'beats-ci-temp'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
@@ -22,11 +23,12 @@ pipeline {
     disableConcurrentBuilds()
   }
   triggers {
-    upstream('Beats/beats-beats-mbp/7.x')
     issueCommentTrigger('(?i)^\\/packag[ing|e]$')
+    // disable upstream trigger on a PR basis
+    upstream("Beats/beats-beats-mbp/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
   }
   parameters {
-    booleanParam(name: 'macos', defaultValue: true, description: 'Allow macOS stages.')
+    booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')
     booleanParam(name: 'linux', defaultValue: true, description: 'Allow linux stages.')
   }
   stages {
@@ -42,7 +44,7 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         setEnvVar("GO_VERSION", readFile("${BASE_DIR}/.go-version").trim())
-        //stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       }
     }
     stage('Build Packages'){
@@ -104,7 +106,7 @@ pipeline {
               ].join(' ')
             }
             steps {
-              withGithubNotify(context: "Packaging ${BEATS_FOLDER}") {
+              withGithubNotify(context: "Packaging Linux ${BEATS_FOLDER}") {
                 release()
                 pushCIDockerImages()
               }
@@ -127,8 +129,10 @@ pipeline {
               ].join(' ')
             }
             steps {
-              withMacOSEnv(){
-                release()
+              withGithubNotify(context: "Packaging MacOS ${BEATS_FOLDER}") {
+                withMacOSEnv(){
+                  release()
+                }
               }
             }
           }
@@ -216,38 +220,15 @@ def publishPackages(baseDir){
 }
 
 def withBeatsEnv(Closure body) {
-  def os = goos()
-  def goRoot = "${env.WORKSPACE}/.gvm/versions/go${GO_VERSION}.${os}.amd64"
-
-  withEnv([
-    "HOME=${env.WORKSPACE}",
-    "GOPATH=${env.WORKSPACE}",
-    "GOROOT=${goRoot}",
-    "PATH=${env.WORKSPACE}/bin:${goRoot}/bin:${env.PATH}",
-    "MAGEFILE_CACHE=${WORKSPACE}/.magefile",
-    "PYTHON_ENV=${WORKSPACE}/python-env"
-  ]) {
-    deleteDir()
-    //unstash 'source'
-    gitCheckout(basedir: "${BASE_DIR}")
-    dir("${env.BASE_DIR}"){
-      sh(label: "Install Go ${GO_VERSION}", script: ".ci/scripts/install-go.sh")
-      sh(label: "Install Mage", script: "make mage")
-      body()
+  withMageEnv(){
+    withEnv([
+      "PYTHON_ENV=${WORKSPACE}/python-env"
+    ]) {
+      deleteDir()
+      unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+      dir("${env.BASE_DIR}"){
+        body()
+      }
     }
   }
-}
-
-def goos(){
-  def labels = env.NODE_LABELS
-
-  if (labels.contains('linux')) {
-    return 'linux'
-  } else if (labels.contains('windows')) {
-    return 'windows'
-  } else if (labels.contains('darwin')) {
-    return 'darwin'
-  }
-
-  error("Unhandled OS name in NODE_LABELS: " + labels)
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu && immutable' }
+  agent none
   environment {
     BASE_DIR = 'src/github.com/elastic/beats'
     JOB_GCS_BUCKET = 'beats-ci-artifacts'
@@ -12,6 +12,7 @@ pipeline {
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     SNAPSHOT = "true"
+    PIPELINE_LOG_LEVEL = "DEBUG"
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -32,106 +33,105 @@ pipeline {
     booleanParam(name: 'linux', defaultValue: true, description: 'Allow linux stages.')
   }
   stages {
-    stage('Checkout') {
+    stage('Filter build') {
+      agent { label 'ubuntu && immutable' }
       when {
         beforeAgent true
-        not {
-          triggeredBy 'SCMTrigger'
+        expression {
+          return isCommentTrigger() || isUserTrigger()
         }
       }
-      options { skipDefaultCheckout() }
-      steps {
-        deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
-        setEnvVar("GO_VERSION", readFile("${BASE_DIR}/.go-version").trim())
-        stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-      }
-    }
-    stage('Build Packages'){
-      when {
-        beforeAgent true
-        not {
-          triggeredBy 'SCMTrigger'
-        }
-      }
-      matrix {
-        axes {
-          axis {
-            name 'BEATS_FOLDER'
-            values (
-              'auditbeat',
-              'filebeat',
-              'heartbeat',
-              'journalbeat',
-              'metricbeat',
-              'packetbeat',
-              'winlogbeat',
-              'x-pack/auditbeat',
-              'x-pack/elastic-agent',
-              'x-pack/dockerlogbeat',
-              'x-pack/filebeat',
-              'x-pack/functionbeat',
-              // 'x-pack/heartbeat',
-              // 'x-pack/journalbeat',
-              'x-pack/metricbeat',
-              // 'x-pack/packetbeat',
-              'x-pack/winlogbeat'
-            )
+      stages {
+        stage('Checkout') {
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}")
+            setEnvVar("GO_VERSION", readFile("${BASE_DIR}/.go-version").trim())
+            stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
           }
         }
-        stages {
-          stage('Package Linux'){
-            agent { label 'ubuntu && immutable' }
-            options { skipDefaultCheckout() }
-            when {
-              beforeAgent true
-              expression {
-                return params.linux
+        stage('Build Packages'){
+          matrix {
+            axes {
+              axis {
+                name 'BEATS_FOLDER'
+                values (
+                  'auditbeat',
+                  'filebeat',
+                  'heartbeat',
+                  'journalbeat',
+                  'metricbeat',
+                  'packetbeat',
+                  'winlogbeat',
+                  'x-pack/auditbeat',
+                  'x-pack/elastic-agent',
+                  'x-pack/dockerlogbeat',
+                  'x-pack/filebeat',
+                  'x-pack/functionbeat',
+                  // 'x-pack/heartbeat',
+                  // 'x-pack/journalbeat',
+                  'x-pack/metricbeat',
+                  // 'x-pack/packetbeat',
+                  'x-pack/winlogbeat'
+                )
               }
             }
-            environment {
-              HOME = "${env.WORKSPACE}"
-              PLATFORMS = [
-                '+all',
-                'linux/amd64',
-                'linux/386',
-                'linux/arm64',
-                'linux/armv7',
-                'linux/ppc64le',
-                'linux/mips64',
-                'linux/s390x',
-                'windows/amd64',
-                'windows/386',
-                (params.macos ? '' : 'darwin/amd64'),
-              ].join(' ')
-            }
-            steps {
-              withGithubNotify(context: "Packaging Linux ${BEATS_FOLDER}") {
-                release()
-                pushCIDockerImages()
+            stages {
+              stage('Package Linux'){
+                agent { label 'ubuntu && immutable' }
+                options { skipDefaultCheckout() }
+                when {
+                  beforeAgent true
+                  expression {
+                    return params.linux
+                  }
+                }
+                environment {
+                  HOME = "${env.WORKSPACE}"
+                  PLATFORMS = [
+                    '+all',
+                    'linux/amd64',
+                    'linux/386',
+                    'linux/arm64',
+                    'linux/armv7',
+                    'linux/ppc64le',
+                    'linux/mips64',
+                    'linux/s390x',
+                    'windows/amd64',
+                    'windows/386',
+                    (params.macos ? '' : 'darwin/amd64'),
+                  ].join(' ')
+                }
+                steps {
+                  withGithubNotify(context: "Packaging Linux ${BEATS_FOLDER}") {
+                    release()
+                    pushCIDockerImages()
+                  }
+                }
               }
-            }
-          }
-          stage('Package Mac OS'){
-            agent { label 'macosx-10.12' }
-            options { skipDefaultCheckout() }
-            when {
-              beforeAgent true
-              expression {
-                return params.macos
-              }
-            }
-            environment {
-              HOME = "${env.WORKSPACE}"
-              PLATFORMS = [
-                '+all',
-                'darwin/amd64',
-              ].join(' ')
-            }
-            steps {
-              withGithubNotify(context: "Packaging MacOS ${BEATS_FOLDER}") {
-                withMacOSEnv(){
-                  release()
+              stage('Package Mac OS'){
+                agent { label 'macosx-10.12' }
+                options { skipDefaultCheckout() }
+                when {
+                  beforeAgent true
+                  expression {
+                    return params.macos
+                  }
+                }
+                environment {
+                  HOME = "${env.WORKSPACE}"
+                  PLATFORMS = [
+                    '+all',
+                    'darwin/amd64',
+                  ].join(' ')
+                }
+                steps {
+                  withGithubNotify(context: "Packaging MacOS ${BEATS_FOLDER}") {
+                    withMacOSEnv(){
+                      release()
+                    }
+                  }
                 }
               }
             }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -12,7 +12,7 @@ pipeline {
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     SNAPSHOT = "true"
-    PIPELINE_LOG_LEVEL = "DEBUG"
+    PIPELINE_LOG_LEVEL = "INFO"
   }
   options {
     timeout(time: 3, unit: 'HOURS')


### PR DESCRIPTION
Original PR 
https://github.com/elastic/beats/pull/19490 https://github.com/elastic/beats/pull/19559

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

* Change to use withMageEnv
* Disable upstream trigger on PRs
* Disable macOS sign packages is a bottleneck

## Why is it important?

This PR fixes the queue-boom occasioned by the upstream trigger on PRs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
