### PR TITLE
Cherry-pick to 7.x: Upgrading mage to v1.10.0 (#19770)

### DIFF
--- a/dev-tools/make/mage-install.mk
+++ b/dev-tools/make/mage-install.mk
@@ -1,4 +1,4 @@
-MAGE_VERSION     ?= v1.9.0
+MAGE_VERSION     ?= v1.10.0
 MAGE_PRESENT     := $(shell mage --version 2> /dev/null | grep $(MAGE_VERSION))
 MAGE_IMPORT_PATH ?= github.com/magefile/mage
 export MAGE_IMPORT_PATH


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Upgrading mage to v1.10.0 (#19770)