### PR TITLE
[DOCS] Remove include for deleted file in monitoring docs

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -40,5 +40,3 @@ include::monitoring-internal-collection.asciidoc[]
 ifndef::serverless[]
 include::monitoring-metricbeat.asciidoc[]
 endif::[]
-
-include::monitoring-internal-collection-legacy.asciidoc[]


### PR DESCRIPTION
Removes include to fix broken doc build. 

DO NOT BACKPORT - 8.0.0 only.