### PR TITLE
Check readStringAndTrimDelimiter error against EOF

### DIFF
--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -478,16 +478,6 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 	offset := 0
 	for {
 		log, err := readStringAndTrimDelimiter(reader)
-		if err != nil {
-			err = errors.Wrap(err, "readStringAndTrimDelimiter failed")
-			p.logger.Error(err)
-			return err
-		}
-
-		if log == "" {
-			break
-		}
-
 		if err == io.EOF {
 			// create event for last line
 			offset += len([]byte(log))
@@ -500,9 +490,13 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 			}
 			return nil
 		} else if err != nil {
-			err = errors.Wrap(err, "ReadString failed")
+			err = errors.Wrap(err, "readStringAndTrimDelimiter failed")
 			p.logger.Error(err)
 			return err
+		}
+
+		if log == "" {
+			break
 		}
 
 		// create event per log line


### PR DESCRIPTION
This PR is continuing with https://github.com/elastic/beats/pull/19972 and fix error checking after `readStringAndTrimDelimiter` function.