### PR TITLE
[docs] Add ECK doc links to Beats

### DIFF
--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -4,6 +4,8 @@
 {beatname_uc} <<running-on-docker,Docker images>> can be used on Kubernetes to
 check files integrity.
 
+Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {beatname_uc} has not yet been

--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -4,7 +4,7 @@
 {beatname_uc} <<running-on-docker,Docker images>> can be used on Kubernetes to
 check files integrity.
 
-Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
 
 ifeval::["{release-state}"=="unreleased"]
 

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -4,6 +4,8 @@
 You can use {beatname_uc} <<running-on-docker,Docker images>> on Kubernetes to
 retrieve and ship container logs.
 
+Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {beatname_uc} has not yet been

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -4,7 +4,7 @@
 You can use {beatname_uc} <<running-on-docker,Docker images>> on Kubernetes to
 retrieve and ship container logs.
 
-Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
 
 ifeval::["{release-state}"=="unreleased"]
 

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -4,6 +4,8 @@
 You can use {beatname_uc} <<running-on-docker,Docker images>> on Kubernetes to
 retrieve cluster metrics.
 
+Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {beatname_uc} has not yet been

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -4,7 +4,7 @@
 You can use {beatname_uc} <<running-on-docker,Docker images>> on Kubernetes to
 retrieve cluster metrics.
 
-Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK].
 
 ifeval::["{release-state}"=="unreleased"]
 


### PR DESCRIPTION
Adds links to ECK docs.

Do not merge until 1.2 is live.

Merge after https://github.com/elastic/docs/pull/1902.