### PR TITLE
Cherry-pick #19617 to 7.8: [ci] fix env variable name for xpack filebeats

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_XPACK_FILEBEAT != "false" && params.macosTest
+              return env.BUILD_FILEBEAT_XPACK != "false" && params.macosTest
             }
           }
           steps {


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [ci] fix env variable name for xpack filebeats (#19617)