### PR TITLE
Cherry-pick #19823 to 7.x: Do not update go.mod during packaging and testing

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -263,6 +263,7 @@ func (b GolangCrossBuilder) Build() error {
 
 	args = append(args,
 		"--rm",
+		"--env", "GOFLAGS=-mod=readonly",
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),

--- a/dev-tools/mage/fields.go
+++ b/dev-tools/mage/fields.go
@@ -102,6 +102,7 @@ func generateFieldsYAML(baseDir, output string, moduleDirs ...string) error {
 	}
 
 	cmd := []string{"run",
+		"-mod=readonly",
 		filepath.Join(beatsDir, globalFieldsCmdPath),
 		"-es_beats_path", beatsDir,
 		"-beat_path", baseDir,
@@ -127,6 +128,7 @@ func GenerateFieldsGo(fieldsYML, out string) error {
 	}
 
 	cmd := []string{"run",
+		"-mod=readonly",
 		filepath.Join(beatsDir, assetCmdPath),
 		"-pkg", "include",
 		"-in", fieldsYML,

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -236,6 +236,7 @@ func initRunner(tester IntegrationTester, dir string, passInEnv map[string]strin
 	// Create the custom env for the runner.
 	env := map[string]string{
 		insideIntegrationTestEnvVar: "true",
+		"GOFLAGS":                   "-mod=vendor",
 	}
 	for name, value := range passInEnv {
 		env[name] = value


### PR DESCRIPTION
Cherry-pick of PR #19823 to 7.x branch. Original message: 

## What does this PR do?

This PR adds `-mod=readonly` to Golang commands.

## Why is it important?

Now that vendor is no longer part of the repo, Go might accidentally update dependencies during integration testing, updating generated assets and packaging. To avoid it, I have added `-mod=readonly` to these commands.

This possibly affects the `apm-server` repo as well. So CC @elastic/apm-server 

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

CC @v1v I believe this PR fixes all our problems with Golang updating reps. But as a safety measure, we should adjust the CIs as well.