### PR TITLE
Cherry-pick #19518, #19528, #19529, #19530, #19571, #19573 to 7.x: Implement storage handling for cursor inputs

### DIFF
--- a/filebeat/input/v2/input-cursor/clean.go
+++ b/filebeat/input/v2/input-cursor/clean.go
@@ -20,8 +20,10 @@ package cursor
 import (
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/go-concert/timed"
 	"github.com/elastic/go-concert/unison"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // cleaner removes finished entries from the registry file.
@@ -41,5 +43,81 @@ type cleaner struct {
 // for a long time, and the life time has been exhausted, then the resource will be removed immediately
 // once the last event has been ACKed.
 func (c *cleaner) run(canceler unison.Canceler, store *store, interval time.Duration) {
-	panic("TODO: implement me")
+	started := time.Now()
+	timed.Periodic(canceler, interval, func() {
+		gcStore(c.log, started, store)
+	})
+}
+
+// gcStore looks for resources to remove and deletes these. `gcStore` receives
+// the start timestamp of the cleaner as reference. If we have entries without
+// updates in the registry, that are older than `started`, we will use `started
+// + ttl` to decide if an entry will be removed. This way old entries are not
+// removed immediately on startup if the Beat is down for a longer period of
+// time.
+func gcStore(log *logp.Logger, started time.Time, store *store) {
+	log.Debugf("Start store cleanup")
+	defer log.Debugf("Done store cleanup")
+
+	states := store.ephemeralStore
+	states.mu.Lock()
+	defer states.mu.Unlock()
+
+	keys := gcFind(states.table, started, time.Now())
+	if len(keys) == 0 {
+		log.Debug("No entries to remove were found")
+		return
+	}
+
+	if err := gcClean(store, keys); err != nil {
+		log.Errorf("Failed to remove all entries from the registry: %+v", err)
+	}
+}
+
+// gcFind searches the store of resources that can be removed. A set of keys to delete is returned.
+func gcFind(table map[string]*resource, started, now time.Time) map[string]struct{} {
+	keys := map[string]struct{}{}
+	for key, resource := range table {
+		clean := checkCleanResource(started, now, resource)
+		if !clean {
+			// do not clean the resource if it is still live or not serialized to the persistent store yet.
+			continue
+		}
+		keys[key] = struct{}{}
+	}
+
+	return keys
+}
+
+// gcClean removes key value pairs in the removeSet from the store.
+// If deletion in the persistent store fails the entry is kept in memory and
+// eventually cleaned up later.
+func gcClean(store *store, removeSet map[string]struct{}) error {
+	for key := range removeSet {
+		if err := store.persistentStore.Remove(key); err != nil {
+			return err
+		}
+		delete(store.ephemeralStore.table, key)
+	}
+	return nil
+}
+
+// checkCleanResource returns true for a key-value pair is assumed to be old,
+// if is not in use and there are no more pending updates that still need to be
+// written to the persistent store anymore.
+func checkCleanResource(started, now time.Time, resource *resource) bool {
+	if !resource.Finished() {
+		return false
+	}
+
+	resource.stateMutex.Lock()
+	defer resource.stateMutex.Unlock()
+
+	ttl := resource.internalState.TTL
+	reference := resource.internalState.Updated
+	if started.After(reference) {
+		reference = started
+	}
+
+	return reference.Add(ttl).Before(now) && resource.stored
 }

--- a/filebeat/input/v2/input-cursor/clean_test.go
+++ b/filebeat/input/v2/input-cursor/clean_test.go
@@ -1,0 +1,162 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cursor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func TestGCStore(t *testing.T) {
+	t.Run("empty store", func(t *testing.T) {
+		started := time.Now()
+
+		backend := createSampleStore(t, nil)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		gcStore(logp.NewLogger("test"), started, store)
+
+		want := map[string]state{}
+		checkEqualStoreState(t, want, backend.snapshot())
+	})
+
+	t.Run("state is still alive", func(t *testing.T) {
+		started := time.Now()
+		const ttl = 60 * time.Second
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-ttl / 2),
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		gcStore(logp.NewLogger("test"), started, store)
+
+		checkEqualStoreState(t, initState, backend.snapshot())
+	})
+
+	t.Run("old state can be removed", func(t *testing.T) {
+		const ttl = 60 * time.Second
+		started := time.Now().Add(-5 * ttl) // cleanup process is running for a while already
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-ttl),
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		gcStore(logp.NewLogger("test"), started, store)
+
+		want := map[string]state{}
+		checkEqualStoreState(t, want, backend.snapshot())
+	})
+
+	t.Run("old state is not removed if cleanup is not active long enough", func(t *testing.T) {
+		const ttl = 60 * time.Minute
+		started := time.Now()
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-2 * ttl),
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		gcStore(logp.NewLogger("test"), started, store)
+
+		checkEqualStoreState(t, initState, backend.snapshot())
+	})
+
+	t.Run("old state but resource is accessed", func(t *testing.T) {
+		const ttl = 60 * time.Second
+		started := time.Now().Add(-5 * ttl) // cleanup process is running for a while already
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-ttl),
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		// access resource and check it is not gc'ed
+		res := store.Get("test::key")
+		gcStore(logp.NewLogger("test"), started, store)
+		checkEqualStoreState(t, initState, backend.snapshot())
+
+		// release resource and check it gets gc'ed
+		res.Release()
+		want := map[string]state{}
+		gcStore(logp.NewLogger("test"), started, store)
+		checkEqualStoreState(t, want, backend.snapshot())
+	})
+
+	t.Run("old state but resource has pending updates", func(t *testing.T) {
+		const ttl = 60 * time.Second
+		started := time.Now().Add(-5 * ttl) // cleanup process is running for a while already
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-ttl),
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		// create pending update operation
+		res := store.Get("test::key")
+		op, err := createUpdateOp(store, res, "test-state-update")
+		require.NoError(t, err)
+		res.Release()
+
+		// cleanup fails
+		gcStore(logp.NewLogger("test"), started, store)
+		checkEqualStoreState(t, initState, backend.snapshot())
+
+		// cancel operation (no more pending operations) and try to gc again
+		op.done(1)
+		gcStore(logp.NewLogger("test"), started, store)
+		want := map[string]state{}
+		checkEqualStoreState(t, want, backend.snapshot())
+	})
+}

