### PR TITLE
Cherry-pick #19913 to 7.9: [Metricbeat] Update MySQL dashboard

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -663,6 +663,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - The `elasticsearch-xpack/index` metricset now reports hidden indices as such. {issue}18639[18639] {pull}18706[18706]
 - Adds support for app insights metrics in the azure module. {issue}18570[18570] {pull}18940[18940]
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
+- Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 
 *Packetbeat*
 

--- a/metricbeat/module/mysql/_meta/kibana/7/dashboard/Metricbeat-mysql-overview.json
+++ b/metricbeat/module/mysql/_meta/kibana/7/dashboard/Metricbeat-mysql-overview.json
@@ -27,14 +27,14 @@
             "gridData": {
               "h": 15,
               "i": "14",
-              "w": 24,
-              "x": 24,
+              "w": 16,
+              "x": 15,
               "y": 38
             },
             "panelIndex": "14",
             "panelRefName": "panel_0",
             "title": "Open Tables, Files, Streams",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -50,7 +50,7 @@
             "panelIndex": "050b110b-0b4d-404a-86c0-fa97f7eed2a0",
             "panelRefName": "panel_1",
             "title": "Rate of Questions",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -66,7 +66,7 @@
             "panelIndex": "988a61d7-ac3e-481e-a6ae-aa75aaa32a3a",
             "panelRefName": "panel_2",
             "title": "Rate of SELECT statements",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -82,7 +82,7 @@
             "panelIndex": "a1f8fa38-a62f-4e05-adde-e995dae9ad83",
             "panelRefName": "panel_3",
             "title": "Rate of INSERT, UPDATE, DELETE",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -98,7 +98,7 @@
             "panelIndex": "d126fb61-605f-43af-b5d5-3fa3c128f726",
             "panelRefName": "panel_4",
             "title": "Connected Threads",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -114,7 +114,7 @@
             "panelIndex": "59586d96-3abd-48a3-a258-cfd620826ec2",
             "panelRefName": "panel_5",
             "title": "Connections",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -130,7 +130,7 @@
             "panelIndex": "dd0cf202-fe22-4daf-8f25-09c64d412bf3",
             "panelRefName": "panel_6",
             "title": "Aborted Connections Rate",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -146,7 +146,7 @@
             "panelIndex": "ead16a55-a2d3-49ae-a09b-a0b03560e9a0",
             "panelRefName": "panel_7",
             "title": "Thread Activity",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -162,7 +162,7 @@
             "panelIndex": "24fc2926-610d-4910-8f3e-eb63ca69788c",
             "panelRefName": "panel_8",
             "title": "Buffer Pool Pages",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -178,23 +178,7 @@
             "panelIndex": "33c10c95-be67-492e-afb5-863f375cffc2",
             "panelRefName": "panel_9",
             "title": "Buffer Pool Utilization",
