### PR TITLE
Cherry-pick to 7.x: Update internal links to external (#19947)

### DIFF
--- a/libbeat/docs/tab-widgets/set-connection.asciidoc
+++ b/libbeat/docs/tab-widgets/set-connection.asciidoc
@@ -1,7 +1,9 @@
 // tag::cloud[]
 
-Specify the <<configure-cloud-id,`cloud.id`>> of your {ess}, and set
-<<configure-cloud-id,`cloud.auth`>> to a user who is authorized to
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
+Specify the {beatname_url}/configure-cloud-id.html[cloud.id] of your {ess}, and set
+{beatname_url}/configure-cloud-id.html[cloud.auth] to a user who is authorized to
 set up {beatname_uc}. For example:
 
 ["source","yaml",subs="attributes"]
@@ -12,7 +14,7 @@ cloud.auth: "{beatname_lc}_setup:{pwd}" <1>
 <1> This examples shows a hard-coded password, but you should store sensitive
 values
 ifndef::serverless[]
-in the <<keystore,secrets keystore>>.
+in the {beatname_url}/keystore.html[secrets keystore].
 endif::[]
 ifdef::serverless[]
 in environment variables.
@@ -34,7 +36,7 @@ output.elasticsearch:
 <1> This examples shows a hard-coded password, but you should store sensitive
 values
 ifndef::serverless[]
-in the <<keystore,secrets keystore>>.
+in the {beatname_url}/keystore.html[secrets keystore].
 endif::[]
 ifdef::serverless[]
 in environment variables.
@@ -60,3 +62,4 @@ specified for the {es} output.
 `kibana_user` {ref}/built-in-roles.html[built-in role] or equivalent
 privileges.
 // end::self-managed[]
+

--- a/libbeat/docs/tab-widgets/start.asciidoc
+++ b/libbeat/docs/tab-widgets/start.asciidoc
@@ -1,4 +1,7 @@
 // tag::deb[]
+
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo service {beatname_pkg} start
@@ -6,12 +9,12 @@ sudo service {beatname_pkg} start
 
 // tag::initd-note[]
 NOTE: If you use an `init.d` script to start {beatname_uc}, you can't specify command
-line flags (see <<command-line-options>>). To specify flags, start {beatname_uc} in
+line flags (see {beatname_url}/command-line-options.html[Command reference]). To specify flags, start {beatname_uc} in
 the foreground.
 
 // end::initd-note[]
 
-Also see <<running-with-systemd>>.
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
 // end::deb[]
 
 // tag::rpm[]
@@ -22,7 +25,7 @@ sudo service {beatname_pkg} start
 
 include::start.asciidoc[tag=initd-note]
 
-Also see <<running-with-systemd>>.
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
 
 // end::rpm[]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update internal links to external (#19947)