--- a/filebeat/input/v2/input-cursor/cursor_test.go
+++ b/filebeat/input/v2/input-cursor/cursor_test.go
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cursor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCursor_IsNew(t *testing.T) {
+	t.Run("true if key is not in store", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		cursor := makeCursor(store, store.Get("test::key"))
+		require.True(t, cursor.IsNew())
+	})
+
+	t.Run("true if key is in store but without cursor value", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: nil},
+		}))
+		defer store.Release()
+
+		cursor := makeCursor(store, store.Get("test::key"))
+		require.True(t, cursor.IsNew())
+	})
+
+	t.Run("false if key with cursor value is in persistent store", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: "test"},
+		}))
+		defer store.Release()
+
+		cursor := makeCursor(store, store.Get("test::key"))
+		require.False(t, cursor.IsNew())
+	})
+
+	t.Run("false if key with cursor value is in memory store only", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: nil},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		op, err := createUpdateOp(store, res, "test-state-update")
+		require.NoError(t, err)
+		defer op.done(1)
+
+		cursor := makeCursor(store, res)
+		require.False(t, cursor.IsNew())
+	})
+}
+
+func TestCursor_Unpack(t *testing.T) {
+	t.Run("nothing to unpack if key is new", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		var st string
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		require.NoError(t, cursor.Unpack(&st))
+		require.Equal(t, "", st)
+	})
+
+	t.Run("unpack fails if types are not compatible", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: "test"},
+		}))
+		defer store.Release()
+
+		var st struct{ A uint }
+		cursor := makeCursor(store, store.Get("test::key"))
+		require.Error(t, cursor.Unpack(&st))
+	})
+
+	t.Run("unpack from state in persistent store", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: "test"},
+		}))
+		defer store.Release()
+
+		var st string
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		require.NoError(t, cursor.Unpack(&st))
+		require.Equal(t, "test", st)
+	})
+
+	t.Run("unpack from in memory state if updates are pending", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {Cursor: "test"},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		op, err := createUpdateOp(store, res, "test-state-update")
+		require.NoError(t, err)
+		defer op.done(1)
+
+		var st string
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		require.NoError(t, cursor.Unpack(&st))
+		require.Equal(t, "test-state-update", st)
+	})
+}

--- a/filebeat/input/v2/input-cursor/manager.go
+++ b/filebeat/input/v2/input-cursor/manager.go
@@ -18,15 +18,19 @@
 package cursor
 
 import (
+	"errors"
+	"sync"
 	"time"
+
+	"github.com/urso/sderr"
+
+	"github.com/elastic/go-concert/unison"
 
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/statestore"
-
-	"github.com/elastic/go-concert/unison"
 )
 
 // InputManager is used to create, manage, and coordinate stateful inputs and
@@ -60,7 +64,9 @@ type InputManager struct {
 	// that will be used to collect events from each source.
 	Configure func(cfg *common.Config) ([]Source, Input, error)
 
-	store *store
+	initOnce sync.Once
+	initErr  error
+	store    *store
 }
 
 // Source describe a source the input can collect data from.
@@ -70,22 +76,118 @@ type Source interface {
 	Name() string
 }
 
+var errNoSourceConfigured = errors.New("no source has been configured")
+var errNoInputRunner = errors.New("no input runner available")
+
 // StateStore interface and configurations used to give the Manager access to the persistent store.
 type StateStore interface {
 	Access() (*statestore.Store, error)
 	CleanupInterval() time.Duration
 }
 
+func (cim *InputManager) init() error {
+	cim.initOnce.Do(func() {
+		if cim.DefaultCleanTimeout <= 0 {
+			cim.DefaultCleanTimeout = 30 * time.Minute
+		}
+
+		log := cim.Logger.With("input_type", cim.Type)
+		var store *store
+		store, cim.initErr = openStore(log, cim.StateStore, cim.Type)
+		if cim.initErr != nil {
+			return
+		}
+
+		cim.store = store
+	})
+
+	return cim.initErr
+}
+
 // Init starts background processes for deleting old entries from the
 // persistent store if mode is ModeRun.
 func (cim *InputManager) Init(group unison.Group, mode v2.Mode) error {
-	panic("TODO: implement me")
+	if mode != v2.ModeRun {
+		return nil
+	}
+
+	if err := cim.init(); err != nil {
+		return err
+	}
+
+	log := cim.Logger.With("input_type", cim.Type)
+
+	store := cim.store
+	cleaner := &cleaner{log: log}
+	store.Retain()
+	err := group.Go(func(canceler unison.Canceler) error {
+		defer cim.shutdown()
+		defer store.Release()
+		interval := cim.StateStore.CleanupInterval()
+		if interval <= 0 {
+			interval = 5 * time.Minute
+		}
+		cleaner.run(canceler, store, interval)
+		return nil
+	})
+	if err != nil {
+		store.Release()
+		cim.shutdown()
+		return sderr.Wrap(err, "Can not start registry cleanup process")
+	}
+
+	return nil
+}
+
+func (cim *InputManager) shutdown() {
+	cim.store.Release()
 }
 
 // Create builds a new v2.Input using the provided Configure function.
 // The Input will run a go-routine per source that has been configured.
 func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
