### PR TITLE
[Elastic Agent] Fix merging of fleet.yml. Add --staging to enroll cmd.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@
 - Forward revision number of the configuration to the endpoint. {pull}19759[19759]
 - Remove support for logs type and use logfile {pull}19761[19761]
 - Avoid comparing uncomparable types on enroll {issue}19976[19976]
+- Fix issues with merging of elastic-agent.yml and fleet.yml {pull}20026[20026]
 
 ==== New features
 
@@ -88,3 +89,4 @@
 - Agent now sends its own logs to elasticsearch {pull}19811[19811]
 - Add --insecure option to enroll command {pull}19900[19900]
 - Will retry to enroll if the server return a 429. {pull}19918[19811]
+- Add --staging option to enroll command {pull}20026[20026]

--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -38,3 +38,6 @@ Force overwrite the current and do not prompt for confirmation.
 
 `--insecure`::
 Allow insecure connection to Kibana.
+
+`--staging`::
+Configures agent to download artifacts from a staging build.

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -13,8 +13,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
@@ -24,6 +22,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/kibana"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
 type store interface {

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -81,9 +81,15 @@ func newManaged(
 	}
 
 	// merge local configuration and configuration persisted from fleet.
-	rawConfig.Merge(config)
+	err = rawConfig.Merge(config)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("fail to merge configuration with %s for the elastic-agent", path),
+			errors.TypeConfig,
+			errors.M(errors.MetaKeyPath, path))
+	}
 
-	cfg, err := configuration.NewFromConfig(config)
+	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
 		return nil, errors.New(err,
 			fmt.Sprintf("fail to unpack configuration from %s", path),

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -44,6 +44,7 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 	cmd.Flags().StringP("ca-sha256", "p", "", "Comma separated list of certificate authorities hash pins used for certificate verifications")
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
 	cmd.Flags().BoolP("insecure", "i", false, "Allow insecure connection to Kibana")
+	cmd.Flags().StringP("staging", "", "", "Configures agent to download artifacts from a staging build")
 
 	return cmd
 }
@@ -65,6 +66,13 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 			fmt.Sprintf("could not parse configuration file %s", pathConfigFile),
 			errors.TypeFilesystem,
 			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+
+	staging, _ := cmd.Flags().GetString("staging")
+	if staging != "" {
+		if len(staging) < 8 {
+			return errors.New(fmt.Errorf("invalid staging build hash; must be at least 8 characters"), "Error")
+		}
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
@@ -105,6 +113,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		CASha256:             caSHA256,
 		Insecure:             insecure,
 		UserProvidedMetadata: make(map[string]interface{}),
+		Staging:              staging,
 	}
 
 	c, err := application.NewEnrollCmd(


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes an issue where the `elastic-agent.yml` and `fleet.yml` configurations where being merged, but the merged config was not being used in the `Unpack` call.

Adds a `--staging f32a4a89` option to `./elastic-agent enroll`. This allows users that are testing staging builds to be able to pull artifacts from that staging build.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So `elastic-agent.yml` and `fleet.yml` are merged and used correctly. To simplify testing of staging builds.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
 ./elastic_agent enroll --insecure http://localhost:5601 Q1JfZVhITUJsUURwelBhQVB2WVQ6NmlFSVNwZVVSU0tlcVI5dXZNNUtFZw --staging f32a4a89
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #19961 
