### PR TITLE
Cherry-pick #19317 to 7.x: Fix ordering and duplicate configs on autodiscover

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -353,7 +353,7 @@ func TestEmitEvent(t *testing.T) {
 		Message  string
 		Flag     string
 		Pod      *kubernetes.Pod
-		Expected bus.Event
+		Expected []bus.Event
 	}{
 		{
 			Message: "Test common pod start",
@@ -389,44 +389,227 @@ func TestEmitEvent(t *testing.T) {
 					},
 				},
 			},
-			Expected: bus.Event{
-				"start":    true,
-				"host":     "127.0.0.1",
-				"port":     0,
-				"id":       cid,
-				"provider": UUID,
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"id":      "foobar",
-						"name":    "filebeat",
-						"image":   "elastic/filebeat:6.3.0",
-						"runtime": "docker",
-					},
-					"pod": common.MapStr{
-						"name": "filebeat",
-						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-					},
-					"node": common.MapStr{
-						"name": "node",
-					},
-					"namespace":   "default",
-					"annotations": common.MapStr{},
-				},
-				"meta": common.MapStr{
+			Expected: []bus.Event{
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"id":       uid,
+					"provider": UUID,
 					"kubernetes": common.MapStr{
-						"namespace": "default",
-						"container": common.MapStr{
-							"name":  "filebeat",
-							"image": "elastic/filebeat:6.3.0",
-						}, "pod": common.MapStr{
+						"pod": common.MapStr{
 							"name": "filebeat",
 							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-						}, "node": common.MapStr{
+						},
+						"node": common.MapStr{
 							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"port":     0,
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "foobar",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "docker",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+			},
+		},
+		{
+			Message: "Test common pod start with multiple ports exposed",
+			Flag:    "start",
+			Pod: &kubernetes.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				TypeMeta: typeMeta,
+				Status: v1.PodStatus{
+					PodIP: podIP,
+					ContainerStatuses: []kubernetes.PodContainerStatus{
+						{
+							Name:        name,
+							ContainerID: containerID,
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
 						},
 					},
 				},
-				"config": []*common.Config{},
+				Spec: v1.PodSpec{
+					NodeName: node,
+					Containers: []kubernetes.Container{
+						{
+							Image: containerImage,
+							Name:  name,
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 8080,
+								},
+								{
+									ContainerPort: 9090,
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: []bus.Event{
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"id":       uid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"port":     int32(8080),
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "foobar",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "docker",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"port":     int32(9090),
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "foobar",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "docker",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
 			},
 		},
 		{
@@ -522,44 +705,75 @@ func TestEmitEvent(t *testing.T) {
 					},
 				},
 			},
-			Expected: bus.Event{
-				"stop":     true,
-				"host":     "",
-				"id":       cid,
-				"port":     0,
-				"provider": UUID,
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"id":      "",
-						"name":    "filebeat",
-						"image":   "elastic/filebeat:6.3.0",
-						"runtime": "",
-					},
-					"pod": common.MapStr{
-						"name": "filebeat",
-						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-					},
-					"node": common.MapStr{
-						"name": "node",
-					},
-					"namespace":   "default",
-					"annotations": common.MapStr{},
-				},
-				"meta": common.MapStr{
+			Expected: []bus.Event{
+				{
+					"stop":     true,
+					"host":     "",
+					"id":       uid,
+					"provider": UUID,
 					"kubernetes": common.MapStr{
-						"namespace": "default",
-						"container": common.MapStr{
-							"name":  "filebeat",
-							"image": "elastic/filebeat:6.3.0",
-						}, "pod": common.MapStr{
+						"pod": common.MapStr{
 							"name": "filebeat",
 							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-						}, "node": common.MapStr{
+						},
+						"node": common.MapStr{
 							"name": "node",
 						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
 					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
 				},
-				"config": []*common.Config{},
+				{
+					"stop":     true,
+					"host":     "",
+					"id":       cid,
+					"port":     0,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
 			},
 		},
 		{
@@ -592,44 +806,176 @@ func TestEmitEvent(t *testing.T) {
 					},
 				},
 			},
-			Expected: bus.Event{
-				"stop":     true,
-				"host":     "127.0.0.1",
-				"port":     0,
-				"id":       cid,
-				"provider": UUID,
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"id":      "",
-						"name":    "filebeat",
-						"image":   "elastic/filebeat:6.3.0",
-						"runtime": "",
-					},
-					"pod": common.MapStr{
-						"name": "filebeat",
-						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-					},
-					"node": common.MapStr{
-						"name": "node",
-					},
-					"namespace":   "default",
-					"annotations": common.MapStr{},
-				},
-				"meta": common.MapStr{
+			Expected: []bus.Event{
+				{
+					"stop":     true,
+					"host":     "127.0.0.1",
+					"id":       uid,
+					"provider": UUID,
 					"kubernetes": common.MapStr{
-						"namespace": "default",
-						"container": common.MapStr{
-							"name":  "filebeat",
-							"image": "elastic/filebeat:6.3.0",
-						}, "pod": common.MapStr{
+						"pod": common.MapStr{
 							"name": "filebeat",
 							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-						}, "node": common.MapStr{
+						},
+						"node": common.MapStr{
 							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"stop":     true,
+					"host":     "127.0.0.1",
+					"port":     0,
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+			},
+		},
+		{
+			Message: "Test stop pod without container id",
+			Flag:    "stop",
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				TypeMeta: typeMeta,
+				Status: v1.PodStatus{
+					PodIP: podIP,
+					ContainerStatuses: []kubernetes.PodContainerStatus{
+						{
+							Name: name,
 						},
 					},
 				},
-				"config": []*common.Config{},
+				Spec: v1.PodSpec{
+					NodeName: node,
+					Containers: []kubernetes.Container{
+						{
+							Image: containerImage,
+							Name:  name,
+						},
+					},
+				},
+			},
+			Expected: []bus.Event{
+				{
+					"stop":     true,
+					"host":     "127.0.0.1",
+					"id":       uid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"stop":     true,
+					"host":     "127.0.0.1",
+					"port":     0,
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							}, "pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
 			},
 		},
 	}
@@ -663,14 +1009,17 @@ func TestEmitEvent(t *testing.T) {
 
 			pod.emit(test.Pod, test.Flag)
 
-			select {
-			case event := <-listener.Events():
-				assert.Equal(t, test.Expected, event, test.Message)
-			case <-time.After(2 * time.Second):
-				if test.Expected != nil {
-					t.Fatal("Timeout while waiting for event")
+			for i := 0; i < len(test.Expected); i++ {
+				select {
+				case event := <-listener.Events():
+					assert.Equal(t, test.Expected[i], event, test.Message)
+				case <-time.After(2 * time.Second):
+					if test.Expected != nil {
+						t.Fatal("Timeout while waiting for event")
+					}
 				}
 			}
+
 		})
 	}
 }

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -133,7 +133,6 @@ func (m *metricHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*c
 		moduleConfig := common.MapStr{
 			"module":     mod,
 			"metricsets": msets,
-			"hosts":      hosts,
 			"timeout":    tout,
 			"period":     ival,
 			"enabled":    true,
@@ -154,21 +153,45 @@ func (m *metricHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*c
 			moduleConfig["password"] = password
 		}
 
-		logp.Debug("hints.builder", "generated config: %v", moduleConfig)
+		// If there are hosts that match, ensure that there is a module config for each valid host.
+		// We do this because every config that is from a Pod that has an exposed port will generate a valid
+		// module config. However, the pod level hint will generate a config with all hosts that are defined in the
+		// config. To make sure that these pod level configs get deduped, it is essential that we generate exactly one
+		// module config per host.
+		if len(hosts) != 0 {
+			for _, h := range hosts {
+				mod := moduleConfig.Clone()
+				mod["hosts"] = []string{h}
 
-		// Create config object
-		cfg, err := common.NewConfigFrom(moduleConfig)
-		if err != nil {
-			logp.Debug("hints.builder", "config merge failed with error: %v", err)
+				logp.Debug("hints.builder", "generated config: %v", mod)
+
+				// Create config object
+				cfg := m.generateConfig(mod)
+				configs = append(configs, cfg)
+			}
+		} else {
+			logp.Debug("hints.builder", "generated config: %v", moduleConfig)
+
+			// Create config object
+			cfg := m.generateConfig(moduleConfig)
+			configs = append(configs, cfg)
 		}
-		logp.Debug("hints.builder", "generated config: %+v", common.DebugString(cfg, true))
-		configs = append(configs, cfg)
+
 	}
 
 	// Apply information in event to the template to generate the final config
 	// This especially helps in a scenario where endpoints are configured as:
 	// co.elastic.metrics/hosts= "${data.host}:9090"
 	return template.ApplyConfigTemplate(event, configs, options...)
+}
+
+func (m *metricHints) generateConfig(mod common.MapStr) *common.Config {
+	cfg, err := common.NewConfigFrom(mod)
+	if err != nil {
+		logp.Debug("hints.builder", "config merge failed with error: %v", err)
+	}
+	logp.Debug("hints.builder", "generated config: %+v", common.DebugString(cfg, true))
+	return cfg
 }
 
 func (m *metricHints) getModule(hints common.MapStr) string {


### PR DESCRIPTION
Cherry-pick of PR #19317 to 7.x branch. Original message: 

Regression

## What does this PR do?

https://github.com/elastic/beats/pull/18979 introduced a pod level event which is generated after all container events. The ordering is wrong in that pod events are sent last which would generate a valid event similar to container events. The ordering needs to be pod first and container events next so that pod events dont override valid container events. One other issue was that the pod level hint generates a single config with all hosts and it wont get over written by container hints causing more than one config to be spun up for the same hint (one with a container meta and one without)

## Why is it important?

Without this, container metadata will never be emitted even if a port belongs to a valid exposed port. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- [ ]

## How to test this PR locally

Generate any event for an exposed port and make sure that container metadata is visible. 

## Related issues


## Use cases


## Screenshots


## Logs

