### PR TITLE
Cherry-pick to 7.x: Update monitoring-internal-collection.asciidoc (#19422) (#19697)

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -102,10 +102,9 @@ monitoring:
   elasticsearch:
     hosts: ["https://example.com:9200", "https://example2.com:9200"]
     username: ""
-    ssl:
-      ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
-      ssl.certificate: "/etc/pki/client/cert.pem"
-      ssl.key: "/etc/pki/client/cert.key"
+    ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+    ssl.certificate: "/etc/pki/client/cert.pem"
+    ssl.key: "/etc/pki/client/cert.key"
 --------------------
 +
 You must specify the `username` as `""` explicitly so that


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update monitoring-internal-collection.asciidoc (#19422) (#19697)