### PR TITLE
Cherry-pick #19821 to 7.x: libbeat/publisher/pipeline: fix data races

### DIFF
--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -67,13 +67,14 @@ func newEventConsumer(
 	queue queue.Queue,
 	ctx *batchContext,
 ) *eventConsumer {
+	consumer := queue.Consumer()
 	c := &eventConsumer{
 		logger: log,
 		sig:    make(chan consumerSignal, 3),
 		out:    nil,
 
 		queue:    queue,
-		consumer: queue.Consumer(),
+		consumer: consumer,
 		ctx:      ctx,
 	}
 
@@ -82,7 +83,7 @@ func newEventConsumer(
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		c.loop(c.consumer)
+		c.loop(consumer)
 	}()
 	return c
 }


### PR DESCRIPTION
Cherry-pick of PR #19821 to 7.x branch. Original message: 

## What does this PR do?

Fix how we pass the initial queue consumer into `eventConsumer.loop`;
we were referencing c.consumer in a background goroutine, which can
race with updates to the consumer.

Update tests to properly load atomic variables. Changed serially updated
`numEvents` vars to basic, non-atomic types.

## Why is it important?

I'm not sure if this particular data race would cause any issues in production,
but we (apm-server) rely on the race detector to pick up real issues. This is
causing our tests to fail.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

(Does this change need a changelog entry? This is a fix to a recently merged change.)

## How to test this PR locally

`go test -race ./libbeat/publisher/pipeline`