### PR TITLE
Run go mod tidy after adding dependencies to generated Beats

### DIFF
--- a/generator/common/beatgen/setup/setup.go
+++ b/generator/common/beatgen/setup/setup.go
@@ -35,7 +35,11 @@ func InitModule() error {
 		return errors.Wrap(err, "error initializing a module for the Beat")
 	}
 
-	return copyReplacedModules()
+	err = copyReplacedModules()
+	if err != nil {
+		return errors.Wrap(err, "error adding replaced modules to go.mod")
+	}
+	return gotool.Mod.Tidy()
 }
 
 func copyReplacedModules() error {


### PR DESCRIPTION
## What does this PR do?

From now on, after the go module is initialized in the generated Beat `go mod tidy` is called to cleanup the file.

## Why is it important?

Now that `-mod=readonly` is added, `go` returns an error if the `go.mod` file needs an update. To avoid it, the file has to be clean.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~