### PR TITLE
Cherry-pick #19619 to 7.x: Init journald input

### DIFF
--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -1,0 +1,167 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mage
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/sh"
+	"github.com/pkg/errors"
+)
+
+type PackageInstaller struct {
+	table map[PlatformDescription][]PackageDependency
+}
+
+type PlatformDescription struct {
+	Name       string
+	Arch       string
+	DefaultTag string
+}
+
+type PackageDependency struct {
+	archTag      string
+	dependencies []string
+}
+
+var (
+	Linux386      = PlatformDescription{Name: "linux/386", Arch: "i386", DefaultTag: "i386"}
+	LinuxAMD64    = PlatformDescription{Name: "linux/amd64", Arch: "", DefaultTag: ""} // builders run on amd64 platform
+	LinuxARM64    = PlatformDescription{Name: "linux/arm64", Arch: "arm64", DefaultTag: "arm64"}
+	LinuxARM5     = PlatformDescription{Name: "linux/arm5", Arch: "armel", DefaultTag: "armel"}
+	LinuxARM6     = PlatformDescription{Name: "linux/arm6", Arch: "armel", DefaultTag: "armel"}
+	LinuxARM7     = PlatformDescription{Name: "linux/arm7", Arch: "armhf", DefaultTag: "armhf"}
+	LinuxMIPS     = PlatformDescription{Name: "linux/mips", Arch: "mips", DefaultTag: "mips"}
+	LinuxMIPSLE   = PlatformDescription{Name: "linux/mipsle", Arch: "mipsel", DefaultTag: "mipsel"}
+	LinuxMIPS64LE = PlatformDescription{Name: "linux/mips64le", Arch: "mips64el", DefaultTag: "mips64el"}
+	LinuxPPC64LE  = PlatformDescription{Name: "linux/ppc64le", Arch: "ppc64el", DefaultTag: "ppc64el"}
+	LinuxS390x    = PlatformDescription{Name: "linux/s390x", Arch: "s390x", DefaultTag: "s390x"}
+)
+
+func NewPackageInstaller() *PackageInstaller {
+	return &PackageInstaller{}
+}
+
+func (i *PackageInstaller) AddEach(ps []PlatformDescription, names ...string) *PackageInstaller {
+	for _, p := range ps {
+		i.Add(p, names...)
+	}
+	return i
+}
+
+func (i *PackageInstaller) Add(p PlatformDescription, names ...string) *PackageInstaller {
+	i.AddPackages(p, p.Packages(names...))
+	return i
+}
+
+func (i *PackageInstaller) AddPackages(p PlatformDescription, details ...PackageDependency) *PackageInstaller {
+	if i.table == nil {
+		i.table = map[PlatformDescription][]PackageDependency{}
+	}
+	i.table[p] = append(i.table[p], details...)
+	return i
+}
+
+func (i *PackageInstaller) Installer(name string) func() error {
+	var platform PlatformDescription
+	for p := range i.table {
+		if p.Name == name {
+			platform = p
+		}
+	}
+
+	if platform.Name == "" {
+		return func() error { return nil }
+	}
+
+	return func() error {
+		return i.Install(platform)
+	}
+}
+
+func (i *PackageInstaller) Install(p PlatformDescription) error {
+	packages := map[string]struct{}{}
+	for _, details := range i.table[p] {
+		for _, name := range details.List() {
+			packages[name] = struct{}{}
+		}
+	}
+
+	j, lst := 0, make([]string, len(packages))
+	for name := range packages {
+		lst[j], j = name, j+1
+	}
+
+	return installDependencies(p.Arch, lst...)
+}
+
+func installDependencies(arch string, pkgs ...string) error {
+	if arch != "" {
+		err := sh.Run("dpkg", "--add-architecture", arch)
+		if err != nil {
+			return errors.Wrap(err, "error while adding architecture")
+		}
+	}
+
+	if err := sh.Run("apt-get", "update"); err != nil {
+		return err
+	}
+
+	params := append([]string{"install", "-y",
+		"--no-install-recommends",
+
+		// Journalbeat is built with old versions of Debian that don't update
+		// their repositories, so they have expired keys.
+		// Allow unauthenticated packages.
+		// This was not enough: "-o", "Acquire::Check-Valid-Until=false",
+		"--allow-unauthenticated",
+	}, pkgs...)
+	return sh.Run("apt-get", params...)
+}
+
+func (p PlatformDescription) Packages(names ...string) PackageDependency {
+	return PackageDependency{}.WithTag(p.DefaultTag).Add(names...)
+}
+
+func (p PackageDependency) Add(deps ...string) PackageDependency {
+	if len(deps) == 0 {
+		return p
+	}
+
+	// always copy to ensure that we never share or overwrite slices due to capacity being too large
+	p.dependencies = append(make([]string, 0, len(p.dependencies)+len(deps)), p.dependencies...)
+	p.dependencies = append(p.dependencies, deps...)
+	return p
+}
+
+func (p PackageDependency) WithTag(tag string) PackageDependency {
+	p.archTag = tag
+	return p
+}
+
+func (p PackageDependency) List() []string {
+	if p.archTag == "" {
+		return p.dependencies
+	}
+
+	names := make([]string, len(p.dependencies))
+	for i, name := range p.dependencies {
+		names[i] = fmt.Sprintf("%v:%v", name, p.archTag)
+	}
+	return names
+}

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.13.10
 RUN \
     apt-get update \
       && apt-get install -y --no-install-recommends \
