### PR TITLE
Cherry-pick #18873 to 7.x: Allow the Docker image to be run with a random user id (#12905)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -372,6 +372,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support for fixed length extraction in `dissect` processor. {pull}17191[17191]
 - Update RPM packages contained in Beat Docker images. {issue}17035[17035]
 - Add TLS support to Kerberos authentication in Elasticsearch. {pull}18607[18607]
+- Change ownership of files in docker images so they can be used in secured environments. {pull}12905[12905]
 - Upgrade k8s.io/client-go and k8s keystore tests. {pull}18817[18817]
 - Add support for multiple sets of hints on autodiscover {pull}18883[18883]
 

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -196,14 +196,15 @@ spec:
           path: /etc
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: auditbeat-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: auditbeat-daemonset-modules
       - name: data
         hostPath:
+          # When auditbeat runs as non-root user, this directory needs to be writable by group (g+w).
           path: /var/lib/auditbeat-data
           type: DirectoryOrCreate
       - name: run-containerd

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -109,14 +109,15 @@ spec:
           path: /etc
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: auditbeat-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: auditbeat-daemonset-modules
       - name: data
         hostPath:
+          # When auditbeat runs as non-root user, this directory needs to be writable by group (g+w).
           path: /var/lib/auditbeat-data
           type: DirectoryOrCreate
       - name: run-containerd

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -112,7 +112,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: filebeat-config
       - name: varlibdockercontainers
         hostPath:
@@ -123,6 +123,7 @@ spec:
       # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
       - name: data
         hostPath:
+          # When filebeat runs as non-root user, this directory needs to be writable by group (g+w).
           path: /var/lib/filebeat-data
           type: DirectoryOrCreate
 ---

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: filebeat-config
       - name: varlibdockercontainers
         hostPath:
@@ -79,5 +79,6 @@ spec:
       # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
       - name: data
         hostPath:
+          # When filebeat runs as non-root user, this directory needs to be writable by group (g+w).
           path: /var/lib/filebeat-data
           type: DirectoryOrCreate

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -177,14 +177,15 @@ spec:
           path: /var/run/docker.sock
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-daemonset-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-daemonset-modules
       - name: data
         hostPath:
+          # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)
           path: /var/lib/metricbeat-data
           type: DirectoryOrCreate
 ---
@@ -302,11 +303,11 @@ spec:
       volumes:
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-deployment-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-deployment-modules
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -84,13 +84,14 @@ spec:
           path: /var/run/docker.sock
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-daemonset-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-daemonset-modules
       - name: data
         hostPath:
+          # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)
           path: /var/lib/metricbeat-data
           type: DirectoryOrCreate

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -61,9 +61,9 @@ spec:
       volumes:
       - name: config
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-deployment-config
       - name: modules
         configMap:
-          defaultMode: 0600
+          defaultMode: 0640
           name: metricbeat-deployment-modules

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -30,7 +30,7 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint
 RUN groupadd --gid 1000 {{ .BeatName }}
 
 RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
-    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
+    chown -R root:root {{ $beatHome }} && \
     find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
     find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
     chmod 0750 {{ $beatBinary }} && \
@@ -43,7 +43,7 @@ RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
     chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
 
 {{- if ne .user "root" }}
-RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
+RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
 {{- end }}
 USER {{ .user }}
 


### PR DESCRIPTION
Cherry-pick of PR #18873 to 7.x branch. Original message: 

Apply changes on ownership proposed in #12905, but keep the permissions, to avoid the
issues reported in #18858.

I think this could be enough to run containers with arbitrary user ids, because beats don't need to write these files, only read them.

Make changes also to the kubernetes reference manifests to help running beats with arbitrary user ids. These manifests still won't work on restricted environments.

Fixes elastic/beats#18871 
Changes were previously reverted in elastic/beats#18872 

Co-authored-by: Michael Morello <michael.morello@elastic.co>

How to test
----
* Do it with auditbeat (that uses the root user by default), and with some other beat like metricbeat or filebeat (that use a non-root user by default):
  * Build the docker image for the beat with `PLATFORMS=linux/amd64 mage package`, or use one of the pre-built snapshots including this change.
  * Run the docker container with and without explicit user id, and check that beat is able to start and read configuration without `--privileged` and without `BEAT_STRICT_PERMS`.
    It should behave the same on these scenarios (auditbeat will fail to configure audit, this is expected unless `--privileged --user 0 --pid=host` is also used):
    * Default user: `docker run -it --rm docker.elastic.co/beats/filebeat:8.0.0`
    * Root: `docker run -it --rm --user 0 docker.elastic.co/beats/filebeat:8.0.0`
    * Beat user: `docker run -it --rm --user 1000 docker.elastic.co/beats/filebeat:8.0.0`
    * Arbitrary user (use any other user id): `docker run -it --rm --user 100042 docker.elastic.co/beats/filebeat:8.0.0`
  * Check that reference kubernetes manifests continue working as they are (using arbitrary user ids there will require more changes).