### PR TITLE
Cherry-pick #19932 to 7.x: [Heartbeat] Add service_name option for APM integration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -253,6 +253,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misuse. {pull}16397[16397]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
+- Add support for new `service_name` option to all monitors. {pull}19932[19932].
 
 *Journalbeat*
 

--- a/heartbeat/_meta/config/beat.reference.yml.tmpl
+++ b/heartbeat/_meta/config/beat.reference.yml.tmpl
@@ -31,6 +31,9 @@ heartbeat.monitors:
   # Human readable display name for this service in Uptime UI and elsewhere
   name: my-icmp-monitor
 
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  # service_name: my-apm-service-name
+
   # Enable/Disable monitor
   #enabled: true
 

--- a/heartbeat/_meta/config/beat.yml.tmpl
+++ b/heartbeat/_meta/config/beat.yml.tmpl
@@ -32,6 +32,8 @@ heartbeat.monitors:
   schedule: '@every 10s'
   # Total test connection and data exchange timeout
   #timeout: 16s
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  #service_name: my-apm-service-name
 
 {{header "Elasticsearch template setting"}}
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -43,7 +43,7 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
 
 [float]
@@ -58,7 +58,7 @@ include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 
 Heartbeat provides monitors to check the status of hosts at set intervals.
 Heartbeat currently provides monitors for ICMP, TCP, and HTTP (see
-<<heartbeat-overview>> for more about these monitors). 
+<<heartbeat-overview>> for more about these monitors).
 
 You configure each monitor individually. In +{beatname_lc}.yml+, specify the
 list of monitors that you want to enable. Each item in the list begins with a
@@ -71,10 +71,19 @@ heartbeat.monitors:
 - type: icmp
   schedule: '*/5 * * * * * *' <1>
   hosts: ["myhost"]
+  id: my-icmp-service
+  name: My ICMP Service
 - type: tcp
   schedule: '@every 5s' <2>
   hosts: ["myhost:12345"]
   mode: any <3>
+  id: my-tcp-service
+- type: http
+  schedule: '@every 5s'
+  urls: ["http://example.net"]
+  service_name: apm-service-name <4>
+  id: my-http-service
+  name: My HTTP Service
 ----------------------------------------------------------------------
 <1> The `icmp` monitor is scheduled to run exactly every 5 seconds (10:00:00,
 10:00:05, and so on). The `schedule` option uses a cron-like syntax based on
@@ -83,7 +92,7 @@ https://github.com/gorhill/cronexpr#implementation[this `cronexpr` implementatio
 was started. Heartbeat adds the `@every` keyword to the syntax provided by the
 `cronexpr` package.
 <3> The `mode` specifies whether to ping one IP (`any`) or all resolvable IPs
-(`all`).
+<4> The `service_name` field can be used to integrate heartbeat with elastic APM via the Uptime UI.
 
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
@@ -106,7 +115,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 `-e` is optional and sends output to standard error instead of the configured log output.
 
 This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}.
-It does not install {beatname_uc} dashboards.  Heartbeat dashboards and 
+It does not install {beatname_uc} dashboards.  Heartbeat dashboards and
 installation steps are available in the
 https://github.com/elastic/uptime-contrib[uptime-contrib] GitHub repository.
 

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -38,6 +38,7 @@ heartbeat.monitors:
 - type: http
   id: service-status
   name: Service Status
+  service_name: my-apm-service-name
   hosts: ["http://localhost:80/service/status"]
   check.response.status: [200]
   schedule: '@every 5s'

--- a/heartbeat/docs/monitors/monitor-common-options.asciidoc
+++ b/heartbeat/docs/monitors/monitor-common-options.asciidoc
@@ -32,6 +32,14 @@ it is recommended that you set this manually.
 Optional human readable name for this monitor. This value appears in the <<exported-fields,exported fields>>
 as `monitor.name`.
 
+
+[float]
+[[service-name]]
+==== `service_name`
+
+Optional APM service name for this monitor. Corresponds to the `service.name` ECS field. Set this when monitoring an app
+that is also using APM to enable integrations between Uptime and APM data in Kibana.
+
 [float]
 [[monitor-enabled]]
 ==== `enabled`

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -31,6 +31,9 @@ heartbeat.monitors:
   # Human readable display name for this service in Uptime UI and elsewhere
   name: my-icmp-monitor
 
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  # service_name: my-apm-service-name
+
   # Enable/Disable monitor
   #enabled: true
 

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -32,6 +32,8 @@ heartbeat.monitors:
   schedule: '@every 10s'
   # Total test connection and data exchange timeout
   #timeout: 16s
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  #service_name: my-apm-service-name
 
 # ======================= Elasticsearch template setting =======================
 

--- a/heartbeat/monitors.d/sample.http.yml.disabled
+++ b/heartbeat/monitors.d/sample.http.yml.disabled
@@ -10,6 +10,9 @@
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My HTTP Monitor
 
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  #service_name: my-apm-service-name
+
   # Enable/Disable monitor
   #enabled: true
 

