### PR TITLE
Cherry-pick #19603 to 7.x: Remove the downloadConfig and retryConfig from plugin/process.Application and plugin/service.Application.

### DIFF
--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -15,12 +15,10 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/operation/config"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/retry"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/tokenbucket"
@@ -52,9 +50,7 @@ type Application struct {
 
 	monitor monitoring.Monitor
 
-	processConfig  *process.Config
-	downloadConfig *artifact.Config
-	retryConfig    *retry.Config
+	processConfig *process.Config
 
 	logger *logger.Logger
 
@@ -84,22 +80,20 @@ func NewApplication(
 
 	b, _ := tokenbucket.NewTokenBucket(ctx, 3, 3, 1*time.Second)
 	return &Application{
-		bgContext:      ctx,
-		id:             id,
-		name:           appName,
-		pipelineID:     pipelineID,
-		logLevel:       logLevel,
-		spec:           spec,
-		srv:            srv,
-		processConfig:  cfg.ProcessConfig,
-		downloadConfig: cfg.DownloadConfig,
-		retryConfig:    cfg.RetryConfig,
-		logger:         logger,
-		limiter:        b,
-		reporter:       reporter,
-		monitor:        monitor,
-		uid:            uid,
-		gid:            gid,
+		bgContext:     ctx,
+		id:            id,
+		name:          appName,
+		pipelineID:    pipelineID,
+		logLevel:      logLevel,
+		spec:          spec,
+		srv:           srv,
+		processConfig: cfg.ProcessConfig,
+		logger:        logger,
+		limiter:       b,
+		reporter:      reporter,
+		monitor:       monitor,
+		uid:           uid,
+		gid:           gid,
 	}, nil
 }
 

--- a/x-pack/elastic-agent/pkg/core/plugin/service/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/service/app.go
@@ -18,12 +18,10 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/operation/config"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/retry"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/tokenbucket"
@@ -55,9 +53,7 @@ type Application struct {
 
 	monitor monitoring.Monitor
 
-	processConfig  *process.Config
-	downloadConfig *artifact.Config
-	retryConfig    *retry.Config
+	processConfig *process.Config
 
 	logger *logger.Logger
 
@@ -88,23 +84,21 @@ func NewApplication(
 
 	b, _ := tokenbucket.NewTokenBucket(ctx, 3, 3, 1*time.Second)
 	return &Application{
-		bgContext:      ctx,
-		id:             id,
-		name:           appName,
-		pipelineID:     pipelineID,
-		logLevel:       logLevel,
-		spec:           spec,
-		srv:            srv,
-		processConfig:  cfg.ProcessConfig,
-		downloadConfig: cfg.DownloadConfig,
-		retryConfig:    cfg.RetryConfig,
-		logger:         logger,
-		limiter:        b,
-		reporter:       reporter,
-		monitor:        monitor,
-		uid:            uid,
-		gid:            gid,
-		credsPort:      credsPort,
+		bgContext:     ctx,
+		id:            id,
+		name:          appName,
+		pipelineID:    pipelineID,
+		logLevel:      logLevel,
+		spec:          spec,
+		srv:           srv,
+		processConfig: cfg.ProcessConfig,
+		logger:        logger,
+		limiter:       b,
+		reporter:      reporter,
+		monitor:       monitor,
+		uid:           uid,
+		gid:           gid,
+		credsPort:     credsPort,
 	}, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #19603 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Remove the downloadConfig and retryConfig from plugin/process.Application and plugin/service.Application.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

They are not used by either.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
