### PR TITLE
Cherry-pick #18683 to 7.x: LIBBEAT: Enhancement Convert dissected values from String to other basic data types and IP

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -385,6 +385,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Upgrade k8s.io/client-go and k8s keystore tests. {pull}18817[18817]
 - Add support for multiple sets of hints on autodiscover {pull}18883[18883]
 - Add a configurable delay between retries when an app metadata cannot be retrieved by `add_cloudfoundry_metadata`. {pull}19181[19181]
+- Add data type conversion in `dissect` processor for converting string values to other basic data types. {pull}18683[18683]
 - Add the `ignore_failure` configuration option to the dissect processor. {pull}19464[19464]
 - Add the `overwrite_keys` configuration option to the dissect processor. {pull}19464[19464]
 - Add support to trim captured values in the dissect processor. {pull}19464[19464]

--- a/libbeat/processors/dissect/config_test.go
+++ b/libbeat/processors/dissect/config_test.go
@@ -137,3 +137,51 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, trimModeAll, cfg.TrimValues)
 	})
 }
+
+func TestConfigForDataType(t *testing.T) {
+	t.Run("valid data type", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "%{value1|integer} %{value2|float} %{value3|boolean} %{value4|long} %{value5|double}",
+			"field":     "message",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
+	t.Run("invalid data type", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "%{value1|int} %{value2|short} %{value3|char} %{value4|void} %{value5|unsigned} id=%{id|xyz} status=%{status|abc} msg=\"%{message}\"",
+			"field":     "message",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+	t.Run("missing data type", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "%{value1|} %{value2|}",
+			"field":     "message",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+}

--- a/libbeat/processors/dissect/const.go
+++ b/libbeat/processors/dissect/const.go
@@ -38,14 +38,18 @@ var (
 	indirectAppendPrefix = "&+"
 	greedySuffix         = "->"
 	pointerFieldPrefix   = "*"
+	dataTypeIndicator    = "|"
+	dataTypeSeparator    = "\\|" // Needed for regexp
 
 	numberRE = "\\d{1,2}"
+	alphaRE  = "[[:alpha:]]*"
 
 	delimiterRE = regexp.MustCompile("(?s)(.*?)%\\{([^}]*?)}")
 	suffixRE    = regexp.MustCompile("(.+?)" + // group 1 for key name
 		"(" + ordinalIndicator + "(" + numberRE + ")" + ")?" + // group 2, 3 for ordinal
 		"(" + fixedLengthIndicator + "(" + numberRE + ")" + ")?" + // group 4, 5 for fixed length
-		"(" + greedySuffix + ")?$") // group 6 for greedy
+		"(" + greedySuffix + ")?" + // group 6 for greedy
+		"(" + dataTypeSeparator + "(" + alphaRE + ")?" + ")?$") // group 7,8 for data type separator and data type
 
 	defaultJoinString = " "
 
@@ -55,4 +59,6 @@ var (
 	errMixedPrefixIndirectAppend = errors.New("mixed prefix `&+`")
 	errMixedPrefixAppendIndirect = errors.New("mixed prefix `&+`")
 	errEmptyKey                  = errors.New("empty key")
+	errInvalidDatatype           = errors.New("invalid data type")
+	errMissingDatatype           = errors.New("missing data type")
 )

--- a/libbeat/processors/dissect/docs/dissect.asciidoc
+++ b/libbeat/processors/dissect/docs/dissect.asciidoc
@@ -11,7 +11,7 @@ The `dissect` processor tokenizes incoming strings using defined patterns.
 -------
 processors:
   - dissect:
-      tokenizer: "%{key1} %{key2}"
+      tokenizer: "%{key1} %{key2} %{key3|convert_datatype}"
       field: "message"
       target_prefix: "dissect"
 -------
@@ -19,6 +19,8 @@ processors:
 The `dissect` processor has the following configuration settings:
 
 `tokenizer`:: The field used to define the *dissection* pattern.
+              Optional convert datatype can be provided after the key using `|` as separator
+              to convert the value from string to integer, long, float, double, boolean or ip.
 
 `field`:: (Optional) The event field to tokenize. Default is `message`.
 
@@ -64,12 +66,12 @@ For this example, imagine that an application generates the following messages:
 
 [source,sh]
 ----
-"App01 - WebServer is starting"
-"App01 - WebServer is up and running"
-"App01 - WebServer is scaling 2 pods"
-"App02 - Database is will be restarted in 5 minutes"
-"App02 - Database is up and running"
-"App02 - Database is refreshing tables"
+"321 - App01 - WebServer is starting"
+"321 - App01 - WebServer is up and running"
+"321 - App01 - WebServer is scaling 2 pods"
+"789 - App02 - Database is will be restarted in 5 minutes"
+"789 - App02 - Database is up and running"
+"789 - App02 - Database is refreshing tables"
 ----
 
 Use the `dissect` processor to split each message into two fields, for example,
@@ -79,7 +81,7 @@ Use the `dissect` processor to split each message into two fields, for example,
 ----
 processors:
   - dissect:
-      tokenizer: '"%{service.name} - %{service.status}"'
+      tokenizer: '"%{pid|integer} - %{service.name} - %{service.status}"'
       field: "message"
       target_prefix: ""
 ----
@@ -89,6 +91,7 @@ This configuration produces fields like:
 [source,json]
 ----
 "service": {
+  "pid": 321,
   "name": "App01",
   "status": "WebServer is up and running"
 },

--- a/libbeat/processors/dissect/validate_test.go
+++ b/libbeat/processors/dissect/validate_test.go
@@ -32,7 +32,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "when we find reference field for all indirect field",
 			p: &parser{
-				fields:          []field{newIndirectField(1, "hello", 0), newNormalField(0, "hola", 1, 0, false)},
+				fields:          []field{newIndirectField(1, "hello", "", 0), newNormalField(0, "hola", "", 1, 0, false)},
 				referenceFields: []field{newPointerField(2, "hello", 0)},
 			},
 			expectError: false,
@@ -40,7 +40,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "when we cannot find all the reference field for all indirect field",
 			p: &parser{
-				fields:          []field{newIndirectField(1, "hello", 0), newNormalField(0, "hola", 1, 0, false)},
+				fields:          []field{newIndirectField(1, "hello", "", 0), newNormalField(0, "hola", "", 1, 0, false)},
 				referenceFields: []field{newPointerField(2, "okhello", 0)},
 			},
 			expectError: true,


### PR DESCRIPTION
Cherry-pick of PR #18683 to 7.x branch. Original message: 

## What does this PR do?
This PR enhances dissect processor to convert string values to integer, long, float, double, boolean or IP. Key and convert data type are separated by `|` separator.

## Why is it important?
It will save CPU cycles converting data from string to other data type using Convert processor

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
Added unit and benchmark test cases.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes https://github.com/elastic/dissect-specification/issues/10 

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->

