### PR TITLE
Add cloudwatch input into Filebeat configure inputs documentation

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -121,3 +121,5 @@ include::inputs/input-tcp.asciidoc[]
 include::inputs/input-udp.asciidoc[]
 
 include::inputs/input-unix.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
@@ -113,7 +113,4 @@ logs:FilterLogEvents
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 
-[id="aws-credentials-config"]
-include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
-
 :type!:


### PR DESCRIPTION
This PR is to add cloudwatch input into Filebeat configure inputs documentation: https://www.elastic.co/guide/en/beats/filebeat/7.x/configuration-filebeat-options.html 