-	panic("TODO: implement me")
+	if err := cim.init(); err != nil {
+		return nil, err
+	}
+
+	settings := struct {
+		ID           string        `config:"id"`
+		CleanTimeout time.Duration `config:"clean_timeout"`
+	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout}
+	if err := config.Unpack(&settings); err != nil {
+		return nil, err
+	}
+
+	sources, inp, err := cim.Configure(config)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == 0 {
+		return nil, errNoSourceConfigured
+	}
+	if inp == nil {
+		return nil, errNoInputRunner
+	}
+
+	return &managedInput{
+		manager:      cim,
+		userID:       settings.ID,
+		sources:      sources,
+		input:        inp,
+		cleanTimeout: settings.CleanTimeout,
+	}, nil
+}
+
+// Lock locks a key for exclusive access and returns an resource that can be used to modify
+// the cursor state and unlock the key.
+func (cim *InputManager) lock(ctx input.Context, key string) (*resource, error) {
+	resource := cim.store.Get(key)
+	err := lockResource(ctx.Logger, resource, ctx.Cancelation)
+	if err != nil {
+		resource.Release()
+		return nil, err
+	}
+	return resource, nil
 }
 
 func lockResource(log *logp.Logger, resource *resource, canceler input.Canceler) error {

--- a/filebeat/input/v2/input-cursor/manager_test.go
+++ b/filebeat/input/v2/input-cursor/manager_test.go
@@ -337,6 +337,7 @@ func TestManager_InputsRun(t *testing.T) {
 		}()
 
 		cancel()
+		wg.Wait()
 		require.NoError(t, err)
 		require.Equal(t, 0, clientCounters.Active())
 	})

