### PR TITLE
Cherry-pick #19945 to 7.9: Packetbeat process monitor: Ignore missing /proc/net/tcp6

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -330,6 +330,7 @@ field. You can revert this change by configuring tags for the module and omittin
 *Packetbeat*
 
 - Enable setting promiscuous mode automatically. {pull}11366[11366]
+- Fix process monitoring when ipv6 is disabled under Linux. {issue}19941[19941] {pull}19945[19945]
 
 *Winlogbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #19945 to 7.9 branch. Original message: 

## What does this PR do?

This makes Packetbeat's process monitor to continue execution when `/proc/net/tcp6 is missing` (ipv6 disabled in kernel).

## Why is it important?

The process monitor feature was not working when ipv6 was disabled.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Boot kernel with `ipv6.disable=1`
- Run packetbeat with `-E packetbeat.procs.enabled=true`

## Related issues

Closes #19941

## Logs

Errors before this fix:

```
2020-07-15T10:01:30.006Z	ERROR	procs/procs_linux.go:73	GetLocalPortToPIDMapping: parsing '/proc/net/tcp6': open /proc/net/tcp6: no such file or directory
2020-07-15T10:01:30.006Z	ERROR	procs/procs.go:224	unable to list local ports: open /proc/net/tcp6: no such file or directory
```

Warning after this fix (shown only once):

```
2020-07-16T12:04:20.802Z	WARN	procs/procs_linux.go:80	No IPv6 socket info reported by the kernel. Process monitor won't enrich IPv6 events
```
