### PR TITLE
Cherry-pick #19433 to 7.x: [MetricBeat] set tags correctly if the dimension value is ARN

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -302,6 +302,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix incorrect usage of hints builder when exposed port is a substring of the hint {pull}19052[19052]
 - Stop counterCache only when already started {pull}19103[19103]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
+- Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -615,6 +615,13 @@ func insertTags(events map[string]mb.Event, identifier string, resourceTagMap ma
 	subIdentifiers := strings.Split(identifier, dimensionSeparator)
 	for _, v := range subIdentifiers {
 		tags := resourceTagMap[v]
+		// some metric dimension values are arn format, eg: AWS/DDOS namespace metric
+		if len(tags) == 0 && strings.HasPrefix(v, "arn:") {
+			resourceID, err := aws.FindIdentifierFromARN(v)
+			if err == nil {
+				tags = resourceTagMap[resourceID]
+			}
+		}
 		if len(tags) != 0 {
 			// By default, replace dot "." using underscore "_" for tag keys.
 			// Note: tag values are not dedotted.

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1407,10 +1407,14 @@ func TestInsertTags(t *testing.T) {
 	tagValue1 := "engineering"
 	tagKey2 := "owner"
 	tagValue2 := "foo"
+	identifierContainsArn := "arn:aws:ec2:ap-northeast-1:111111111111:eip-allocation/eipalloc-0123456789abcdef,SYNFlood"
+	tagKey3 := "env"
+	tagValue3 := "dev"
 
 	events := map[string]mb.Event{}
 	events[identifier1] = aws.InitEvent(regionName, accountName, accountID)
 	events[identifier2] = aws.InitEvent(regionName, accountName, accountID)
+	events[identifierContainsArn] = aws.InitEvent(regionName, accountName, accountID)
 
 	resourceTagMap := map[string][]resourcegroupstaggingapi.Tag{}
 	resourceTagMap["test-s3-1"] = []resourcegroupstaggingapi.Tag{
@@ -1423,6 +1427,12 @@ func TestInsertTags(t *testing.T) {
 		{
 			Key:   awssdk.String(tagKey2),
 			Value: awssdk.String(tagValue2),
+		},
+	}
+	resourceTagMap["eipalloc-0123456789abcdef"] = []resourcegroupstaggingapi.Tag{
+		{
+			Key:   awssdk.String(tagKey3),
+			Value: awssdk.String(tagValue3),
 		},
 	}
 
@@ -1443,6 +1453,12 @@ func TestInsertTags(t *testing.T) {
 			identifier2,
 			"aws.tags.owner",
 			tagValue2,
+		},
+		{
+			"test identifier with arn value",
+			identifierContainsArn,
+			"aws.tags.env",
+			tagValue3,
 		},
 	}
 

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -188,9 +188,9 @@ func GetResourcesTags(svc resourcegroupstaggingapiiface.ClientAPI, resourceTypeF
 		}
 
 		for _, resourceTag := range output.ResourceTagMappingList {
-			identifier, err := findIdentifierFromARN(*resourceTag.ResourceARN)
+			identifier, err := FindIdentifierFromARN(*resourceTag.ResourceARN)
 			if err != nil {
-				err = errors.Wrap(err, "error findIdentifierFromARN")
+				err = errors.Wrap(err, "error FindIdentifierFromARN")
 				return nil, err
 			}
 			resourceTagMap[identifier] = resourceTag.Tags
@@ -199,7 +199,7 @@ func GetResourcesTags(svc resourcegroupstaggingapiiface.ClientAPI, resourceTypeF
 	return resourceTagMap, nil
 }
 
-func findIdentifierFromARN(resourceARN string) (string, error) {
+func FindIdentifierFromARN(resourceARN string) (string, error) {
 	arnParsed, err := arn.Parse(resourceARN)
 	if err != nil {
 		err = errors.Wrap(err, "error Parse arn")

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -377,7 +377,7 @@ func TestFindIdentifierFromARN(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		identifier, err := findIdentifierFromARN(c.resourceARN)
+		identifier, err := FindIdentifierFromARN(c.resourceARN)
 		assert.NoError(t, err)
 		assert.Equal(t, c.expectedIdentifier, identifier)
 	}


### PR DESCRIPTION
Cherry-pick of PR #19433 to 7.x branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->


## What does this PR do?

This PR is to fix setting resource tags when dimension value is ARN format, I found this issue in `AWS/DDoSProtection` namespace metrics.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

cloudwatch module should set event tags correctly  if dimension value is ARN format and `tags.resource_type_filter` param is configured 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues


- Closes elastic/beats#19111


## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

test with aws shield service and EIP resource , I have put some demo metrics before running test ,so the namespace is `DDoSProtection`. The actual value is `AWS/DDoSProtection` if you get metrics that created by aws.

```
metricbeat.modules:
  - module: aws
    period: 1h
    access_key_id: 
    secret_access_key: 
    metrics:
      - namespace: DDoSProtection
        statistic: ['Maximum']
        name:
          [
            'DDoSDetected',
            'DDoSAttackBitsPerSecond',
            'DDoSAttackPacketsPerSecond',
            'DDoSAttackRequestsPerSecond',
          ]
        tags.resource_type_filter: ec2:elastic-ip
```

![image](https://user-images.githubusercontent.com/12824991/85848815-65649480-b7dc-11ea-8026-d6f6839cc18d.png)


