### PR TITLE
Remove GOFLAGS=-mod=vendor from integration tests

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -236,7 +236,6 @@ func initRunner(tester IntegrationTester, dir string, passInEnv map[string]strin
 	// Create the custom env for the runner.
 	env := map[string]string{
 		insideIntegrationTestEnvVar: "true",
-		"GOFLAGS":                   "-mod=vendor",
 	}
 	for name, value := range passInEnv {
 		env[name] = value


### PR DESCRIPTION
## What does this PR do?

There is no more vendor folder so remove this flag when running integration tests. While running
tests we were seeing this:

    run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
    go: inconsistent vendoring in /go/src/github.com/elastic/beats:

## Why is it important?

Fixes test failures.

## Logs

- Sample failure that this fixes: https://travis-ci.org/github/elastic/beats/jobs/707616460#L1766-L1767
