### PR TITLE
Cherry-pick #19839 to 7.x: Do not use vendor folder during integration tests

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -236,7 +236,7 @@ func initRunner(tester IntegrationTester, dir string, passInEnv map[string]strin
 	// Create the custom env for the runner.
 	env := map[string]string{
 		insideIntegrationTestEnvVar: "true",
-		"GOFLAGS":                   "-mod=vendor",
+		"GOFLAGS":                   "-mod=readonly",
 	}
 	for name, value := range passInEnv {
 		env[name] = value


### PR DESCRIPTION
Cherry-pick of PR #19839 to 7.x branch. Original message: 

