### PR TITLE
Cherry-pick #19960 to 7.x: [ci] Favor direct mage invocation on CI

### DIFF
--- a/.ci/scripts/travis_has_changes.sh
+++ b/.ci/scripts/travis_has_changes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Changes on these files will trigger all builds.
+COMMON_DIRLIST="dev-tools .travis.yml testing .ci"
+
+# Commit range to check for. For example master...<PR branch>
+RANGE=$TRAVIS_COMMIT_RANGE
+DIRLIST="$@ $COMMON_DIRLIST"
+
+# Find modified files in range and filter out docs only changes.
+CHANGED_FILES=$(git diff --name-only $RANGE | grep -v '.asciidoc')
+
+beginswith() { case $2 in "$1"*) true;; *) false;; esac }
+
+for path in $DIRLIST; do
+  for changed in $CHANGED_FILES; do
+    if beginswith $path $changed; then
+      exit 0 # found a match -> continue testing
+    fi
+  done
+done
+
+echo "NOT testing required. Modified files: $CHANGED_FILES"
+exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,193 +37,287 @@ jobs:
 
     # Filebeat
     - os: linux
-      env: TARGETS="-C filebeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh filebeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=filebeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh filebeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=filebeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/filebeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/filebeat filebeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/filebeat
+        - MAGE='build test'
       go: $(GO_VERSION)
       stage: test
 
     # Heartbeat
     - os: linux
-      env: TARGETS="-C heartbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh heartbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=heartbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh heartbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=heartbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Auditbeat
     - os: linux
-      env: TARGETS="-C auditbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh auditbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=auditbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh auditbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=auditbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh auditbeat libbeat || travis_terminate 0
       env: TARGETS="-C auditbeat crosscompile"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/auditbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/auditbeat auditbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/auditbeat
+        - MAGE='build test'
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/auditbeat auditbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/auditbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Libbeat
     - os: linux
-      env: TARGETS="-C libbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh libbeat || travis_terminate 0
+      env:
+        - PROJECT=libbeat
+        - MAGE='build test'
+        # The libbeat tests are so verbose that they exceed the maximum allowed log length of Travis CI.
+        - MAGEFILE_VERBOSE=false
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh libbeat || travis_terminate 0
       env: TARGETS="-C libbeat crosscompile"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh libbeat || travis_terminate 0
       env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/libbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/libbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/libbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Metricbeat
     - os: linux
-      env: TARGETS="-C metricbeat unit-tests"
+      before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=metricbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
-      install: 
+      install:
         - .ci/scripts/install-kind.sh
         - .ci/scripts/install-kubectl.sh
       env:
-        - TARGETS="-C metricbeat integration-tests"
         - K8S_VERSION=v1.17.2
         - KIND_VERSION=v0.7.0
+        - PROJECT=metricbeat
+        - MAGE='goIntegTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C metricbeat system-tests"
+      before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=metricbeat
+        - MAGE='pythonIntegTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="-C metricbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=metricbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
       env: TARGETS="-C metricbeat crosscompile"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/metricbeat unit-tests"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/metricbeat metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/metricbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/metricbeat integration-tests"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/metricbeat metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/metricbeat
+        - MAGE='goIntegTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C x-pack/metricbeat system-tests"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/metricbeat metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/metricbeat
+        - MAGE='pythonIntegTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="-C x-pack/metricbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh metricbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/metricbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Packetbeat
     - os: linux
-      env: TARGETS="-C packetbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh packetbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=packetbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Winlogbeat
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh winlogbeat libbeat || travis_terminate 0
       env: TARGETS="-C winlogbeat crosscompile"
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Functionbeat
     - os: linux
-      env: TARGETS="-C x-pack/functionbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/functionbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/functionbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/functionbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/functionbeat
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       before_install: .ci/scripts/travis_has_changes.sh x-pack/functionbeat libbeat || travis_terminate 0
-      env: TARGETS="-C x-pack/functionbeat test-gcp-functions"
+      env:
+        - PROJECT=x-pack/functionbeat
+        - MAGE='testGCPFunctions'
       go: 1.13.1
       stage: test
 
     # Docker Log Driver
     - os: linux
-      env: TARGETS="-C x-pack/dockerlogbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh x-pack/dockerlogbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=x-pack/dockerlogbeat
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Journalbeat
     - os: linux
-      env: TARGETS="-C journalbeat testsuite"
+      before_install: .ci/scripts/travis_has_changes.sh journalbeat libbeat || travis_terminate 0
+      env:
+        - PROJECT=journalbeat
+        - MAGE='build goUnitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Agent
     - os: linux
       before_install: .ci/scripts/travis_has_changes.sh x-pack/elastic-agent libbeat || travis_terminate 0
