### PR TITLE
update link to discuss forums in libbeat docs

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -10,7 +10,7 @@ The open source community has been hard at work developing new Beats. You can ch
 out some of them here.
 
 Have a question about a community Beat? You can post questions and discuss issues in the
-https://discuss.elastic.co/c/beats/community-beats[Community Beats] category of the Beats discussion forum.
+https://discuss.elastic.co/tags/c/elastic-stack/beats/28/beats-development[Community Beats] category of the Beats discussion forum.
 
 Have you created a Beat that's not listed? Add the name and description of your Beat to the source document for
 https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc[Community Beats] and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[Beats GitHub repository] to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce] your new Beat in the Elastic


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
updated the link to the appropriate Community Beats discuss forums, since it pointed to a page that no longer exists. The updated link should point to the Beats discuss forums with a "beats-development" tag.
