### PR TITLE
Cherry-pick #19650 to 7.x: Pin version of pip and setuptools in Dockerfiles

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -11,6 +11,6 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -13,6 +13,6 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -11,8 +11,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -13,8 +13,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -12,8 +12,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Libbeat specific

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -11,8 +11,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Add healthcheck for the docker/healthcheck metricset to check during testing.

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -13,6 +13,6 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -12,8 +12,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment

--- a/x-pack/libbeat/Dockerfile
+++ b/x-pack/libbeat/Dockerfile
@@ -12,8 +12,8 @@ RUN \
 
 ENV PYTHON_ENV=/tmp/python-env
 
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade pip==20.1.1
+RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2
 
 # Setup work environment


### PR DESCRIPTION
Cherry-pick of PR #19650 to 7.x branch. Original message: 

When installing docker-compose with setuptools 48.0.0, it cannot find
the yaml library, that seems to be installed in a different path. Using
this new version some libraries are installed under
/usr/local/lib/python3.7/dist-packages and some others under
/usr/lib/python3.7/dist-packages.

This fixes issues appearing in CI like:
```
17:21:45  Traceback (most recent call last):
17:21:45    File "/usr/local/bin/docker-compose", line 5, in <module>
17:21:45      from compose.cli.main import main
17:21:45    File "/usr/local/lib/python3.7/dist-packages/compose/cli/main.py", line 22, in <module>
17:21:45      from ..bundle import get_image_digests
17:21:45    File "/usr/local/lib/python3.7/dist-packages/compose/bundle.py", line 12, in <module>
17:21:45      from .config.serialize import denormalize_config
17:21:45    File "/usr/local/lib/python3.7/dist-packages/compose/config/__init__.py", line 6, in <module>
17:21:45      from .config import ConfigurationError
17:21:45    File "/usr/local/lib/python3.7/dist-packages/compose/config/config.py", line 13, in <module>
17:21:45      import yaml
17:21:45  ModuleNotFoundError: No module named 'yaml'
```

For future investigations, setuptools changelog for 48.0.0 https://setuptools.readthedocs.io/en/latest/history.html#v48-0-0