### PR TITLE
Cherry-pick #19764 to 7.7: [Auditbeat] Fix up socket dataset runaway CPU usage

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,7 +79,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - system/package: Fix parsing of Installed-Size field of DEB packages. {issue}16661[16661] {pull}17188[17188]
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
-- system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix parsing of Installed-Size field of DEB packages. {issue}16661[16661] {pull}17188[17188]
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
+- system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
+- system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
 
 *Filebeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,7 +80,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix parsing of Installed-Size field of DEB packages. {issue}16661[16661] {pull}17188[17188]
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033]
-- system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
 

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -147,7 +147,6 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	lPort, rPort := be16(localPort), be16(remotePort)
 	lAddr, rAddr := ipv4(localIP), ipv4(remoteIP)
 	evs := []event{
-
 		callExecve(meta(1234, 1234, 1), []string{"/usr/bin/curl", "https://example.net/", "-o", "/tmp/site.html"}),
 		&commitCreds{Meta: meta(1234, 1234, 2), UID: 501, GID: 20, EUID: 501, EGID: 20},
 		&execveRet{Meta: meta(1234, 1234, 2), Retval: 1234},
@@ -291,6 +290,32 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 			t.Fatal("expected value not found")
 		}
 	}
+}
+
+func TestSocketExpirationWithOverwrittenSockets(t *testing.T) {
+	const (
+		sock          uintptr = 0xff1234
+		flowTimeout           = time.Hour
+		socketTimeout         = time.Minute * 3
+		closeTimeout          = time.Minute
+	)
+	st := makeState(nil, (*logWrapper)(t), flowTimeout, socketTimeout, closeTimeout, time.Second)
+	now := time.Now()
+	st.clock = func() time.Time {
+		return now
+	}
+	if err := feedEvents([]event{
+		&inetCreate{Meta: meta(1234, 1236, 5), Proto: 0},
+		&sockInitData{Meta: meta(1234, 1236, 5), Sock: sock},
+		&inetCreate{Meta: meta(1234, 1237, 5), Proto: 0},
+		&sockInitData{Meta: meta(1234, 1237, 5), Sock: sock},
+	}, st, t); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(closeTimeout + 1)
+	st.ExpireOlder()
+	now = now.Add(socketTimeout + 1)
+	st.ExpireOlder()
 }
 
 func TestUDPOutgoingSinglePacketWithProcess(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #19764 to 7.7 branch. Original message: 

## What does this PR do?

Fix for auditbeat runaway CPU usage: https://github.com/elastic/beats/issues/19141

So, here's the explanation, basically everything was pretty much as described in the previous PR (#19033), the only additional things that I found were that:

1. When a `*socket` is terminated by another socket with a different kernel `tid` it's moved to the `closing` LRU list.
2. The new `*socket` is added to the state `socks` map with the ptr reference pointing to it
3. The reaper comes along and hits the following code path:

```go
	for item := s.closing.peek(); item != nil && item.Timestamp().Before(deadline); {
		if sock, ok := item.(*socket); ok {
			s.onSockTerminated(sock)
		} else {
			s.closing.get()
		}
		item = s.closing.peek()
	}
```
4. The old "terminated" socket is now in a "closing" state, so `onSockTerminated` is called _again_
5. In `onSockTerminated` the socket is pruned _again_ from the `socks` map with the call to `delete(s.socks, sock.sock)`
6. The problem is that the `socks` map now refers to the new `*socket` rather than the old one
7. Eventually if the new `*socket` times out `onSockDestroyed` is called on it with the code that's doing the peek on the `socketLRU` in the reaper code
8. That was taking a reference to the socket pointer that had been deleted from the `socks` map in step 5
9. `onSockDestroyed` was running the following code:

```go
	sock, found = s.socks[ptr]
	if !found {
		return nil
	}
```
10. `found` was returning `false` and the function was returning
11. Because of the call to `s.socketLRU.peek()` the same socket was getting returned over and over, resulting in the reaper routine getting wedged in a tight `for` loop (hence the high CPU usage).

## The fix

Basically we pass a reference to the `*socket` object in the reaper's `onSockDestroyed` call, that way we don't have to look up the socket in `s.socks` and, instead handle the socket closure directly.

## Related issues

- Closes #19141