### PR TITLE
Cherry-pick #19590 to 7.9: ci: apm-server-update trigered only on upstream, comments, and manual triggered

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent none
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -27,63 +27,67 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i).*/run\\s+(?:apm-beats-update\\W+)?.*')
+    upstream("Beats/beats-beats-mbp/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
   }
   stages {
-    /**
-     Checkout the code and stash it, to use it on other stages.
-    */
-    stage('Checkout') {
-      options { skipDefaultCheckout() }
-      steps {
-        deleteDir()
-        gitCheckout(basedir: "${BEATS_DIR}", githubNotifyFirstTimeContributor: false)
-        script {
-          dir("${BEATS_DIR}"){
-            env.GO_VERSION = readFile(".go-version").trim()
-            def regexps =[
-              "^devtools/mage.*",
-              "^libbeat/scripts/Makefile",
-            ]
-            env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
-            // Skip all the stages except docs for PR's with asciidoc changes only
-            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
-          }
-        }
-      }
-    }
-    /**
-    updates beats updates the framework part and go parts of beats.
-    Then build and test.
-    Finally archive the results.
-    */
-    stage('Update Beats') {
-      options { skipDefaultCheckout() }
+    stage('Filter build') {
+      agent { label 'ubuntu && immutable' }
       when {
         beforeAgent true
-        anyOf {
-          branch 'master'
-          branch "\\d+\\.\\d+"
-          branch "v\\d?"
-          tag "v\\d+\\.\\d+\\.\\d+*"
-          allOf {
-            expression { return env.BEATS_UPDATED != "false" || isCommentTrigger() }
-            changeRequest()
-          }
-
+        expression {
+          return isCommentTrigger() || isUserTrigger()
         }
       }
-      steps {
-        withGithubNotify(context: 'Check Apm Server Beats Update') {
-          beatsUpdate()
+      /**
+       Checkout the code and stash it, to use it on other stages.
+      */
+      stage('Checkout') {
+        steps {
+          deleteDir()
+          gitCheckout(basedir: "${BEATS_DIR}", githubNotifyFirstTimeContributor: false)
+          script {
+            dir("${BEATS_DIR}"){
+              env.GO_VERSION = readFile(".go-version").trim()
+              def regexps =[
+                "^devtools/mage.*",
+                "^libbeat/scripts/Makefile",
+              ]
+              env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
+              // Skip all the stages except docs for PR's with asciidoc changes only
+              env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+            }
+          }
+        }
+      }
+      /**
+      updates beats updates the framework part and go parts of beats.
+      Then build and test.
+      Finally archive the results.
+      */
+      stage('Update Beats') {
+        options { skipDefaultCheckout() }
+        when {
+          beforeAgent true
+          anyOf {
+            branch 'master'
+            branch "\\d+\\.\\d+"
+            branch "v\\d?"
+            tag "v\\d+\\.\\d+\\.\\d+*"
+            allOf {
+              expression { return env.BEATS_UPDATED != "false" || isCommentTrigger() }
+              changeRequest()
+            }
+
+          }
+        }
+        steps {
+          withGithubNotify(context: 'Check Apm Server Beats Update') {
+            beatsUpdate()
+          }
         }
       }
     }
   }
-  // post {
-  //   cleanup {
-  //     notifyBuildResult()
-  //   }
-  // }
 }
 
 def beatsUpdate() {


### PR DESCRIPTION
Backports the following commits to 7.9:
 - ci: apm-server-update trigered only on upstream, comments, and manual triggered (#19590)