### PR TITLE
add while pattern multiline reader to Filebeat

### DIFF
--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -23,7 +23,7 @@ Also read <<yaml-tips>> and <<regexp-support>> to avoid common mistakes.
 
 You can specify the following options in the +{beatname_lc}.inputs+ section of
 the +{beatname_lc}.yml+ config file to control how {beatname_uc} deals with messages
-that span multiple lines. 
+that span multiple lines.
 
 The following example shows how to configure {beatname_uc} to handle a multiline message where the first line of the message begins with a bracket (`[`).
 
@@ -47,8 +47,8 @@ multiline.match: after
     at org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction.checkBlock(TransportDeleteIndexAction.java:75)
 -------------------------------------------------------------------------------------
 
-*`multiline.type`*:: Defines which aggregation method to use. The default is `pattern`. The other option
-is `count` which lets you aggregate constant number of lines.
+*`multiline.type`*:: Defines which aggregation method to use. The default is `pattern`. The other options
+is `count` which lets you aggregate constant number of lines and `while-pattern` which aggregate lines by pattern without match option.
 
 *`multiline.pattern`*:: Specifies the regular expression pattern to match. Note that the regexp patterns supported by {beatname_uc}
 differ somewhat from the patterns supported by Logstash. See <<regexp-support>> for a list of supported regexp patterns.
@@ -71,7 +71,7 @@ the pattern.
 +
 NOTE: The `after` setting is equivalent to `previous` in https://www.elastic.co/guide/en/logstash/current/plugins-codecs-multiline.html[Logstash], and `before` is equivalent to `next`.
 
-*`multiline.flush_pattern`*:: Specifies a regular expression, in which the current multiline will be flushed from memory, ending the multiline-message.
+*`multiline.flush_pattern`*:: Specifies a regular expression, in which the current multiline will be flushed from memory, ending the multiline-message. Work only with `pattern` type.
 
 *`multiline.max_lines`*:: The maximum number of lines that can be combined into one event. If
 the multiline message contains more than `max_lines`, any additional

--- a/libbeat/reader/multiline/multiline.go
+++ b/libbeat/reader/multiline/multiline.go
@@ -31,10 +31,14 @@ func New(
 	maxBytes int,
 	config *Config,
 ) (reader.Reader, error) {
-	if config.Type == patternMode {
+	switch config.Type {
+	case patternMode:
 		return newMultilinePatternReader(r, separator, maxBytes, config)
-	} else if config.Type == countMode {
+	case countMode:
 		return newMultilineCountReader(r, separator, maxBytes, config)
+	case whilePatternMode:
+		return newMultilineWhilePatternReader(r, separator, maxBytes, config)
+	default:
+		return nil, fmt.Errorf("unknown multiline type %d", config.Type)
 	}
-	return nil, fmt.Errorf("unknown multiline type %d", config.Type)
 }

--- a/libbeat/reader/multiline/multiline_config.go
+++ b/libbeat/reader/multiline/multiline_config.go
@@ -29,15 +29,18 @@ type multilineType uint8
 const (
 	patternMode multilineType = iota
 	countMode
+	whilePatternMode
 
-	patternStr = "pattern"
-	countStr   = "count"
+	patternStr      = "pattern"
+	countStr        = "count"
+	whilePatternStr = "while-pattern"
 )
 
 var (
 	multilineTypes = map[string]multilineType{
-		patternStr: patternMode,
-		countStr:   countMode,
+		patternStr:      patternMode,
+		countStr:        countMode,
+		whilePatternStr: whilePatternMode,
 	}
 )
 
@@ -68,6 +71,10 @@ func (c *Config) Validate() error {
 	} else if c.Type == countMode {
 		if c.LinesCount == 0 {
 			return fmt.Errorf("multiline.count_lines cannot be zero when count based is selected")
+		}
+	} else if c.Type == whilePatternMode {
+		if c.Pattern == nil {
+			return fmt.Errorf("multiline.pattern cannot be empty when pattern based matching is selected")
 		}
 	}
 	return nil

--- a/libbeat/reader/multiline/multiline_test.go
+++ b/libbeat/reader/multiline/multiline_test.go
@@ -241,6 +241,48 @@ func TestMultilineCount(t *testing.T) {
 	)
 }
 
