### PR TITLE
Skip flaky integration tests for appsearch/stats metricset

### DIFF
--- a/x-pack/metricbeat/module/appsearch/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/appsearch/stats/stats_integration_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test; see ")
 	service := compose.EnsureUpWithTimeout(t, 570, "appsearch")
 
 	config := getConfig("stats", service.Host())
@@ -30,6 +31,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
+	t.Skip("flaky test; see https://github.com/elastic/beats/issues/19739")
 	service := compose.EnsureUp(t, "appsearch")
 
 	config := getConfig("stats", service.Host())

--- a/x-pack/metricbeat/module/appsearch/test_appsearch.py
+++ b/x-pack/metricbeat/module/appsearch/test_appsearch.py
@@ -10,7 +10,8 @@ class Test(XPackTest):
     COMPOSE_SERVICES = ['appsearch']
     COMPOSE_TIMEOUT = 600
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
+    # @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
+    @unittest.skip("Skipped as flaky: https://github.com/elastic/beats/issues/19739")
     def test_stats(self):
         self.render_config_template(modules=[{
             "name": "appsearch",


### PR DESCRIPTION
## What does this PR do?

Skips the flaky tests for the `appsearch/stats` metricset.

## Why is it important?

Tests are flaky causing unrelated build failures in most PR and master builds.

## Related issues

- Relates to #19739.
