### PR TITLE
Remove Dynamic Script Compilations warning in Cisco module (#19840)

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -24,17 +24,6 @@ Cisco ASA devices also support exporting flow records using NetFlow, which is
 supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 {beatname_uc}.
 
-[WARNING]
-=======================================
-Some filesets in this module make extensive use of ingest pipeline scripts.
-This can cause their ingest pipelines to fail loading due to exceeding the
-default compilation limits:
-
-`[script] Too many dynamic script compilations within, max: [75/5m]`
-
-Check the <<dynamic-script-compilations>> section for more information.
-=======================================
-
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
@@ -346,22 +335,6 @@ will be found under `rsa.raw`. The default is false.
 :has-dashboards!:
 
 :fileset_ex!:
-
-[float]
-[[dynamic-script-compilations]]
-=== Dynamic Script Compilations
-
-The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and
-make extensive use of script processors and painless conditions. This can cause
-the pipelines to fail loading the first time the module is used, due to exceeding
-the maximum script compilation limits. It is recommended to tune the following
-parameters on your Elasticsearch cluster:
-
-- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
-  Increase to at least `100/5m`.
-
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
-  Increase to at least `200` if using both filesets or other script-heavy modules.
 
 [float]
 === Example dashboard

--- a/filebeat/docs/modules/sophosxg.asciidoc
+++ b/filebeat/docs/modules/sophosxg.asciidoc
@@ -132,22 +132,6 @@ This is a list of FortiOS fields that are mapped to ECS.
 
 :fileset_ex!:
 
-[float]
-[[dynamic-script-compilations-sophosxg]]
-=== Dynamic Script Compilations
-
-The `sophosxg` filesets are based on Elasticsearch ingest pipelines and
-make extensive use of script processors and painless conditions. This can cause
-the pipelines to fail loading the first time the module is used, due to exceeding
-the maximum script compilation limits. It is recommended to tune the following
-parameters on your Elasticsearch cluster:
-
-- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
-  Increase to at least `100/5m`.
-
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
-  Increase to at least `300` if using both filesets or other script-heavy modules.
-
 :modulename!:
 
 

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -19,17 +19,6 @@ Cisco ASA devices also support exporting flow records using NetFlow, which is
 supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 {beatname_uc}.
 
-[WARNING]
-=======================================
-Some filesets in this module make extensive use of ingest pipeline scripts.
-This can cause their ingest pipelines to fail loading due to exceeding the
-default compilation limits:
-
-`[script] Too many dynamic script compilations within, max: [75/5m]`
-
-Check the <<dynamic-script-compilations>> section for more information.
-=======================================
-
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
@@ -341,22 +330,6 @@ will be found under `rsa.raw`. The default is false.
 :has-dashboards!:
 
 :fileset_ex!:
-
-[float]
-[[dynamic-script-compilations]]
-=== Dynamic Script Compilations
-
-The `asa` and `ftd` filesets are based on Elasticsearch ingest pipelines and
-make extensive use of script processors and painless conditions. This can cause
-the pipelines to fail loading the first time the module is used, due to exceeding
-the maximum script compilation limits. It is recommended to tune the following
-parameters on your Elasticsearch cluster:
-
-- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
-  Increase to at least `100/5m`.
-
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
-  Increase to at least `200` if using both filesets or other script-heavy modules.
 
 [float]
 === Example dashboard

--- a/x-pack/filebeat/module/sophosxg/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sophosxg/_meta/docs.asciidoc
@@ -127,20 +127,4 @@ This is a list of FortiOS fields that are mapped to ECS.
 
 :fileset_ex!:
 
-[float]
-[[dynamic-script-compilations-sophosxg]]
-=== Dynamic Script Compilations
-
-The `sophosxg` filesets are based on Elasticsearch ingest pipelines and
-make extensive use of script processors and painless conditions. This can cause
-the pipelines to fail loading the first time the module is used, due to exceeding
-the maximum script compilation limits. It is recommended to tune the following
-parameters on your Elasticsearch cluster:
-
-- {ref}/circuit-breaker.html#script-compilation-circuit-breaker[script.max_compilations_rate]:
-  Increase to at least `100/5m`.
-
-- {ref}/modules-scripting-using.html#modules-scripting-using-caching[script.cache.max_size]:
-  Increase to at least `300` if using both filesets or other script-heavy modules.
-
 :modulename!:


### PR DESCRIPTION
(cherry picked from commit e3ca37a67ccb48e8a5c50642711591bee89670e7)