### PR TITLE
Packetbeat process monitor: Ignore missing /proc/net/tcp6

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -286,6 +286,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Packetbeat*
 
 - Enable setting promiscuous mode automatically. {pull}11366[11366]
+- Fix process monitoring when ipv6 is disabled under Linux. {issue}19941[19941] {pull}19945[19945]
 
 *Winlogbeat*
 

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -68,8 +68,10 @@ func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transp
 		logp.Err("GetLocalPortToPIDMapping: parsing '%s': %s", sourceFiles.ipv4, err)
 		return nil, err
 	}
+
 	ipv6socks, err := socketsFromProc(sourceFiles.ipv6, true)
-	if err != nil {
+	// Ignore the error when /proc/net/tcp6 doesn't exists (ipv6 disabled).
+	if err != nil && !os.IsNotExist(err) {
 		logp.Err("GetLocalPortToPIDMapping: parsing '%s': %s", sourceFiles.ipv6, err)
 		return nil, err
 	}

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
@@ -51,6 +52,8 @@ var procFiles = map[applayer.Transport]struct {
 	applayer.TransportTCP: {"/proc/net/tcp", "/proc/net/tcp6"},
 }
 
+var warnIPv6Once sync.Once
+
 // GetLocalPortToPIDMapping returns the list of local port numbers and the PID
 // that owns them.
 func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[endpoint]int, err error) {
@@ -71,9 +74,15 @@ func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transp
 
 	ipv6socks, err := socketsFromProc(sourceFiles.ipv6, true)
 	// Ignore the error when /proc/net/tcp6 doesn't exists (ipv6 disabled).
-	if err != nil && !os.IsNotExist(err) {
-		logp.Err("GetLocalPortToPIDMapping: parsing '%s': %s", sourceFiles.ipv6, err)
-		return nil, err
+	if err != nil {
+		if os.IsNotExist(err) {
+			warnIPv6Once.Do(func() {
+				logp.Warn("No IPv6 socket info reported by the kernel. Process monitor won't enrich IPv6 events")
+			})
+		} else {
+			logp.Err("GetLocalPortToPIDMapping: parsing '%s': %s", sourceFiles.ipv6, err)
+			return nil, err
+		}
 	}
 	socksMap := map[uint64]*socketInfo{}
 	for _, s := range ipv4socks {


### PR DESCRIPTION
## What does this PR do?

This makes Packetbeat's process monitor to continue execution when `/proc/net/tcp6 is missing` (ipv6 disabled in kernel).

## Why is it important?

The process monitor feature was not working when ipv6 was disabled.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Boot kernel with `ipv6.disable=1`
- Run packetbeat with `-E packetbeat.procs.enabled=true`

## Related issues

Closes #19941

## Logs

Errors before this fix:

```
2020-07-15T10:01:30.006Z	ERROR	procs/procs_linux.go:73	GetLocalPortToPIDMapping: parsing '/proc/net/tcp6': open /proc/net/tcp6: no such file or directory
2020-07-15T10:01:30.006Z	ERROR	procs/procs.go:224	unable to list local ports: open /proc/net/tcp6: no such file or directory
```

Warning after this fix (shown only once):

```
2020-07-16T12:04:20.802Z	WARN	procs/procs_linux.go:80	No IPv6 socket info reported by the kernel. Process monitor won't enrich IPv6 events
```