+func TestMultilineWhilePattern(t *testing.T) {
+	pattern := match.MustCompile(`^{`)
+	testMultilineOK(t,
+		Config{
+			Type:    whilePatternMode,
+			Pattern: &pattern,
+			Negate:  false,
+		},
+		3,
+		"{line1\n{line1.1\n",
+		"not matched line\n",
+		"{line2\n{line2.1\n",
+	)
+	// use negated
+	testMultilineOK(t,
+		Config{
+			Type:    whilePatternMode,
+			Pattern: &pattern,
+			Negate:  true,
+		},
+		3,
+		"{line1\n",
+		"panic:\n~stacktrace~\n",
+		"{line2\n",
+	)
+	// truncated
+	maxLines := 2
+	testMultilineTruncated(t,
+		Config{
+			Type:     whilePatternMode,
+			Pattern:  &pattern,
+			MaxLines: &maxLines,
+		},
+		1,
+		true,
+		[]string{
+			"{line1\n{line1.1\n{line1.2\n"},
+		[]string{
+			"{line1\n{line1.1\n"},
+	)
+}
+
 func testMultilineOK(t *testing.T, cfg Config, events int, expected ...string) {
 	_, buf := createLineBuffer(expected...)
 	r := createMultilineTestReader(t, buf, cfg)

--- a/libbeat/reader/multiline/while.go
+++ b/libbeat/reader/multiline/while.go
@@ -1,0 +1,209 @@
+package multiline
+
+import (
+	"github.com/elastic/beats/v7/libbeat/common/match"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/reader"
+	"github.com/elastic/beats/v7/libbeat/reader/readfile"
+)
+
+// MultiLine reader combining multiple line events into one multi-line event.
+//
+// Consecutive lines that satisfy the regular expression will be combined.
+//
+// The maximum number of bytes and lines to be returned is fully configurable.
+// Even if limits are reached subsequent lines are matched, until event is
+// fully finished.
+//
+// Errors will force the multiline reader to return the currently active
+// multiline event first and finally return the actual error on next call to Next.
+type whilePatternReader struct {
+	reader    reader.Reader
+	matcher   lineMatcherFunc
+	logger    *logp.Logger
+	msgBuffer *messageBuffer
+	state     func(*whilePatternReader) (reader.Message, error)
+}
+
+func newMultilineWhilePatternReader(
+	r reader.Reader,
+	separator string,
+	maxBytes int,
+	config *Config,
+) (reader.Reader, error) {
+	maxLines := defaultMaxLines
+	if config.MaxLines != nil {
+		maxLines = *config.MaxLines
+	}
+
+	tout := defaultMultilineTimeout
+	if config.Timeout != nil {
+		tout = *config.Timeout
+	}
+
+	if tout > 0 {
+		r = readfile.NewTimeoutReader(r, sigMultilineTimeout, tout)
+	}
+
+	matcherFunc := lineMatcher(*config.Pattern)
+	if config.Negate {
+		matcherFunc = negatedLineMatcher(matcherFunc)
+	}
+
+	pr := &whilePatternReader{
+		reader:    r,
+		matcher:   matcherFunc,
+		msgBuffer: newMessageBuffer(maxBytes, maxLines, []byte(separator), config.SkipNewLine),
+		logger:    logp.NewLogger("reader_multiline"),
+		state:     (*whilePatternReader).readFirst,
+	}
+	return pr, nil
+}
+
+// Next returns next multi-line event.
+func (pr *whilePatternReader) Next() (reader.Message, error) {
+	return pr.state(pr)
+}
+
+func (pr *whilePatternReader) readFirst() (reader.Message, error) {
+	for {
+		message, err := pr.reader.Next()
+		if err != nil {
+			// no lines buffered -> ignore timeout
+			if err == sigMultilineTimeout {
+				continue
+			}
+
+			pr.logger.Debug("Multiline event flushed because timeout reached.")
+
+			// pass error to caller (next layer) for handling
+			return message, err
+		}
+
+		if message.Bytes == 0 {
+			continue
+		}
+
+		// no match, return message
+		if !pr.matcher(message.Content) {
+			return message, nil
+		}
+
+		// Start new multiline event
+		pr.msgBuffer.startNewMessage(message)
+		pr.setState((*whilePatternReader).readNext)
+		return pr.readNext()
+	}
+}
+
+func (pr *whilePatternReader) readNext() (reader.Message, error) {
+	for {
+		message, err := pr.reader.Next()
+		if err != nil {
+			// handle multiline timeout signal
+			if err == sigMultilineTimeout {
+				// no lines buffered -> ignore timeout
+				if pr.msgBuffer.isEmpty() {
+					continue
+				}
+
+				pr.logger.Debug("Multiline event flushed because timeout reached.")
+
+				// return collected multiline event and
+				// empty buffer for new multiline event
+				msg := pr.msgBuffer.finalize()
+				pr.resetState()
+				return msg, nil
+			}
+
+			// handle error without any bytes returned from reader
+			if message.Bytes == 0 {
+				// no lines buffered -> return error
+				if pr.msgBuffer.isEmpty() {
+					return reader.Message{}, err
+				}
+
+				// lines buffered, return multiline and error on next read
+				return pr.collectMessageAfterError(err)
+			}
+
+			// handle error with some content being returned by reader and
+			// line matching multiline criteria or no multiline started yet
+			if pr.msgBuffer.isEmptyMessage() || pr.matcher(message.Content) {
+				pr.msgBuffer.addLine(message)
+
+				// return multiline and error on next read
+				return pr.collectMessageAfterError(err)
+			}
+
+			// no match, return current multiline and return current line on next
+			// call to readNext
+			msg := pr.msgBuffer.finalize()
+			pr.msgBuffer.load(message)
+			pr.setState((*whilePatternReader).notMatchedMessageLoad)
+			return msg, nil
+		}
+
+		// no match, return message if buffer is empty, otherwise return current
+		// multiline and save message to buffer
+		if !pr.matcher(message.Content) {
+			if pr.msgBuffer.isEmptyMessage() {
+				return message, nil
+			} else {
+				msg := pr.msgBuffer.finalize()
+				pr.msgBuffer.load(message)
+				pr.setState((*whilePatternReader).notMatchedMessageLoad)
+				return msg, nil
+			}
+		}
+
+		// add line to current multiline event
+		pr.msgBuffer.addLine(message)
+	}
+}
+
+func (pr *whilePatternReader) collectMessageAfterError(err error) (reader.Message, error) {
+	msg := pr.msgBuffer.finalize()
+	pr.msgBuffer.setErr(err)
+	pr.setState((*whilePatternReader).readFailed)
+	return msg, nil
+}
+
+// readFailed returns empty message and error and resets line reader
+func (pr *whilePatternReader) readFailed() (reader.Message, error) {
+	err := pr.msgBuffer.err
+	pr.msgBuffer.setErr(nil)
+	pr.resetState()
+	return reader.Message{}, err
+}
+
+// notMatchedMessageLoad returns not matched message from buffer
+func (pr *whilePatternReader) notMatchedMessageLoad() (reader.Message, error) {
+	msg := pr.msgBuffer.finalize()
+	pr.resetState()
+	return msg, nil
+}
+
+// resetState sets state of the reader to readFirst
+func (pr *whilePatternReader) resetState() {
+	pr.setState((*whilePatternReader).readFirst)
+}
+
+// setState sets state to the given function
+func (pr *whilePatternReader) setState(next func(pr *whilePatternReader) (reader.Message, error)) {
+	pr.state = next
+}
+
+type lineMatcherFunc func(content []byte) bool
+
+func lineMatcher(pat match.Matcher) lineMatcherFunc {
+	return func(content []byte) bool {
+		return pat.Match(content)
+	}
+}
+
+func negatedLineMatcher(m lineMatcherFunc) lineMatcherFunc {
+	return func(content []byte) bool {
+		return !m(content)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Added a new type for multiline reader. It combines the lines that satisfy the pattern.

## Why is it important?

The current pattern reader combines lines matching the pattern + line at the beginning or at the end. So you need to know where the multiline starts (or ends), and in cases where the logs are collected from different sources, there can be many different multilines (panic, exception python ...)

I would like to configure filebeat once according to the following rule: usually, the application writes logs in the json format, in cases of exceptions it writes multiline in some format (not json) and needs to detect such multilines.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

- Aggregate stacktraces from many different programming languages, without the need to describe each stackrace

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
