### PR TITLE
[Elastic Agent] Require --insecure on enroll for connection to Kibana

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -12,6 +12,8 @@
 - Rename agent to elastic-agent {pull}17391[17391]
 - Change fleet.yml structure, causes upgraded agent to register as new agent {pull}19248[19248]
 - Remove obfuscation of fleet.yml, causes re-enroll of agent to Fleet {pull}19678[19678]
+- Rename enroll --ca_sha256 to --ca-sha256 {pull}19900[19900]
+- Rename enroll --certificate_authorities to --certificate-authorities {pull}19900[19900]
 
 ==== Bugfixes
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -83,3 +83,4 @@
 - Agent now load balances across multiple Kibana instances {pull}19628[19628]
 - Configuration cleanup {pull}19848[19848]
 - Agent now sends its own logs to elasticsearch {pull}19811[19811]
+- Add --insecure option to enroll command {pull}19900[19900]

--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -7,16 +7,34 @@ experimental[]
 The `elastic-agent run` command provides flags that alter the behavior of an
 agent:
 
-`-path.home`::
+`--path.home`::
 The home directory of the {agent}. `path.home` determines the location of the
 configuration files and data directory.
++
+If not specified, {agent} uses current working directory.
 
-`-c`::
-The configuration file to load. If not specified, {agent} uses
-`{path.home}/elastic-agent.yml`.
-
-`-path.data`::
+`--path.data`::
 The data directory used by {agent} to store downloaded artifacts. Also stores
 logs for any {beats} started and managed by {agent}.
 +
 If not specified, {agent} uses `{path.home}/data`.
+
+`-c`::
+The configuration file to load.
++
+If not specified, {agent} uses `{path.home}/elastic-agent.yml`.
+
+The `elastic-agent enroll` command provides flags that alter the behaviour of
+the enrollment process.
+
+`--ca-sha256`::
+Comma separated list of certificate authorities hash pins used for certificate verifications.
+
+`--certificate-authorities`::
+Comma separated list of root certificate for server verifications.
+
+`--force`::
+Force overwrite the current and do not prompt for confirmation.
+
+`--insecure`::
+Allow insecure connection to Kibana.

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -82,6 +82,11 @@ func (e *EnrollCmdOption) kibanaConfig() (*kibana.Config, error) {
 			CASha256: e.CASha256,
 		}
 	}
+	if e.Insecure {
+		cfg.TLS = &tlscommon.Config{
+			VerificationMode: tlscommon.VerifyNone,
+		}
+	}
 
 	return cfg, nil
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -87,10 +87,10 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 	url := args[0]
 	enrollmentToken := args[1]
 
-	caStr, _ := cmd.Flags().GetString("certificate_authorities")
+	caStr, _ := cmd.Flags().GetString("certificate-authorities")
 	CAs := cli.StringToSlice(caStr)
 
-	caSHA256str, _ := cmd.Flags().GetString("ca_sha256")
+	caSHA256str, _ := cmd.Flags().GetString("ca-sha256")
 	caSHA256 := cli.StringToSlice(caSHA256str)
 
 	delay(defaultDelay)

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -41,7 +41,7 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 	cmd.Flags().StringP("certificate-authorities", "a", "", "Comma separated list of root certificate for server verifications")
 	cmd.Flags().StringP("ca-sha256", "p", "", "Comma separated list of certificate authorities hash pins used for certificate verifications")
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
-	cmd.Flags().BoolP("insecure", "i", false, "Allow insecure connection")
+	cmd.Flags().BoolP("insecure", "i", false, "Allow insecure connection to Kibana")
 
 	return cmd
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -38,9 +38,10 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 		},
 	}
 
-	cmd.Flags().StringP("certificate_authorities", "a", "", "Comma separated list of root certificate for server verifications")
-	cmd.Flags().StringP("ca_sha256", "p", "", "Comma separated list of certificate authorities hash pins used for certificate verifications")
+	cmd.Flags().StringP("certificate-authorities", "a", "", "Comma separated list of root certificate for server verifications")
+	cmd.Flags().StringP("ca-sha256", "p", "", "Comma separated list of certificate authorities hash pins used for certificate verifications")
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
+	cmd.Flags().BoolP("insecure", "i", false, "Allow insecure connection")
 
 	return cmd
 }
@@ -76,6 +77,8 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		}
 	}
 
+	insecure, _ := cmd.Flags().GetBool("insecure")
+
 	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
 	if err != nil {
 		return err
@@ -98,6 +101,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		URL:                  url,
 		CAs:                  CAs,
 		CASha256:             caSHA256,
+		Insecure:			  insecure,
 		UserProvidedMetadata: make(map[string]interface{}),
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -101,7 +101,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		URL:                  url,
 		CAs:                  CAs,
 		CASha256:             caSHA256,
-		Insecure:			  insecure,
+		Insecure:             insecure,
 		UserProvidedMetadata: make(map[string]interface{}),
 	}
 

--- a/x-pack/elastic-agent/pkg/kibana/config.go
+++ b/x-pack/elastic-agent/pkg/kibana/config.go
@@ -27,9 +27,16 @@ type Config struct {
 // Protocol define the protocol to use to make the connection. (Either HTTPS or HTTP)
 type Protocol string
 
+const (
+	// ProtocolHTTP is HTTP protocol connection to Kibana.
+	ProtocolHTTP Protocol = "http"
+	// ProtocolHTTPS is HTTPS protocol connection to Kibana.
+	ProtocolHTTPS Protocol = "https"
+)
+
 // Unpack the protocol.
 func (p *Protocol) Unpack(from string) error {
-	if from != "https" && from != "http" {
+	if Protocol(from) != ProtocolHTTPS && Protocol(from) != ProtocolHTTP {
 		return fmt.Errorf("invalid protocol %s, accepted values are 'http' and 'https'", from)
 	}
 
@@ -40,7 +47,7 @@ func (p *Protocol) Unpack(from string) error {
 // DefaultClientConfig creates default configuration for kibana client.
 func DefaultClientConfig() *Config {
 	return &Config{
-		Protocol: Protocol("http"),
+		Protocol: ProtocolHTTP,
 		Host:     "localhost:5601",
 		Path:     "",
 		SpaceID:  "",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a `--insecure` option to `enroll` command to allow enrollment to Kibana with SSL that is insecure. Adds the requirement of using `--insecure` when using the HTTP protocol.

This also includes a rename of `--ca_sha256` to `--ca-sha256` and `--certificate_authorities` to `--certificate-authorities`. From a command line standpoint I think its best to standardize on `-` versus a mix of `-` and `_`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To strongly require users to use secure connection to Kibana.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
$ ./elastic-agent enroll http://localhost:5601 abcd
The Elastic Agent is currently in BETA and should not be used in production
Error: connection to Kibana is insecure, strongly recommended to use a secure connection (override with --insecure)
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #19624 