### PR TITLE
Move unix socket to v2 input API

### DIFF
--- a/filebeat/include/list.go
+++ b/filebeat/include/list.go
@@ -31,7 +31,6 @@ import (
 	_ "github.com/elastic/beats/v7/filebeat/input/syslog"
 	_ "github.com/elastic/beats/v7/filebeat/input/tcp"
 	_ "github.com/elastic/beats/v7/filebeat/input/udp"
-	_ "github.com/elastic/beats/v7/filebeat/input/unix"
 	_ "github.com/elastic/beats/v7/filebeat/module/apache"
 	_ "github.com/elastic/beats/v7/filebeat/module/auditd"
 	_ "github.com/elastic/beats/v7/filebeat/module/elasticsearch"

--- a/filebeat/input/default-inputs/inputs.go
+++ b/filebeat/input/default-inputs/inputs.go
@@ -19,6 +19,7 @@ package inputs
 
 import (
 	"github.com/elastic/beats/v7/filebeat/beater"
+	"github.com/elastic/beats/v7/filebeat/input/unix"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -32,5 +33,7 @@ func Init(info beat.Info, log *logp.Logger, components beater.StateStore) []v2.P
 }
 
 func genericInputs() []v2.Plugin {
-	return []v2.Plugin{}
+	return []v2.Plugin{
+		unix.Plugin(),
+	}
 }

--- a/filebeat/input/default-inputs/inputs_other.go
+++ b/filebeat/input/default-inputs/inputs_other.go
@@ -28,5 +28,5 @@ import (
 type osComponents interface{}
 
 func osInputs(info beat.Info, log *logp.Logger, components osComponents) []v2.Plugin {
-	return nil
+	return []v2.Plugin{}
 }

--- a/filebeat/input/unix/config.go
+++ b/filebeat/input/unix/config.go
@@ -22,24 +22,20 @@ import (
 
 	"github.com/dustin/go-humanize"
 
-	"github.com/elastic/beats/v7/filebeat/harvester"
 	"github.com/elastic/beats/v7/filebeat/inputsource/unix"
 )
 
 type config struct {
-	unix.Config               `config:",inline"`
-	harvester.ForwarderConfig `config:",inline"`
-
+	unix.Config   `config:",inline"`
 	LineDelimiter string `config:"line_delimiter" validate:"nonzero"`
 }
 
-var defaultConfig = config{
-	ForwarderConfig: harvester.ForwarderConfig{
-		Type: "unix",
-	},
-	Config: unix.Config{
-		Timeout:        time.Minute * 5,
-		MaxMessageSize: 20 * humanize.MiByte,
-	},
-	LineDelimiter: "\n",
+func defaultConfig() config {
+	return config{
+		Config: unix.Config{
+			Timeout:        time.Minute * 5,
+			MaxMessageSize: 20 * humanize.MiByte,
+		},
+		LineDelimiter: "\n",
+	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

Move the "unix" input to input v2 API

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

run `test_unix.py` system test.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #15324 