### PR TITLE
Cherry-pick #19601 to 7.8: Add missing azure metricsets in azure doc

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -178,6 +178,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
+- Add missing info about the rest of the azure metricsets in the documentation. {pull}19601[19601]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/azure.asciidoc
+++ b/metricbeat/docs/modules/azure.asciidoc
@@ -85,6 +85,26 @@ so the `period` for `compute_vm_scaleset` metricset  should be `300s` or multipl
 This metricset will collect metrics from the storage accounts, these metrics will have a timegrain every 5 minutes,
 so the `period` for `storage` metricset  should be `300s` or multiples of `300s`.
 
+[float]
+=== `container_instance`
+This metricset will collect metrics from specified container groups, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_instance` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `container_registry`
+This metricset will collect metrics from the container registries, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_registry` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `container_service`
+This metricset will collect metrics from the container services, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_service` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `database_account`
+This metricset will collect relevant metrics from specified database accounts, these metrics will have a timegrain every 5 minutes,
+so the `period` for `database_account` metricset  should be `300s` or multiples of `300s`.
+
 
 [float]
 == Additional notes about metrics and costs

--- a/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
@@ -77,6 +77,26 @@ so the `period` for `compute_vm_scaleset` metricset  should be `300s` or multipl
 This metricset will collect metrics from the storage accounts, these metrics will have a timegrain every 5 minutes,
 so the `period` for `storage` metricset  should be `300s` or multiples of `300s`.
 
+[float]
+=== `container_instance`
+This metricset will collect metrics from specified container groups, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_instance` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `container_registry`
+This metricset will collect metrics from the container registries, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_registry` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `container_service`
+This metricset will collect metrics from the container services, these metrics will have a timegrain every 5 minutes,
+so the `period` for `container_service` metricset  should be `300s` or multiples of `300s`.
+
+[float]
+=== `database_account`
+This metricset will collect relevant metrics from specified database accounts, these metrics will have a timegrain every 5 minutes,
+so the `period` for `database_account` metricset  should be `300s` or multiples of `300s`.
+
 
 [float]
 == Additional notes about metrics and costs

--- a/x-pack/metricbeat/module/azure/compute_vm/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/compute_vm/_meta/docs.asciidoc
@@ -10,9 +10,9 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list virtual machines we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will select all virtual machines inside the resource group.
 
-If none of the options are entered then we will select all virtual machine from the entire subscription
+If none of the options are entered then all virtual machine inside the subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/_meta/docs.asciidoc
@@ -10,11 +10,10 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list virtual machine scalesets we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will return all virtual machine scalesets inside the resource group.
 
-If none of the options are entered then we will select all virtual machine scalesets from the entire subscription
+If none of the options are entered then all virtual machine scalesets inside the subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
-If vmname dimensions apply to these metrics then we will separate values per vm.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 
 

--- a/x-pack/metricbeat/module/azure/container_instance/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/container_instance/_meta/docs.asciidoc
@@ -10,9 +10,9 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list of container groups we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will return all container groups inside the resource group.
 
-If none of the options are entered then we will select all the container groups from the entire subscription
+If none of the options are entered then all the container groups inside the subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 

--- a/x-pack/metricbeat/module/azure/container_registry/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/container_registry/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 This is the container_registry metricset of the module azure.
 
-This metricset allows users to retrieve all metrics from specified virtual machines.
+This metricset allows users to retrieve all metrics from specified container registries.
 
 include::../../_meta/shared-azure.asciidoc[]
 
@@ -10,9 +10,9 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list virtual machines we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will return all container registries inside the resource group.
 
-If none of the options are entered then we will select all virtual machine from the entire subscription
+If none of the options are entered then all container registries from the entire subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 

--- a/x-pack/metricbeat/module/azure/container_service/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/container_service/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 This is the container_service metricset of the module azure.
 
-This metricset allows users to retrieve all metrics from specified virtual machines.
+This metricset allows users to retrieve all metrics from specified container services.
 
 include::../../_meta/shared-azure.asciidoc[]
 
@@ -10,9 +10,9 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list virtual machines we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will return all container services inside the resource group.
 
-If none of the options are entered then we will select all virtual machine from the entire subscription
+If none of the options are entered then all container services inside the subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 

--- a/x-pack/metricbeat/module/azure/database_account/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/database_account/_meta/docs.asciidoc
@@ -12,9 +12,9 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list of databases we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will select all database accounts inside the resource group.
 
-If none of the options are entered then we will select all databases from the entire subscription
+If none of the options are entered then all database accounts inside the subscription are taken in account.
 For each metric the primary aggregation assigned will be retrieved.
 A default non configurable timegrain of 5 min is set so users are advised to configure an interval of 300s or  a multiply of it.
 

--- a/x-pack/metricbeat/module/azure/storage/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/storage/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ include::../../_meta/shared-azure.asciidoc[]
 `resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
   Should return a list of resources.
 
-`resource_group`:: (_[]string_) This option should return a list of storage accounts we want to apply our metric configuration options on.
+`resource_group`:: (_[]string_) This option will return all storage accounts inside the resource group.
 
 `service_type`:: (_[]string_) This configuration key can be used with any of the 2 options above, for example:
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19601 to 7.8 branch. Original message:

## What does this PR do?

Add missing metricsets info in the metricbeat module azure documentation.

## Why is it important?

Missing info about the container metricsets.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


Should fix https://github.com/elastic/beats/issues/19363