### PR TITLE
Cherry-pick #19675 to 7.9: Fix nanocore sum for non default intervals on Kubernetes Overview Dashboard

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.5.0...v7.5.1[View commits]
 - Fix ListMetrics pagination in aws module. {issue}14926[14926] {pull}14942[14942]
 - Fix CPU count in docker/cpu in cases where no `online_cpus` are reported {pull}15070[15070]
 - Add domain state to kvm module {pull}17673[17673]
+- Fix Kubernetes Overview Dashboard to correctly display non 10s intervals for node usage {pull}19675[19675]
 
 [[release-notes-7.5.0]]
 === Beats version 7.5.0

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/Metricbeat-kubernetes-overview.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/Metricbeat-kubernetes-overview.json
@@ -126,6 +126,28 @@
                                         "field": "kubernetes.container.cpu.usage.nanocores",
                                         "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
                                         "type": "sum"
+                                    },
+                                    {
+                                        "id": "8b346300-bf95-11ea-a07c-851701f0d645",
+                                        "type": "avg",
+                                        "field": "metricset.period"
+                                    },
+                                    {
+                                        "id": "25ae6580-bf95-11ea-a07c-851701f0d645",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "id": "39e40aa0-bf95-11ea-a07c-851701f0d645",
+                                                "name": "sum_nanocores",
+                                                "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28"
+                                            },
+                                            {
+                                                "id": "85213600-bf95-11ea-a07c-851701f0d645",
+                                                "name": "avg_period",
+                                                "field": "8b346300-bf95-11ea-a07c-851701f0d645"
+                                            }
+                                        ],
+                                        "script": "params.sum_nanocores / (params._interval / params.avg_period)"
                                     }
                                 ],
                                 "override_index_pattern": 0,


### PR DESCRIPTION
Cherry-pick of PR #19675 to 7.9 branch. Original message: 

Bug

## What does this PR do?

The Kibana visualization `CPU usage by node  [Metricbeat Kubernetes] ECS` did not account for x-axis scaling.
In case the scaling aligned with the value from metricset.period it was correct.
In every other case, the sum was not correctly calculated as it did not take into account how big the buckets in the visualizations would be.

## Why is it important?

It allows to correctly see the usage of nodes on the Kubernetes Dashboard on longer time ranges.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] _I have commented my code, particularly in hard-to-understand areas_
- [ ] _I have made corresponding changes to the documentation_
- [ ] _I have made corresponding change to the default configuration files_
- [ ] _I have added tests that prove my fix is effective or that my feature works_
- [ ] _I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`._

## Author's Checklist

- [ ]

## How to test this PR locally

- Load the dashboard and select a scaling that results in in non 10 seconds intervals for the visualization.

## Screenshots

Confirmed working on non 10 seconds scaling.
![image](https://user-images.githubusercontent.com/16025288/86611288-c5aebf80-bfae-11ea-911d-f32bf159af58.png)


