### PR TITLE
[jjbb] Use GitHub app token

### DIFF
--- a/.ci/jobs/apm-beats-update.yml
+++ b/.ci/jobs/apm-beats-update.yml
@@ -23,7 +23,7 @@
         notification-context: 'apm-beats-update'
         repo: 'beats'
         repo-owner: 'elastic'
-        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        credentials-id: github-app-beats-ci
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:

--- a/.ci/jobs/beats-windows-mbp.yml
+++ b/.ci/jobs/beats-windows-mbp.yml
@@ -15,10 +15,10 @@
           discover-tags: false
           # Run MBP for the master branch and PRs
           head-filter-regex: '(master|PR-.*)'
-          notification-context: 'beats-ci'
+          notification-context: 'beats-ci/windows'
           repo: beats
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-beats-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -22,7 +22,7 @@
         notification-context: "beats-ci"
         repo: 'beats'
         repo-owner: 'elastic'
-        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        credentials-id: github-app-beats-ci
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:

--- a/.ci/jobs/golang-crossbuild-mbp.yml
+++ b/.ci/jobs/golang-crossbuild-mbp.yml
@@ -16,7 +16,7 @@
           notification-context: 'beats-ci'
           repo: golang-crossbuild
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-beats-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -19,7 +19,7 @@
           notification-context: 'beats-packaging'
           repo: 'beats'
           repo-owner: 'elastic'
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-beats-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:


### PR DESCRIPTION
## What does this PR do?

A new GH app has been created to help with the number of API Calls done when using the Jenkins Multibranch pipeline

## Why is it important?

- From 5k quota to up to 3 times more.
- Changes have being done in the UI already.


```
Started
[Mon Jul 13 16:12:10 UTC 2020] Starting branch indexing...
Connecting to https://api.github.com using 72677/****** (Jenkins - beats-ci)
Examining elastic/beats
```

### Used to be

![image](https://user-images.githubusercontent.com/2871786/87329966-c35ce000-c52f-11ea-85dc-9fb2a43ac2a0.png)

### Now

![image](https://user-images.githubusercontent.com/2871786/87330010-d53e8300-c52f-11ea-86c4-5473fe1ac582.png)



For further details please refers to:
- https://www.jenkins.io/blog/2020/04/16/github-app-authentication/