-      env: TARGETS="-C x-pack/elastic-agent testsuite"
+      env:
+        - PROJECT=x-pack/elastic-agent
+        - MAGE='build test'
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       before_install: .ci/scripts/travis_has_changes.sh x-pack/elastic-agent libbeat || travis_terminate 0
-      env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/elastic-agent testsuite"
+      env:
+        - PROJECT=x-pack/elastic-agent
+        - MAGE='build unitTest'
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Generators
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh generator metricbeat libbeat || travis_terminate 0
       env: TARGETS="-C generator/_templates/metricbeat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh generator libbeat || travis_terminate 0
       env: TARGETS="-C generator/_templates/beat test test-package"
       go: $TRAVIS_GO_VERSION
       stage: test
 
     - os: osx
+      before_install: .ci/scripts/travis_has_changes.sh generator metricbeat libbeat || travis_terminate 0
       env: TARGETS="-C generator/_templates/metricbeat test"
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
+      before_install: .ci/scripts/travis_has_changes.sh generator libbeat || travis_terminate 0
       env: TARGETS="-C generator/_templates/beat test"
       go: $TRAVIS_GO_VERSION
       stage: test
 
     # Kubernetes
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh deploy/kubernetes metricbeat filebeat libbeat || travis_terminate 0
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_K8S_VERSION=v1.9.4
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh deploy/kubernetes metricbeat filebeat libbeat  || travis_terminate 0
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_K8S_VERSION=v1.10.0
       stage: test
     - os: linux
+      before_install: .ci/scripts/travis_has_changes.sh deploy/kubernetes metricbeat filebeat libbeat || travis_terminate 0
       dist: xenial
       install: deploy/kubernetes/.travis/setup.sh
       env:
@@ -267,7 +361,12 @@ addons:
       - python3.6
       - python3.6-venv
 
-before_install:
+
+
+# Skips installations step
+install: true
+
+before_script:
   - if [ x$TRAVIS_DIST = xtrusty ]; then sudo ln -sf python3.6 /usr/bin/python3; fi
   - python --version
   - python3 --version
@@ -279,17 +378,21 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv==16.7.9; fi
-
-
-# Skips installations step
-install: true
+  - make mage
 
 script:
   # Replacement for travis_wait which doesn't print output in real time.
   # Default Travis timeout is 10min, so this workaround prints timestamps every 9min to reset the counter.
   # Using seconds (540s = 9min) instead of minutes for shell compatibility reasons.
   - while sleep 540; do echo "=====[ ${SECONDS} seconds still running ]====="; done &
-  - make $TARGETS
+  - if [[ -n "$MAGE" ]]; then
+        echo ">> mage $MAGE from $PROJECT";
+        cd "$PROJECT";
+        mage $MAGE;
+      else
+        echo ">> make $TARGETS";
+        make $TARGETS;
+      fi
   - kill %1
 
 notifications:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget(context: "Filebeat oss Linux", directory: 'filebeat', target: 'testsuite', withModule: true)
