### PR TITLE
Cherry-pick #19558 to 7.9: Update Jenkinsfile to check go.mod instead of vendor/

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1104,7 +1104,7 @@ def isChanged(patterns){
 def isChangedOSSCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
-    "^vendor/.*",
+    "^go.mod",
     "^libbeat/.*",
     "^testing/.*",
     "^dev-tools/.*",
@@ -1117,7 +1117,7 @@ def isChangedOSSCode(patterns) {
 def isChangedXPackCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
-    "^vendor/.*",
+    "^go.mod",
     "^libbeat/.*",
     "^dev-tools/.*",
     "^testing/.*",


### PR DESCRIPTION
Cherry-pick of PR #19558 to 7.9 branch. Original message: 

Beats has moved to go modules and no longer maintains an explicit vendor folder, but Jenkins is configured to check that folder for dependency updates, which means that dependency updates aren't running all the tests they should be. This change reconfigures it to check `go.mod` instead.