### PR TITLE
Cherry-pick #19539 to 7.8: Fix configuration values in the perfmon metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -178,6 +178,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
+- Fix config example in the perfmon configuration files. {pull}19539[19539]
 - Add missing info about the rest of the azure metricsets in the documentation. {pull}19601[19601]
 
 *Packetbeat*

--- a/metricbeat/docs/modules/windows.asciidoc
+++ b/metricbeat/docs/modules/windows.asciidoc
@@ -33,10 +33,10 @@ metricbeat.modules:
 #  - object: 'Process'
 #    instance: ["*"]
 #    counters:
-#    - name: 'Disk Writes/sec'
-#      field: physical_disk.write.per_sec
+#    - name: '% Processor Time'
+#      field: cpu_usage
 #      format: "float"
-#    - name: "% Disk Write Time"
+#    - name: "Thread Count"
 
 - module: windows
   metricsets: ["service"]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -865,10 +865,10 @@ metricbeat.modules:
 #  - object: 'Process'
 #    instance: ["*"]
 #    counters:
-#    - name: 'Disk Writes/sec'
-#      field: physical_disk.write.per_sec
+#    - name: '% Processor Time'
+#      field: cpu_usage
 #      format: "float"
-#    - name: "% Disk Write Time"
+#    - name: "Thread Count"
 
 - module: windows
   metricsets: ["service"]

--- a/metricbeat/module/windows/_meta/config.reference.yml
+++ b/metricbeat/module/windows/_meta/config.reference.yml
@@ -8,10 +8,10 @@
 #  - object: 'Process'
 #    instance: ["*"]
 #    counters:
-#    - name: 'Disk Writes/sec'
-#      field: physical_disk.write.per_sec
+#    - name: '% Processor Time'
+#      field: cpu_usage
 #      format: "float"
-#    - name: "% Disk Write Time"
+#    - name: "Thread Count"
 
 - module: windows
   metricsets: ["service"]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1298,10 +1298,10 @@ metricbeat.modules:
 #  - object: 'Process'
 #    instance: ["*"]
 #    counters:
-#    - name: 'Disk Writes/sec'
-#      field: physical_disk.write.per_sec
+#    - name: '% Processor Time'
+#      field: cpu_usage
 #      format: "float"
-#    - name: "% Disk Write Time"
+#    - name: "Thread Count"
 
 - module: windows
   metricsets: ["service"]


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19539 to 7.8 branch. Original message:

## What does this PR do?

Fixes the counter paths in the configuration example , perfmon metricset.

## Why is it important?

A working default example.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
