### PR TITLE
Remove script.cache.max_size / script.max_compilations_rate from Filebeat

### DIFF
--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -40,8 +40,6 @@ services:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
-    environment:
-      script.cache.max_size: "500"
 
   kafka:
     build: ${ES_BEATS}/testing/environments/docker/kafka

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -75,14 +75,6 @@ class Test(BaseTest):
 
         self.index_name = "test-filebeat-modules"
 
-        body = {
-            "transient": {
-                "script.max_compilations_rate": "2000/1m"
-            }
-        }
-
-        self.es.transport.perform_request('PUT', "/_cluster/settings", body=body)
-
     @parameterized.expand(load_fileset_test_cases)
     @unittest.skipIf(not INTEGRATION_TESTS,
                      "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -45,14 +45,6 @@ class Test(BaseTest):
             pass
         self.wait_until(lambda: not self.es.indices.exists(index_name))
 
-        body = {
-            "transient": {
-                "script.max_compilations_rate": "100/1m"
-            }
-        }
-
-        self.es.transport.perform_request('PUT', "/_cluster/settings", body=body)
-
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             elasticsearch=dict(

--- a/x-pack/filebeat/docker-compose.yml
+++ b/x-pack/filebeat/docker-compose.yml
@@ -26,6 +26,4 @@ services:
     extends:
       file: ${ES_BEATS}/testing/environments/${STACK_ENVIRONMENT}.yml
       service: elasticsearch
-    environment:
-      script.cache.max_size: "500"
 


### PR DESCRIPTION
## What does this PR do?

These settings has been removed as per https://github.com/elastic/elasticsearch/pull/59262 causing the ES container to not launch.

    elasticsearch_1  | java.lang.IllegalArgumentException: unknown setting [script.cache.max_size] please check that any required plugins are installed, or check the breaking changes documentation for removed settings

## Why is it important?

This fixes the Filebeat integration tests with Elasticsearch.