--- a/filebeat/input/v2/input-cursor/manager_test.go
+++ b/filebeat/input/v2/input-cursor/manager_test.go
@@ -1,0 +1,607 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cursor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+	"github.com/elastic/go-concert/unison"
+)
+
+type fakeTestInput struct {
+	OnTest func(Source, input.TestContext) error
+	OnRun  func(input.Context, Source, Cursor, Publisher) error
+}
+
+type stringSource string
+
+func TestManager_Init(t *testing.T) {
+	// Integration style tests for the InputManager and the state garbage collector
+
+	t.Run("stopping the taskgroup kills internal go-routines", func(t *testing.T) {
+		numRoutines := runtime.NumGoroutine()
+
+		var grp unison.TaskGroup
+		store := createSampleStore(t, nil)
+		manager := &InputManager{
+			Logger:              logp.NewLogger("test"),
+			StateStore:          store,
+			Type:                "test",
+			DefaultCleanTimeout: 10 * time.Millisecond,
+		}
+
+		err := manager.Init(&grp, v2.ModeRun)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+		grp.Stop()
+
+		// wait for all go-routines to be gone
+
+		for numRoutines < runtime.NumGoroutine() {
+			time.Sleep(1 * time.Millisecond)
+		}
+	})
+
+	t.Run("collect old entries after startup", func(t *testing.T) {
+		store := createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:     1 * time.Millisecond,
+				Updated: time.Now().Add(-24 * time.Hour),
+			},
+		})
+		store.GCPeriod = 10 * time.Millisecond
+
+		var grp unison.TaskGroup
+		defer grp.Stop()
+		manager := &InputManager{
+			Logger:              logp.NewLogger("test"),
+			StateStore:          store,
+			Type:                "test",
+			DefaultCleanTimeout: 10 * time.Millisecond,
+		}
+
+		err := manager.Init(&grp, v2.ModeRun)
+		require.NoError(t, err)
+
+		for len(store.snapshot()) > 0 {
+			time.Sleep(1 * time.Millisecond)
+		}
+	})
+}
+
+func TestManager_Create(t *testing.T) {
+	t.Run("fail if no source is configured", func(t *testing.T) {
+		manager := constInput(t, nil, &fakeTestInput{})
+		_, err := manager.Create(common.NewConfig())
+		require.Error(t, err)
+	})
+
+	t.Run("fail if config error", func(t *testing.T) {
+		manager := failingManager(t, errors.New("oops"))
+		_, err := manager.Create(common.NewConfig())
+		require.Error(t, err)
+	})
+
+	t.Run("fail if no input runner is returned", func(t *testing.T) {
+		manager := constInput(t, sourceList("test"), nil)
+		_, err := manager.Create(common.NewConfig())
+		require.Error(t, err)
+	})
+
+	t.Run("configure ok", func(t *testing.T) {
+		manager := constInput(t, sourceList("test"), &fakeTestInput{})
+		_, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+	})
+
+	t.Run("configuring inputs with overlapping sources is allowed", func(t *testing.T) {
+		manager := simpleManagerWithConfigure(t, func(cfg *common.Config) ([]Source, Input, error) {
+			config := struct{ Sources []string }{}
+			err := cfg.Unpack(&config)
+			return sourceList(config.Sources...), &fakeTestInput{}, err
+		})
+
+		_, err := manager.Create(common.MustNewConfigFrom(map[string]interface{}{
+			"sources": []string{"a"},
+		}))
+		require.NoError(t, err)
+
+		_, err = manager.Create(common.MustNewConfigFrom(map[string]interface{}{
+			"sources": []string{"a"},
+		}))
+		require.NoError(t, err)
+	})
+}
+
+func TestManager_InputsTest(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+
+	sources := sourceList("source1", "source2")
+
+	t.Run("test is run for each source", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sources, &fakeTestInput{
+			OnTest: func(source Source, _ v2.TestContext) error {
+				mu.Lock()
+				defer mu.Unlock()
+				seen = append(seen, source.Name())
+				return nil
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		err = inp.Test(input.TestContext{})
+		require.NoError(t, err)
+
+		sort.Strings(seen)
+		require.Equal(t, []string{"source1", "source2"}, seen)
+	})
+
+	t.Run("cancel gets distributed to all source tests", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sources, &fakeTestInput{
+			OnTest: func(_ Source, ctx v2.TestContext) error {
+				<-ctx.Cancelation.Done()
+				return nil
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.TODO())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = inp.Test(input.TestContext{Cancelation: ctx})
+		}()
+
+		cancel()
+		wg.Wait()
+		require.NoError(t, err)
+	})
+
+	t.Run("fail if test for one source fails", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		failing := Source(stringSource("source1"))
+		sources := []Source{failing, stringSource("source2")}
+
+		manager := constInput(t, sources, &fakeTestInput{
+			OnTest: func(source Source, _ v2.TestContext) error {
+				if source == failing {
+					t.Log("return error")
+					return errors.New("oops")
+				}
+				t.Log("return ok")
+				return nil
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = inp.Test(input.TestContext{})
+			t.Logf("Test returned: %v", err)
+		}()
+
+		wg.Wait()
+		require.Error(t, err)
+	})
+
+	t.Run("panic is captured", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sources, &fakeTestInput{
+			OnTest: func(source Source, _ v2.TestContext) error {
+				panic("oops")
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = inp.Test(input.TestContext{Logger: logp.NewLogger("test")})
+			t.Logf("Test returned: %v", err)
+		}()
+
+		wg.Wait()
+		require.Error(t, err)
+	})
+}
+
+func TestManager_InputsRun(t *testing.T) {
+	// Integration style tests for the InputManager and Input.Run
+
+	t.Run("input returned with error", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sourceList("test"), &fakeTestInput{
+			OnRun: func(_ input.Context, _ Source, _ Cursor, _ Publisher) error {
+				return errors.New("oops")
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var clientCounters pubtest.ClientCounter
+		err = inp.Run(v2.Context{
+			Logger:      manager.Logger,
+			Cancelation: cancelCtx,
+		}, clientCounters.BuildConnector())
+		require.Error(t, err)
+		require.Equal(t, 0, clientCounters.Active())
+	})
+
+	t.Run("panic is captured", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sourceList("test"), &fakeTestInput{
+			OnRun: func(_ input.Context, _ Source, _ Cursor, _ Publisher) error {
+				panic("oops")
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var clientCounters pubtest.ClientCounter
+		err = inp.Run(v2.Context{
+			Logger:      manager.Logger,
+			Cancelation: cancelCtx,
+		}, clientCounters.BuildConnector())
+		require.Error(t, err)
+		require.Equal(t, 0, clientCounters.Active())
+	})
+
+	t.Run("shutdown on signal", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		manager := constInput(t, sourceList("test"), &fakeTestInput{
+			OnRun: func(ctx input.Context, _ Source, _ Cursor, _ Publisher) error {
+				<-ctx.Cancelation.Done()
+				return nil
+			},
+		})
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var clientCounters pubtest.ClientCounter
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = inp.Run(v2.Context{
+				Logger:      manager.Logger,
+				Cancelation: cancelCtx,
+			}, clientCounters.BuildConnector())
+		}()
+
+		cancel()
+		require.NoError(t, err)
+		require.Equal(t, 0, clientCounters.Active())
+	})
+
+	t.Run("continue sending from last known position", func(t *testing.T) {
+		log := logp.NewLogger("test")
+
+		type runConfig struct{ Max int }
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		manager := simpleManagerWithConfigure(t, func(cfg *common.Config) ([]Source, Input, error) {
+			config := runConfig{}
+			if err := cfg.Unpack(&config); err != nil {
+				return nil, nil, err
+			}
+
+			inp := &fakeTestInput{
+				OnRun: func(_ input.Context, _ Source, cursor Cursor, pub Publisher) error {
+					state := struct{ N int }{}
+					if !cursor.IsNew() {
+						if err := cursor.Unpack(&state); err != nil {
+							return fmt.Errorf("failed to unpack cursor: %w", err)
+						}
+					}
+
+					for i := 0; i < config.Max; i++ {
+						event := beat.Event{Fields: common.MapStr{"n": state.N}}
+						state.N++
+						pub.Publish(event, state)
+					}
+					return nil
+				},
+			}
+
+			return sourceList("test"), inp, nil
+		})
+
+		var ids []int
+		pipeline := pubtest.ConstClient(&pubtest.FakeClient{
+			PublishFunc: func(event beat.Event) {
+				id := event.Fields["n"].(int)
+				ids = append(ids, id)
+			},
+		})
+
+		// create and run first instance
+		inp, err := manager.Create(common.MustNewConfigFrom(runConfig{Max: 3}))
+		require.NoError(t, err)
+		require.NoError(t, inp.Run(input.Context{
+			Logger:      log,
+			Cancelation: context.Background(),
+		}, pipeline))
+
+		// create and run second instance instance
+		inp, err = manager.Create(common.MustNewConfigFrom(runConfig{Max: 3}))
+		require.NoError(t, err)
+		inp.Run(input.Context{
+			Logger:      log,
+			Cancelation: context.Background(),
+		}, pipeline)
+
+		// verify
+		assert.Equal(t, []int{0, 1, 2, 3, 4, 5}, ids)
+	})
+
+	t.Run("event ACK triggers execution of update operations", func(t *testing.T) {
+		defer resources.NewGoroutinesChecker().Check(t)
+
+		store := createSampleStore(t, nil)
+		var wgSend sync.WaitGroup
+		wgSend.Add(1)
+		manager := constInput(t, sourceList("key"), &fakeTestInput{
+			OnRun: func(ctx input.Context, _ Source, _ Cursor, pub Publisher) error {
+				defer wgSend.Done()
+				fields := common.MapStr{"hello": "world"}
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state1")
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state2")
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state3")
+				pub.Publish(beat.Event{Fields: fields}, nil)
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state4")
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state5")
+				pub.Publish(beat.Event{Fields: fields}, "test-cursor-state6")
+				return nil
+			},
+		})
+		manager.StateStore = store
+
+		inp, err := manager.Create(common.NewConfig())
+		require.NoError(t, err)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// setup publishing pipeline and capture ACKer, so we can simulate progress in the Output
+		var acker func([]interface{})
+		var activeEventPrivate []interface{}
+
+		ackEvents := func(n int) {
+			data, rest := activeEventPrivate[:n], activeEventPrivate[n:]
+			activeEventPrivate = rest
+			acker(data)
+		}
+
+		var wgACKer sync.WaitGroup
+		wgACKer.Add(1)
+		pipeline := &pubtest.FakeConnector{
+			ConnectFunc: func(cfg beat.ClientConfig) (beat.Client, error) {
+				defer wgACKer.Done()
+				acker = cfg.ACKEvents
+				return &pubtest.FakeClient{
+					PublishFunc: func(event beat.Event) {
+						activeEventPrivate = append(activeEventPrivate, event.Private)
+					},
+				}, nil
+			},
+		}
+
+		// start the input
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = inp.Run(v2.Context{
+				Logger:      manager.Logger,
+				Cancelation: cancelCtx,
+			}, pipeline)
+		}()
+		// wait for test setup to shutdown
+		defer wg.Wait()
+
+		// wait for setup complete and events being send (pending operations in the pipeline)
+		wgACKer.Wait()
+		wgSend.Wait()
+
+		// 1. No cursor state in store yet, all operations are still pending
+		require.Equal(t, nil, store.snapshot()["test::key"].Cursor)
+
+		// ACK first 2 events and check snapshot state
+		ackEvents(2)
+		require.Equal(t, "test-cursor-state2", store.snapshot()["test::key"].Cursor)
+
+		// ACK 1 events and check snapshot state (3 events published)
+		ackEvents(1)
+		require.Equal(t, "test-cursor-state3", store.snapshot()["test::key"].Cursor)
+
+		// ACK event without cursor update and check snapshot state not modified
+		ackEvents(1)
+		require.Equal(t, "test-cursor-state3", store.snapshot()["test::key"].Cursor)
+
+		// ACK rest
+		ackEvents(3)
+		require.Equal(t, "test-cursor-state6", store.snapshot()["test::key"].Cursor)
+	})
+}
+
+func TestLockResource(t *testing.T) {
+	t.Run("can lock unused resource", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		err := lockResource(logp.NewLogger("test"), res, context.TODO())
+		require.NoError(t, err)
+	})
+
+	t.Run("fail to lock resource in use when context is cancelled", func(t *testing.T) {
+		log := logp.NewLogger("test")
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		resUsed := store.Get("test::key")
+		err := lockResource(log, resUsed, context.TODO())
+		require.NoError(t, err)
+
+		// fail to lock resource in use
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+		resFail := store.Get("test::key")
+		err = lockResource(log, resFail, ctx)
+		require.Error(t, err)
+		resFail.Release()
+
+		// unlock and release resource in use -> it should be marked finished now
+		releaseResource(resUsed)
+		require.True(t, resUsed.Finished())
+	})
+
+	t.Run("succeed to lock resource after it has been released", func(t *testing.T) {
+		log := logp.NewLogger("test")
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		resUsed := store.Get("test::key")
+		err := lockResource(log, resUsed, context.TODO())
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resOther := store.Get("test::key")
+			err := lockResource(log, resOther, context.TODO())
+			if err == nil {
+				releaseResource(resOther)
+			}
+		}()
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			releaseResource(resUsed)
+		}()
+
+		wg.Wait() // <- block forever if waiting go-routine can not acquire lock
+	})
+}
+
+func (s stringSource) Name() string { return string(s) }
+
+func simpleManagerWithConfigure(t *testing.T, configure func(*common.Config) ([]Source, Input, error)) *InputManager {
+	return &InputManager{
+		Logger:     logp.NewLogger("test"),
+		StateStore: createSampleStore(t, nil),
+		Type:       "test",
+		Configure:  configure,
+	}
+}
+
+func constConfigureResult(t *testing.T, sources []Source, inp Input, err error) *InputManager {
+	return simpleManagerWithConfigure(t, func(cfg *common.Config) ([]Source, Input, error) {
+		return sources, inp, err
+	})
+}
+
+func failingManager(t *testing.T, err error) *InputManager {
+	return constConfigureResult(t, nil, nil, err)
+}
+
+func constInput(t *testing.T, sources []Source, inp Input) *InputManager {
+	return constConfigureResult(t, sources, inp, nil)
+}
+
+func (f *fakeTestInput) Name() string { return "test" }
+
+func (f *fakeTestInput) Test(source Source, ctx input.TestContext) error {
+	if f.OnTest != nil {
+		return f.OnTest(source, ctx)
+	}
+	return nil
+}
+
+func (f *fakeTestInput) Run(ctx input.Context, source Source, cursor Cursor, pub Publisher) error {
+	if f.OnRun != nil {
+		return f.OnRun(ctx, source, cursor, pub)
+	}
+	return nil
+}
+
+func sourceList(names ...string) []Source {
+	tmp := make([]Source, len(names))
+	for i, name := range names {
+		tmp[i] = stringSource(name)
+	}
+	return tmp
+}

