### PR TITLE
Bumping up app search image version to 7.6.2

### DIFF
--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -2,11 +2,11 @@ version: '2.3'
 
 services:
   appsearch:
-    image: docker.elastic.co/integrations-ci/beats-appsearch:${APPSEARCH_VERSION:-7.5.0}-1
+    image: docker.elastic.co/integrations-ci/beats-appsearch:${APPSEARCH_VERSION:-7.6.2}-1
     build:
       context: ./_meta
       args:
-        APPSEARCH_VERSION: ${APPSEARCH_VERSION:-7.5.0}
+        APPSEARCH_VERSION: ${APPSEARCH_VERSION:-7.6.2}
     depends_on:
       - elasticsearch
     environment:


### PR DESCRIPTION
## What does this PR do?

Bumps up the App search docker image version 7.6.2.

## Why is it important?

App search depends on Elasticsearch. We have already bumped up the Elasticsearch docker image version to 7.7.0. However, we did not bump up the App search docker image version. It was left at 7.5.0, which does not work with Elasticsearch 7.7.0.

Ideally we could bump up the App search docker image version to 7.7.0 but evidently such an image tag does not exist in the Elastic docker repository. So we are bumping up to the highest version available that is also compatible with Elasticsearch 7.7.0, which is App search 7.6.2.


## Related issues
- Closes #19739
- Supersedes #19740
