### PR TITLE
Cherry-pick #19586 to 7.x: Make Agent beta and Constraints experimental 

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent_configuration_example.yml
+++ b/x-pack/elastic-agent/docs/elastic-agent_configuration_example.yml
@@ -110,6 +110,7 @@ inputs:
     name: epm/nginx
     version: 1.7.0
     dataset.namespace: prod
+    # constraints are still Experimental and should not be used in production.
     constraints?:
       # Contraints look are not final
       - os.platform: { in: "windows" }
@@ -129,6 +130,7 @@ inputs:
     name: epm/nginx
     version: 1.7.0
     dataset.namespace: prod
+    # constraints are still Experimental and should not be used in production.
     constraints?:
       # Contraints look are not final
       - os.platform: { in: "windows" }

--- a/x-pack/elastic-agent/pkg/agent/application/filters/constraints_filter.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/constraints_filter.go
@@ -28,6 +28,7 @@ var (
 )
 
 // ConstraintFilter filters ast based on included constraints.
+// constraints are still Experimental and should not be used in production.
 func ConstraintFilter(log *logger.Logger, ast *transpiler.AST) error {
 	// get datasources
 	inputsNode, found := transpiler.Lookup(ast, inputsKey)

--- a/x-pack/elastic-agent/pkg/agent/warn/warn.go
+++ b/x-pack/elastic-agent/pkg/agent/warn/warn.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
-const message = "The Elastic Agent is currently in Experimental and should not be used in production"
+const message = "The Elastic Agent is currently in BETA and should not be used in production"
 
 // LogNotGA warns the users in the log that the Elastic Agent is not GA.
 func LogNotGA(log *logger.Logger) {


### PR DESCRIPTION
Cherry-pick of PR #19586 to 7.x branch. Original message:

## What does this PR do?

As for 7.9 Agent is in Beta and Constraints stays in experimental due to planned changes. 
This PR marks this accordingly

## Why is it important?

To avoid confusion in use cases and prevent relying on constraints

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
