### PR TITLE
Cherry-pick #19434 to 7.x: Use MODULE in metricbeat python system tests

### DIFF
--- a/docs/devguide/metricset-details.asciidoc
+++ b/docs/devguide/metricset-details.asciidoc
@@ -290,24 +290,22 @@ func TestData(t *testing.T) {
 ===== Running the Tests
 
 To run all the tests, run `make testsuite`. To only run unit tests, run
-`make unit-tests` or for integration tests `make integration-tests-environment`. Be aware that
-a running Docker environment is needed for integration and system tests.
+`mage unitTest`, or for integration tests `mage integTest`.
+Be aware that a running Docker environment is needed for integration and system
+tests.
 
 To run `TestData` and generate the `data.json` file, run
 `go test -tags=integration -data -run TestData` in the directory where your test is located.
 
-Sometimes you may want to run a single integration test, for example, to test a
-module such as the `apache` module. To do this, you can:
+To run the integration tests for a single module, set the `MODULE` environment
+variable to the name of the directory of the module. For example you can run the
+following command to run integration tests for `apache` module:
 
-. Start the Docker service by running
-`docker-compose run -p port:port apache`. You can skip this step if, like the
-`golang` module, your module doesn't need a Docker service.
+[source,shell]
+----
+MODULE=apache mage integTest
+----
 
-. Run `cd tests/system` to change to the folder that contains the integration
-tests.
-
-. Run `INTEGRATION_TESTS=true nosetests test_apache.py`,
-remembering to replace `test_apache.py` with your own test file.
 
 [float]
 === Documentation

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -190,6 +190,7 @@ func GoIntegTest(ctx context.Context) error {
 
 // PythonIntegTest executes the python system tests in the integration
 // environment (Docker).
+// Use MODULE=module to run only tests for `module`.
 // Use NOSE_TESTMATCH=pattern to only run tests matching the specified pattern.
 // Use any other NOSE_* environment variable to influence the behavior of
 // nosetests.
@@ -203,6 +204,6 @@ func PythonIntegTest(ctx context.Context) error {
 	}
 	return runner.Test("pythonIntegTest", func() error {
 		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
+		return devtools.PythonNoseTestForModule(devtools.DefaultPythonTestIntegrationArgs())
 	})
 }

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -145,6 +145,7 @@ func GoIntegTest(ctx context.Context) error {
 
 // PythonIntegTest executes the python system tests in the integration
 // environment (Docker).
+// Use MODULE=module to run only tests for `module`.
 // Use NOSE_TESTMATCH=pattern to only run tests matching the specified pattern.
 // Use any other NOSE_* environment variable to influence the behavior of
 // nosetests.
@@ -158,6 +159,6 @@ func PythonIntegTest(ctx context.Context) error {
 	}
 	return runner.Test("pythonIntegTest", func() error {
 		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
+		return devtools.PythonNoseTestForModule(devtools.DefaultPythonTestIntegrationArgs())
 	})
 }


### PR DESCRIPTION
Cherry-pick of PR #19434 to 7.x branch. Original message: 

## What does this PR do?

Use `MODULE` environment variable to run the tests for a single module as
run in CI.

## Why is it important?

Faster CI builds, and easier to locally reproduce failures in CI.

## Related issues

- Related to #18678, fixes it for metricbeat