--- a/filebeat/input/v2/input-cursor/publish_test.go
+++ b/filebeat/input/v2/input-cursor/publish_test.go
@@ -1,0 +1,158 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cursor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
+)
+
+func TestPublish(t *testing.T) {
+	t.Run("event with cursor state creates update operation", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		var actual beat.Event
+		client := &pubtest.FakeClient{
+			PublishFunc: func(event beat.Event) { actual = event },
+		}
+		publisher := cursorPublisher{nil, client, &cursor}
+		publisher.Publish(beat.Event{}, "test")
+
+		require.NotNil(t, actual.Private)
+	})
+
+	t.Run("event without cursor creates no update operation", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		var actual beat.Event
+		client := &pubtest.FakeClient{
+			PublishFunc: func(event beat.Event) { actual = event },
+		}
+		publisher := cursorPublisher{nil, client, &cursor}
+		publisher.Publish(beat.Event{}, nil)
+		require.Nil(t, actual.Private)
+	})
+
+	t.Run("publish returns error if context has been cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		cursor := makeCursor(store, store.Get("test::key"))
+
+		publisher := cursorPublisher{ctx, &pubtest.FakeClient{}, &cursor}
+		err := publisher.Publish(beat.Event{}, nil)
+		require.Equal(t, context.Canceled, err)
+	})
+}
+
+func TestOp_Execute(t *testing.T) {
+	t.Run("applying final op marks the key as finished", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		res := store.Get("test::key")
+
+		// create op and release resource. The 'resource' must still be active
+		op := mustCreateUpdateOp(t, store, res, "test-updated-cursor-state")
+		res.Release()
+		require.False(t, res.Finished())
+
+		// this was the last op, the resource should become inactive
+		op.Execute(1)
+		require.True(t, res.Finished())
+
+		// validate state:
+		inSyncCursor := storeInSyncSnapshot(store)["test::key"].Cursor
+		inMemCursor := storeMemorySnapshot(store)["test::key"].Cursor
+		want := "test-updated-cursor-state"
+		assert.Equal(t, want, inSyncCursor)
+		assert.Equal(t, want, inMemCursor)
+	})
+
+	t.Run("acking multiple ops applies the latest update and marks key as finished", func(t *testing.T) {
+		// when acking N events, intermediate updates are dropped in favor of the latest update operation.
+		// This test checks that the resource is correctly marked as finished.
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		res := store.Get("test::key")
+
+		// create update operations and release resource. The 'resource' must still be active
+		mustCreateUpdateOp(t, store, res, "test-updated-cursor-state-dropped")
+		op := mustCreateUpdateOp(t, store, res, "test-updated-cursor-state-final")
+		res.Release()
+		require.False(t, res.Finished())
+
+		// this was the last op, the resource should become inactive
+		op.Execute(2)
+		require.True(t, res.Finished())
+
+		// validate state:
+		inSyncCursor := storeInSyncSnapshot(store)["test::key"].Cursor
+		inMemCursor := storeMemorySnapshot(store)["test::key"].Cursor
+		want := "test-updated-cursor-state-final"
+		assert.Equal(t, want, inSyncCursor)
+		assert.Equal(t, want, inMemCursor)
+	})
+
+	t.Run("ACK only subset of pending ops will only update up to ACKed state", func(t *testing.T) {
+		// when acking N events, intermediate updates are dropped in favor of the latest update operation.
+		// This test checks that the resource is correctly marked as finished.
+
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		res := store.Get("test::key")
+
+		// create update operations and release resource. The 'resource' must still be active
+		op1 := mustCreateUpdateOp(t, store, res, "test-updated-cursor-state-intermediate")
+		op2 := mustCreateUpdateOp(t, store, res, "test-updated-cursor-state-final")
+		res.Release()
+		require.False(t, res.Finished())
+
+		defer op2.done(1) // cleanup after test
+
+		// this was the intermediate op, the resource should still be active
+		op1.Execute(1)
+		require.False(t, res.Finished())
+
+		// validate state (in memory state is always up to data to most recent update):
+		inSyncCursor := storeInSyncSnapshot(store)["test::key"].Cursor
+		inMemCursor := storeMemorySnapshot(store)["test::key"].Cursor
+		assert.Equal(t, "test-updated-cursor-state-intermediate", inSyncCursor)
+		assert.Equal(t, "test-updated-cursor-state-final", inMemCursor)
+	})
+}
+
+func mustCreateUpdateOp(t *testing.T, store *store, resource *resource, updates interface{}) *updateOp {
+	op, err := createUpdateOp(store, resource, updates)
+	if err != nil {
+		t.Fatalf("Failed to create update op: %v", err)
+	}
+	return op
+}

