### PR TITLE
Cherry-pick #19771 to 7.x: Fix flakiness on test caused by cancelled requests

### DIFF
--- a/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
+++ b/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
@@ -110,7 +110,7 @@ func makeApiRequests(t *testing.T, ctx context.Context, address string) {
 	}
 
 	for {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+		req, err := http.NewRequest(http.MethodGet, address, nil)
 		require.NoError(t, err)
 		resp, err := client.Do(req)
 		require.NoError(t, err)


### PR DESCRIPTION
Cherry-pick of PR #19771 to 7.x branch. Original message: 

Don't use request with context on cloudfoundry input tests while
simulating requests, so we don't have to handle errors by context
cancellation. We don't really care if there is an ongoing request when
tests finish.