### PR TITLE
[ci] fix env variable name for xpack filebeats

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_XPACK_FILEBEAT != "false" && params.macosTest
+              return env.BUILD_FILEBEAT_XPACK != "false" && params.macosTest
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1053,11 +1053,6 @@ def dumpFilteredEnvironment(){
   echo "DOCKER_CACHE: ${env.DOCKER_CACHE}"
   echo "GOPACKAGES_COMMA_SEP: ${env.GOPACKAGES_COMMA_SEP}"
   echo "PIP_INSTALL_PARAMS: ${env.PIP_INSTALL_PARAMS}"
-  echo(env.getEnvironment()
-          .findAll{ it.key.startsWith('BUILD_') }
-          .collect(
-            {"${it.key} = ${it.value}"}
-          ).join("\n"))
   echo "### END ENV DUMP ###"
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1053,6 +1053,11 @@ def dumpFilteredEnvironment(){
   echo "DOCKER_CACHE: ${env.DOCKER_CACHE}"
   echo "GOPACKAGES_COMMA_SEP: ${env.GOPACKAGES_COMMA_SEP}"
   echo "PIP_INSTALL_PARAMS: ${env.PIP_INSTALL_PARAMS}"
+  env.each { k, v ->
+    if (k.startsWith('BUILD_')) {
+      echo "${k}: ${v}"
+    }
+  }
   echo "### END ENV DUMP ###"
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1053,11 +1053,11 @@ def dumpFilteredEnvironment(){
   echo "DOCKER_CACHE: ${env.DOCKER_CACHE}"
   echo "GOPACKAGES_COMMA_SEP: ${env.GOPACKAGES_COMMA_SEP}"
   echo "PIP_INSTALL_PARAMS: ${env.PIP_INSTALL_PARAMS}"
-  env.each { k, v ->
-    if (k.startsWith('BUILD_')) {
-      echo "${k}: ${v}"
-    }
-  }
+  echo(env.getEnvironment()
+          .findAll{ it.key.startsWith('BUILD_') }
+          .collect(
+            {"${it.key} = ${it.value}"}
+          ).join("\n"))
   echo "### END ENV DUMP ###"
 }
 


### PR DESCRIPTION
## What does this PR do?

Fix the env variable name that got a typo

## Why is it important?

Otherwise x-pack/filebeats for MacOSX will be run always