### PR TITLE
Cherry-pick #19589 to 7.x: ci: enable upstream triggering on the packaging job

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -38,7 +38,7 @@ pipeline {
       when {
         beforeAgent true
         expression {
-          return isCommentTrigger() || isUserTrigger()
+          return isCommentTrigger() || isUserTrigger() || isUpstreamTrigger()
         }
       }
       stages {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: enable upstream triggering on the packaging job (#19589)