### PR TITLE
Cherry-pick #19717 to 7.x: Convert cloudfoundry input to v2

### DIFF
--- a/x-pack/filebeat/include/list.go
+++ b/x-pack/filebeat/include/list.go
@@ -10,7 +10,6 @@ import (
 	// Import packages that need to register themselves.
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/awscloudwatch"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/azureeventhub"
-	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/cloudfoundry"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/googlepubsub"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/http_endpoint"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/httpjson"

--- a/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
+++ b/x-pack/filebeat/input/cloudfoundry/input_integration_test.go
@@ -11,16 +11,17 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/beats/v7/filebeat/channel"
-	"github.com/elastic/beats/v7/filebeat/input"
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	cftest "github.com/elastic/beats/v7/x-pack/libbeat/common/cloudfoundry/test"
 )
 
@@ -40,63 +41,50 @@ func testInput(t *testing.T, version string) {
 	config := common.MustNewConfigFrom(cftest.GetConfigFromEnv(t))
 	config.SetString("version", -1, version)
 
+	input, err := Plugin().Manager.Create(config)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Ensure that there is something happening in the firehose
 	apiAddress, err := config.String("api_address", -1)
 	require.NoError(t, err)
-
-	// Ensure that there is something happening in the firehose
 	go makeApiRequests(t, ctx, apiAddress)
 
-	events := make(chan beat.Event)
-	connector := channel.ConnectorFunc(func(*common.Config, beat.ClientConfig) (channel.Outleter, error) {
-		return newOutleter(events), nil
-	})
+	ch := make(chan beat.Event)
+	client := &pubtest.FakeClient{
+		PublishFunc: func(evt beat.Event) {
+			if ctx.Err() != nil {
+				return
+			}
 
-	inputCtx := input.Context{Done: make(chan struct{})}
+			select {
+			case ch <- evt:
+			case <-ctx.Done():
+			}
+		},
+	}
 
-	input, err := NewInput(config, connector, inputCtx)
-	require.NoError(t, err)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 
-	go input.Run()
-	defer input.Stop()
+		inputCtx := v2.Context{
+			Logger:      logp.NewLogger("test"),
+			Cancelation: ctx,
+		}
+		input.Run(inputCtx, pubtest.ConstClient(client))
+	}()
 
 	select {
-	case e := <-events:
+	case e := <-ch:
 		t.Logf("Event received: %+v", e)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for events")
-	}
-}
-
-type outleter struct {
-	events chan<- beat.Event
-	done   chan struct{}
-}
-
-func newOutleter(events chan<- beat.Event) *outleter {
-	return &outleter{
-		events: events,
-		done:   make(chan struct{}),
-	}
-}
-
-func (o *outleter) Close() error {
-	close(o.done)
-	return nil
-}
-
-func (o *outleter) Done() <-chan struct{} {
-	return o.done
-}
-
-func (o *outleter) OnEvent(e beat.Event) bool {
-	select {
-	case o.events <- e:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/x-pack/filebeat/input/default-inputs/inputs.go
+++ b/x-pack/filebeat/input/default-inputs/inputs.go
@@ -10,6 +10,7 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/cloudfoundry"
 )
 
 func Init(info beat.Info, log *logp.Logger, store beater.StateStore) []v2.Plugin {
@@ -20,5 +21,7 @@ func Init(info beat.Info, log *logp.Logger, store beater.StateStore) []v2.Plugin
 }
 
 func xpackInputs(info beat.Info, log *logp.Logger, store beater.StateStore) []v2.Plugin {
-	return []v2.Plugin{}
+	return []v2.Plugin{
+		cloudfoundry.Plugin(),
+	}
 }

--- a/x-pack/libbeat/common/cloudfoundry/rlplistener.go
+++ b/x-pack/libbeat/common/cloudfoundry/rlplistener.go
@@ -66,8 +66,8 @@ func (c *RlpListener) Start(ctx context.Context) {
 	}
 	es := rlpClient.Stream(ctx, l)
 
+	c.wg.Add(1)
 	go func() {
-		c.wg.Add(1)
 		defer c.wg.Done()
 		for {
 			select {
@@ -107,6 +107,10 @@ func (c *RlpListener) Stop() {
 	if c.cancel != nil {
 		c.cancel()
 	}
+	c.wg.Wait()
+}
+
+func (c *RlpListener) Wait() {
 	c.wg.Wait()
 }
 


### PR DESCRIPTION
Cherry-pick of PR #19717 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Refactoring

## What does this PR do?

Move cloudfoundry input to v2 input API


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 
