### PR TITLE
[Winlogbeat] Remove beta tag from Powershell and Security modules

### DIFF
--- a/winlogbeat/docs/modules/powershell.asciidoc
+++ b/winlogbeat/docs/modules/powershell.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 == PowerShell Module
 
-beta[]
-
 The PowerShell module processes event log records from the Microsoft-Windows-PowerShell/Operational and Windows PowerShell logs.
 
 The module has transformations for the following event IDs:

--- a/winlogbeat/docs/modules/security.asciidoc
+++ b/winlogbeat/docs/modules/security.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 == Security Module
 
-beta[]
-
 The security module processes event log records from the Security log.
 
 The module has transformations for the following event IDs:

--- a/x-pack/winlogbeat/module/powershell/_meta/docs.asciidoc
+++ b/x-pack/winlogbeat/module/powershell/_meta/docs.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 == PowerShell Module
 
-beta[]
-
 The PowerShell module processes event log records from the Microsoft-Windows-PowerShell/Operational and Windows PowerShell logs.
 
 The module has transformations for the following event IDs:

--- a/x-pack/winlogbeat/module/security/_meta/docs.asciidoc
+++ b/x-pack/winlogbeat/module/security/_meta/docs.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 == Security Module
 
-beta[]
-
 The security module processes event log records from the Security log.
 
 The module has transformations for the following event IDs:


### PR DESCRIPTION
## What does this PR do?

Removes `beta[]` tag from Powershell and Security modules.

## Why is it important?

We want to release Powershell as GA, and Security was wrongly tagged as `beta[]`

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~

- [x] I have made corresponding changes to the documentation

~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


