### PR TITLE
Test export commands in all Beats

### DIFF
--- a/auditbeat/tests/system/test_base.py
+++ b/auditbeat/tests/system/test_base.py
@@ -6,9 +6,10 @@ import unittest
 from auditbeat import *
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
+from beat import common_tests
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
     def test_start_stop(self):
         """
         Auditbeat starts and stops without error.

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -3,9 +3,10 @@ import unittest
 from filebeat import BaseTest
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
+from beat import common_tests
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     def test_base(self):
         """

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -4,10 +4,11 @@ import unittest
 from heartbeat import BaseTest
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
+from beat import common_tests
 import nose.tools
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     def test_base(self):
         """

--- a/journalbeat/tests/system/test_base.py
+++ b/journalbeat/tests/system/test_base.py
@@ -6,9 +6,10 @@ import unittest
 import time
 import yaml
 from shutil import copyfile
+from beat import common_tests
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "Journald only on Linux")
     def test_start_with_local_journal(self):

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -24,10 +24,10 @@ class TestExportsMixin:
         assert exit_code == 0
         output = self.get_log()
         trailer = "\nPASS\n"
-        if not output.endswith(trailer):
-            raise Exception("didn't return expected trailer:{} got:{}".format(trailer.__repr__(),
-                                                                              output[-100:].__repr__()))
-        return output[:-len(trailer)]
+        pos = output.rfind(trailer)
+        if pos == -1:
+            raise Exception("didn't return expected trailer:{} got:{}".format(trailer.__repr__(),                                                   output[-100:].__repr__()))
+        return output[:pos]
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_export_ilm_policy(self):

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -24,7 +24,9 @@ class TestExportsMixin:
         assert exit_code == 0
         output = self.get_log()
         trailer = "\nPASS\n"
-        assert output.endswith(trailer)
+        if not output.endswith(trailer):
+            raise Exception("didn't return expected trailer:{} got:{}".format(trailer.__repr__(),
+                                                                              output[-100:].__repr__()))
         return output[:-len(trailer)]
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+import yaml
+
+from beat.beat import INTEGRATION_TESTS
+
+
+class TestExportsMixin:
+
+    def run_export_cmd(self, cmd, extra=[]):
+        """
+        Runs the given export command and returns the output as a string.
+        Raises an exception if the command fails.
+        :param cmd: the export command
+        :param extra: Extra arguments (optional)
+        :return: The output as a string.
+        """
+        self.render_config_template()
+
+        args = ["export", cmd]
+        if len(extra) != 0:
+            args += extra
+        exit_code = self.run_beat(extra_args=args, logging_args=[])
+        assert exit_code == 0
+        output = self.get_log()
+        trailer = "\nPASS\n"
+        assert output.endswith(trailer)
+        return output[:-len(trailer)]
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_export_ilm_policy(self):
+        """
+        Test that the ilm-policy can be exported with `export ilm-policy`
+        """
+        output = self.run_export_cmd("ilm-policy")
+        js = json.loads(output)
+        assert "policy" in js
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_export_template(self):
+        """
+        Test that the template can be exported with `export template`
+        """
+        output = self.run_export_cmd("template")
+        js = json.loads(output)
+        assert "index_patterns" in js and "mappings" in js
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_export_index_pattern(self):
+        """
+        Test that the index-pattern can be exported with `export index-pattern`
+        """
+        output = self.run_export_cmd("index-pattern")
+        js = json.loads(output)
+        assert "objects" in js
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_export_config(self):
+        """
+        Test that the config can be exported with `export config`
+        """
+        output = self.run_export_cmd("config")
+        yml = yaml.load(output)
+        assert isinstance(yml, dict)

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -26,7 +26,8 @@ class TestExportsMixin:
         trailer = "\nPASS\n"
         pos = output.rfind(trailer)
         if pos == -1:
-            raise Exception("didn't return expected trailer:{} got:{}".format(trailer.__repr__(),                                                   output[-100:].__repr__()))
+            raise Exception("didn't return expected trailer:{} got:{}".format(
+                trailer.__repr__(),                                                   output[-100:].__repr__()))
         return output[:pos]
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -1,4 +1,5 @@
 from base import BaseTest
+from beat import common_tests
 
 import json
 import os
@@ -9,7 +10,7 @@ import sys
 import unittest
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     def test_base(self):
         """

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -6,9 +6,10 @@ import shutil
 from metricbeat import BaseTest
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
+from beat import common_tests
 
 
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     COMPOSE_SERVICES = ['elasticsearch', 'kibana']
 

--- a/packetbeat/tests/system/test_base.py
+++ b/packetbeat/tests/system/test_base.py
@@ -1,0 +1,11 @@
+import os
+import sys
+from packetbeat import BaseTest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
+
+from beat import common_tests
+
+
+class Test(BaseTest, common_tests.TestExportsMixin):
+    pass

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import unittest
 from winlogbeat import BaseTest
+from beat import common_tests
 
 """
 Contains tests for config parsing.
@@ -10,7 +11,7 @@ Contains tests for config parsing.
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
 
     def test_valid_config(self):
         """

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -3,9 +3,9 @@ from functionbeat import BaseTest
 import json
 import os
 import unittest
+from beat import common_tests
 
-
-class Test(BaseTest):
+class Test(BaseTest, common_tests.TestExportsMixin):
     @unittest.skip("temporarily disabled")
     def test_base(self):
         """

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -5,6 +5,7 @@ import os
 import unittest
 from beat import common_tests
 
+
 class Test(BaseTest, common_tests.TestExportsMixin):
     @unittest.skip("temporarily disabled")
     def test_base(self):


### PR DESCRIPTION
## What does this PR do?

This adds 4 new integration tests to all Beats that test export commands:

> beatname export ilm-policy
> beatname export template
> beatname export index-pattern
> beatname export config

## Why is it important?

In the past we've been hit by some of the export commands failing and there was no test to check that. There's generic tests in libbeat using _mockbeat,_ but in the case of fields definitions, the export command might fail due to problems with the fields built into a particular Beat.

For example, if a Filebeat module defines a field that duplicates a field defined in another place, this was silently accepted but it would cause `filebeat export index-pattern` to fail with:

> Error generating Index Pattern: field <log.file.path> is duplicated, remove it or set 'overwrite: true', {Name:log.file.path Type:keyword Description:The file from which the line was read. This field contains the absolute path to the file. For example: `/var/log/system.log`.
 Format: Fields:[] MultiFields:[] Enabled:<nil> Analyzer: SearchAnalyzer: Norms:false Dynamic:{Value:<nil>} Index:<nil> DocValues:<nil> CopyTo: IgnoreAbove:0 AliasPath: MigrationAlias:false Dimension:<nil> ObjectType: ObjectTypeMappingType: ScalingFactor:0 ObjectTypeParams:[] Analyzed:<nil> Count:0 Searchable:<nil> Aggregatable:<nil> Script: Pattern: InputFormat: OutputFormat: OutputPrecision:<nil> LabelTemplate: UrlTemplate:[] OpenLinkInCurrentTab:<nil> Overwrite:false DefaultField:<nil> Path:log.file.path}, {"aggregatable":true,"analyzed":false,"count":0,"doc_values":true,"indexed":true,"name":"log.file.path","scripted":false,"searchable":true,"type":"string"}.

These new tests will validate that the export commands work for each individual Beat. Actual validation is limited to checking that the command succeeds and that it returns a valid JSON (ilm-policy, template, index-pattern) or YAML (config).

Ideally we would like to catch these kind of errors (esp. fields-definitions related errors) at an earlier stage, but it's worth having this last line of validation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