-            "version": "7.3.1"
-          },
-          {
-            "embeddableConfig": {
-              "title": "Network Traffic"
-            },
-            "gridData": {
-              "h": 15,
-              "i": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
-              "w": 24,
-              "x": 0,
-              "y": 38
-            },
-            "panelIndex": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
-            "panelRefName": "panel_10",
-            "title": "Network Traffic",
-            "version": "7.3.1"
+            "version": "7.7.0"
           },
           {
             "embeddableConfig": {
@@ -208,9 +192,89 @@
               "y": 24
             },
             "panelIndex": "d35d7c5e-8832-40e2-8c77-953ad320c853",
-            "panelRefName": "panel_11",
+            "panelRefName": "panel_10",
             "title": "Buffer Pool Efficiency",
-            "version": "7.3.1"
+            "version": "7.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Network Traffic"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
+              "w": 15,
+              "x": 0,
+              "y": 38
+            },
+            "panelIndex": "3cd58868-0d03-4715-9ecc-9fba3cde47c1",
+            "panelRefName": "panel_11",
+            "title": "Network Traffic",
+            "version": "7.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Open Tables Cache"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "277c8209-3c5f-41f5-95f4-de0782917fba",
+              "w": 17,
+              "x": 31,
+              "y": 38
+            },
+            "panelIndex": "277c8209-3c5f-41f5-95f4-de0782917fba",
+            "panelRefName": "panel_12",
+            "title": "Open Tables Cache",
+            "version": "7.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Connection Errors"
+            },
+            "gridData": {
+              "h": 13,
+              "i": "9487b742-3e7f-4d57-af32-014ad360235c",
+              "w": 13,
+              "x": 0,
+              "y": 53
+            },
+            "panelIndex": "9487b742-3e7f-4d57-af32-014ad360235c",
+            "panelRefName": "panel_13",
+            "title": "Connection Errors",
+            "version": "7.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Commands Operations"
+            },
+            "gridData": {
+              "h": 13,
+              "i": "00cd9f15-01bd-43f3-a8c5-43d6ff17dad3",
+              "w": 20,
+              "x": 13,
+              "y": 53
+            },
+            "panelIndex": "00cd9f15-01bd-43f3-a8c5-43d6ff17dad3",
+            "panelRefName": "panel_14",
+            "title": "Commands Operations",
+            "version": "7.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "SSL Cache"
+            },
+            "gridData": {
+              "h": 13,
+              "i": "cd4deb30-c0dd-4f23-8868-ecffd73b2406",
+              "w": 15,
+              "x": 33,
+              "y": 53
+            },
+            "panelIndex": "cd4deb30-c0dd-4f23-8868-ecffd73b2406",
+            "panelRefName": "panel_15",
+            "title": "SSL Cache",
+            "version": "7.7.0"
           }
         ],
         "timeRestore": false,
@@ -273,19 +337,39 @@
           "type": "visualization"
         },
         {
-          "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
+          "id": "a1e00160-63a4-11ea-a83e-25b8612d00cc",
           "name": "panel_10",
           "type": "visualization"
         },
         {
-          "id": "a1e00160-63a4-11ea-a83e-25b8612d00cc",
+          "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
           "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "cd72e030-c6a6-11ea-a106-5be590f42b74",
+          "name": "panel_12",
+          "type": "visualization"
+        },
+        {
+          "id": "0774bbb0-c69c-11ea-a106-5be590f42b74",
+          "name": "panel_13",
+          "type": "visualization"
+        },
+        {
+          "id": "3e5c4490-c6a1-11ea-a106-5be590f42b74",
+          "name": "panel_14",
+          "type": "visualization"
+        },
+        {
+          "id": "8b276c80-c6ad-11ea-a106-5be590f42b74",
+          "name": "panel_15",
           "type": "visualization"
         }
       ],
       "type": "dashboard",
-      "updated_at": "2020-03-16T13:01:34.528Z",
-      "version": "WzQ2NzAsMV0="
+      "updated_at": "2020-07-15T15:17:01.974Z",
+      "version": "WzM4MywxXQ=="
     },
     {
       "attributes": {
@@ -334,6 +418,7 @@
                 ],
                 "point_size": "0",
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -356,6 +441,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -378,6 +464,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -394,12 +481,12 @@
       },
       "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:01:07.859Z",
-      "version": "WzQ2NjksMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIwNywxXQ=="
     },
     {
       "attributes": {
@@ -465,6 +552,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -481,12 +569,12 @@
       },
       "id": "4fa69a10-630b-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T12:58:09.873Z",
-      "version": "WzQ2NTQsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIwOCwxXQ=="
     },
     {
       "attributes": {
@@ -552,6 +640,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -568,12 +657,12 @@
       },
       "id": "7ea77d30-630a-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T12:59:11.517Z",
-      "version": "WzQ2NTUsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIwOSwxXQ=="
     },
     {
       "attributes": {
@@ -639,6 +728,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -673,6 +763,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -707,6 +798,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -723,12 +815,12 @@
       },
       "id": "779ee920-6309-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T12:59:32.603Z",
-      "version": "WzQ2NTYsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxMCwxXQ=="
     },
     {
       "attributes": {
@@ -790,6 +882,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -806,12 +899,12 @@
       },
       "id": "fc6b5a40-630d-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T12:59:47.044Z",
-      "version": "WzQ2NTcsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxMSwxXQ=="
     },
     {
       "attributes": {
@@ -872,6 +965,7 @@
                 ],
                 "point_size": "0",
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -894,6 +988,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -916,6 +1011,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -932,12 +1028,12 @@
       },
       "id": "493e8460-630d-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:08.292Z",