+         libsystemd-dev \
          netcat \
          rsync \
          python3 \

--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux,cgo
+// +build linux,cgo,withjournald
 
 package journald
 

--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build linux,cgo
+
+package journald
+
+import (
+	"errors"
+	"time"
+
+	"github.com/elastic/beats/v7/journalbeat/pkg/journalfield"
+	"github.com/elastic/beats/v7/journalbeat/pkg/journalread"
+)
+
+// Config stores the options of a journald input.
+type config struct {
+	// Paths stores the paths to the journal files to be read.
+	Paths []string `config:"paths"`
+
+	// Backoff is the current interval to wait before
+	// attemting to read again from the journal.
+	Backoff time.Duration `config:"backoff" validate:"min=0,nonzero"`
+
+	// MaxBackoff is the limit of the backoff time.
+	MaxBackoff time.Duration `config:"max_backoff" validate:"min=0,nonzero"`
+
+	// Seek is the method to read from journals.
+	Seek journalread.SeekMode `config:"seek"`
+
+	// CursorSeekFallback sets where to seek if registry file is not available.
+	CursorSeekFallback journalread.SeekMode `config:"cursor_seek_fallback"`
+
+	// Matches store the key value pairs to match entries.
+	Matches []journalfield.Matcher `config:"include_matches"`
+
+	// SaveRemoteHostname defines if the original source of the entry needs to be saved.
+	SaveRemoteHostname bool `config:"save_remote_hostname"`
+}
+
+var errInvalidSeekFallback = errors.New("invalid setting for cursor_seek_fallback")
+
+func defaultConfig() config {
+	return config{
+		Backoff:            1 * time.Second,
+		MaxBackoff:         20 * time.Second,
+		Seek:               journalread.SeekCursor,
+		CursorSeekFallback: journalread.SeekHead,
+		SaveRemoteHostname: false,
+	}
+}
+
+func (c *config) Validate() error {
+	if c.CursorSeekFallback != journalread.SeekHead && c.CursorSeekFallback != journalread.SeekTail {
+		return errInvalidSeekFallback
+	}
+	return nil
+}

