### PR TITLE
Disable journald input build from filebeat

### DIFF
--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux,cgo
+// +build linux,cgo,withjournald
 
 package journald
 

--- a/filebeat/input/journald/conv.go
+++ b/filebeat/input/journald/conv.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo,withjournald
+
 package journald
 
 import (

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux,cgo
+// +build linux,cgo,withjournald
 
 package journald
 

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -49,9 +49,9 @@ var (
 		devtools.LinuxS390x,
 	}
 
-	deps = devtools.NewPackageInstaller().
-		AddEach(journaldPlatforms, "libsystemd-dev").
-		Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
+	journaldDeps = devtools.NewPackageInstaller().
+			AddEach(journaldPlatforms, "libsystemd-dev").
+			Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
 )
 
 func init() {
@@ -69,7 +69,9 @@ func Build() error {
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
-	mg.Deps(deps.Installer(devtools.Platform.Name))
+	// XXX: enable once we have systemd available in the cross build image
+	// mg.Deps(journaldDeps.Installer(devtools.Platform.Name))
+
 	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Fix

## What does this PR do?

Disable build of journald input.

## Why is it important?

Fix packaging that still relies on old debian version

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~