### PR TITLE
Cherry-pick #19345 to 7.x: Accept prefix as metric_types for stackdriver metricset in GCP

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -596,7 +596,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add new fields to HAProxy module. {issue}18523[18523]
 - Add Tomcat overview dashboard {pull}14026[14026]
 - Accept prefix as metric_types config parameter in googlecloud stackdriver metricset. {pull}19345[19345]
-- Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add dashboards for googlecloud load balancing metricset. {pull}18369[18369]
 - Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add support for v1 consumer API in Cloud Foundry module, use it by default. {pull}19268[19268]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -595,6 +595,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add memory metrics into compute googlecloud. {pull}18802[18802]
 - Add new fields to HAProxy module. {issue}18523[18523]
 - Add Tomcat overview dashboard {pull}14026[14026]
+- Accept prefix as metric_types config parameter in googlecloud stackdriver metricset. {pull}19345[19345]
+- Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add dashboards for googlecloud load balancing metricset. {pull}18369[18369]
 - Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add support for v1 consumer API in Cloud Foundry module, use it by default. {pull}19268[19268]

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/_meta/docs.asciidoc
@@ -16,18 +16,19 @@ call.
 [float]
 == Metricset config and parameters
 
-* *metric_types*: Required, a list of metric type strings. Each call of the
+* *metric_types*: Required, a list of metric type strings, or a list of metric
+type prefixes. For example, `instance/cpu` is the prefix for metric type
+`instance/cpu/usage_time`, `instance/cpu/utilization` etc Each call of the
 `ListTimeSeries` API can return any number of time series from a single metric
 type. Metric type is to used for identifying a specific time series.
 
 * *aligner*: A single string with which aggregation operation need to be applied
 onto time series data for ListTimeSeries API. If it's not given, default aligner
-is set to be `ALIGN_NONE`. Google Cloud also supports `ALIGN_DELTA`, `ALIGN_RATE`,
-`ALIGN_MIN`, `ALIGN_MAX`, `ALIGN_MEAN`, `ALIGN_COUNT`, `ALIGN_SUM` and etc.
+is `ALIGN_NONE`. Google Cloud also supports `ALIGN_DELTA`, `ALIGN_RATE`,
+`ALIGN_MIN`, `ALIGN_MAX`, `ALIGN_MEAN`, `ALIGN_COUNT`, `ALIGN_SUM` etc.
 Please see
 https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#aligner[Aggregation Aligner]
 for the full list of aligners.
-
 
 [float]
 === Example Configuration
@@ -37,7 +38,7 @@ are specified: first one is to collect CPU usage time and utilization with
 aggregation aligner ALIGN_MEAN; second one is to collect uptime with aggregation
 aligner ALIGN_SUM. These metric types all have 240 seconds ingest delay time and
 60 seconds sample period. With `period` specified as `300s` in the config below,
-Metricbeat will collect compute metrics from googlecloud every 5-minute with
+Metricbeat will collect compute metrics from Google Cloud every 5-minute with
 given aggregation aligner applied for each metric type.
 +
 [source,yaml]
@@ -69,7 +70,7 @@ are specified: first one is to collect CPU usage time and utilization with
 aggregation aligner ALIGN_MEAN; second one is to collect uptime with aggregation
 aligner ALIGN_SUM. These metric types all have 240 seconds ingest delay time and
 60 seconds sample period. With `period` specified as `60s` in the config below,
-Metricbeat will collect compute metrics from googlecloud every minute with no
+Metricbeat will collect compute metrics from Google Cloud every minute with no
 aggregation. This case, the aligners specified in the configuration will be
 ignored.
 +
@@ -93,4 +94,33 @@ ignored.
       service: compute
       metric_types:
         - "instance/uptime"