--- a/filebeat/input/journald/conv.go
+++ b/filebeat/input/journald/conv.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package journald
+
+import (
+	"time"
+
+	"github.com/elastic/beats/v7/journalbeat/pkg/journalfield"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func eventFromFields(
+	log *logp.Logger,
+	timestamp uint64,
+	entryFields map[string]string,
+	saveRemoteHostname bool,
+) beat.Event {
+	created := time.Now()
+	c := journalfield.NewConverter(log, nil)
+	fields := c.Convert(entryFields)
+	fields.Put("event.kind", "event")
+
+	// if entry is coming from a remote journal, add_host_metadata overwrites the source hostname, so it
+	// has to be copied to a different field
+	if saveRemoteHostname {
+		remoteHostname, err := fields.GetValue("host.hostname")
+		if err == nil {
+			fields.Put("log.source.address", remoteHostname)
+		}
+	}
+
+	fields.Put("event.created", created)
+	receivedByJournal := time.Unix(0, int64(timestamp)*1000)
+
+	return beat.Event{
+		Timestamp: receivedByJournal,
+		Fields:    fields,
+	}
+}

--- a/filebeat/input/journald/conv.go
+++ b/filebeat/input/journald/conv.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo,withjournald
+
 package journald
 
 import (

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux,cgo
+// +build linux,cgo,withjournald
 
 package journald
 

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -1,0 +1,205 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build linux,cgo
+
+package journald
+
+import (
+	"time"
+
+	"github.com/coreos/go-systemd/v22/sdjournal"
+	"github.com/urso/sderr"
+
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
+	"github.com/elastic/beats/v7/journalbeat/pkg/journalfield"
+	"github.com/elastic/beats/v7/journalbeat/pkg/journalread"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/backoff"
+	"github.com/elastic/beats/v7/libbeat/feature"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+type journald struct {
+	Backoff            time.Duration
+	MaxBackoff         time.Duration
+	Seek               journalread.SeekMode
+	CursorSeekFallback journalread.SeekMode
+	Matches            []journalfield.Matcher
+	SaveRemoteHostname bool
+}
+
+type checkpoint struct {
+	Version            int
+	Position           string
+	RealtimeTimestamp  uint64
+	MonotonicTimestamp uint64
+}
+
+// LocalSystemJournalID is the ID of the local system journal.
+const localSystemJournalID = "LOCAL_SYSTEM_JOURNAL"
+
+const pluginName = "journald"
+
+// Plugin creates a new journald input plugin for creating a stateful input.
+func Plugin(log *logp.Logger, store cursor.StateStore) input.Plugin {
+	return input.Plugin{
+		Name:       pluginName,
+		Stability:  feature.Experimental,
+		Deprecated: false,
+		Info:       "journald input",
+		Doc:        "The journald input collects logs from the local journald service",
+		Manager: &cursor.InputManager{
+			Logger:     log,
+			StateStore: store,
+			Type:       pluginName,
+			Configure:  configure,
+		},
+	}
+}
+
+type pathSource string
+
+var cursorVersion = 1
+
+func (p pathSource) Name() string { return string(p) }
+
+func configure(cfg *common.Config) ([]cursor.Source, cursor.Input, error) {
+	config := defaultConfig()
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, nil, err
+	}
+
+	paths := config.Paths
+	if len(paths) == 0 {
+		paths = []string{localSystemJournalID}
+	}
+
+	sources := make([]cursor.Source, len(paths))
+	for i, p := range paths {
+		sources[i] = pathSource(p)
+	}
+
+	return sources, &journald{
+		Backoff:            config.Backoff,
+		MaxBackoff:         config.MaxBackoff,
+		Seek:               config.Seek,
+		CursorSeekFallback: config.CursorSeekFallback,
+		Matches:            config.Matches,
+		SaveRemoteHostname: config.SaveRemoteHostname,
+	}, nil
+}
+
+func (inp *journald) Name() string { return pluginName }
+
+func (inp *journald) Test(src cursor.Source, ctx input.TestContext) error {
+	reader, err := inp.open(ctx.Logger, ctx.Cancelation, src)
+	if err != nil {
+		return err
+	}
+	return reader.Close()
+}
+
+func (inp *journald) Run(
+	ctx input.Context,
+	src cursor.Source,
+	cursor cursor.Cursor,
+	publisher cursor.Publisher,
+) error {
+	log := ctx.Logger.With("path", src.Name())
+	checkpoint := initCheckpoint(log, cursor)
+
+	reader, err := inp.open(ctx.Logger, ctx.Cancelation, src)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	if err := reader.Seek(seekBy(ctx.Logger, checkpoint, inp.Seek, inp.CursorSeekFallback)); err != nil {
+		log.Error("Continue from current position. Seek failed with: %v", err)
+	}
+
+	for {
+		entry, err := reader.Next(ctx.Cancelation)
+		if err != nil {
+			return err
+		}
+
+		event := eventFromFields(ctx.Logger, entry.RealtimeTimestamp, entry.Fields, inp.SaveRemoteHostname)
+
+		checkpoint.Position = entry.Cursor
+		checkpoint.RealtimeTimestamp = entry.RealtimeTimestamp
+		checkpoint.MonotonicTimestamp = entry.MonotonicTimestamp
+
+		if err := publisher.Publish(event, checkpoint); err != nil {
+			return err
+		}
+	}
+}
+
+func (inp *journald) open(log *logp.Logger, canceler input.Canceler, src cursor.Source) (*journalread.Reader, error) {
+	backoff := backoff.NewExpBackoff(canceler.Done(), inp.Backoff, inp.MaxBackoff)
+	reader, err := journalread.Open(log, src.Name(), backoff, withFilters(inp.Matches))
+	if err != nil {
+		return nil, sderr.Wrap(err, "failed to create reader for %{path} journal", src.Name())
+	}
+
+	return reader, nil
+}
+
+func initCheckpoint(log *logp.Logger, c cursor.Cursor) checkpoint {
+	if c.IsNew() {
+		return checkpoint{Version: cursorVersion}
+	}
+
+	var cp checkpoint
+	err := c.Unpack(&cp)
+	if err != nil {
+		log.Errorf("Reset journald position. Failed to read checkpoint from registry: %v", err)
+		return checkpoint{Version: cursorVersion}
+	}
+
+	if cp.Version != cursorVersion {
+		log.Error("Reset journald position. invalid journald position entry.")
+		return checkpoint{Version: cursorVersion}
+	}
+
+	return cp
+}
+
+func withFilters(filters []journalfield.Matcher) func(*sdjournal.Journal) error {
+	return func(j *sdjournal.Journal) error {
+		return journalfield.ApplyMatchersOr(j, filters)
+	}
+}
+
+// seekBy tries to find the last known position in the journal, so we can continue collecting
+// from the last known position.
+// The checkpoint is ignored if the user has configured the input to always
+// seek to the head/tail of the journal on startup.
+func seekBy(log *logp.Logger, cp checkpoint, seek, defaultSeek journalread.SeekMode) (journalread.SeekMode, string) {
+	mode := seek
+	if mode == journalread.SeekCursor && cp.Position == "" {
+		mode = defaultSeek
+		if mode != journalread.SeekHead && mode != journalread.SeekTail {
+			log.Error("Invalid option for cursor_seek_fallback")
+			mode = journalread.SeekHead
+		}
+	}
+	return mode, cp.Position
+}

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -39,6 +39,21 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
+// declare journald dependencies for cross build target
+var (
+	journaldPlatforms = []devtools.PlatformDescription{
+		devtools.Linux386, devtools.LinuxAMD64,
+		devtools.LinuxARM64, devtools.LinuxARM5, devtools.LinuxARM6, devtools.LinuxARM7,
+		devtools.LinuxMIPS, devtools.LinuxMIPSLE, devtools.LinuxMIPS64LE,
+		devtools.LinuxPPC64LE,
+		devtools.LinuxS390x,
+	}
+
+	deps = devtools.NewPackageInstaller().
+		AddEach(journaldPlatforms, "libsystemd-dev").
+		Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
+)
+
 func init() {
 	common.RegisterCheckDeps(Update)
 	test.RegisterDeps(IntegTest)
@@ -54,6 +69,7 @@ func Build() error {
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
+	mg.Deps(deps.Installer(devtools.Platform.Name))
 	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
 }
 

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -49,9 +49,9 @@ var (
 		devtools.LinuxS390x,
 	}
 
-	deps = devtools.NewPackageInstaller().
-		AddEach(journaldPlatforms, "libsystemd-dev").
-		Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
+	journaldDeps = devtools.NewPackageInstaller().
+			AddEach(journaldPlatforms, "libsystemd-dev").
+			Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
 )
 
 func init() {
@@ -69,7 +69,9 @@ func Build() error {
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
-	mg.Deps(deps.Installer(devtools.Platform.Name))
+	// XXX: enable once we have systemd available in the cross build image
+	// mg.Deps(journaldDeps.Installer(devtools.Platform.Name))
+
 	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
 }
 


### PR DESCRIPTION
Cherry-pick of PR #19619 to 7.x branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

This changes introduces the journald input in filebeat based on the
input v2 API. Most of the reading and field transformation code is
shared with journalbeat

Integration tests are not yet implemented. I'd sugest to reimplement the existing journalbeat python tests in this package as more simple go based tests. Most of the reading and event transformation support is already shared with journalbeat, which gives us at least some confidence.

Note: this is just the input implementation. The API is not fully hooked up yet in Filebeat, which means that the input is not available to be configured yet.

## Why is it important?

Provide journald input to the Agent

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

Configure input with `journald` type. The input settings match the ones currently found for journalbeat.

Sample configuration:

```
filebeat.inputs:
- type: journald
  include_matches:
  - syslog.identifier=test


output.console:
  codec.format:
    string: '%{[@timestamp]} - %{[syslog.identifier]}: %{[message]}'
```

use systemd-cat to write logs:

```
echo "<message>" | systemd-cat -t test
```

- Check output that logs are collected (Note: default input backoff is max 1min, might take a while if filebeat is started first)
- Restart and check old logs are not collected
- add more log entries and check they are collected.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#15324 