### PR TITLE
Cherry-pick #19516 to 7.x: Prepare input/file for changes in the registrar

### DIFF
--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -30,16 +30,16 @@ import (
 
 // State is used to communicate the reading state of a file
 type State struct {
-	Id          string            `json:"-"` // local unique id to make comparison more efficient
-	Finished    bool              `json:"-"` // harvester state
-	Fileinfo    os.FileInfo       `json:"-"` // the file info
-	Source      string            `json:"source"`
-	Offset      int64             `json:"offset"`
-	Timestamp   time.Time         `json:"timestamp"`
-	TTL         time.Duration     `json:"ttl"`
-	Type        string            `json:"type"`
-	Meta        map[string]string `json:"meta"`
-	FileStateOS file.StateOS
+	Id          string            `json:"-" struct:"-"` // local unique id to make comparison more efficient
+	Finished    bool              `json:"-" struct:"-"` // harvester state
+	Fileinfo    os.FileInfo       `json:"-" struct:"-"` // the file info
+	Source      string            `json:"source" struct:"source"`
+	Offset      int64             `json:"offset" struct:"offset"`
+	Timestamp   time.Time         `json:"timestamp" struct:"timestamp"`
+	TTL         time.Duration     `json:"ttl" struct:"ttl"`
+	Type        string            `json:"type"  struct:"type"`
+	Meta        map[string]string `json:"meta" struct:"meta,omitempty"`
+	FileStateOS file.StateOS      `json:"FileStateOS" struct:"FileStateOS"`
 }
 
 // NewState creates a new file state

--- a/filebeat/input/file/states.go
+++ b/filebeat/input/file/states.go
@@ -94,6 +94,12 @@ func (s *States) findPrevious(id string) int {
 // The number of states that were cleaned up and number of states that can be
 // cleaned up in the future is returned.
 func (s *States) Cleanup() (int, int) {
+	return s.CleanupWith(nil)
+}
+
+// CleanupWith cleans up the state array. It calls `fn` with the state ID, for
+// each entry to be removed.
+func (s *States) CleanupWith(fn func(string)) (int, int) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -114,7 +120,11 @@ func (s *States) Cleanup() (int, int) {
 				continue
 			}
 
-			delete(s.idx, state.ID())
+			id := state.ID()
+			delete(s.idx, id)
+			if fn != nil {
+				fn(id)
+			}
 			logp.Debug("state", "State removed for %v because of older: %v", state.Source, state.TTL)
 
 			L--


### PR DESCRIPTION
Cherry-pick of PR #19516 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

Planned changes in the registrar will introduce a key-value store.
This changes prepares the input/file package for upcoming updates.

## Why is it important?

This PR is part of the Filebeat v2 input.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#15324 
