### PR TITLE
Move file metrics to dataset endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Adds Gsuite Admin support. {pull}19769[19769]
 - Adds Gsuite Drive support. {pull}19704[19704]
 - Adds Gsuite Groups support. {pull}19725[19725]
+- Move file metrics to dataset endpoint {pull}19977[19977]
 
 *Heartbeat*
 

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -58,7 +58,7 @@ import (
 
 var (
 	harvesterMetrics = monitoring.Default.NewRegistry("filebeat.harvester")
-	filesMetrics     = harvesterMetrics.NewRegistry("files")
+	filesMetrics     = monitoring.GetNamespace("dataset").GetRegistry()
 
 	harvesterStarted   = monitoring.NewInt(harvesterMetrics, "started")
 	harvesterClosed    = monitoring.NewInt(harvesterMetrics, "closed")


### PR DESCRIPTION
Breaking change

## What does this PR do?

The filemetrics are on the stats endpoint. It ideally is supposed to be on `/dataset` similar to metricbeat. This PR moves them to the right endpoint

## Why is it important?

We use stats endpoint to collect metrics. These file metrics make the endpoint to verbose. 

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

