### PR TITLE
[build] Minimize Go and Python downloads from containers

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -9,8 +9,6 @@ RUN \
          librpm-dev \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -19,6 +19,7 @@ package mage
 
 import (
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"os"
 	"path"
@@ -94,6 +95,8 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 	dockerRepoRoot := filepath.Join("/go/src", repo.CanonicalRootImportPath)
 	dockerGoCache := filepath.Join(dockerRepoRoot, "build/docker-gocache")
 	magePath := filepath.Join("/go/src", repo.CanonicalRootImportPath, repo.SubDir, "build/mage-linux-amd64")
+	goPkgCache := filepath.Join(filepath.SplitList(build.Default.GOPATH)[0], "pkg/mod/cache/download")
+	dockerGoPkgCache := "/gocache"
 
 	// Execute the inside of docker-compose.
 	args := []string{"-p", dockerComposeProjectName(), "run",
@@ -105,6 +108,9 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 		"-e", "STACK_ENVIRONMENT=" + StackEnvironment,
 		"-e", "TESTING_ENVIRONMENT=" + StackEnvironment,
 		"-e", "GOCACHE=" + dockerGoCache,
+		// Use the host machine's pkg cache to minimize external downloads.
+		"-v", goPkgCache + ":" + dockerGoPkgCache + ":ro",
+		"-e", "GOPROXY=file://" + dockerGoPkgCache,
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -110,7 +110,7 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 		"-e", "GOCACHE=" + dockerGoCache,
 		// Use the host machine's pkg cache to minimize external downloads.
 		"-v", goPkgCache + ":" + dockerGoPkgCache + ":ro",
-		"-e", "GOPROXY=file://" + dockerGoPkgCache,
+		"-e", "GOPROXY=file://" + dockerGoPkgCache + ",direct",
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -12,8 +12,6 @@ RUN \
          libpcap-dev \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -9,8 +9,6 @@ RUN \
          python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -11,8 +11,6 @@ RUN \
          python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -10,8 +10,6 @@ RUN \
          python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -11,8 +11,6 @@ RUN \
          unzip \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -11,8 +11,6 @@ RUN \
          libpcap-dev \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -10,8 +10,6 @@ RUN \
          python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2

--- a/x-pack/libbeat/Dockerfile
+++ b/x-pack/libbeat/Dockerfile
@@ -10,8 +10,6 @@ RUN \
          python3-venv \
       && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_ENV=/tmp/python-env
-
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade docker-compose==1.23.2


### PR DESCRIPTION
## What does this PR do?

**Use host's Go pkg cache as GOPROXY in container**

When running integration tests in a container that involve buillding or testing Go code,
the container must download the Go module dependencies. If the host has already
downloaded them then this will allow the host's packages to be used as a cache.

This mounts $GOPATH/pkg/mod/cache/download inside the container then sets
GOPROXY to point to a file:// URL.

 **Use Python venv from repo root**

Instead of creating (and downloading) a new python venv on every container launch
reuse a shared venv from $repoRoot/build/ve/docker.

## Why is it important?

This allows for faster more reliable integ testing. It mostly helps developers who are running locally, less so for CI because each CI test uses a new machine were the host has none of the Go/Python packages already. But if we change CI images to contain some of the deps in the image then this would help.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