--- a/filebeat/input/v2/input-cursor/store_test.go
+++ b/filebeat/input/v2/input-cursor/store_test.go
@@ -1,0 +1,351 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cursor
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+)
+
+type testStateStore struct {
+	Store    *statestore.Store
+	GCPeriod time.Duration
+}
+
+func TestStore_OpenClose(t *testing.T) {
+	t.Run("releasing store closes", func(t *testing.T) {
+		var closed bool
+		cleanup := closeStoreWith(func(s *store) {
+			closed = true
+			s.close()
+		})
+		defer cleanup()
+
+		store := testOpenStore(t, "test", nil)
+		store.Release()
+
+		require.True(t, closed)
+	})
+
+	t.Run("fail if persistent store can not be accessed", func(t *testing.T) {
+		_, err := openStore(logp.NewLogger("test"), testStateStore{}, "test")
+		require.Error(t, err)
+	})
+
+	t.Run("load from empty", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+		require.Equal(t, 0, len(storeMemorySnapshot(store)))
+		require.Equal(t, 0, len(storeInSyncSnapshot(store)))
+	})
+
+	t.Run("already available state is loaded", func(t *testing.T) {
+		states := map[string]state{
+			"test::key0": {Cursor: "1"},
+			"test::key1": {Cursor: "2"},
+		}
+
+		store := testOpenStore(t, "test", createSampleStore(t, states))
+		defer store.Release()
+
+		checkEqualStoreState(t, states, storeMemorySnapshot(store))
+		checkEqualStoreState(t, states, storeInSyncSnapshot(store))
+	})
+
+	t.Run("ignore entries with wrong index on open", func(t *testing.T) {
+		states := map[string]state{
+			"test::key0": {Cursor: "1"},
+			"other::key": {Cursor: "2"},
+		}
+
+		store := testOpenStore(t, "test", createSampleStore(t, states))
+		defer store.Release()
+
+		want := map[string]state{
+			"test::key0": {Cursor: "1"},
+		}
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+}
+
+func TestStore_Get(t *testing.T) {
+	t.Run("find existing resource", func(t *testing.T) {
+		cursorState := state{Cursor: "1"}
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key0": cursorState,
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key0")
+		require.NotNil(t, res)
+		defer res.Release()
+
+		// check in memory state matches matches original persistent state
+		require.Equal(t, cursorState, res.stateSnapshot())
+		// check assumed in-sync state matches matches original persistent state
+		require.Equal(t, cursorState, res.inSyncStateSnapshot())
+	})
+
+	t.Run("access unknown resource", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		require.NotNil(t, res)
+		defer res.Release()
+
+		// new resource has empty state
+		require.Equal(t, state{}, res.stateSnapshot())
+	})
+
+	t.Run("same resource is returned", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		res1 := store.Get("test::key")
+		require.NotNil(t, res1)
+		defer res1.Release()
+
+		res2 := store.Get("test::key")
+		require.NotNil(t, res2)
+		defer res2.Release()
+
+		assert.Equal(t, res1, res2)
+	})
+}
+
+func TestStore_UpdateTTL(t *testing.T) {
+	t.Run("add TTL for new entry to store", func(t *testing.T) {
+		// when creating a resource we set the TTL and insert a new key value pair without cursor value into the store:
+		store := testOpenStore(t, "test", createSampleStore(t, nil))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		store.UpdateTTL(res, 60*time.Second)
+
+		want := map[string]state{
+			"test::key": {
+				TTL:     60 * time.Second,
+				Updated: res.internalState.Updated,
+				Cursor:  nil,
+			},
+		}
+
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+
+	t.Run("update TTL for in-sync resource does not overwrite state", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    1 * time.Second,
+				Cursor: "test",
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		store.UpdateTTL(res, 60*time.Second)
+		want := map[string]state{
+			"test::key": {
+				Updated: res.internalState.Updated,
+				TTL:     60 * time.Second,
+				Cursor:  "test",
+			},
+		}
+
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+
+	t.Run("update TTL for resource with pending updates", func(t *testing.T) {
+		// This test updates the resource TTL while update operations are still
+		// pending, but not synced to the persistent store yet.
+		// UpdateTTL changes the state in the persistent store immediately, and must therefore
+		// serialize the old in-sync state with update meta-data.
+
+		// create store
+		backend := createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    1 * time.Second,
+				Cursor: "test",
+			},
+		})
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		// create pending update operation
+		res := store.Get("test::key")
+		op, err := createUpdateOp(store, res, "test-state-update")
+		require.NoError(t, err)
+		defer op.done(1)
+
+		// Update key/value pair TTL. This will update the internal state in the
+		// persistent store only, not modifying the old cursor state yet.
+		store.UpdateTTL(res, 60*time.Second)
+
+		// validate
+		wantMemoryState := state{
+			Updated: res.internalState.Updated,
+			TTL:     60 * time.Second,
+			Cursor:  "test-state-update",
+		}
+		wantInSyncState := state{
+			Updated: res.internalState.Updated,
+			TTL:     60 * time.Second,
+			Cursor:  "test",
+		}
+
+		checkEqualStoreState(t, map[string]state{"test::key": wantMemoryState}, storeMemorySnapshot(store))
+		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, storeInSyncSnapshot(store))
+		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, backend.snapshot())
+	})
+}
+
+func closeStoreWith(fn func(s *store)) func() {
+	old := closeStore
+	closeStore = fn
+	return func() {
+		closeStore = old
+	}
+}
+
+func testOpenStore(t *testing.T, prefix string, persistentStore StateStore) *store {
+	if persistentStore == nil {
+		persistentStore = createSampleStore(t, nil)
+	}
+
+	store, err := openStore(logp.NewLogger("test"), persistentStore, prefix)
+	if err != nil {
+		t.Fatalf("failed to open the store")
+	}
+	return store
+}
+
+func createSampleStore(t *testing.T, data map[string]state) testStateStore {
+	storeReg := statestore.NewRegistry(storetest.NewMemoryStoreBackend())
+	store, err := storeReg.Get("test")
+	if err != nil {
+		t.Fatalf("Failed to access store: %v", err)
+	}
+
+	for k, v := range data {
+		if err := store.Set(k, v); err != nil {
+			t.Fatalf("Error when populating the sample store: %v", err)
+		}
+	}
+
+	return testStateStore{
+		Store: store,
+	}
+}
+
+func (ts testStateStore) WithGCPeriod(d time.Duration) testStateStore { ts.GCPeriod = d; return ts }
+func (ts testStateStore) CleanupInterval() time.Duration              { return ts.GCPeriod }
+func (ts testStateStore) Access() (*statestore.Store, error) {
+	if ts.Store == nil {
+		return nil, errors.New("no store configured")
+	}
+	return ts.Store, nil
+}
+
+// snapshot copies all key/value pairs from the persistent store into a table for inspection.
+func (ts testStateStore) snapshot() map[string]state {
+	states := map[string]state{}
+	err := ts.Store.Each(func(key string, dec statestore.ValueDecoder) (bool, error) {
+		var st state
+		if err := dec.Decode(&st); err != nil {
+			return false, err
+		}
+		states[key] = st
+		return true, nil
+	})
+
+	if err != nil {
+		panic("unexpected decode error from persistent test store")
+	}
+	return states
+}
+
+// storeMemorySnapshot copies all key/value pairs into a table for inspection.
+// The state returned reflects the in memory state, which can be ahead of the
+// persistent state.
+//
+// Note: The state returned by storeMemorySnapshot is always ahead of the state returned by storeInSyncSnapshot.
+//       All key value pairs are fully in-sync, if both snapshot functions return the same state.
+func storeMemorySnapshot(store *store) map[string]state {
+	store.ephemeralStore.mu.Lock()
+	defer store.ephemeralStore.mu.Unlock()
+
+	states := map[string]state{}
+	for k, res := range store.ephemeralStore.table {
+		states[k] = res.stateSnapshot()
+	}
+	return states
+}
+
+// storeInSyncSnapshot copies all key/value pairs into the table for inspection.
+// The state returned reflects the current state that the in-memory tables assumed to be
+// written to the persistent store already.
+
+// Note: The state returned by storeMemorySnapshot is always ahead of the state returned by storeInSyncSnapshot.
+//       All key value pairs are fully in-sync, if both snapshot functions return the same state.
+func storeInSyncSnapshot(store *store) map[string]state {
+	store.ephemeralStore.mu.Lock()
+	defer store.ephemeralStore.mu.Unlock()
+
+	states := map[string]state{}
+	for k, res := range store.ephemeralStore.table {
+		states[k] = res.inSyncStateSnapshot()
+	}
+	return states
+}
+
+// checkEqualStoreState compares 2 store snapshot tables for equality. The test
+// fails with Errorf if the state differ.
+//
+// Note: testify is too strict when comparing timestamp, better use checkEqualStoreState.
+func checkEqualStoreState(t *testing.T, want, got map[string]state) bool {
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("store state mismatch (-want +got):\n%s", d)
+		return false
+	}
+	return true
+}
+
+// requireEqualStoreState compares 2 store snapshot tables for equality. The test
+// fails with Fatalf if the state differ.
+//
+// Note: testify is too strict when comparing timestamp, better use checkEqualStoreState.
+func requireEqualStoreState(t *testing.T, want, got map[string]state) bool {
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("store state mismatch (-want +got):\n%s", d)
+		return false
+	}
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -142,6 +142,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tsg/go-daemon v0.0.0-20200207173439-e704b93fd89b
 	github.com/tsg/gopacket v0.0.0-20200626092518-2ab8e397a786