+----
+
+* `stackdriver` metricset is enabled to collect metrics from all zones under
+`europe-west1-c` region in `elastic-observability` project. One set of metrics
+will be collected: metric types that starts with `instance/cpu` under `compute`
+service with aligner ALIGN_NONE. These metric types all have 240 seconds ingest
+delay time and 60 seconds sample period. With `period` specified as `1m` in
+the config below, Metricbeat will collect compute metrics from Google Cloud
+every minute with no aggregation. The metric types in `compute` service with
+`instance/cpu` prefix are: `instance/cpu/reserved_cores`,
+`instance/cpu/scheduler_wait_time`, `instance/cpu/usage_time`, and
+`instance/cpu/utilization`.
+
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - stackdriver
+  zone: "europe-west1-c"
+  project_id: elastic-observability
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - aligner: ALIGN_NONE
+      service: compute
+      metric_types:
+        - "instance/cpu"
 ----

--- a/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
+++ b/x-pack/metricbeat/module/googlecloud/stackdriver/metrics_requester.go
@@ -76,17 +76,16 @@ func (r *stackdriverMetricsRequester) Metrics(ctx context.Context, sdc stackDriv
 	results := make([]timeSeriesWithAligner, 0)
 
 	aligner := sdc.Aligner
-	serviceName := sdc.ServiceName
-	for _, mt := range sdc.MetricTypes {
+	for mt, meta := range metricsMeta {
 		wg.Add(1)
 
+		metricMeta := meta
 		go func(mt string) {
 			defer wg.Done()
 
-			metricMeta := metricsMeta[mt]
 			r.logger.Debugf("For metricType %s, metricMeta = %s", mt, metricMeta)
 			interval, aligner := getTimeIntervalAligner(metricMeta.ingestDelay, metricMeta.samplePeriod, r.config.period, aligner)
-			ts := r.Metric(ctx, serviceName+".googleapis.com/"+mt, interval, aligner)
+			ts := r.Metric(ctx, mt, interval, aligner)
 			lock.Lock()
 			defer lock.Unlock()
 			results = append(results, ts)


### PR DESCRIPTION
Cherry-pick of PR #19345 to 7.x branch. Original message: 

## What does this PR do?

This PR is to add accepting prefix using `metric_types` config parameter into `stackdriver` metricset for user to specify a prefix of the metric types instead of listing out all metric types one by one in the config.

## Why is it important?

This will make stackdriver configuration a lot shorter/simpler. For example, if you want to collect all instance metric types for compute service, you can use:
```
- module: googlecloud
  metricsets:
    - stackdriver
  period: 1m
  metrics:
    - aligner: ALIGN_NONE
      service: compute
      metric_types: 
        - "instance"
```
Instead of listing all metric types like below:
```
- module: googlecloud
  metricsets:
    - stackdriver
  period: 1m
  metrics:
    - aligner: ALIGN_NONE
      service: compute
      metric_types:
        - "instance/cpu/reserved_cores"
        - "instance/cpu/scheduler_wait_time"
        - "instance/cpu/usage_time"
        - "instance/cpu/utilization"
        - "instance/disk/max_read_bytes_count"
        - "instance/disk/max_read_ops_count"
        - "instance/disk/max_write_bytes_count"
        - "instance/disk/max_write_ops_count"
        - "instance/disk/read_bytes_count"
        - "instance/disk/read_ops_count"
        ......
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Note: I need to spend some time on figuring out how to mock GCP APIs or add integration tests for GCP overall in a separate PR.

## How to test this PR locally
Enable `googlecloud` module and change googlecloud.yml to:
```
- module: googlecloud
  metricsets:
    - stackdriver
  zone: "europe-west1-c"
  project_id: elastic-observability
  credentials_file_path: "your JSON credentials file path"
  exclude_labels: false
  period: 1m
  metrics:
    - aligner: ALIGN_NONE
      service: compute
      metric_types: 
        - "instance/cpu"
```

Start Metricbeat and you should see these cpu metrics collected:
```
googlecloud.stackdriver.instance.cpu.reserved_cores.value
googlecloud.stackdriver.instance.cpu.usage_time.value
googlecloud.stackdriver.instance.cpu.utilization.value
```
Note: `googlecloud.stackdriver.instance.cpu.scheduler_wait_time` might not exist because it is only available for VMs that belong to the e2 family and it's for measuring the wait time for vCPU is ready to run but unexpectedly not scheduled to run.

