### PR TITLE
Cherry-pick #17627 to 7.x: [metricbeat] add state_statefulset in metricbeat k8s recommended config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -634,6 +634,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Added documentation for running Metricbeat in Cloud Foundry. {pull}17275[17275]
 - Refactor windows/perfmon metricset configuration options and event output. {pull}17596[17596]
 - Reference kubernetes manifests mount data directory from the host when running metricbeat as daemonset, so data persist between executions in the same node. {pull}17429[17429]
+- Add `state_statefulset` metricset to Metricbeat recommended configuration for k8s. {pull}17627[17627]
 - Add more detailed error messages, system tests and small refactoring to the service metricset in windows. {pull}17725[17725]
 - Stack Monitoring modules now auto-configure required metricsets when `xpack.enabled: true` is set. {issue}16471[[16471] {pull}17609[17609]
 - Add Metricbeat IIS module dashboards. {pull}17966[17966]

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -234,6 +234,7 @@ data:
         - state_container
         - state_cronjob
         - state_resourcequota
+        - state_statefulset
         # Uncomment this to get k8s events:
         #- event
       period: 10s

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
@@ -43,6 +43,7 @@ data:
         - state_container
         - state_cronjob
         - state_resourcequota
+        - state_statefulset
         # Uncomment this to get k8s events:
         #- event
       period: 10s


### PR DESCRIPTION
Cherry-pick of PR #17627 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
This PR add [`state_statefulset` metricset](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-metricset-kubernetes-state_statefulset.html) in recommended k8s configuration.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
`state_*` metricsets for other K8S recources like `deployment`, `replicaset` and `pod` are present in recommended configuration.

Any reason not to add `statefulset`?

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