-      "version": "WzQ2NTgsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxMiwxXQ=="
     },
     {
       "attributes": {
@@ -1003,6 +1099,7 @@
                 ],
                 "point_size": 1,
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1035,6 +1132,7 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1051,12 +1149,12 @@
       },
       "id": "bf60bc10-639b-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:17.572Z",
-      "version": "WzQ2NTksMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxMywxXQ=="
     },
     {
       "attributes": {
@@ -1105,6 +1203,7 @@
                 ],
                 "point_size": "0",
                 "seperate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none"
               },
@@ -1149,6 +1248,7 @@
                 ],
                 "point_size": "0",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1165,12 +1265,12 @@
       },
       "id": "822df290-630f-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:25.480Z",
-      "version": "WzQ2NjAsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxNCwxXQ=="
     },
     {
       "attributes": {
@@ -1224,6 +1324,7 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1246,6 +1347,7 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1268,6 +1370,7 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1284,12 +1387,12 @@
       },
       "id": "98c7bca0-63a2-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:34.413Z",
-      "version": "WzQ2NjQsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxNSwxXQ=="
     },
     {
       "attributes": {
@@ -1383,6 +1486,7 @@
                 ],
                 "point_size": "2",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1399,140 +1503,12 @@
       },
       "id": "96d46630-63a4-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:42.999Z",