+            mageTarget(context: "Filebeat oss Linux", directory: "filebeat", target: "build test", withModule: true)
           }
         }
         stage('Filebeat x-pack'){
@@ -157,7 +157,7 @@ pipeline {
             }
           }
           steps {
-            mageTarget(context: "Filebeat x-pack Linux", directory: "x-pack/filebeat", target: "update build test", withModule: true)
+            mageTarget(context: "Filebeat x-pack Linux", directory: "x-pack/filebeat", target: "build test", withModule: true)
           }
         }
         stage('Filebeat Mac OS X'){
@@ -234,7 +234,7 @@ pipeline {
           stages {
             stage('Heartbeat oss'){
               steps {
-                makeTarget(context: "Heartbeat oss Linux", directory: 'heartbeat', target: "testsuite")
+                mageTarget(context: "Heartbeat oss Linux", directory: "heartbeat", target: "build test")
               }
             }
             stage('Heartbeat Mac OS X'){
@@ -280,7 +280,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget(context: "Auditbeat oss Linux", directory: 'auditbeat', target: "testsuite", withModule: true)
+            mageTarget(context: "Auditbeat oss Linux", directory: "auditbeat", target: "build test")
           }
         }
         stage('Auditbeat crosscompile'){
@@ -378,7 +378,7 @@ pipeline {
           stages {
             stage('Libbeat oss'){
               steps {
-                makeTarget(context: "Libbeat oss Linux", directory: 'libbeat', target: "testsuite")
+                mageTarget(context: "Libbeat oss Linux", directory: "libbeat", target: "build test")
               }
             }
             stage('Libbeat crosscompile'){
@@ -403,7 +403,7 @@ pipeline {
             }
           }
           steps {
-            makeTarget(context: "Libbeat x-pack Linux", directory: 'x-pack/libbeat', target: "testsuite")
+            mageTarget(context: "Libbeat x-pack Linux", directory: "x-pack/libbeat", target: "build test")
           }
         }
         stage('Metricbeat OSS Unit tests'){
@@ -419,8 +419,8 @@ pipeline {
             mageTarget(context: "Metricbeat OSS linux/amd64 (unitTest)", directory: "metricbeat", target: "build unitTest")
           }
         }
-        stage('Metricbeat OSS Integration tests'){
-          agent { label 'ubuntu-18 && immutable' }
+        stage('Metricbeat OSS Go Integration tests'){
+          agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
@@ -432,8 +432,8 @@ pipeline {
             mageTarget(context: "Metricbeat OSS linux/amd64 (goIntegTest)", directory: "metricbeat", target: "goIntegTest", withModule: true)
           }
         }
-        stage('Metricbeat Python integration tests'){
-          agent { label 'ubuntu-18 && immutable' }
+        stage('Metricbeat OSS Python Integration tests'){
+          agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
@@ -550,8 +550,8 @@ pipeline {
             mageTargetWin(context: "Metricbeat x-pack Windows", directory: "x-pack/metricbeat", target: "build unitTest")
           }
         }
-        stage('Packetbeat'){
-          agent { label 'ubuntu-18 && immutable' }
+        stage('Packetbeat OSS'){
+          agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
@@ -560,9 +560,40 @@ pipeline {
             }
           }
           stages {
-            stage('Packetbeat oss'){
+            stage('Packetbeat Linux'){
               steps {
-                makeTarget(context: "Packetbeat oss Linux", directory: 'packetbeat', target: "testsuite")
+                mageTarget(context: "Packetbeat OSS Linux", directory: "packetbeat", target: "build test")
+              }
+            }
+            stage('Packetbeat Mac OS X'){
+              agent { label 'macosx' }
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.macosTest
+                }
+              }
+              steps {
+                mageTarget(context: "Packetbeat OSS Mac OS X", directory: "packetbeat", target: "build unitTest")
+              }
+              post {
+                always {
+                  delete()
+                }
+              }
+            }
+            stage('Packetbeat Windows'){
+              agent { label 'windows-immutable && windows-2019' }
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression {
+                  return params.windowsTest
+                }
+              }
+              steps {
+                mageTargetWin(context: "Packetbeat OSS Windows", directory: "packetbeat", target: "build unitTest")
               }
             }
           }
@@ -579,7 +610,7 @@ pipeline {
           stages {
             stage('Dockerlogbeat'){
               steps {
-                mageTarget(context: "Elastic Docker Logging Driver Plugin unit tests", directory: "x-pack/dockerlogbeat", target: "update build test")
+                mageTarget(context: "Elastic Docker Logging Driver Plugin unit tests", directory: "x-pack/dockerlogbeat", target: "build test")
               }
             }
           }
@@ -641,7 +672,7 @@ pipeline {
               steps {
                 mageTarget(context: "Functionbeat x-pack Linux", directory: "x-pack/functionbeat", target: "update build test")
                 withEnv(["GO_VERSION=1.13.1"]){
-                  makeTarget(context: "Functionbeat x-pack Linux", directory: 'x-pack/functionbeat', target: "test-gcp-functions")
+                  mageTarget(context: "Functionbeat x-pack Linux", directory: "x-pack/functionbeat", target: "testGCPFunctions")
                 }
               }
             }
@@ -690,7 +721,7 @@ pipeline {
           stages {
             stage('Journalbeat oss'){
               steps {
-                makeTarget(context: "Journalbeat Linux", directory: 'journalbeat', target: "testsuite")
+                mageTarget(context: "Journalbeat Linux", directory: "journalbeat", target: "build goUnitTest")
               }
             }
           }

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -31,9 +31,9 @@ import (
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
-	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
@@ -41,6 +41,8 @@ import (
 func init() {
 	common.RegisterCheckDeps(Update)
 	unittest.RegisterGoTestDeps(fieldsYML)
+	integtest.RegisterGoTestDeps(fieldsYML)
+	integtest.RegisterPythonTestDeps(Dashboards)
 
 	devtools.BeatDescription = "Audit the activities of users and processes on your system."
 }

--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -74,7 +74,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: heartbeat
-        image: docker.elastic.co/beats/heartbeat:7.9.0
+        image: docker.elastic.co/beats/heartbeat:7.10.0
         args: [
           "-c", "/etc/heartbeat.yml",
           "-e",

--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -213,7 +213,7 @@ func NewIntegrationRunners(path string, passInEnv map[string]string) (Integratio
 	return runners, nil
 }
 
-// NewDockerIntegrationRunner returns an intergration runner configured only for docker.
+// NewDockerIntegrationRunner returns an integration runner configured only for docker.
 func NewDockerIntegrationRunner(passThroughEnvVars ...string) (*IntegrationRunner, error) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -22,6 +22,7 @@ import (
 	"go/build"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -162,6 +163,13 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 func (d *DockerIntegrationTester) InsideTest(test func() error) error {
 	// Fix file permissions after test is done writing files as root.
 	if runtime.GOOS != "windows" {
+		repo, err := GetProjectRepoInfo()
+		if err != nil {
+			return err
+		}
+
+		// Handle virtualenv and the current project dir.
+		defer DockerChown(path.Join(repo.RootDir, "build"))
 		defer DockerChown(".")
 	}
 	return test()

--- a/filebeat/tests/system/test_input.py
+++ b/filebeat/tests/system/test_input.py
@@ -713,6 +713,7 @@ class Test(BaseTest):
         # assert that renaming of the file went undetected
         assert not self.log_contains("File rename was detected:" + testfile + " -> " + renamedfile)
 
+    @unittest.skip("Skipped as flaky: https://github.com/elastic/beats/issues/20010")
     @unittest.skipIf(sys.platform.startswith("win"), "inode_marker is not supported on windows")
     def test_inode_marker_based_identity_tracking(self):
         """

--- a/heartbeat/magefile.go
+++ b/heartbeat/magefile.go
@@ -33,9 +33,9 @@ import (
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
-	"github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
-	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )

--- a/libbeat/tests/system/test_http.py
+++ b/libbeat/tests/system/test_http.py
@@ -24,7 +24,7 @@ class Test(BaseTest):
         r = requests.get("http://localhost:5066")
         assert r.status_code == 200
 
-        data = json.loads(r.content)
+        data = json.loads(r.content.decode('utf_8'))
 
         assert data["beat"] == "mockbeat"
         assert data["version"] == "9.9.9"
@@ -36,7 +36,7 @@ class Test(BaseTest):
         r = requests.get("http://localhost:5066/stats")
         assert r.status_code == 200
 
-        data = json.loads(r.content)
+        data = json.loads(r.content.decode('utf_8'))
 
         # Test one data point
         assert data["libbeat"]["config"]["scans"] == 0

--- a/magefile.go
+++ b/magefile.go
@@ -135,7 +135,6 @@ func CheckLicenseHeaders() error {
 			licenser.Exclude("x-pack"),
 			licenser.Exclude("generator/_templates/beat/{beat}"),
 			licenser.Exclude("generator/_templates/metricbeat/{beat}"),
-			licenser.Exclude("generator/_templates/beat/{beat}"),
 		),
 		licenser(
 			licenser.Check(),

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -35,7 +35,7 @@ import (
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
 	// mage:import
@@ -44,6 +44,7 @@ import (
 
 func init() {
 	common.RegisterCheckDeps(Update)
+	unittest.RegisterPythonTestDeps(fieldsYML, Dashboards)
 
 	devtools.BeatDescription = "Packetbeat analyzes network traffic and sends the data to Elasticsearch."
 }

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -126,7 +126,7 @@ class BaseTest(TestCase):
                     types=None,
                     required_fields=None):
         jsons = []
-        with open(os.path.join(self.working_dir, output_file), "r") as f:
+        with open(os.path.join(self.working_dir, output_file), "r", encoding='utf_8') as f:
             for line in f:
                 document = self.flatten_object(json.loads(line), self.dict_fields)
                 if not types or document["type"] in types:

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -12,9 +12,9 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
-	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )


### PR DESCRIPTION
Cherry-pick of PR #19960 to 7.x branch. Original message: 

## What does this PR do?

Favor direct mage invocation on CI.

This changes Jenkins and Travis to directly invoke mage where
possible instead of going through make. Some of the remaining
make don't yet have a mage equivalant (mainly crosscompile).

For Packetbeat this add Jenkins stages to test on darwin and Windows.

There were a few fixes I had to make related to these changes:

- Add some mage target dependencies to ensure fields and dashboards
are ready when tests use them.
- Swap the order of the Go imports for dev-tools/mage/targets/integtest
and unittest so that unit tests run before integ tests when running
the 'mage test' target.
- chown the shared Python venv that is in the root of the repo after
Dockerized integ tests exit to ensure there are no permissions issues
caused by root owned files.
- I found a few Python string encoding issues that caused tests failures.
I thought we fixed these during the Python 3 conversion, but something
here exposed a few that we didn't address.

One thing of note that I did not correct. Journalbeat has system tests
but they are not executed. The existing/old Makefile has SYSTEM_TESTS=false
so they are not executed. So when I switched it to mage I left it as
'mage goUnitTest' to avoid the Python when failed when I tried it.

## Why is it important?

We want to remove the older Makefile logic so we need to migrate towards mage.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
