### PR TITLE
Cherry-pick #19159 to 7.x: Specify an ECS version in Auditbeat/Packetbeat/Winlogbeat

### DIFF
--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -24,12 +24,19 @@ import (
 	"github.com/elastic/beats/v7/auditbeat/core"
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/mb/module"
 )
 
-// Name of the beat (auditbeat).
-const Name = "auditbeat"
+const (
+	// Name of the beat (auditbeat).
+	Name = "auditbeat"
+
+	// ecsVersion specifies the version of ECS that Auditbeat is implementing.
+	ecsVersion = "1.5.0"
+)
 
 // RootCmd for running auditbeat.
 var RootCmd *cmd.BeatsRootCmd
@@ -39,6 +46,13 @@ var ShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show modules information",
 }
+
+// withECSVersion is a modifier that adds ecs.version to events.
+var withECSVersion = processing.WithFields(common.MapStr{
+	"ecs": common.MapStr{
+		"version": ecsVersion,
+	},
+})
 
 func init() {
 	create := beater.Creator(
@@ -51,6 +65,7 @@ func init() {
 		RunFlags:      runFlags,
 		Name:          Name,
 		HasDashboards: true,
+		Processing:    processing.MakeDefaultSupport(true, withECSVersion, processing.WithHost, processing.WithAgentMeta()),
 	}
 	RootCmd = cmd.GenRootCmdWithSettings(create, settings)
 	RootCmd.AddCommand(ShowCmd)

--- a/auditbeat/main.go
+++ b/auditbeat/main.go
@@ -22,10 +22,6 @@ import (
 
 	"github.com/elastic/beats/v7/auditbeat/cmd"
 
-	// Register modules.
-	_ "github.com/elastic/beats/v7/auditbeat/module/auditd"
-	_ "github.com/elastic/beats/v7/auditbeat/module/file_integrity"
-
 	// Register includes.
 	_ "github.com/elastic/beats/v7/auditbeat/include"
 )

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -22,16 +22,30 @@ import (
 
 	"github.com/spf13/pflag"
 
-	// import protocol modules
-	_ "github.com/elastic/beats/v7/packetbeat/include"
-
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/packetbeat/beater"
+
+	// Register fields and protocol modules.
+	_ "github.com/elastic/beats/v7/packetbeat/include"
 )
 
-// Name of this beat
-var Name = "packetbeat"
+const (
+	// Name of this beat.
+	Name = "packetbeat"
+
+	// ecsVersion specifies the version of ECS that Packetbeat is implementing.
+	ecsVersion = "1.5.0"
+)
+
+// withECSVersion is a modifier that adds ecs.version to events.
+var withECSVersion = processing.WithFields(common.MapStr{
+	"ecs": common.MapStr{
+		"version": ecsVersion,
+	},
+})
 
 // RootCmd to handle beats cli
 var RootCmd *cmd.BeatsRootCmd
@@ -48,6 +62,7 @@ func init() {
 		RunFlags:      runFlags,
 		Name:          Name,
 		HasDashboards: true,
+		Processing:    processing.MakeDefaultSupport(true, withECSVersion, processing.WithHost, processing.WithAgentMeta()),
 	}
 	RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
 	RootCmd.AddCommand(genDevicesCommand())

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/winlogbeat/beater"
 
@@ -32,12 +33,24 @@ import (
 	_ "github.com/elastic/beats/v7/winlogbeat/processors/script/javascript/module/winlogbeat"
 )
 
-// Name of this beat
-var Name = "winlogbeat"
+const (
+	// Name of this beat.
+	Name = "winlogbeat"
 
-// RootCmd to handle beats cli
+	// ecsVersion specifies the version of ECS that Winlogbeat is implementing.
+	ecsVersion = "1.5.0"
+)
+
+// withECSVersion is a modifier that adds ecs.version to events.
+var withECSVersion = processing.WithFields(common.MapStr{
+	"ecs": common.MapStr{
+		"version": ecsVersion,
+	},
+})
+
+// RootCmd to handle beats CLI.
 var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
 	Name:          Name,
 	HasDashboards: true,
-	Processing:    processing.MakeDefaultSupport(true, processing.WithECS, processing.WithAgentMeta()),
+	Processing:    processing.MakeDefaultSupport(true, withECSVersion, processing.WithAgentMeta()),
 })


### PR DESCRIPTION
Cherry-pick of PR #19159 to 7.x branch. Original message: 

## What does this PR do?

When we update the Beat (include all of its modules) we will then bump the ECS
version that it includes in events.

I went for a less granular approach than what is being used in Filebeat because
I think it's desirable to move a whole beat to a new ECS version "at once" and
more realistic to do so with these Beats that have fewer updates. By "at once" I
mean we won't release a version that is partially updated. This implies that if
we will be making multiple commits that we should use a feature branch to
ensure the update is atomic.



## Why is it important?

We want the `ecs.version` to accurately represent the schema that is implemented.


## Related issues

- Closes #17688