### PR TITLE
Cherry-pick #19551 to 7.x: Fix service start type mapping in windows/service metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -310,6 +310,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
+- Fix mapping of service start type in the service metricset, windows module. {pull}19551[19551]
 - Fix config example in the perfmon configuration files. {pull}19539[19539]
 - Add missing info about the rest of the azure metricsets in the documentation. {pull}19601[19601]
 - Fix k8s scheduler compatibility issue. {pull}19699[19699]

--- a/metricbeat/module/windows/service/service_integration_test.go
+++ b/metricbeat/module/windows/service/service_integration_test.go
@@ -86,6 +86,7 @@ func TestReadService(t *testing.T) {
 					assert.Equal(t, w.ProcessId, s["pid"],
 						"PID of service %v does not match", w.DisplayName)
 				}
+				assert.NotEmpty(t, s["start_type"])
 				// For some services DisplayName and Name are the same. It seems to be a bug from the wmi query.
 				if w.DisplayName != w.Name {
 					assert.Equal(t, w.DisplayName, s["display_name"],

--- a/metricbeat/module/windows/service/service_status.go
+++ b/metricbeat/module/windows/service/service_status.go
@@ -55,7 +55,9 @@ const (
 	ConfigPreshutdownInfo        ConfigInformation = 7
 	ConfigRequiredPrivilegesInfo ConfigInformation = 6
 	ConfigServiceSidInfo         ConfigInformation = 5
+)
 
+const (
 	StartTypeBoot ServiceStartType = iota
 	StartTypeSystem
 	StartTypeAutomatic


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19551 to 7.x branch. Original message:

## What does this PR do?

Fixes start type service mapping.

## Why is it important?

Service start type property returned an empty string

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
