### PR TITLE
Remove more vendor references from scripts used in the CIs

### DIFF
--- a/.ci/scripts/travis_has_changes.sh
+++ b/.ci/scripts/travis_has_changes.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 # Changes on these files will trigger all builds.
-COMMON_DIRLIST="vendor dev-tools .travis.yml testing .ci"
+COMMON_DIRLIST="dev-tools .travis.yml testing .ci"
 
 # Commit range to check for. For example master...<PR branch>
 RANGE=$TRAVIS_COMMIT_RANGE

--- a/.ci/windows.groovy
+++ b/.ci/windows.groovy
@@ -594,7 +594,7 @@ def isChanged(patterns){
 def isChangedOSSCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
-    "^vendor/.*",
+    "^go.mod",
     "^libbeat/.*",
     "^testing/.*",
     "^dev-tools/.*",
@@ -607,7 +607,7 @@ def isChangedOSSCode(patterns) {
 def isChangedXPackCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
-    "^vendor/.*",
+    "^go.mod",
     "^libbeat/.*",
     "^dev-tools/.*",
     "^testing/.*",
@@ -817,9 +817,10 @@ def getVendorPatterns(beatName){
     "PATH=${env.WORKSPACE}/bin:${goRoot}/bin:${env.PATH}",
   ]) {
     output = sh(label: 'Get vendor dependency patterns', returnStdout: true, script: """
-      go list -mod=vendor -f '{{ .ImportPath }}{{ "\\n" }}{{ join .Deps "\\n" }}' ./${beatName}\
-        |awk '{print \$1"/.*"}'\
-        |sed -e "s#github.com/elastic/beats/v7/##g"
+      go list -deps ./${beatName} \
+        | grep 'elastic/beats' \
+        | sed -e "s#github.com/elastic/beats/v7/##g" \
+        | awk '{print "^" \$1 "/.*"}'
     """)
   }
   return output?.split('\n').collect{ item -> item as String }


### PR DESCRIPTION
## What does this PR do?

This PR follows up the removal of vendor folder from the repository by adjusting the CI scripts for Windows and Travis.

## Why is it important?

To make sure everything gets tested which has to be checked.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~