--- a/heartbeat/monitors.d/sample.icmp.yml.disabled
+++ b/heartbeat/monitors.d/sample.icmp.yml.disabled
@@ -10,6 +10,9 @@
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My ICMP Monitor
 
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  #service_name: my-apm-service-name
+
   # Enable/Disable monitor
   #enabled: true
 

--- a/heartbeat/monitors.d/sample.tcp.yml.disabled
+++ b/heartbeat/monitors.d/sample.tcp.yml.disabled
@@ -12,8 +12,8 @@
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My TCP monitor
 
-  # Monitor name used for job name and document type
-  #name: tcp
+  # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
+  #service_name: my-apm-service-name
 
   # Enable/Disable monitor
   #enabled: true

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -78,8 +79,8 @@ func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[
 	jobs, endpoints, err := create("tls", config)
 	require.NoError(t, err)
 
-	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "tls", "", "http", sched, time.Duration(0))[0]
+	sched := schedule.MustParse("@every 1s")
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "tls", Type: "http", Schedule: sched, Timeout: 1})[0]
 
 	event := &beat.Event{}
 	_, err = job(event)
@@ -318,7 +319,7 @@ func TestLargeResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "test", "", "http", sched, time.Duration(0))[0]
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "test", Type: "http", Schedule: sched, Timeout: 1})[0]
 
 	event := &beat.Event{}
 	_, err = job(event)
@@ -514,7 +515,7 @@ func TestRedirect(t *testing.T) {
 	require.NoError(t, err)
 
 	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "test", "", "http", sched, time.Duration(0))[0]
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "test", Type: "http", Schedule: sched, Timeout: 1})[0]
 
 	// Run this test multiple times since in the past we had an issue where the redirects
 	// list was added onto by each request. See https://github.com/elastic/beats/pull/15944
@@ -561,7 +562,7 @@ func TestNoHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "test", "", "http", sched, time.Duration(0))[0]
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "test", Type: "http", Schedule: sched, Timeout: 1})[0]
 
 	event := &beat.Event{}
 	_, err = job(event)

--- a/heartbeat/monitors/active/icmp/icmp_test.go
+++ b/heartbeat/monitors/active/icmp/icmp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
 	"github.com/elastic/beats/v7/heartbeat/look"
 	"github.com/elastic/beats/v7/heartbeat/monitors"
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -69,7 +70,7 @@ func execTestICMPCheck(t *testing.T, cfg Config) (mockLoop, *beat.Event) {
 	require.Equal(t, 1, endpoints)
 	e := &beat.Event{}
 	sched, _ := schedule.Parse("@every 1s")
-	wrapped := wrappers.WrapCommon(j, "test", "", "icmp", sched, time.Duration(0))
+	wrapped := wrappers.WrapCommon(j, stdfields.StdMonitorFields{ID: "test", Type: "icmp", Schedule: sched, Timeout: 1})
 	wrapped[0](e)
 	return tl, e
 }

--- a/heartbeat/monitors/active/tcp/helpers_test.go
+++ b/heartbeat/monitors/active/tcp/helpers_test.go
@@ -22,13 +22,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -42,8 +41,8 @@ func testTCPConfigCheck(t *testing.T, configMap common.MapStr, host string, port
 	jobs, endpoints, err := create("tcp", config)
 	require.NoError(t, err)
 
-	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "test", "", "tcp", sched, time.Duration(0))[0]
+	sched := schedule.MustParse("@every 1s")
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1})[0]
 
 	event := &beat.Event{}
 	_, err = job(event)

--- a/heartbeat/monitors/active/tcp/tls_test.go
+++ b/heartbeat/monitors/active/tcp/tls_test.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -187,8 +187,8 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 	jobs, endpoints, err := createWithResolver(config, resolver)
 	require.NoError(t, err)
 
-	sched, _ := schedule.Parse("@every 1s")
-	job := wrappers.WrapCommon(jobs, "test", "", "tcp", sched, time.Duration(0))[0]
+	sched := schedule.MustParse("@every 1s")
+	job := wrappers.WrapCommon(jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1})[0]
 
 	event := &beat.Event{}
 	_, err = job(event)