-      "version": "WzQ2NjUsMV0="
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
-        },
-        "title": "Network Traffic [Metricbeat MySQL] ECS",
-        "uiStateJSON": {},
-        "version": 1,
-        "visState": {
-          "aggs": [],
-          "params": {
-            "axis_formatter": "number",
-            "axis_position": "left",
-            "axis_scale": "normal",
-            "default_index_pattern": "metricbeat-*",
-            "default_timefield": "@timestamp",
-            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-            "index_pattern": "metricbeat-*",
-            "interval": "auto",
-            "isModelInvalid": false,
-            "legend_position": "bottom",
-            "series": [
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "rgba(0,98,177,1)",
-                "fill": 0.5,
-                "formatter": "bytes",
-                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99",
-                "label": "Received bytes",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "field": "mysql.status.bytes.received",
-                    "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
-                    "type": "max"
-                  },
-                  {
-                    "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
-                    "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
-                    "type": "derivative",
-                    "unit": "1s"
-                  },
-                  {
-                    "field": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
-                    "id": "788d3c90-6310-11ea-99e6-b5eed31db613",
-                    "type": "positive_only",
-                    "unit": ""
-                  },
-                  {
-                    "id": "88f8e160-6310-11ea-99e6-b5eed31db613",
-                    "script": "params.received != null \u0026\u0026 params.received \u003e 0 ? params.received * -1 : null",
-                    "type": "calculation",
-                    "variables": [
-                      {
-                        "field": "788d3c90-6310-11ea-99e6-b5eed31db613",
-                        "id": "8beb4660-6310-11ea-99e6-b5eed31db613",
-                        "name": "received"
-                      }
-                    ]
-                  }
-                ],
-                "point_size": "0",
-                "seperate_axis": 0,
-                "split_mode": "everything",
-                "stacked": "none",
-                "type": "timeseries"
-              },
-              {
-                "axis_position": "right",
-                "chart_type": "line",
-                "color": "#68BC00",
-                "fill": 0.5,
-                "formatter": "bytes",
-                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                "label": "Sent bytes",
-                "line_width": 1,
-                "metrics": [
-                  {
-                    "field": "mysql.status.bytes.sent",
-                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "type": "max"
-                  },
-                  {
-                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
-                    "id": "23cfda50-f1f7-11e7-a752-236fe3270d99",
-                    "type": "derivative",
-                    "unit": "1s"
-                  },
-                  {
-                    "field": "23cfda50-f1f7-11e7-a752-236fe3270d99",
-                    "id": "ad26a900-6310-11ea-99e6-b5eed31db613",
-                    "type": "positive_only",
-                    "unit": ""
-                  }
-                ],
-                "point_size": "0",
-                "seperate_axis": 0,
-                "split_mode": "everything",
-                "stacked": "none",
-                "type": "timeseries"
-              }
-            ],
-            "show_grid": 1,
-            "show_legend": 1,
-            "time_field": "@timestamp",
-            "type": "timeseries"
-          },
-          "title": "Network Traffic [Metricbeat MySQL] ECS",
-          "type": "metrics"
-        }
-      },
-      "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
-      "migrationVersion": {
-        "visualization": "7.4.2"
-      },
-      "references": [],
-      "type": "visualization",
-      "updated_at": "2020-03-16T13:00:59.606Z",
-      "version": "WzQ2NjcsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxNiwxXQ=="
     },
     {
       "attributes": {
@@ -1627,6 +1603,7 @@
                 ],
                 "point_size": "2",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "type": "timeseries"
@@ -1643,13 +1620,763 @@
       },
       "id": "a1e00160-63a4-11ea-a83e-25b8612d00cc",
       "migrationVersion": {
-        "visualization": "7.4.2"
+        "visualization": "7.7.0"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2020-03-16T13:00:51.577Z",
-      "version": "WzQ2NjYsMV0="
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxOCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Network Traffic [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,98,177,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99",
+                "label": "Received bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.bytes.received",
+                    "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
+                    "type": "max"
+                  },
+                  {
+                    "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99",
+                    "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "2b1c2392-f1f7-11e7-a752-236fe3270d99",
+                    "id": "788d3c90-6310-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  },
+                  {
+                    "id": "88f8e160-6310-11ea-99e6-b5eed31db613",
+                    "script": "params.received != null \u0026\u0026 params.received \u003e 0 ? params.received * -1 : null",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "788d3c90-6310-11ea-99e6-b5eed31db613",
+                        "id": "8beb4660-6310-11ea-99e6-b5eed31db613",
+                        "name": "received"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Sent bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.bytes.sent",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "23cfda50-f1f7-11e7-a752-236fe3270d99",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "23cfda50-f1f7-11e7-a752-236fe3270d99",
+                    "id": "ad26a900-6310-11ea-99e6-b5eed31db613",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": "0",
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Network Traffic [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "c8661020-6310-11ea-a83e-25b8612d00cc",
+      "migrationVersion": {
+        "visualization": "7.7.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-07-15T12:11:22.038Z",
+      "version": "WzIxNywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Open Tables Cache [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Hits",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.table.open_cache.hits",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "534a23e0-c6a6-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "60ab20c0-c6a6-11ea-880f-352bebf10188",
+                "label": "Misses",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.table.open_cache.misses",
+                    "id": "60ab47d0-c6a6-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "60ab47d0-c6a6-11ea-880f-352bebf10188",
+                    "id": "6a1519e0-c6a6-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "69113e70-c6a6-11ea-880f-352bebf10188",
+                "label": "Overflows",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.table.open_cache.overflows",
+                    "id": "69113e71-c6a6-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "69113e71-c6a6-11ea-880f-352bebf10188",
+                    "id": "75a108a0-c6a6-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Open Tables Cache [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "cd72e030-c6a6-11ea-a106-5be590f42b74",
+      "migrationVersion": {
+        "visualization": "7.7.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-07-15T15:12:29.413Z",
+      "version": "WzM3NSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Connection Errors [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Max",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.connection.errors.max",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "percentiles": [
+                      {
+                        "id": "968f0500-c69a-11ea-880f-352bebf10188",
+                        "mode": "line",
+                        "shade": 0.2,
+                        "value": 50
+                      }
+                    ],
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "a088e210-c69a-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "a61998a0-c69a-11ea-880f-352bebf10188",
+                "label": "Accept",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.connection.errors.accept",
+                    "id": "a61998a1-c69a-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "a61998a1-c69a-11ea-880f-352bebf10188",
+                    "id": "a8f8c3c0-c69a-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "b6a26260-c69a-11ea-880f-352bebf10188",
+                "label": "Internal",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.connection.errors.internal",
+                    "id": "b6a26261-c69a-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "b6a26261-c69a-11ea-880f-352bebf10188",
+                    "id": "c09d02c0-c69a-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "c713d390-c69a-11ea-880f-352bebf10188",
+                "label": "Select",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.connection.errors.select",
+                    "id": "c713d391-c69a-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c713d391-c69a-11ea-880f-352bebf10188",
+                    "id": "4ace8360-c69b-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(253,161,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "50c798b0-c69b-11ea-880f-352bebf10188",
+                "label": "Peer Address",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.connection.errors.peer_address",
+                    "id": "50c798b1-c69b-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "50c798b1-c69b-11ea-880f-352bebf10188",
+                    "id": "78d49650-c69b-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Connection Errors [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "0774bbb0-c69c-11ea-a106-5be590f42b74",
+      "migrationVersion": {
+        "visualization": "7.7.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-07-15T13:06:43.051Z",
+      "version": "WzM0OCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Commands Operations [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Select",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.select",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "e76f75d0-c6a0-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(219,223,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "ed3a0110-c6a0-11ea-880f-352bebf10188",
+                "label": "Update",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.update",
+                    "id": "ed3a0111-c6a0-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "ed3a0111-c6a0-11ea-880f-352bebf10188",
+                    "id": "f961e1b0-c6a0-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "00b3f750-c6a1-11ea-880f-352bebf10188",
+                "label": "Delete",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.delete",
+                    "id": "00b3f751-c6a1-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "00b3f751-c6a1-11ea-880f-352bebf10188",
+                    "id": "09f46f70-c6a1-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "0f38dac0-c6a1-11ea-880f-352bebf10188",
+                "label": "Insert",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.command.insert",
+                    "id": "0f38dac1-c6a1-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "0f38dac1-c6a1-11ea-880f-352bebf10188",
+                    "id": "1d1cc340-c6a1-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Commands Operations [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "3e5c4490-c6a1-11ea-a106-5be590f42b74",
+      "migrationVersion": {
+        "visualization": "7.7.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-07-15T13:44:02.649Z",
+      "version": "WzM1NSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SSL Cache [Metricbeat MySQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Hits",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.ssl.hits",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "1a353d40-c6ad-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(253,161,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "2dd02900-c6ad-11ea-880f-352bebf10188",
+                "label": "Misses",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.ssl.misses",
+                    "id": "2dd02901-c6ad-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "2dd02901-c6ad-11ea-880f-352bebf10188",
+                    "id": "327cc120-c6ad-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "3f459cb0-c6ad-11ea-880f-352bebf10188",
+                "label": "Size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mysql.status.cache.ssl.size",
+                    "id": "3f459cb1-c6ad-11ea-880f-352bebf10188",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3f459cb1-c6ad-11ea-880f-352bebf10188",
+                    "id": "426ccd50-c6ad-11ea-880f-352bebf10188",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "SSL Cache [Metricbeat MySQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "8b276c80-c6ad-11ea-a106-5be590f42b74",
+      "migrationVersion": {
+        "visualization": "7.7.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-07-15T15:12:05.448Z",
+      "version": "WzM3NCwxXQ=="
     }
   ],
-  "version": "7.3.1"
+  "version": "7.7.0"
 }


### PR DESCRIPTION
Cherry-pick of PR #19913 to 7.9 branch. Original message: 

## What does this PR do?
Update MySQL dashboard with the metrics merged in https://github.com/elastic/beats/pull/19844


## Related issues

- Implements https://github.com/elastic/beats/issues/16955

## Screenshots

![image](https://user-images.githubusercontent.com/4249331/87460667-7f400d00-c60d-11ea-84f8-729fd4939b8d.png)