### PR TITLE
Cherry-pick #19980 to 7.x: Do not compare err with custom type

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@
 - Properly stops subprocess on shutdown {pull}19567[19567]
 - Forward revision number of the configuration to the endpoint. {pull}19759[19759]
 - Remove support for logs type and use logfile {pull}19761[19761]
+- Avoid comparing uncomparable types on enroll {issue}19976[19976]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -122,7 +122,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 
 	backExp := backoff.NewExpBackoff(signal, 60*time.Second, 10*time.Minute)
 
-	for err == fleetapi.ErrTooManyRequests {
+	for errors.Is(err, fleetapi.ErrTooManyRequests) {
 		fmt.Fprintln(streams.Out, "Too many requests on the remote server, will retry in a moment.")
 		backExp.Wait()
 		fmt.Fprintln(streams.Out, "Retrying to enroll...")


### PR DESCRIPTION
Cherry-pick of PR #19980 to 7.x branch. Original message:

## What does this PR do?

Fixes #19976 by using comparison from errors package instead of comparing custom types

## Why is it important?

Avoid panics

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @ph