### PR TITLE
Cherry-pick to 7.8: Clean up heading tags in Elastic Agent docs (#19963)

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -15,7 +15,7 @@ To alter this behavior, configure the output and other configuration settings:
 * <<elastic-agent-monitoring-configuration>>
 * <<elastic-agent-datasource-configuration>>
 
-[float]
+[discrete]
 [[elastic-agent-output-configuration]]
 == Output settings
 
@@ -51,7 +51,7 @@ username and password pair, and the second one contains an API key.
 A default output configuration is required.
 ==============
 
-[float]
+[discrete]
 [[elastic-agent-monitoring-configuration]]
 == {beats} monitoring settings
 
@@ -81,6 +81,7 @@ To enable monitoring, set `settings.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is disabled. Set
 `use_output` to specify the output to which monitoring events are sent.
 
+[discrete]
 [[elastic-agent-datasource-configuration]]
 == Datasource settings
 

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -7,7 +7,7 @@ experimental[]
 {agent} runs in two modes: standalone or fleet. The two modes differ in how you
 configure and manage the Agent.
 
-[float]
+[discrete]
 [[fleet-mode]]
 == Run in {fleet} mode
 
@@ -40,7 +40,7 @@ To start {agent}, run:
 ./elastic-agent run
 ----
 
-[float]
+[discrete]
 [[standalone-mode]]
 == Run in standalone mode (default)
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Clean up heading tags in Elastic Agent docs (#19963)