### PR TITLE
Cherry-pick #19973 to 7.9: Add cloudwatch input into Filebeat configure inputs documentation

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -84,6 +84,8 @@ You can configure {beatname_uc} to use the following inputs:
 
 include::multiline.asciidoc[]
 
+include::../../x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc[]
+
 include::../../x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-cloudfoundry.asciidoc[]
@@ -121,5 +123,3 @@ include::inputs/input-tcp.asciidoc[]
 include::inputs/input-udp.asciidoc[]
 
 include::inputs/input-unix.asciidoc[]
-
-include::../../x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc[]

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -121,3 +121,5 @@ include::inputs/input-tcp.asciidoc[]
 include::inputs/input-udp.asciidoc[]
 
 include::inputs/input-unix.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -5,7 +5,7 @@
 :type: s3
 
 [id="{beatname_lc}-input-{type}"]
-=== s3 input
+=== S3 input
 
 ++++
 <titleabbrev>S3</titleabbrev>

--- a/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
@@ -5,10 +5,10 @@
 :type: awscloudwatch
 
 [id="{beatname_lc}-input-{type}"]
-=== awscloudwatch input
+=== AWS CloudWatch input
 
 ++++
-<titleabbrev>awscloudwatch</titleabbrev>
+<titleabbrev>AWS CloudWatch</titleabbrev>
 ++++
 
 beta[]

--- a/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
@@ -113,7 +113,4 @@ logs:FilterLogEvents
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 
-[id="aws-credentials-config"]
-include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
-
 :type!:


### PR DESCRIPTION
Cherry-pick of PR #19973 to 7.9 branch. Original message: 

This PR is to add cloudwatch input into Filebeat configure inputs documentation: https://www.elastic.co/guide/en/beats/filebeat/7.x/configuration-filebeat-options.html 