### PR TITLE
Cherry-pick #19537 to 7.8: Fix empty field error in the iis/application pool metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,7 +169,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 - Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
-- Stop counterCache only when already started {pull}19103[19103]
 - Fix empty field name errors in the application pool metricset. {pull}19537[19537]
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,6 +169,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix compute and pubsub dashboard for googlecloud module. {issue}18962[18962] {pull}18980[18980]
 - Fix crash on vsphere module when Host information is not available. {issue}18996[18996] {pull}19078[19078]
 - Remove dedot for tag values in aws module. {issue}19112[19112] {pull}19221[19221]
+- Stop counterCache only when already started {pull}19103[19103]
+- Fix empty field name errors in the application pool metricset. {pull}19537[19537]
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
 - Fix config example in the perfmon configuration files. {pull}19539[19539]

--- a/x-pack/metricbeat/module/iis/application_pool/reader_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader_test.go
@@ -16,28 +16,26 @@ import (
 
 // TestNewReaderValid should successfully instantiate the reader.
 func TestNewReaderValid(t *testing.T) {
-	reader, err := newReader()
+	var config Config
+	reader, err := newReader(config)
 	assert.Nil(t, err)
 	assert.NotNil(t, reader)
-	assert.NotNil(t, reader.Query)
-	assert.NotNil(t, reader.Query.Handle)
-	assert.NotNil(t, reader.Query.Counters)
-	assert.Zero(t, len(reader.Query.Counters))
+	assert.NotNil(t, reader.query)
+	assert.NotNil(t, reader.query.Handle)
+	assert.NotNil(t, reader.query.Counters)
 	defer reader.close()
 }
 
 // TestInitCounters should successfully instantiate the reader counters.
 func TestInitCounters(t *testing.T) {
-	reader, err := newReader()
+	var config Config
+	reader, err := newReader(config)
 	assert.NotNil(t, reader)
 	assert.Nil(t, err)
-
-	err = reader.initCounters([]string{})
-	assert.Nil(t, err)
 	// if iis is not enabled, the reader.ApplicationPools is empty
-	if len(reader.ApplicationPools) > 0 {
-		assert.NotZero(t, len(reader.Query.Counters))
-		assert.NotZero(t, len(reader.WorkerProcesses))
+	if len(reader.applicationPools) > 0 {
+		assert.NotZero(t, len(reader.query.Counters))
+		assert.NotZero(t, len(reader.workerProcesses))
 	}
 	defer reader.close()
 }
@@ -55,6 +53,6 @@ func TestGetProcessIds(t *testing.T) {
 	counterList[key] = counters
 	workerProcesses := getProcessIds(counterList)
 	assert.NotZero(t, len(workerProcesses))
-	assert.Equal(t, float64(workerProcesses[0].ProcessId), counters[0].Measurement.(float64))
-	assert.Equal(t, workerProcesses[0].InstanceName, counters[0].Instance)
+	assert.Equal(t, float64(workerProcesses[0].processId), counters[0].Measurement.(float64))
+	assert.Equal(t, workerProcesses[0].instanceName, counters[0].Instance)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19537 to 7.8 branch. Original message:

## What does this PR do?

Fixes  errors as:
```
"metricset":{"name":"application_pool","period":10000},"service":{"type":"iis"}}, Private:interface {}(nil), TimeSeries:true}, Flags:0x0, Cache:publisher.EventCache{m:common.MapStr(nil)}} (status=400): {"type":"mapper_parsing_exception","reason":"failed to parse","caused_by":{"type":"illegal_argument_exception","reason":"field name cannot be an empty string"}}
```

also improves refresh functionality

## Why is it important?

Errors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run the IIS module wit the application pool metricset enabled