+	github.com/urso/sderr v0.0.0-20200210124243-c2a16f3d43ec
 	github.com/vmware/govmomi v0.0.0-20170802214208-2cad15190b41
 	github.com/yuin/gopher-lua v0.0.0-20170403160031-b402f3114ec7 // indirect
 	go.elastic.co/apm v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,7 @@ go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.3.0 h1:sFPn2GLc3poCkfrpIXGhBD2X0CMIo4Q/zSULXrj/+uc=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=


### PR DESCRIPTION
Cherry-pick of PR #19518, #19528, #19529, #19530, #19571, #19573 to 7.x branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

This change provide the store implementation that is used by the cursor
input to track ephemeral and persistent state.

The full list of changes will include:
- Introduce v2 API interfaces
- Introduce [compatibility layer](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/input/v2/compat) to integrate API with existing functionality
- Introduce helpers for writing [stateless](https://github.com/urso/beats/blob/fb-input-v2-combined/filebeat/input/v2/input-stateless/stateless.go) inputs.
- Introduce helpers for writing [inputs that store a state](https://github.com/urso/beats/tree/fb-input-v2-combined/filebeat/input/v2/input-cursor) between restarts.
- Integrate new API with [existing inputs and modules](https://github.com/urso/beats/blob/fb-input-v2-combined/filebeat/beater/filebeat.go#L301) in filebeat.

## Why is it important?

Implement support for statefull inputs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

`go test`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123


- Relates #123


- Requires #123


- Superseds elastic/beats#123
-->
- Relates elastic/beats#15324 