### PR TITLE
Cherry-pick to 7.7: ci: set builds as skipped when they do not match the trigger (#19750)

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -35,7 +35,14 @@ pipeline {
       when {
         beforeAgent true
         expression {
-          return isCommentTrigger() || isUserTrigger()
+          def ret = isCommentTrigger() || isUserTrigger()
+          if(!ret){
+            currentBuild.result = 'NOT_BUILT'
+            currentBuild.description = "The build has been skipped"
+            currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
+            echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, and GitHub comment")
+          }
+          return ret
         }
       }
       /**

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -38,7 +38,14 @@ pipeline {
       when {
         beforeAgent true
         expression {
-          return isCommentTrigger() || isUserTrigger() || isUpstreamTrigger()
+          def ret = isCommentTrigger() || isUserTrigger() || isUpstreamTrigger()
+          if(!ret){
+            currentBuild.result = 'NOT_BUILT'
+            currentBuild.description = "The build has been skipped"
+            currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
+            echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, GitHub comment, and upstream job")
+          }
+          return ret
         }
       }
       stages {


### PR DESCRIPTION
Backports the following commits to 7.7:
 - ci: set builds as skipped when they do not match the trigger (#19750)