### PR TITLE
Cherry-pick #19819 to 7.x: Fix typo in ILM warning message

### DIFF
--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -241,7 +241,7 @@ func (m *indexManager) VerifySetup(loadTemplate, loadILM LoadMode) (bool, string
 	if !ilmComponent.load {
 		warn += "ILM policy and write alias loading not enabled.\n"
 	} else if !ilmComponent.overwrite {
-		warn += "Overwriting ILM policy is disabled. Set `setup.ilm.overwrite:true` for enabling.\n"
+		warn += "Overwriting ILM policy is disabled. Set `setup.ilm.overwrite: true` for enabling.\n"
 	}
 	if !templateComponent.load {
 		warn += "Template loading not enabled.\n"


### PR DESCRIPTION
Cherry-pick of PR #19819 to 7.x branch. Original message: 

## What does this PR do?
It is a fix typo PR. It only adds a space for proper YAML in ILM warning message.

I ran `grep -lri 'setup.ilm.overwrite:true'` in the repository root folder to find files where this typo could be and it only showed 1. So I think the issue #18100    could be closed.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
If a user follows the instruction, it leads to an error because the YAML syntax is wrong in the message.

Closes elastic/beats#18100