--- a/heartbeat/monitors/stdfields/stdfields.go
+++ b/heartbeat/monitors/stdfields/stdfields.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package monitors
+package stdfields
 
 import (
 	"time"
@@ -29,18 +29,19 @@ import (
 // ErrPluginDisabled is returned when the monitor plugin is marked as disabled.
 var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
 
-// MonitorPluginInfo represents the generic configuration options around a monitor plugin.
-type MonitorPluginInfo struct {
-	ID       string             `config:"id"`
-	Name     string             `config:"name"`
-	Type     string             `config:"type" validate:"required"`
-	Schedule *schedule.Schedule `config:"schedule" validate:"required"`
-	Timeout  time.Duration      `config:"timeout"`
-	Enabled  bool               `config:"enabled"`
+// StdMonitorFields represents the generic configuration options around a monitor plugin.
+type StdMonitorFields struct {
+	ID          string             `config:"id"`
+	Name        string             `config:"name"`
+	Type        string             `config:"type" validate:"required"`
+	Schedule    *schedule.Schedule `config:"schedule" validate:"required"`
+	Timeout     time.Duration      `config:"timeout"`
+	ServiceName string             `config:"service_name"`
+	Enabled     bool               `config:"enabled"`
 }
 
-func pluginInfo(config *common.Config) (MonitorPluginInfo, error) {
-	mpi := MonitorPluginInfo{Enabled: true}
+func ConfigToStdMonitorFields(config *common.Config) (StdMonitorFields, error) {
+	mpi := StdMonitorFields{Enabled: true}
 
 	if err := config.Unpack(&mpi); err != nil {
 		return mpi, errors.Wrap(err, "error unpacking monitor plugin config")

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -116,7 +116,7 @@ func (t *configuredJob) Start() {
 	}
 
 	tf := t.makeSchedulerTaskFunc()
-	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.monitor.id, tf)
+	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.monitor.stdFields.ID, tf)
 	if err != nil {
 		logp.Err("could not start monitor: %v", err)
 	}

--- a/heartbeat/monitors/wrappers/monitors.go
+++ b/heartbeat/monitors/wrappers/monitors.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
-
 	"github.com/gofrs/uuid"
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
@@ -31,32 +29,34 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/look"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
+	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // WrapCommon applies the common wrappers that all monitor jobs get.
-func WrapCommon(js []jobs.Job, id string, name string, typ string, sched *schedule.Schedule, timeout time.Duration) []jobs.Job {
+func WrapCommon(js []jobs.Job, stdMonFields stdfields.StdMonitorFields) []jobs.Job {
 	return jobs.WrapAllSeparately(
 		jobs.WrapAll(
 			js,
 			addMonitorStatus,
 			addMonitorDuration,
 		), func() jobs.JobWrapper {
-			return addMonitorMeta(id, name, typ, len(js) > 1, sched, timeout)
+			return addMonitorMeta(stdMonFields, len(js) > 1)
 		}, func() jobs.JobWrapper {
 			return makeAddSummary()
 		})
 }
 
 // addMonitorMeta adds the id, name, and type fields to the monitor.
-func addMonitorMeta(id string, name string, typ string, isMulti bool, sched *schedule.Schedule, timeout time.Duration) jobs.JobWrapper {
+func addMonitorMeta(stdMonFields stdfields.StdMonitorFields, isMulti bool) jobs.JobWrapper {
 	return func(job jobs.Job) jobs.Job {
 		return func(event *beat.Event) ([]jobs.Job, error) {
 			started := time.Now()
 			cont, e := job(event)
-			thisID := id
+			thisID := stdMonFields.ID
 
 			if isMulti {
 				url, err := event.GetValue("url.full")
@@ -65,20 +65,25 @@ func addMonitorMeta(id string, name string, typ string, isMulti bool, sched *sch
 					url = "n/a"
 				}
 				urlHash, _ := hashstructure.Hash(url, nil)
-				thisID = fmt.Sprintf("%s-%x", id, urlHash)
+				thisID = fmt.Sprintf("%s-%x", stdMonFields.ID, urlHash)
 			}
 
-			eventext.MergeEventFields(
-				event,
-				common.MapStr{
-					"monitor": common.MapStr{
-						"id":       thisID,
-						"name":     name,
-						"type":     typ,
-						"timespan": timespan(started, sched, timeout),
-					},
+			fieldsToMerge := common.MapStr{
+				"monitor": common.MapStr{
+					"id":       thisID,
+					"name":     stdMonFields.Name,
+					"type":     stdMonFields.Type,
+					"timespan": timespan(started, stdMonFields.Schedule, stdMonFields.Timeout),
 				},
-			)
+			}
+
+			if stdMonFields.ServiceName != "" {
+				fieldsToMerge["service"] = common.MapStr{
+					"name": stdMonFields.ServiceName,
+				}
+			}
+
+			eventext.MergeEventFields(event, fieldsToMerge)
 
 			return cont, e
 		}

--- a/heartbeat/scheduler/schedule/schedule.go
+++ b/heartbeat/scheduler/schedule/schedule.go
@@ -18,6 +18,7 @@
 package schedule
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -59,6 +60,14 @@ func Parse(in string) (*Schedule, error) {
 		return nil, err
 	}
 	return &Schedule{s}, nil
+}
+
+func MustParse(in string) *Schedule {
+	sched, err := Parse(in)
+	if err != nil {
+		panic(fmt.Sprintf("could not parse schedule parsed with MustParse: %s", err))
+	}
+	return sched
 }
 
 func (s intervalScheduler) Next(t time.Time) time.Time {


### PR DESCRIPTION
Cherry-pick of PR #19932 to 7.x branch. Original message: 

## What does this PR do?

Adds a new standard `service_name` option to the heartbeat config file. While possible with `fields` already, adding this as a first class option encourages use of this important field for integration.

First step toward https://github.com/elastic/uptime/issues/220

This PR also refactors some internal bits where we were passing too many parameters already, and adding `service_name` would just be too much. We now pass a single larger struct for common monitor options which cleans up a lot of the code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run against ES with `service_name` in your config and see that `service.name` is populated.
