### PR TITLE
Cherry-pick #19398 to 7.x: Add support for named ports in autodiscover (hints & templates)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -602,6 +602,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add dashboards for googlecloud load balancing metricset. {pull}18369[18369]
 - Update Couchbase to version 6.5 {issue}18595[18595] {pull}19055[19055]
 - Add support for v1 consumer API in Cloud Foundry module, use it by default. {pull}19268[19268]
+- Add support for named ports in autodiscover. {pull}19398[19398]
 - Add param `aws_partition` to support aws-cn, aws-us-gov regions. {issue}18850[18850] {pull}19423[19423]
 
 *Packetbeat*

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -191,6 +191,9 @@ func (p *pod) GenerateHints(event bus.Event) bus.Event {
 	if port, ok := event["port"]; ok {
 		e["port"] = port
 	}
+	if ports, ok := event["ports"]; ok {
+		e["ports"] = ports
+	}
 
 	if rawCont, ok := kubeMeta["container"]; ok {
 		container = rawCont.(common.MapStr)
@@ -300,6 +303,7 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 		}
 	}
 
+	podPorts := common.MapStr{}
 	// Emit container and port information
 	for _, c := range containers {
 		// If it doesn't have an ID, container doesn't exist in
@@ -349,6 +353,7 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 		}
 
 		for _, port := range c.Ports {
+			podPorts[port.Name] = port.ContainerPort
 			event := bus.Event{
 				"provider":   p.uuid,
 				"id":         eventID,
@@ -385,6 +390,7 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 			"id":         fmt.Sprint(pod.GetObjectMeta().GetUID()),
 			flag:         true,
 			"host":       host,
+			"ports":      podPorts,
 			"kubernetes": kubemeta,
 			"meta": common.MapStr{
 				"kubernetes": meta,

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -395,6 +395,7 @@ func TestEmitEvent(t *testing.T) {
 					"host":     "127.0.0.1",
 					"id":       uid,
 					"provider": UUID,
+					"ports":    common.MapStr{},
 					"kubernetes": common.MapStr{
 						"pod": common.MapStr{
 							"name": "filebeat",
@@ -493,9 +494,11 @@ func TestEmitEvent(t *testing.T) {
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: 8080,
+									Name:          "port1",
 								},
 								{
 									ContainerPort: 9090,
+									Name:          "port2",
 								},
 							},
 						},
@@ -508,6 +511,10 @@ func TestEmitEvent(t *testing.T) {
 					"host":     "127.0.0.1",
 					"id":       uid,
 					"provider": UUID,
+					"ports": common.MapStr{
+						"port1": int32(8080),
+						"port2": int32(9090),
+					},
 					"kubernetes": common.MapStr{
 						"pod": common.MapStr{
 							"name": "filebeat",
@@ -711,6 +718,7 @@ func TestEmitEvent(t *testing.T) {
 					"host":     "",
 					"id":       uid,
 					"provider": UUID,
+					"ports":    common.MapStr{},
 					"kubernetes": common.MapStr{
 						"pod": common.MapStr{
 							"name": "filebeat",
@@ -812,6 +820,7 @@ func TestEmitEvent(t *testing.T) {
 					"host":     "127.0.0.1",
 					"id":       uid,
 					"provider": UUID,
+					"ports":    common.MapStr{},
 					"kubernetes": common.MapStr{
 						"pod": common.MapStr{
 							"name": "filebeat",
@@ -913,6 +922,7 @@ func TestEmitEvent(t *testing.T) {
 					"host":     "127.0.0.1",
 					"id":       uid,
 					"provider": UUID,
+					"ports":    common.MapStr{},
 					"kubernetes": common.MapStr{
 						"pod": common.MapStr{
 							"name": "filebeat",

--- a/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
+++ b/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
@@ -101,6 +101,9 @@ func NewKubernetesSecretsKeystore(keystoreNamespace string, ks8client k8s.Interf
 func (k *KubernetesSecretsKeystore) Retrieve(key string) (*keystore.SecureString, error) {
 	// key = "kubernetes.somenamespace.somesecret.value"
 	tokens := strings.Split(key, ".")
+	if len(tokens) > 0 && tokens[0] != "kubernetes" {
+		return nil, keystore.ErrKeyDoesntExists
+	}
 	if len(tokens) != 4 {
 		k.logger.Debugf(
 			"not valid secret key: %v. Secrets should be of the following format %v",

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -369,6 +369,85 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
+			message: "Named port in the hints should return the corresponding container port",
+			event: bus.Event{
+				"host":  "1.2.3.4",
+				"ports": common.MapStr{"some": 3306},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "${data.host}:${data.ports.some}",
+					},
+				},
+			},
+			len: 1,
+			result: []common.MapStr{
+				{
+					"module":     "mockmoduledefaults",
+					"namespace":  "test",
+					"metricsets": []string{"default"},
+					"hosts":      []interface{}{"1.2.3.4:3306"},
+					"timeout":    "3s",
+					"period":     "1m",
+					"enabled":    true,
+				},
+			},
+		},
+		{
+			message: "Named port in the hints should return the corresponding container port for complex hosts",
+			event: bus.Event{
+				"host":  "1.2.3.4",
+				"ports": common.MapStr{"prometheus": 3306},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "http://${data.host}:${data.ports.prometheus}/metrics",
+					},
+				},
+			},
+			len: 1,
+			result: []common.MapStr{
+				{
+					"module":     "mockmoduledefaults",
+					"namespace":  "test",
+					"metricsets": []string{"default"},
+					"hosts":      []interface{}{"http://1.2.3.4:3306/metrics"},
+					"timeout":    "3s",
+					"period":     "1m",
+					"enabled":    true,
+				},
+			},
+		},
+		{
+			message: "data.port in the hints should return the corresponding container port",
+			event: bus.Event{
+				"host":  "1.2.3.4",
+				"port":  3306,
+				"ports": common.MapStr{"prometheus": 3306},
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module":    "mockmoduledefaults",
+						"namespace": "test",
+						"hosts":     "${data.host}:${data.port}",
+					},
+				},
+			},
+			len: 1,
+			result: []common.MapStr{
+				{
+					"module":     "mockmoduledefaults",
+					"namespace":  "test",
+					"metricsets": []string{"default"},
+					"hosts":      []interface{}{"1.2.3.4:3306"},
+					"timeout":    "3s",
+					"period":     "1m",
+					"enabled":    true,
+				},
+			},
+		},
+		{
 			message: "Module with mutliple sets of hints must return the right configs",
 			event: bus.Event{
 				"host": "1.2.3.4",

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -11,8 +11,11 @@ it. Hints tell {beatname_uc} how to get metrics for the given container. This is
 [float]
 ===== `co.elastic.metrics/hosts`
 
-Hosts setting to use with the given module. Hosts can include `${data.host}` and `${data.port}`
-values from the autodiscover event, ie: `${data.host}:80`.
+Hosts setting to use with the given module. Hosts can include `${data.host}`, `${data.port}`,
+`${data.ports.<port_name>}` values from the autodiscover event, ie: `${data.host}:80`.
+For Kuberentes autodiscover events users can leverage port names as well,
+like `http://${data.host}:${data.ports.prometheus}/metrics`.
+In the last one we refer to the container port with name `prometheus`.
 
 [float]
 ===== `co.elastic.metrics/metricsets`

--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -34,6 +34,9 @@ Pods share an identical host. If only the `{data.host}` variable is interpolated
 then one config will be generated per host. The configs will be identical.
 After they are de-duplicated, only one will be used.
 
+In order to target one specific exposed port `{data.host}:{data.ports.web}` can be used
+in template config, where `web` is the name of the exposed container port.
+
 [float]
 [[kubernetes-secrets]]
 ===== Metricbeat Autodiscover Secret Management


### PR DESCRIPTION
Cherry-pick of PR #19398 to 7.x branch. Original message: 

## What does this PR do?
Adds support for named ports in hints based autodiscover.
When for instance we have a target container like:
```
spec:
  containers:
    - name: natsqueue
      image: nats
      command: ["/nats-server"]
      args: ["-m", "8222"]
      ports:
        - name: web
          containerPort: 8222
          protocol: TCP
```
then we can reference the name of the port with `co.elastic.metrics/hosts: '${data.host}:${data.ports.web}'` in the annotations.

## Why is it important?
To cover cases like https://github.com/elastic/beats/issues/15796.

## Manual Testing

### Hints based Autodiscover
1. Deploy Metricbeat on k8s with hints autodiscover enabled:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      node: ${NODE_NAME}
      hints.enabled: true
```
2. Deploy a target Pod using the following spec:
```
apiVersion: v1
kind: Service
metadata:
  name: nats
  labels:
    app: nats
spec:
  clusterIP: None
  ports:
  - name: web
    port: 8222
    protocol: TCP
  selector:
    app: nats
  type: ClusterIP
---
apiVersion: v1
kind: Pod
metadata:
  name: nats
  labels:
    app: name
  annotations:
    co.elastic.metrics/module: nats
    co.elastic.metrics/metricsets: stats
    co.elastic.metrics/hosts: '${data.host}:${data.ports.web}'
spec:
  containers:
    - name: natsqueue
      image: nats
      command: ["/nats-server"]
      args: ["-m", "8222"]
      ports:
        - name: web
          containerPort: 8222
          protocol: TCP
```
3. Make sure that Nats metrics are being collected
4. Verify that old behaviour is not broken by deploying target with the following 2 different annotations:
`co.elastic.metrics/hosts: '${data.host}:8222'` and `co.elastic.metrics/hosts: '${data.host}:${data.port}`


### Template based Autodiscover
1. Deploy Metricbeat on k8s with hints autodiscover enabled:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      host: "${NODE_NAME}"
      templates:
        - condition:
            contains:
              kubernetes.annotations.nats.io/scrape: "true"
          config:
            - module: nats
              period: 10s
              hosts: ["${data.host}:${data.ports.web}"]
```
2. Deploy a target Pod using the following spec:
```
apiVersion: v1
kind: Service
metadata:
  name: nats
  labels:
    app: nats
spec:
  clusterIP: None
  ports:
  - name: web
    port: 8222
    protocol: TCP
  selector:
    app: nats
  type: ClusterIP
---
apiVersion: v1
kind: Pod
metadata:
  name: nats
  labels:
    app: name
  annotations:
    nats.io/scrape: "true"
spec:
  containers:
    - name: natsqueue
      image: nats
      command: ["/nats-server"]
      args: ["-m", "8222"]
      ports:
        - name: web
          containerPort: 8222
          protocol: TCP
```
3. Make sure that Nats metrics are being collected
4. Verify that old behaviour is not broken by deploying target with the following 2 different annotations:
`co.elastic.metrics/hosts: '${data.host}:8222'` and `co.elastic.metrics/hosts: '${data.host}:${data.port}`




Closes #15796