### PR TITLE
Cherry-pick #19812 to 7.x: [Bug] fix bug with empty filter values returning no results in system/service

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -233,6 +233,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix tls mapping in suricata module {issue}19492[19492] {pull}19494[19494]
 - Fix memory leak in tcp and unix input sources. {pull}19459[19459]
 - Fix Cisco ASA dissect pattern for 313008 & 313009 messages. {pull}19149[19149]
+- Fix bug with empty filter values in system/service {pull}19812[19812]
 
 *Heartbeat*
 

--- a/metricbeat/module/system/service/service_test.go
+++ b/metricbeat/module/system/service/service_test.go
@@ -31,10 +31,12 @@ import (
 
 var exampleUnits = []dbus.UnitStatus{
 	dbus.UnitStatus{
-		Name: "sshd.service",
+		Name:      "sshd.service",
+		LoadState: "active",
 	},
 	dbus.UnitStatus{
-		Name: "metricbeat.service",
+		Name:      "metricbeat.service",
+		LoadState: "active",
 	},
 	dbus.UnitStatus{
 		Name: "filebeat.service",
@@ -103,4 +105,24 @@ func TestFilterMatches(t *testing.T) {
 	shouldMatch, err := matchUnitPatterns(filtersMatch, exampleUnits)
 	assert.NoError(t, err)
 	assert.Len(t, shouldMatch, 1)
+}
+
+func TestNoFilter(t *testing.T) {
+	shouldReturnResults, err := matchUnitPatterns([]string{}, exampleUnits)
+	assert.NoError(t, err)
+	assert.Len(t, shouldReturnResults, 3)
+}
+
+func TestUnitStateFilter(t *testing.T) {
+	stateFilter := []string{
+		"active",
+	}
+	shouldReturnResults := matchUnitState(stateFilter, exampleUnits)
+	assert.Len(t, shouldReturnResults, 2)
+
+}
+
+func TestUnitStateNoFilter(t *testing.T) {
+	shouldReturnResults := matchUnitState([]string{}, exampleUnits)
+	assert.Len(t, shouldReturnResults, 3)
 }


### PR DESCRIPTION
Cherry-pick of PR #19812 to 7.x branch. Original message: 


## What does this PR do?

This fixes a bug where if the system/service module is running on an OS with an older version of systemd, **and** a user hasn't configured `pattern_filter`, the metricset will return no results. When using the systemd `ListUnitsFiltered` API call, we don't bypass the pattern_filter in cases where the filter is empty.

## Why is it important?

It's a bug, the metricset won't return any data.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## How to test this PR locally

- Build and Run on CentOS 7, which uses a sufficiently old version of systemd.
- Enable the `system/service` metricset
- make sure `service.pattern_filter` isn't configured.
- Make sure we get data.

