### PR TITLE
Cherry-pick to 7.8: Bumping up app search image version to 7.6.2 (#19744)

### DIFF
--- a/x-pack/metricbeat/module/appsearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/appsearch/docker-compose.yml
@@ -2,11 +2,11 @@ version: '2.3'
 
 services:
   appsearch:
-    image: docker.elastic.co/integrations-ci/beats-appsearch:${APPSEARCH_VERSION:-7.5.0}-1
+    image: docker.elastic.co/integrations-ci/beats-appsearch:${APPSEARCH_VERSION:-7.6.2}-1
     build:
       context: ./_meta
       args:
-        APPSEARCH_VERSION: ${APPSEARCH_VERSION:-7.5.0}
+        APPSEARCH_VERSION: ${APPSEARCH_VERSION:-7.6.2}
     depends_on:
       - elasticsearch
     environment:


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Bumping up app search image version to 7.6.2 (#19744)