### PR TITLE
Cherry-pick #19531 to 7.x: Add `docker logs` support to the Elastic Log Driver

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -632,6 +632,9 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support for event IDs 4673,4674,4697,4698,4699,4700,4701,4702,4768,4769,4770,4771,4776,4778,4779,4964 to the Security module {pull}17517[17517]
 - Add registry and code signature information and ECS categorization fields for sysmon module {pull}18058[18058]
 
+*Elastic Log Driver*
+- Add support for `docker logs` command {pull}19531[19531]
+
 ==== Deprecated
 
 *Affecting all Beats*

--- a/x-pack/dockerlogbeat/config.json
+++ b/x-pack/dockerlogbeat/config.json
@@ -13,7 +13,31 @@
     ],
     "socket": "beatSocket.sock"
   },
+  "mounts": [
+    {
+      "name": "LOG_DIR",
+      "description": "Mount for local log cache",
+      "destination": "/var/log/docker",
+      "source": "/var/lib/docker",
+      "type": "none",
+      "options": [
+        "rw",
+        "rbind"
+      ],
+      "Settable": [
+        "source"
+      ]
+    }
+  ],
   "env": [
+    {
+      "description": "Destroy logs after a container has stopped",
+      "name": "DESTROY_LOGS_ON_STOP",
+      "value": "false",
+      "Settable": [
+        "value"
+      ]
+    },
     {
       "description": "debug level",
       "name": "LOG_DRIVER_LEVEL",

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -49,10 +49,6 @@ format is `"username:password"`.
 [[es-output-options]]
 === {es} output options
 
-// TODO: Add the following settings. Syntax is a little different so we might
-// need to add deameon examples that show how to specify these settings:
-// `output.elasticsearch.indices
-// `output.elasticsearch.pipelines`
 
 [options="header"]
 |=====
@@ -117,3 +113,72 @@ for more information about the environment variables.
 
 
 |=====
+
+
+[float]
+[[local-log-opts]]
+=== Configuring the local log
+This plugin fully supports `docker logs`, and it maintains a local copy of logs that can be read without a connection to Elasticsearch. The plugin mounts the `/var/lib/docker` directory on the host to write logs to `/var/log/containers` on the host. If you want to change the log location on the host, you must change the mount inside the plugin:
+
+1. Disable the plugin:
++
+["source","sh",subs="attributes"] 
+----
+docker plugin disable elastic/{log-driver-alias}:{version}
+----
+
+2. Set the bindmount directory:
++
+["source","sh",subs="attributes"]
+----
+docker plugin set elastic/{log-driver-alias}:{version} LOG_DIR.source=NEW_LOG_LOCATION
+----
++
+
+3. Enable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin enable elastic/{log-driver-alias}:{version}
+----
+
+
+The local log also supports the `max-file`, `max-size` and `compress` options that are https://docs.docker.com/config/containers/logging/json-file/#options[a part of the Docker default file logger]. For example:
+
+["source","sh",subs="attributes"]
+----
+docker run --log-driver=elastic/{log-driver-alias}:{version} \
+           --log-opt endpoint="myhost:9200" \
+           --log-opt user="myusername" \
+           --log-opt password="mypassword" \
+           --log-opt max-file=10 \
+           --log-opt max-size=5M \
+           --log-opt compress=true \
+           -it debian:jessie /bin/bash
+----
+
+
+In situations where logs can't be easily managed, for example, you can also configure the plugin to remove log files when a container is stopped. This will prevent you from reading logs on a stopped container, but it will rotate logs without user intervention. To enable removal of logs for stopped containers, you must change the `DESTROY_LOGS_ON_STOP` environment variable: 
+
+1. Disable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin disable elastic/{log-driver-alias}:{version}
+----
+
+2. Enable log removal:
++
+["source","sh",subs="attributes"]
+----
+docker plugin set elastic/{log-driver-alias}:{version} DESTROY_LOGS_ON_STOP=true
+----
++
+
+3. Enable the plugin:
++
+["source","sh",subs="attributes"]
+----
+docker plugin enable elastic/{log-driver-alias}:{version}
+----
+

--- a/x-pack/dockerlogbeat/main.go
+++ b/x-pack/dockerlogbeat/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/docker/go-plugins-helpers/sdk"
 
@@ -41,6 +42,14 @@ func genNewMonitoringConfig() (*common.Config, error) {
 	return cfg, nil
 }
 
+func setDestroyLogsOnStop() (bool, error) {
+	setting, ok := os.LookupEnv("DESTROY_LOGS_ON_STOP")
+	if !ok {
+		return false, nil
+	}
+	return strconv.ParseBool(setting)
+}
+
 func fatal(format string, vs ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, vs...)
 	os.Exit(1)
@@ -60,12 +69,18 @@ func main() {
 		fatal("error starting log handler: %s", err)
 	}
 
-	pipelines := pipelinemanager.NewPipelineManager(logcfg)
+	logDestroy, err := setDestroyLogsOnStop()
+	if err != nil {
+		fatal("DESTROY_LOGS_ON_STOP must be 'true' or 'false': %s", err)
+	}
+	pipelines := pipelinemanager.NewPipelineManager(logDestroy)
 
 	sdkHandler := sdk.NewHandler(`{"Implements": ["LoggingDriver"]}`)
 	// Create handlers for startup and shutdown of the log driver
 	sdkHandler.HandleFunc("/LogDriver.StartLogging", startLoggingHandler(pipelines))
 	sdkHandler.HandleFunc("/LogDriver.StopLogging", stopLoggingHandler(pipelines))
+	sdkHandler.HandleFunc("/LogDriver.Capabilities", reportCaps())
+	sdkHandler.HandleFunc("/LogDriver.ReadLogs", readLogHandler(pipelines))
 
 	err = sdkHandler.ServeUnix("beatSocket", 0)
 	if err != nil {

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -5,12 +5,17 @@
 package pipelinemanager
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/daemon/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker/daemon/logger/jsonfilelog"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -85,7 +90,17 @@ func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock
 	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInputFromLine(t, logString))
 	require.NoError(t, err)
 
-	client, err := newClientFromPipeline(mockConnector, reader, 123, cfgObject)
+	info := logger.Info{
+		ContainerID: "b87d3b0379f816a5f2f7070f28cc05e2f564a3fb549a67c64ec30fc5b04142ed",
+		LogPath:     filepath.Join("/tmp/dockerbeattest/", string(time.Now().Unix())),
+	}
+
+	err = os.MkdirAll(filepath.Dir(info.LogPath), 0755)
+	assert.NoError(t, err)
+	localLog, err := jsonfilelog.New(info)
+	assert.NoError(t, err)
+
+	client, err := newClientFromPipeline(mockConnector, reader, 123, cfgObject, localLog)
 	require.NoError(t, err)
 
 	return client

--- a/x-pack/dockerlogbeat/pipelinemanager/config.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/config.go
@@ -35,7 +35,7 @@ func NewCfgFromRaw(input map[string]string) (ContainerOutputConfig, error) {
 	newCfg := ContainerOutputConfig{}
 	endpoint, ok := input["hosts"]
 	if !ok {
-		return newCfg, errors.New("An endpoint flag is required")
+		return newCfg, errors.New("A hosts flag is required")
 	}
 
 	endpointList := strings.Split(endpoint, ",")

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -5,7 +5,11 @@
 package pipelinemanager
 
 import (
+	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/mitchellh/hashstructure"
@@ -14,7 +18,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/docker/docker/api/types/plugins/logdriver"
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/daemon/logger/jsonfilelog"
+
+	protoio "github.com/gogo/protobuf/io"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -41,14 +49,23 @@ type PipelineManager struct {
 	pipelines map[uint64]*Pipeline
 	// clients config: filepath
 	clients map[string]*ClientLogger
+	// Client Logger key: container hash
+	clientLogger map[string]logger.Logger
+	// logDirectory is the bindmount for local container logsd
+	logDirectory string
+	// destroyLogsOnStop indicates for the client to remove log files when a container stops
+	destroyLogsOnStop bool
 }
 
 // NewPipelineManager creates a new Pipeline map
-func NewPipelineManager(logCfg *common.Config) *PipelineManager {
+func NewPipelineManager(logDestroy bool) *PipelineManager {
 	return &PipelineManager{
-		Logger:    logp.NewLogger("PipelineManager"),
-		pipelines: make(map[uint64]*Pipeline),
-		clients:   make(map[string]*ClientLogger),
+		Logger:            logp.NewLogger("PipelineManager"),
+		pipelines:         make(map[uint64]*Pipeline),
+		clients:           make(map[string]*ClientLogger),
+		clientLogger:      make(map[string]logger.Logger),
+		logDirectory:      "/var/log/docker/containers",
+		destroyLogsOnStop: logDestroy,
 	}
 }
 
@@ -62,13 +79,16 @@ func (pm *PipelineManager) CloseClientWithFile(file string) error {
 
 	hash := cl.pipelineHash
 
+	// remove the logger
+	pm.removeLogger(cl.ContainerMeta)
+
 	pm.Logger.Debugf("Closing Client first from pipelineManager")
 	err = cl.Close()
 	if err != nil {
 		return errors.Wrap(err, "error closing client")
 	}
 
-	//if the pipeline is no longer in use, clean up
+	// if the pipeline is no longer in use, clean up
 	pm.removePipelineIfNeeded(hash)
 
 	return nil
@@ -89,18 +109,88 @@ func (pm *PipelineManager) CreateClientWithConfig(containerConfig ContainerOutpu
 
 	reader, err := pipereader.NewReaderFromPath(file)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, errors.Wrap(err, "error creating reader for docker log stream")
+	}
+
+	// Why is this empty by default? What should be here? Who knows!
+	if info.LogPath == "" {
+		info.LogPath = filepath.Join(pm.logDirectory, info.ContainerID, fmt.Sprintf("%s-json.log", info.ContainerID))
+	}
+	err = os.MkdirAll(filepath.Dir(info.LogPath), 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating directory for local logs")
+	}
+	// set a default log size
+	if _, ok := info.Config["max-size"]; !ok {
+		info.Config["max-size"] = "10M"
+	}
+	// set a default log count
+	if _, ok := info.Config["max-file"]; !ok {
+		info.Config["max-file"] = "5"
+	}
+
+	localLog, err := jsonfilelog.New(info)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating local log")
 	}
 
 	//actually get to crafting the new client.
-	cl, err := newClientFromPipeline(pipeline.pipeline, reader, hashstring, info)
+	cl, err := newClientFromPipeline(pipeline.pipeline, reader, hashstring, info, localLog)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating client")
 	}
 
 	pm.registerClient(cl, hashstring, file)
-
+	pm.registerLogger(localLog, info)
 	return cl, nil
+}
+
+// CreateReaderForContainer responds to docker logs requests to pull local logs from the json logger
+func (pm *PipelineManager) CreateReaderForContainer(info logger.Info, config logger.ReadConfig) (io.ReadCloser, error) {
+	logObject, exists := pm.getLogger(info)
+	if !exists {
+		return nil, fmt.Errorf("Could not find logger for %s", info.ContainerID)
+	}
+	pipeReader, pipeWriter := io.Pipe()
+	logReader, ok := logObject.(logger.LogReader)
+	if !ok {
+		return nil, fmt.Errorf("logger does not support reading")
+	}
+
+	go func() {
+		watcher := logReader.ReadLogs(config)
+
+		enc := protoio.NewUint32DelimitedWriter(pipeWriter, binary.BigEndian)
+		defer enc.Close()
+		defer watcher.ConsumerGone()
+		var rawLog logdriver.LogEntry
+		for {
+			select {
+			case msg, ok := <-watcher.Msg:
+				if !ok {
+					pipeWriter.Close()
+					return
+				}
+				rawLog.Line = msg.Line
+				rawLog.Partial = msg.PLogMetaData != nil
+				rawLog.TimeNano = msg.Timestamp.UnixNano()
+				rawLog.Source = msg.Source
+
+				if err := enc.WriteMsg(&rawLog); err != nil {
+					pipeWriter.CloseWithError(err)
+					return
+				}
+
+			case err := <-watcher.Err:
+				pipeWriter.CloseWithError(err)
+				return
+
+			}
+		}
+
+	}()
+
+	return pipeReader, nil
 }
 
 //===================
@@ -134,6 +224,13 @@ func (pm *PipelineManager) getClient(file string) (*ClientLogger, bool) {
 	return cli, exists
 }
 
+func (pm *PipelineManager) getLogger(info logger.Info) (logger.Logger, bool) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	logger, exists := pm.clientLogger[info.ContainerID]
+	return logger, exists
+}
+
 // removePipeline removes a pipeline from the manager if it's refcount is zero.
 func (pm *PipelineManager) removePipelineIfNeeded(hash uint64) {
 	pm.mu.Lock()
@@ -159,6 +256,35 @@ func (pm *PipelineManager) registerClient(cl *ClientLogger, hash uint64, clientF
 	defer pm.mu.Unlock()
 	pm.clients[clientFile] = cl
 	pm.pipelines[hash].refCount++
+}
+
+// registerLogger registers a local logger used for reading back logs
+func (pm *PipelineManager) registerLogger(log logger.Logger, info logger.Info) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.clientLogger[info.ContainerID] = log
+}
+
+// removeLogger removes a logging instace
+func (pm *PipelineManager) removeLogger(info logger.Info) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	logger, exists := pm.clientLogger[info.ContainerID]
+	if !exists {
+		return
+	}
+	logger.Close()
+	delete(pm.clientLogger, info.ContainerID)
+	if pm.destroyLogsOnStop {
+		pm.removeLogFile(info.ContainerID)
+	}
+}
+
+// removeLogFile removes a log file for a given container. Disabled by default.
+func (pm *PipelineManager) removeLogFile(id string) error {
+	toRemove := filepath.Join(pm.logDirectory, id)
+
+	return os.Remove(toRemove)
 }
 
 // removeClient deregisters a client

--- a/x-pack/dockerlogbeat/pipereader/reader.go
+++ b/x-pack/dockerlogbeat/pipereader/reader.go
@@ -54,7 +54,7 @@ func (reader *PipeReader) ReadMessage(log *logdriver.LogEntry) error {
 	for {
 		lenFrame, err = reader.getValidLengthFrame()
 		if err != nil {
-			return errors.Wrap(err, "error getting length frame")
+			return err
 		}
 		if lenFrame <= reader.maxSize {
 			break

--- a/x-pack/dockerlogbeat/readme.md
+++ b/x-pack/dockerlogbeat/readme.md
@@ -48,3 +48,13 @@ The location of the logs AND the container base directory in the docker docs is 
 You can use this to find the list of plugins running on the host: `runc --root /containers/services/docker/rootfs/run/docker/plugins/runtime-root/plugins.moby/ list`
 
 The logs are in `/var/log/docker`. If you want to make the logs useful, you need to find the ID of the plugin. Back on the darwin host, run `docker plugin inspect $name_of_plugin | grep Id` use the hash ID to grep through the logs: `grep 22bb02c1506677cd48cc1cfccc0847c1b602f48f735e51e4933001804f86e2e docker.*`
+
+
+## Local logs
+
+This plugin fully supports `docker logs`, and it maintains a local copy of logs that can be read without a connection to Elasticsearch. Unfortunately, due to the limitations in the docker plugin API, we can't "clean up" log files when a container is destroyed. The plugin mounts the `/var/lib/docker` directory on the host to write logs. This mount point can be changed via [Docker](https://docs.docker.com/engine/reference/commandline/plugin_set/#change-the-source-of-a-mount). The plugin can also be configured to do a "hard" cleanup and destroy logs when a container stops. To enable this, set the `DESTROY_LOGS_ON_STOP` environment var inside the plugin:
+```
+docker plugin set d805664c550e DESTROY_LOGS_ON_STOP=true
+```
+
+You can also set `max-file`, `max-size` and `compress` via `--log-opts`


### PR DESCRIPTION
Cherry-pick of PR #19531 to 7.x branch. Original message: 

## What does this PR do?
See https://github.com/elastic/beats/issues/19371 and https://github.com/elastic/beats/issues/13990

This PR adds support for the `docker logs` command to the Elastic Log Driver. This basically re-implements the "default" log driver, using Docker's own libraries, inside the Elastic Log Driver. In theory this should be a simple addition, as we're just gluing existing libraries on top on what we already have. 


There's still some oddities going on here:


- We're getting interesting error messages if you run `docker logs -f` for an expended period of time without additional log lines: `Error grabbing logs: error decoding log message: net/http: request canceled (Client.Timeout exceeded while reading body)` This doesn't _seem_ to be something in my library. Looks like it was due to this PR here: https://github.com/docker/cli/pull/1872
## Why is it important?

This is a "must have" from the Cloud folks, and it's good to have in general. Also required for docker certification.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. build and install the plugin via `mage buildAndInstall`
2. Checkout the main readme in `dockerlogbeat` for an example of how to run the plugin against a container
3. Run the `docker logs` command against that container with various options, make sure everything works as expected.

