### PR TITLE
prefer testify Error/NoError over NotNil/Nil

### DIFF
--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -34,24 +34,24 @@ func TestReadConfig2(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	config := &Config{}
 
 	// Reads second config file
 	err = cfgfile.Read(config, absPath+"/config2.yml")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetConfigFiles_File(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, err := getConfigFiles(absPath + "/config.yml")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(files))
 
 	assert.Equal(t, absPath+"/config.yml", files[0])
@@ -61,11 +61,11 @@ func TestGetConfigFiles_Dir(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, err := getConfigFiles(absPath)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(files))
 
 	assert.Equal(t, filepath.Join(absPath, "/config.yml"), files[0])
@@ -76,11 +76,11 @@ func TestGetConfigFiles_EmptyDir(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, err := getConfigFiles(absPath + "/logs")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 }
 
@@ -88,12 +88,12 @@ func TestGetConfigFiles_Invalid(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Invalid directory
 	files, err := getConfigFiles(absPath + "/qwerwer")
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, files)
 }
 
@@ -101,11 +101,11 @@ func TestMergeConfigFiles(t *testing.T) {
 	absPath, err := filepath.Abs("../tests/files/")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, err := getConfigFiles(absPath)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(files))
 
 	config := &Config{}

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -142,7 +142,7 @@ func TestAvailableProcessors(t *testing.T) {
 	}
 
 	err = checkAvailableProcessors(client, requiredProcessors)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ingest-test")
 	assert.Contains(t, err.Error(), "ingest-hello")
 }
@@ -235,7 +235,7 @@ func TestLoadMultiplePipelinesWithRollback(t *testing.T) {
 	}
 
 	err = reg.LoadPipelines(client, false)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid_processor")
 
 	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-pipeline", "", nil, nil)

--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -45,13 +45,13 @@ func InitMatchers(exprs ...string) ([]match.Matcher, error) {
 
 func TestMatchAnyRegexps(t *testing.T) {
 	matchers, err := InitMatchers("\\.gz$")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, MatchAny(matchers, "/var/log/log.gz"), true)
 }
 
 func TestExcludeLine(t *testing.T) {
 	regexp, err := InitMatchers("^DBG")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, MatchAny(regexp, "DBG: a debug message"))
 	assert.False(t, MatchAny(regexp, "ERR: an error message"))
 }
@@ -59,7 +59,7 @@ func TestExcludeLine(t *testing.T) {
 func TestIncludeLine(t *testing.T) {
 	regexp, err := InitMatchers("^ERR", "^WARN")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, MatchAny(regexp, "DBG: a debug message"))
 	assert.True(t, MatchAny(regexp, "ERR: an error message"))
 	assert.True(t, MatchAny(regexp, "WARNING: a simple warning message"))
@@ -67,5 +67,5 @@ func TestIncludeLine(t *testing.T) {
 
 func TestInitRegexp(t *testing.T) {
 	_, err := InitMatchers("(((((")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/filebeat/input/log/harvester_test.go
+++ b/filebeat/input/log/harvester_test.go
@@ -41,7 +41,7 @@ func TestReadLine(t *testing.T) {
 	logFile := absPath + "/tmp" + strconv.Itoa(rand.Int()) + ".log"
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	if err != nil {
 		t.Fatalf("Error creating the absolute path: %s", absPath)
@@ -51,18 +51,18 @@ func TestReadLine(t *testing.T) {
 	defer file.Close()
 	defer os.Remove(logFile)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, file)
 
 	firstLineString := "9Characte\n"
 	secondLineString := "This is line 2\n"
 
 	length, err := file.WriteString(firstLineString)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, length)
 
 	length, err = file.WriteString(secondLineString)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, length)
 
 	file.Sync()
@@ -70,7 +70,7 @@ func TestReadLine(t *testing.T) {
 	// Open file for reading
 	readFile, err := os.Open(logFile)
 	defer readFile.Close()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	source := File{File: readFile}
 
@@ -102,7 +102,7 @@ func TestReadLine(t *testing.T) {
 	// Read third line
 	_, text, bytesread, _, err := readLine(r)
 	t.Logf("received line: '%s'\n", text)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
 
@@ -111,7 +111,7 @@ func TestReadLine(t *testing.T) {
 	t.Logf("received line: '%s'\n", text)
 	assert.Equal(t, text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Read third line, which doesn't exist
 	_, text, bytesread, _, err = readLine(r)

--- a/filebeat/processor/add_kubernetes_metadata/matchers_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers_test.go
@@ -132,7 +132,7 @@ func executeTestWithResourceType(t *testing.T, cfgLogsPath string, cfgResourceTy
 	}
 
 	logMatcher, err := newLogsPathMatcher(*testConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	input := common.MapStr{
 		"log": common.MapStr{

--- a/heartbeat/look/look_test.go
+++ b/heartbeat/look/look_test.go
@@ -32,7 +32,7 @@ import (
 // helper
 func testRTT(t *testing.T, expected time.Duration, provided time.Duration) {
 	actual, err := RTT(provided).GetValue("us")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 

--- a/heartbeat/monitors/active/http/config_test.go
+++ b/heartbeat/monitors/active/http/config_test.go
@@ -88,10 +88,10 @@ func TestConfigValidate(t *testing.T) {
 
 			err := config.Validate()
 			if test.result {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.convertedHost, config.Hosts[0])
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 		})

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -246,7 +246,7 @@ func Test_readPrefixAndHash(t *testing.T) {
 			expectedHash := sha256.Sum256([]byte(tt.body))
 			assert.Equal(t, hex.EncodeToString(expectedHash[:]), gotHashStr)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -131,7 +131,7 @@ func TestSplitHostnamePort(t *testing.T) {
 
 func makeTestHTTPRequest(t *testing.T) *http.Request {
 	req, err := http.NewRequest("GET", "http://example.net", nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return req
 }
 
@@ -168,7 +168,7 @@ func TestRequestBuildingWithCustomHost(t *testing.T) {
 
 	request, err := buildRequest("localhost", &config, encoder)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, "custom-host", request.Host)
 		assert.Equal(t, "custom-host", request.Header.Get("Host"))
 	}
@@ -177,7 +177,7 @@ func TestRequestBuildingWithCustomHost(t *testing.T) {
 func TestRequestBuildingWithNoUserAgent(t *testing.T) {
 	request, err := buildRequest("localhost", &Config{}, nilEncoder{})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, useragent.UserAgent("Heartbeat"), request.Header.Get("User-Agent"))
 }
 
@@ -196,6 +196,6 @@ func TestRequestBuildingWithExplicitUserAgent(t *testing.T) {
 
 	request, err := buildRequest("localhost", &config, nilEncoder{})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedUserAgent, request.Header.Get("User-Agent"))
 }

--- a/libbeat/autodiscover/appender_test.go
+++ b/libbeat/autodiscover/appender_test.go
@@ -53,16 +53,16 @@ func TestAppenderRegistry(t *testing.T) {
 	cfg, err := common.NewConfigFrom(&config)
 
 	// Make sure that config building doesn't fail
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	appender, err := reg.BuildAppender(cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, appender)
 
 	// Attempt to build using an array of configs
 	Registry.AddAppender("fake", newFakeAppender)
 	cfgs := []*common.Config{cfg}
 	appenders, err := NewAppenders(cfgs)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(appenders), 1)
 
 	// Attempt to build using an incorrect config
@@ -70,10 +70,10 @@ func TestAppenderRegistry(t *testing.T) {
 		Type: "wrong",
 	}
 	icfg, err := common.NewConfigFrom(&incorrectConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cfgs = append(cfgs, icfg)
 	appenders, err = NewAppenders(cfgs)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, appenders)
 
 	// Try to append onto an event using fakeAppender and the result should have one item

--- a/libbeat/autodiscover/appenders/config/config_test.go
+++ b/libbeat/autodiscover/appenders/config/config_test.go
@@ -92,11 +92,11 @@ condition.equals:
 			}
 
 			appender, err := NewConfigAppender(config)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, appender)
 
 			eveConfig, err := common.NewConfigFrom(&test.eventConfig)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			test.event["config"] = []*common.Config{eveConfig}
 			appender.Append(test.event)

--- a/libbeat/autodiscover/builder_test.go
+++ b/libbeat/autodiscover/builder_test.go
@@ -55,10 +55,10 @@ func TestBuilderRegistry(t *testing.T) {
 	cfg, err := common.NewConfigFrom(&config)
 
 	// Make sure that config building doesn't fail
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	builder, err := reg.BuildBuilder(cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, builder)
 
 	// Try to create a config with fake builder and assert length

--- a/libbeat/autodiscover/providers/kubernetes/config_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/config_test.go
@@ -44,7 +44,7 @@ func TestConfigWithCustomBuilders(t *testing.T) {
 	config := common.MustNewConfigFrom(&cfg)
 	c := defaultConfig()
 	err := config.Unpack(&c)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	cfg1 := common.MapStr{
 		"hints.enabled": false,
@@ -52,7 +52,7 @@ func TestConfigWithCustomBuilders(t *testing.T) {
 	config, err = common.NewConfigFrom(&cfg1)
 	c = defaultConfig()
 	err = config.Unpack(&c)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConfigWithIncorrectScope(t *testing.T) {
@@ -65,7 +65,7 @@ func TestConfigWithIncorrectScope(t *testing.T) {
 	config := common.MustNewConfigFrom(&cfg)
 	c := defaultConfig()
 	err := config.Unpack(&c)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "service", c.Resource)
 	assert.Equal(t, "cluster", c.Scope)

--- a/libbeat/cfgfile/cfgfile_test.go
+++ b/libbeat/cfgfile/cfgfile_test.go
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) {
 	os.Setenv("TEST_KEY", "test_value")
 
 	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	config := &TestConfig{}
 

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -50,7 +50,7 @@ func TestParseTime(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := ParseTime(test.Input)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.Output, time.Time(result))
 	}
 }
@@ -70,7 +70,7 @@ func TestParseTimeNegative(t *testing.T) {
 
 	for _, test := range tests {
 		_, err := ParseTime(test.Input)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, test.Err, err.Error())
 	}
 }
@@ -99,7 +99,7 @@ func TestTimeMarshal(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := json.Marshal(test.Input)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.Output, string(result))
 	}
 }

--- a/libbeat/common/file/file_other_test.go
+++ b/libbeat/common/file/file_other_test.go
@@ -31,10 +31,10 @@ import (
 
 func TestGetOSFileState(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileinfo, err := file.Stat()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state := GetOSState(fileinfo)
 
@@ -50,10 +50,10 @@ func TestGetOSFileState(t *testing.T) {
 
 func TestGetOSFileStateStat(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileinfo, err := os.Stat(file.Name())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state := GetOSState(fileinfo)
 

--- a/libbeat/common/file/file_windows_test.go
+++ b/libbeat/common/file/file_windows_test.go
@@ -29,10 +29,10 @@ import (
 
 func TestGetOSState(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileinfo, err := file.Stat()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state := GetOSState(fileinfo)
 
@@ -43,10 +43,10 @@ func TestGetOSState(t *testing.T) {
 
 func TestGetOSStateStat(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileinfo, err := os.Stat(file.Name())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state := GetOSState(fileinfo)
 

--- a/libbeat/common/kubernetes/metadata/namespace_test.go
+++ b/libbeat/common/kubernetes/metadata/namespace_test.go
@@ -139,7 +139,7 @@ func TestNamespace_GenerateFromName(t *testing.T) {
 		metagen := NewNamespaceMetadataGenerator(cfg, namespaces)
 
 		accessor, err := meta.Accessor(test.input)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.GenerateFromName(fmt.Sprint(accessor.GetName())))

--- a/libbeat/common/kubernetes/metadata/node_test.go
+++ b/libbeat/common/kubernetes/metadata/node_test.go
@@ -121,7 +121,7 @@ func TestNode_GenerateFromName(t *testing.T) {
 		metagen := NewNodeMetadataGenerator(cfg, nodes)
 
 		accessor, err := meta.Accessor(test.input)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.GenerateFromName(fmt.Sprint(accessor.GetName())))

--- a/libbeat/common/kubernetes/metadata/pod_test.go
+++ b/libbeat/common/kubernetes/metadata/pod_test.go
@@ -138,7 +138,7 @@ func TestPod_Generate(t *testing.T) {
 	config, err := common.NewConfigFrom(map[string]interface{}{
 		"include_annotations": []string{"app"},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	metagen := NewPodMetadataGenerator(config, nil, nil, nil)
 	for _, test := range tests {
@@ -254,13 +254,13 @@ func TestPod_GenerateFromName(t *testing.T) {
 		config, err := common.NewConfigFrom(map[string]interface{}{
 			"include_annotations": []string{"app"},
 		})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		pods := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		pods.Add(test.input)
 		metagen := NewPodMetadataGenerator(config, pods, nil, nil)
 
 		accessor, err := meta.Accessor(test.input)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.GenerateFromName(fmt.Sprint(accessor.GetNamespace(), "/", accessor.GetName())))
@@ -360,7 +360,7 @@ func TestPod_GenerateWithNodeNamespace(t *testing.T) {
 		config, err := common.NewConfigFrom(map[string]interface{}{
 			"include_annotations": []string{"app"},
 		})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		pods := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		pods.Add(test.input)
 

--- a/libbeat/common/kubernetes/metadata/service_test.go
+++ b/libbeat/common/kubernetes/metadata/service_test.go
@@ -209,7 +209,7 @@ func TestService_GenerateFromName(t *testing.T) {
 		metagen := NewServiceMetadataGenerator(cfg, services, nil)
 
 		accessor, err := meta.Accessor(test.input)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.GenerateFromName(fmt.Sprint(accessor.GetNamespace(), "/", accessor.GetName())))

--- a/libbeat/common/net_test.go
+++ b/libbeat/common/net_test.go
@@ -28,13 +28,13 @@ import (
 func TestIsLoopback(t *testing.T) {
 	check, err := IsLoopback("127.0.0.1")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, check)
 }
 
 func TestIsLoopback_false(t *testing.T) {
 	check, err := IsLoopback("192.168.1.1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, check)
 }
 

--- a/libbeat/common/streambuf/ascii_test.go
+++ b/libbeat/common/streambuf/ascii_test.go
@@ -30,7 +30,7 @@ func Test_UntilCRLFOK(t *testing.T) {
 	b.Advance(2)
 	d, err := b.UntilCRLF()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, d, []byte("test"))
 	assert.Equal(t, 0, b.Len())
@@ -51,13 +51,13 @@ func Test_UntilCRLFCont(t *testing.T) {
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	err = b.Append([]byte("\r\nabc"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, 4, b.LeftBehind())
 
 	d, err := b.UntilCRLF()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, d, []byte("test"))
 	assert.Equal(t, 3, b.Len())
@@ -67,7 +67,7 @@ func Test_UntilCRLFOnlyCRThenCRLF(t *testing.T) {
 	b := New([]byte("test\rtest\r\nabc"))
 	d, err := b.UntilCRLF()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, d, []byte("test\rtest"))
 	assert.Equal(t, 3, b.Len())
@@ -80,13 +80,13 @@ func Test_UntilCRLFOnlyCRThenCRLFWithCont(t *testing.T) {
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	err = b.Append([]byte("\nabc"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, 9, b.LeftBehind())
 
 	d, err := b.UntilCRLF()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, d, []byte("test\rtest"))
 	assert.Equal(t, 3, b.Len())
@@ -96,7 +96,7 @@ func Test_IgnoreSymbolOK(t *testing.T) {
 	b := New([]byte("  test"))
 	err := b.IgnoreSymbol(' ')
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, 4, b.Len())
 }
@@ -118,7 +118,7 @@ func Test_IgnoreSymbolCont(t *testing.T) {
 	b.Append([]byte("  test"))
 	err = b.IgnoreSymbol(' ')
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 	assert.Equal(t, 4, b.Len())
 }
@@ -127,7 +127,7 @@ func Test_UntilSymbolOK(t *testing.T) {
 	b := New([]byte("test "))
 	d, err := b.UntilSymbol(' ', true)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte("test"), d)
 }
 
@@ -148,7 +148,7 @@ func Test_UntilSymbolCont(t *testing.T) {
 	b.Append([]byte("t "))
 	d, err := b.UntilSymbol(' ', true)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte("test"), d)
 }
 
@@ -156,7 +156,7 @@ func Test_UntilSymbolOrEnd(t *testing.T) {
 	b := New([]byte("test"))
 	d, err := b.UntilSymbol(' ', false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte("test"), d)
 }
 
@@ -164,7 +164,7 @@ func Test_AsciiUintOK(t *testing.T) {
 	b := New([]byte("123 "))
 	v, err := b.UintASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(123), v)
 }
 
@@ -195,7 +195,7 @@ func Test_AsciiUintCont(t *testing.T) {
 	b.Append([]byte("34 "))
 	v, err := b.UintASCII(true)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(1234), v)
 }
 
@@ -203,7 +203,7 @@ func Test_AsciiUintOrEndOK(t *testing.T) {
 	b := New([]byte("12"))
 	v, err := b.UintASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(12), v)
 }
 
@@ -211,7 +211,7 @@ func Test_AsciiIntOK(t *testing.T) {
 	b := New([]byte("123 "))
 	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(123), v)
 }
 
@@ -219,7 +219,7 @@ func Test_AsciiIntPosOK(t *testing.T) {
 	b := New([]byte("+123 "))
 	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(123), v)
 }
 
@@ -227,7 +227,7 @@ func Test_AsciiIntNegOK(t *testing.T) {
 	b := New([]byte("-123 "))
 	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(-123), v)
 }
 
@@ -258,7 +258,7 @@ func Test_AsciiIntCont(t *testing.T) {
 	b.Append([]byte("34 "))
 	v, err := b.IntASCII(true)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(1234), v)
 }
 
@@ -266,7 +266,7 @@ func Test_AsciiIntOrEndOK(t *testing.T) {
 	b := New([]byte("12"))
 	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(12), v)
 }
 
@@ -274,7 +274,7 @@ func Test_AsciiMatchOK(t *testing.T) {
 	b := New([]byte("match test"))
 	r, err := b.MatchASCII([]byte("match"))
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, r)
 	assert.Equal(t, 10, b.Len()) // check no bytes consumed
 }
@@ -283,7 +283,7 @@ func Test_AsciiMatchNo(t *testing.T) {
 	b := New([]byte("match test"))
 	r, err := b.MatchASCII([]byte("batch"))
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, r)
 	assert.Equal(t, 10, b.Len()) // check no bytes consumed
 }
@@ -297,7 +297,7 @@ func Test_AsciiMatchCont(t *testing.T) {
 	b.Append([]byte("ch test"))
 	r, err := b.MatchASCII([]byte("match"))
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, r)
 	assert.Equal(t, 10, b.Len()) // check no bytes consumed
 }

--- a/libbeat/common/streambuf/io_test.go
+++ b/libbeat/common/streambuf/io_test.go
@@ -67,7 +67,7 @@ func Test_ReadByteOK(t *testing.T) {
 	b := New([]byte{1})
 	v, err := b.ReadByte()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, byte(1), v)
 
 	_, err = b.ReadByte()
@@ -79,10 +79,10 @@ func Test_ReadUnreadByteOK(t *testing.T) {
 	v, err := b.ReadByte()
 	b.checkInvariants(t)
 	assert.Equal(t, byte(1), v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = b.UnreadByte()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, b.Len())
 }
 
@@ -109,7 +109,7 @@ func Test_UnreadAfterEOFOK(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 
 	err = b.UnreadByte()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_WriteByte(t *testing.T) {
@@ -117,7 +117,7 @@ func Test_WriteByte(t *testing.T) {
 
 	err := b.WriteByte(1)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, b.Len())
 	assert.Equal(t, byte(1), b.Bytes()[0])
 }
@@ -130,7 +130,7 @@ func Test_WriteByteEOFCheck(t *testing.T) {
 
 	err = b.WriteByte(1)
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_WriteByteFixedFail(t *testing.T) {
@@ -147,13 +147,13 @@ func Test_ReadBufSmaller(t *testing.T) {
 	n, err := b.Read(tmp)
 	b.checkInvariants(t)
 	assert.Equal(t, 5, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{1, 2, 3, 4, 5}, tmp[:n])
 
 	n, err = b.Read(tmp)
 	b.checkInvariants(t)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{6, 7, 8}, tmp[:n])
 
 	n, err = b.Read(tmp)
@@ -168,7 +168,7 @@ func Test_ReadBufBigger(t *testing.T) {
 	n, err := b.Read(tmp)
 	b.checkInvariants(t)
 	assert.Equal(t, 8, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, tmp[:n])
 
 	n, err = b.Read(tmp)
@@ -189,7 +189,7 @@ func Test_WriteOK(t *testing.T) {
 	n, err := b.Write([]byte{1, 2, 3})
 	b.checkInvariants(t)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, b.Len())
 }
 
@@ -200,7 +200,7 @@ func Test_WriteDoesNotRetain(t *testing.T) {
 	n, err := b.Write(tmp)
 	b.checkInvariants(t)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Bytes()[0] = 'a'
 	assert.Equal(t, byte(1), tmp[0])
@@ -217,7 +217,7 @@ func Test_WriteNil(t *testing.T) {
 	b := New([]byte{1, 2, 3})
 	n, err := b.Write(nil)
 	assert.Equal(t, 0, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_ReadFromOK(t *testing.T) {
@@ -226,7 +226,7 @@ func Test_ReadFromOK(t *testing.T) {
 
 	n, err := b.ReadFrom(from)
 	assert.Equal(t, int64(4), n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{1, 2, 3, 4}, b.Bytes())
 
 	// check buffers are not retained
@@ -249,7 +249,7 @@ func Test_ReadFromIfEOF(t *testing.T) {
 	// copy from
 	n, err := b.ReadFrom(from)
 	assert.Equal(t, int64(4), n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{1, 2, 3, 4}, b.Bytes())
 
 	// check buffers are not retained
@@ -273,12 +273,12 @@ func Test_ReadFromFailOnFixed(t *testing.T) {
 func Test_ReadRuneOK(t *testing.T) {
 	b := New([]byte("xäüö"))
 	r, s, err := b.ReadRune()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 'x', r)
 	assert.Equal(t, 1, s)
 
 	r, s, err = b.ReadRune()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 'ä', r)
 	assert.Equal(t, 2, s)
 }
@@ -302,7 +302,7 @@ func Test_ReadAtOK(t *testing.T) {
 
 	tmp := make([]byte, 2)
 	n, err := b.ReadAt(tmp, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
 	assert.Equal(t, []byte{3, 4}, tmp[:n])
 
@@ -328,7 +328,7 @@ func Test_WriteAtToNil(t *testing.T) {
 	b := New(nil)
 	n, err := b.WriteAt([]byte{1, 2, 3}, 4)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_WriteAtOverwrites(t *testing.T) {
@@ -336,14 +336,14 @@ func Test_WriteAtOverwrites(t *testing.T) {
 	b.Advance(1)
 	n, err := b.WriteAt([]byte{1, 2, 3}, 1)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{'b', 1, 2, 3}, b.Bytes())
 
 	b = New(make([]byte, 3, 20))
 	b.Advance(2)
 	n, err = b.WriteAt([]byte{1, 2, 3}, 1)
 	assert.Equal(t, 3, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 4, b.Len())
 	// assert.Equal(t, []byte{0, 1, 2, 3}, b.Bytes())
 }

--- a/libbeat/common/streambuf/net_test.go
+++ b/libbeat/common/streambuf/net_test.go
@@ -44,7 +44,7 @@ func Test_ReadNetUint8Data(t *testing.T) {
 	b := New([]byte{10})
 	v, err := b.ReadNetUint8()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(10), v)
 }
 
@@ -59,7 +59,7 @@ func Test_ReadNetUint8AtFailed(t *testing.T) {
 func Test_ReadNetUint8AtInRange(t *testing.T) {
 	b := New([]byte{1, 2, 3})
 	v, err := b.ReadNetUint8At(2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(3), v)
 }
 
@@ -73,11 +73,11 @@ func Test_ReadNetUint8AtOutOfRange(t *testing.T) {
 func Test_WriteNetUint8At(t *testing.T) {
 	b := New(nil)
 	err := b.WriteNetUint8At(10, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Advance(1)
 	tmp, err := b.ReadNetUint8()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(10), tmp)
 }
 
@@ -100,7 +100,7 @@ func Test_ReadNetUint16Data(t *testing.T) {
 	b := New([]byte{0xf1, 0xf2})
 	v, err := b.ReadNetUint16()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(0xf1f2), v)
 }
 
@@ -115,7 +115,7 @@ func Test_ReadNetUint16AtFailed(t *testing.T) {
 func Test_ReadNetUint16AtInRange(t *testing.T) {
 	b := New([]byte{0xf1, 0xf2, 0xf3})
 	v, err := b.ReadNetUint16At(1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(0xf2f3), v)
 }
 
@@ -129,11 +129,11 @@ func Test_ReadNetUint16AtOutOfRange(t *testing.T) {
 func Test_WriteNetUint16At(t *testing.T) {
 	b := New(nil)
 	err := b.WriteNetUint16At(0x1f2f, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Advance(1)
 	tmp, err := b.ReadNetUint16()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(0x1f2f), tmp)
 }
 
@@ -156,7 +156,7 @@ func Test_ReadNetUint32Data(t *testing.T) {
 	b := New([]byte{0xf1, 0xf2, 0xf3, 0xf4})
 	v, err := b.ReadNetUint32()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0xf1f2f3f4), v)
 }
 
@@ -171,7 +171,7 @@ func Test_ReadNetUint32AtFailed(t *testing.T) {
 func Test_ReadNetUint32AtInRange(t *testing.T) {
 	b := New([]byte{0xf1, 0xf2, 0xf3, 0xf4, 0xf5})
 	v, err := b.ReadNetUint32At(1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0xf2f3f4f5), v)
 }
 
@@ -185,11 +185,11 @@ func Test_ReadNetUint32AtOutOfRange(t *testing.T) {
 func Test_WriteNetUint32At(t *testing.T) {
 	b := New(nil)
 	err := b.WriteNetUint32At(0x1f2f3f4f, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Advance(1)
 	tmp, err := b.ReadNetUint32()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0x1f2f3f4f), tmp)
 }
 
@@ -216,7 +216,7 @@ func Test_ReadNetUint64Data(t *testing.T) {
 	})
 	v, err := b.ReadNetUint64()
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(0xf0f1f2f3f4f5f6f7), v)
 }
 
@@ -235,7 +235,7 @@ func Test_ReadNetUint64AtInRange(t *testing.T) {
 		0xfa, 0xfb, 0xfc, 0xfd, 0xfe,
 	})
 	v, err := b.ReadNetUint64At(1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(0xf1f2f3f4f5f6f7f8), v)
 }
 
@@ -249,10 +249,10 @@ func Test_ReadNetUint64AtOutOfRange(t *testing.T) {
 func Test_WriteNetUint64At(t *testing.T) {
 	b := New(nil)
 	err := b.WriteNetUint64At(0x1f2f3f4f5f6f7f8f, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Advance(1)
 	tmp, err := b.ReadNetUint64()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint64(0x1f2f3f4f5f6f7f8f), tmp)
 }

--- a/libbeat/common/streambuf/streambuf_test.go
+++ b/libbeat/common/streambuf/streambuf_test.go
@@ -83,7 +83,7 @@ func Test_SnapshotRestore(t *testing.T) {
 	err := b.Advance(5)
 	assert.Equal(t, 5, b.BufferConsumed())
 	assert.Equal(t, 4, b.Len())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 
 	b.Restore(snapshot)
@@ -139,7 +139,7 @@ func Test_AppendOnFixedLater(t *testing.T) {
 	b := New([]byte("abc"))
 
 	err := b.Append([]byte("def"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	b.Fix()
 	err = b.Append([]byte("def"))
@@ -163,7 +163,7 @@ func Test_AppendAfterNoMoreBytes(t *testing.T) {
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	err = b.Append([]byte(" test"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, b.Failed())
 }
 
@@ -244,7 +244,7 @@ func Test_CollectData(t *testing.T) {
 	d, err := b.Collect(2)
 
 	b.checkInvariants(t)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte("te"), d)
 }
 
@@ -281,7 +281,7 @@ func Test_CollectWithSuffixData(t *testing.T) {
 	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
 	b.checkInvariants(t)
 	assert.False(t, b.Failed())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte("test"), d)
 }
 

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -55,7 +55,7 @@ func mustLoad(t *testing.T, yamlStr string) *Config {
 
 func TestEmptyTlsConfig(t *testing.T) {
 	cfg, err := load("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, cfg, &Config{})
 }
@@ -73,20 +73,20 @@ func TestLoadWithEmptyValues(t *testing.T) {
     supported_protocols:
   `)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, cfg, &Config{})
 }
 
 func TestNoLoadNilConfig(t *testing.T) {
 	cfg, err := LoadTLSConfig(nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, cfg)
 }
 
 func TestNoLoadDisabledConfig(t *testing.T) {
 	enabled := false
 	cfg, err := LoadTLSConfig(&Config{Enabled: &enabled})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, cfg)
 }
 

--- a/libbeat/common/transport/transptest/testing_test.go
+++ b/libbeat/common/transport/transptest/testing_test.go
@@ -149,7 +149,7 @@ func TestTransportFailConnectUnknownAddress(t *testing.T) {
 					}
 
 					err = transp.Connect()
-					assert.NotNil(t, err)
+					assert.Error(t, err)
 				})
 			}
 		})
@@ -171,7 +171,7 @@ func TestTransportClosedOnWriteReadError(t *testing.T) {
 		var buf [10]byte
 		transp.Write([]byte("test3"))
 		_, err = transp.Read(buf[:])
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	})
 }
 

--- a/libbeat/common/url_test.go
+++ b/libbeat/common/url_test.go
@@ -81,7 +81,7 @@ func TestGetUrl(t *testing.T) {
 
 	for input, output := range inputOutput {
 		urlNew, err := MakeURL("", "", input, 9200)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, output, urlNew, fmt.Sprintf("input: %v", input))
 	}
 
@@ -94,7 +94,7 @@ func TestGetUrl(t *testing.T) {
 
 	for input, output := range inputOutputWithDefaults {
 		urlNew, err := MakeURL("https", "/hello", input, 9200)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, output, urlNew)
 	}
 }
@@ -111,7 +111,7 @@ func TestURLParamsEncode(t *testing.T) {
 	for input, output := range inputOutputWithParams {
 		urlNew, err := MakeURL("", "", input, 5601)
 		urlWithParams := EncodeURLParams(urlNew, params)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, output, urlWithParams)
 	}
 }

--- a/libbeat/conditions/conditions_test.go
+++ b/libbeat/conditions/conditions_test.go
@@ -36,7 +36,7 @@ func TestCreateNilCondition(t *testing.T) {
 
 func GetCondition(t *testing.T, config Config) Condition {
 	cond, err := NewCondition(&config)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return cond
 }
 

--- a/libbeat/conditions/equals_test.go
+++ b/libbeat/conditions/equals_test.go
@@ -31,7 +31,7 @@ func TestEqualsCreate(t *testing.T) {
 	}
 
 	_, err := NewCondition(&config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestEqualsSingleFieldPositiveMatch(t *testing.T) {

--- a/libbeat/conditions/matcher_test.go
+++ b/libbeat/conditions/matcher_test.go
@@ -35,7 +35,7 @@ func TestRegxpCreate(t *testing.T) {
 		}},
 	}
 	_, err := NewCondition(&config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestContainsMultiFieldPositiveMatch(t *testing.T) {

--- a/libbeat/conditions/range_test.go
+++ b/libbeat/conditions/range_test.go
@@ -34,7 +34,7 @@ func TestRangeCreateNumeric(t *testing.T) {
 		}},
 	}
 	_, err := NewCondition(&config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestRangeCreateLexicographic(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRangeCreateLexicographic(t *testing.T) {
 		}},
 	}
 	_, err := NewCondition(&config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestRangeSingleFieldNegativeMatch(t *testing.T) {

--- a/libbeat/esleg/eslegclient/api_test.go
+++ b/libbeat/esleg/eslegclient/api_test.go
@@ -81,7 +81,7 @@ func TestReadQueryResult(t *testing.T) {
 	json := queryResult.Source
 	result, err := readQueryResult(json)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, queryResult.Ok, result.Ok)
 	assert.Equal(t, queryResult.Index, result.Index)
 	assert.Equal(t, queryResult.Type, result.Type)
@@ -96,7 +96,7 @@ func TestReadQueryResult(t *testing.T) {
 func TestReadQueryResult_empty(t *testing.T) {
 	result, err := readQueryResult(nil)
 	assert.Nil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // Check invalid query result object
@@ -125,7 +125,7 @@ func TestReadSearchResult(t *testing.T) {
 
 		results, err := readSearchResult(json)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, resultsObject.Took, results.Took)
 		assert.Equal(t, resultsObject.Hits, results.Hits)
 		assert.Equal(t, resultsObject.Shards, results.Shards)
@@ -147,7 +147,7 @@ func TestReadSearchResult(t *testing.T) {
 
 		results, err := readSearchResult(json)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, resultsObject.Took, results.Took)
 		assert.Equal(t, resultsObject.Hits, results.Hits)
 		assert.Equal(t, resultsObject.Shards, results.Shards)
@@ -158,7 +158,7 @@ func TestReadSearchResult(t *testing.T) {
 func TestReadSearchResult_empty(t *testing.T) {
 	results, err := readSearchResult(nil)
 	assert.Nil(t, results)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReadSearchResult_invalid(t *testing.T) {

--- a/libbeat/keystore/file_keystore_test.go
+++ b/libbeat/keystore/file_keystore_test.go
@@ -280,7 +280,7 @@ func createAndReadKeystoreSecret(t *testing.T, password []byte, key string, valu
 	defer os.Remove(path)
 
 	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	writableKeystore, err := AsWritableKeystore(keyStore)
 	assert.NoError(t, err)

--- a/libbeat/keystore/secure_string_test.go
+++ b/libbeat/keystore/secure_string_test.go
@@ -30,7 +30,7 @@ func TestGet(t *testing.T) {
 	s := NewSecureString(secret)
 	v, err := s.Get()
 	assert.Equal(t, secret, v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestStringMarshalingS(t *testing.T) {

--- a/libbeat/mapping/field_test.go
+++ b/libbeat/mapping/field_test.go
@@ -527,7 +527,7 @@ func TestFieldsCanConcat(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := test.fields.canConcat(test.key, strings.Split(test.key, "."))
 			if test.err == "" {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				return
 			}
 			if assert.Error(t, err) {

--- a/libbeat/metric/system/memory/memory_test.go
+++ b/libbeat/metric/system/memory/memory_test.go
@@ -33,7 +33,7 @@ func TestGetMemory(t *testing.T) {
 	mem, err := Get()
 
 	assert.NotNil(t, mem)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.True(t, (mem.Total > 0))
 	assert.True(t, (mem.Used > 0))
@@ -50,7 +50,7 @@ func TestGetSwap(t *testing.T) {
 	swap, err := GetSwap()
 
 	assert.NotNil(t, swap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.True(t, (swap.Total >= 0))
 	assert.True(t, (swap.Used >= 0))

--- a/libbeat/metric/system/process/process_test.go
+++ b/libbeat/metric/system/process/process_test.go
@@ -37,7 +37,7 @@ func TestPids(t *testing.T) {
 	pids, err := Pids()
 
 	assert.NotNil(t, pids)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Assuming at least 2 processes are running
 	assert.True(t, (len(pids) > 1))

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -115,7 +115,7 @@ func TestConsoleOutput(t *testing.T) {
 		t.Run(test.title, func(t *testing.T) {
 			batch := outest.NewBatch(test.events...)
 			lines, err := run(test.codec, batch)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.expected, lines)
 
 			// check batch correctly signalled

--- a/libbeat/outputs/elasticsearch/bulk_test.go
+++ b/libbeat/outputs/elasticsearch/bulk_test.go
@@ -83,7 +83,7 @@ func TestESNoErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 200}}`)
 	code, msg, err := readStatusItem(response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 200, code)
 	assert.Equal(t, "", msg)
 }
@@ -92,7 +92,7 @@ func TestES1StyleErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 400, "error": "test error"}}`)
 	code, msg, err := readStatusItem(response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 400, code)
 	assert.Equal(t, `"test error"`, msg)
 }
@@ -101,7 +101,7 @@ func TestES2StyleErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 400, "error": {"reason": "test_error"}}}`)
 	code, msg, err := readStatusItem(response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 400, code)
 	assert.Equal(t, `{"reason": "test_error"}`, msg)
 }
@@ -120,7 +120,7 @@ func TestES2StyleExtendedErrorStatus(t *testing.T) {
     }`)
 	code, _, err := readStatusItem(response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 400, code)
 }
 

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -179,9 +179,9 @@ func TestDecodeBase64Run(t *testing.T) {
 
 			newEvent, err := f.Run(event)
 			if !test.error {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			assert.Equal(t, test.Output, newEvent.Fields)

--- a/libbeat/processors/actions/decompress_gzip_field_test.go
+++ b/libbeat/processors/actions/decompress_gzip_field_test.go
@@ -180,9 +180,9 @@ func TestDecompressGzip(t *testing.T) {
 
 			newEvent, err := f.Run(event)
 			if !test.error {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			assert.Equal(t, test.output, newEvent.Fields)

--- a/libbeat/processors/actions/extract_field_test.go
+++ b/libbeat/processors/actions/extract_field_test.go
@@ -92,10 +92,10 @@ func TestCommonPaths(t *testing.T) {
 
 		event, err := runExtractField(t, testConfig, input)
 		if test.Error {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			result, err := event.Fields.GetValue(test.Target)
 			if err != nil {
 				t.Fatalf("could not get target field: %s", err)

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -245,9 +245,9 @@ func TestRenameRun(t *testing.T) {
 
 			newEvent, err := f.Run(event)
 			if !test.error {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			assert.True(t, reflect.DeepEqual(newEvent.Fields, test.Output))

--- a/libbeat/processors/actions/replace_test.go
+++ b/libbeat/processors/actions/replace_test.go
@@ -152,9 +152,9 @@ func TestReplaceRun(t *testing.T) {
 
 			newEvent, err := f.Run(event)
 			if !test.error {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			assert.True(t, reflect.DeepEqual(newEvent.Fields, test.Output))

--- a/libbeat/processors/add_kubernetes_metadata/indexers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers_test.go
@@ -38,7 +38,7 @@ func TestPodIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
 	podIndexer, err := NewPodNameIndexer(*testConfig, metagen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
@@ -89,7 +89,7 @@ func TestPodUIDIndexer(t *testing.T) {
 	metaGenWithPodUID := metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil)
 
 	podUIDIndexer, err := NewPodUIDIndexer(*testConfig, metaGenWithPodUID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	ns := "testns"
@@ -138,7 +138,7 @@ func TestContainerIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
 	conIndexer, err := NewContainerIndexer(*testConfig, metagen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	ns := "testns"
@@ -227,7 +227,7 @@ func TestFilteredGenMeta(t *testing.T) {
 	var testConfig = common.NewConfig()
 
 	podIndexer, err := NewPodNameIndexer(*testConfig, metagen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	ns := "testns"
@@ -264,12 +264,12 @@ func TestFilteredGenMeta(t *testing.T) {
 		"include_annotations": []string{"a"},
 		"include_labels":      []string{"foo"},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil)
 
 	podIndexer, err = NewPodNameIndexer(*testConfig, filteredGen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	indexers = podIndexer.GetMetadata(&pod)
 	assert.Equal(t, len(indexers), 1)
@@ -301,12 +301,12 @@ func TestFilteredGenMetaExclusion(t *testing.T) {
 	config, err := common.NewConfigFrom(map[string]interface{}{
 		"exclude_labels": []string{"x"},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil)
 
 	podIndexer, err := NewPodNameIndexer(*testConfig, filteredGen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	ns := "testns"
@@ -326,7 +326,7 @@ func TestFilteredGenMetaExclusion(t *testing.T) {
 		Spec: v1.PodSpec{},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	indexers := podIndexer.GetMetadata(&pod)
 	assert.Equal(t, len(indexers), 1)
@@ -349,7 +349,7 @@ func TestIpPortIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
 	ipIndexer, err := NewIPPortIndexer(*testConfig, metagen)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	podName := "testpod"
 	ns := "testns"
@@ -386,7 +386,7 @@ func TestIpPortIndexer(t *testing.T) {
 
 	// Meta doesn't have container info
 	_, err = indexers[0].Data.GetValue("kubernetes.container.name")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	expected := common.MapStr{
 		"pod": common.MapStr{

--- a/libbeat/processors/add_kubernetes_metadata/matchers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/matchers_test.go
@@ -31,16 +31,16 @@ func TestFieldMatcher(t *testing.T) {
 	}
 	fieldCfg, err := common.NewConfigFrom(testCfg)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	matcher, err := NewFieldMatcher(*fieldCfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	testCfg["lookup_fields"] = "foo"
 	fieldCfg, _ = common.NewConfigFrom(testCfg)
 
 	matcher, err = NewFieldMatcher(*fieldCfg)
 	assert.NotNil(t, matcher)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	input := common.MapStr{
 		"foo": "bar",
@@ -61,16 +61,16 @@ func TestFieldFormatMatcher(t *testing.T) {
 	testCfg := map[string]interface{}{}
 	fieldCfg, err := common.NewConfigFrom(testCfg)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	matcher, err := NewFieldFormatMatcher(*fieldCfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	testCfg["format"] = `%{[namespace]}/%{[pod]}`
 	fieldCfg, _ = common.NewConfigFrom(testCfg)
 
 	matcher, err = NewFieldFormatMatcher(*fieldCfg)
 	assert.NotNil(t, matcher)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	event := common.MapStr{
 		"namespace": "foo",
@@ -90,7 +90,7 @@ func TestFieldFormatMatcher(t *testing.T) {
 	fieldCfg, _ = common.NewConfigFrom(testCfg)
 	matcher, err = NewFieldFormatMatcher(*fieldCfg)
 	assert.NotNil(t, matcher)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	event = common.MapStr{
 		"dimensions": common.MapStr{

--- a/libbeat/processors/urldecode/urldecode_test.go
+++ b/libbeat/processors/urldecode/urldecode_test.go
@@ -201,9 +201,9 @@ func TestURLDecode(t *testing.T) {
 
 			newEvent, err := f.Run(event)
 			if !test.error {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			assert.Equal(t, test.Output, newEvent.Fields)

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -294,10 +294,10 @@ func TestTemplateWithData(t *testing.T) {
 	for _, test := range dataTests {
 		_, _, err := esClient.Index(setup.config.Name, "_doc", "", nil, test.data)
 		if test.error {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 	}
 }

--- a/metricbeat/autodiscover/appender/kubernetes/token/token_test.go
+++ b/metricbeat/autodiscover/appender/kubernetes/token/token_test.go
@@ -84,7 +84,7 @@ token_path: "test"
 		writeFile("test", "foo bar")
 
 		appender, err := NewTokenAppender(config)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, appender)
 
 		appender.Append(test.event)

--- a/metricbeat/helper/windows/pdh/pdh_query_windows_test.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows_test.go
@@ -28,7 +28,7 @@ import (
 func TestOpenSuccessful(t *testing.T) {
 	var q Query
 	err := q.Open()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer q.Close()
 }
 
@@ -85,7 +85,7 @@ func TestSuccessfulQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	list, err := q.GetFormattedCounterValues()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 }
 

--- a/metricbeat/helper/windows/pdh/pdh_windows_test.go
+++ b/metricbeat/helper/windows/pdh/pdh_windows_test.go
@@ -59,7 +59,7 @@ func TestPdhGetFormattedCounterValueInvalidCounter(t *testing.T) {
 // TestPdhExpandWildCardPathInvalidPath will test for invalid query path.
 func TestPdhExpandWildCardPathInvalidPath(t *testing.T) {
 	utfPath, err := syscall.UTF16PtrFromString("sdfhsdhfd")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	queryList, err := PdhExpandWildCardPath(utfPath)
 	assert.Nil(t, queryList)
 	assert.EqualValues(t, err, PDH_INVALID_PATH)
@@ -122,7 +122,7 @@ func TestPdhSuccessfulCounterRetrieval(t *testing.T) {
 	}
 	for _, counter := range counters {
 		counterType, counterValue, err := PdhGetFormattedCounterValueDouble(counter)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotZero(t, counterType)
 		assert.NotNil(t, counterValue)
 	}

--- a/metricbeat/module/graphite/server/data_test.go
+++ b/metricbeat/module/graphite/server/data_test.go
@@ -84,7 +84,7 @@ func TestMetricProcessorDeleteTemplate(t *testing.T) {
 func TestMetricProcessorProcess(t *testing.T) {
 	processor := GetMetricProcessor()
 	event, err := processor.Process("test.localhost.bash.stats 42 1500934723")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, event)
 
 	tag := event["tag"].(common.MapStr)
@@ -101,7 +101,7 @@ func TestMetricProcessorProcess(t *testing.T) {
 	assert.Equal(t, event["@timestamp"], timestamp)
 
 	event, err = processor.Process("test.localhost.bash.stats 42")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, event)
 
 	assert.NotNil(t, event["stats"])

--- a/metricbeat/module/munin/munin_test.go
+++ b/metricbeat/module/munin/munin_test.go
@@ -39,7 +39,7 @@ func TestList(t *testing.T) {
 
 	list, err := n.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := []string{"cpu", "df", "uptime"}
 	assert.ElementsMatch(t, expected, list)

--- a/metricbeat/module/windows/perfmon/reader_integration_test.go
+++ b/metricbeat/module/windows/perfmon/reader_integration_test.go
@@ -37,7 +37,7 @@ func TestNewReaderWhenQueryPathNotProvided(t *testing.T) {
 		Counters:          []Counter{counter},
 	}
 	reader, err := NewReader(config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, reader)
 	assert.EqualValues(t, err.Error(), `failed to expand counter (query=""): no query path given`)
 }
@@ -52,7 +52,7 @@ func TestNewReaderWithValidQueryPath(t *testing.T) {
 	}
 	reader, err := NewReader(config)
 	defer reader.Close()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, reader)
 	assert.NotNil(t, reader.query)
 	assert.NotNil(t, reader.query.Handle)
@@ -76,11 +76,11 @@ func TestReadSuccessfully(t *testing.T) {
 	//Some counters, such as rate counters, require two counter values in order to compute a displayable value. In this case we call reader.Read() twice.
 	// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).
 	events, err := reader.Read()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, events)
 	assert.Zero(t, len(events))
 	events, err = reader.Read()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, events)
 	assert.NotZero(t, len(events))
 }

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -78,7 +78,7 @@ func TestAmqp_UnknownMethod(t *testing.T) {
 	_, amqp := amqpModForTests()
 
 	data, err := hex.DecodeString("0100010000000f006e000c0000075465737447657401ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
 
@@ -97,7 +97,7 @@ func TestAmqp_FrameSize(t *testing.T) {
 
 	//incomplete frame
 	data, err := hex.DecodeString("0100000000000c000a001fffff000200")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -119,7 +119,7 @@ func TestAmqp_PartialFrameSize(t *testing.T) {
 
 	//incomplete frame
 	data, err := hex.DecodeString("414d515000060606010000000000")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -139,7 +139,7 @@ func TestAmqp_WrongShortStringSize(t *testing.T) {
 
 	data, err := hex.DecodeString("02000100000019003c000000000000000000058000ac" +
 		"746578742f706c61696ece")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, _ := amqp.amqpMessageParser(stream)
@@ -156,7 +156,7 @@ func TestAmqp_QueueDeclaration(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000001a0032000a00000e5468697320697" +
 		"3206120544553541800000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 
@@ -188,7 +188,7 @@ func TestAmqp_ExchangeDeclaration(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000001c0028000a00000a6c6f67735f746f7" +
 		"0696305746f7069630200000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 
@@ -221,7 +221,7 @@ func TestAmqp_BasicConsume(t *testing.T) {
 
 	data, err := hex.DecodeString("01000100000028003c001400000e4957616e74" +
 		"546f436f6e73756d650d6d6973746572436f6e73756d650300000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 
@@ -254,7 +254,7 @@ func TestAmqp_ExchangeDeletion(t *testing.T) {
 
 	data, err := hex.DecodeString("010001000000100028001400000844656c65746" +
 		"54d6501ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 
@@ -282,7 +282,7 @@ func TestAmqp_ExchangeBind(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000001c0028001e0000057465737431" +
 		"057465737432044d5346540000000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 
@@ -316,9 +316,9 @@ func TestAmqp_ExchangeUnbindTransaction(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000001c00280028000005746573743105" +
 		"7465737432044d5346540000000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("0100010000000400280033ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -351,13 +351,13 @@ func TestAmqp_PublishMessage(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000001b003c002800000a6c6f67735f746f70" +
 		"696308414d51507465737400ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("02000100000019003c0000000000000000001c800" +
 		"00a746578742f706c61696ece")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data3, err := hex.DecodeString("0300010000001c48656c6c6f204461726c696e67" +
 		"2049276d20686f6d6520616761696ece")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -401,12 +401,12 @@ func TestAmqp_DeliverMessage(t *testing.T) {
 	data, err := hex.DecodeString("01000100000034003c003c0d6d6973746572436f6e73" +
 		"756d650000000000000002000c7465737445786368616e67650b7465737444656c697" +
 		"66572ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("02000100000019003c000000000000000000058" +
 		"0000a746578742f706c61696ece")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data3, err := hex.DecodeString("030001000000056b696b6f6fce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -450,7 +450,7 @@ func TestAmqp_MessagePropertiesFields(t *testing.T) {
 		"40000000000002060a656c206d656e73616a650000000055f81dc00c6c6f7665206d65" +
 		"7373616765ce0300010000001a5465737420686561646572206669656c647320666f72" +
 		"65766572ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -492,7 +492,7 @@ func TestAmqp_ChannelError(t *testing.T) {
 		"6f5f64656c6574652720666f722065786368616e676520277465737445786368616e676" +
 		"52720696e2076686f737420272f273a207265636569766564202774727565272062757" +
 		"42063757272656e74206973202766616c7365270028000ace")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data1, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -537,7 +537,7 @@ func TestAmqp_NoWaitQueueDeleteMethod(t *testing.T) {
 
 	data, err := hex.DecodeString("010001000000120032002800000a546573745468" +
 		"6f6d617304ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -568,7 +568,7 @@ func TestAmqp_RejectMessage(t *testing.T) {
 	amqp.sendRequest = true
 
 	data, err := hex.DecodeString("0100010000000d003c005a000000000000000101ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -599,9 +599,9 @@ func TestAmqp_GetEmptyMethod(t *testing.T) {
 
 	data, err := hex.DecodeString("01000100000013003c004600000b526f626269" +
 		"654b65616e6501ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("01000100000005003c004800ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -627,12 +627,12 @@ func TestAmqp_GetMethod(t *testing.T) {
 
 	data, err := hex.DecodeString("0100010000000f003c0046000007546573744" +
 		"7657401ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("0100010000001a003c00470000000000000001" +
 		"0000075465737447657400000001ce02000100000019003c000000000000000000" +
 		"1280000a746578742f706c61696ece03000100000012476574206d6520696620796" +
 		"f752064617265ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -660,7 +660,7 @@ func TestAmqp_MaxBodyLength(t *testing.T) {
 	data, err := hex.DecodeString("01000100000010003c002800000007546573744d617" +
 		"800ce02000100000019003c0000000000000000001680000a746578742f706c61696ece" +
 		"0300010000001649276d2061207665727920626967206d657373616765ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -691,7 +691,7 @@ func TestAmqp_MaxBodyLength(t *testing.T) {
 		"17800ce02000100000018003c0000000000000000003a800009696d6167652f676966" +
 		"ce0300010000003a41414141414141414141414141414141414141414141414141414141" +
 		"414141414141414141414141414141414141414141414141414141414141ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple = testTCPTuple()
 
@@ -731,7 +731,7 @@ func TestAmqp_HideArguments(t *testing.T) {
 	data, err := hex.DecodeString("0100010000004d0032000a00000a5465737448656164" +
 		"6572180000003704626f6f6c74010362697462050568656c6c6f530000001f4869206461" +
 		"726c696e6720c3aac3aac3aac3aac3aac3aac3aae697a5e69cacce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: data}
 	private := protos.ProtocolData(new(amqpPrivateData))
@@ -757,7 +757,7 @@ func TestAmqp_HideArguments(t *testing.T) {
 		"4657200ce02000100000026003c0000000000000000001a98800a746578742f706c61696" +
 		"e02060a656c206d656e73616a65ce0300010000001a54657374206865616465722066696" +
 		"56c647320666f7265766572ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcptuple = testTCPTuple()
 	req = protos.Packet{Payload: data}
 	private = protos.ProtocolData(new(amqpPrivateData))
@@ -787,9 +787,9 @@ func TestAmqp_RecoverMethod(t *testing.T) {
 	amqp.sendRequest = true
 
 	data, err := hex.DecodeString("01000100000005003c006e01ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("01000100000004003c006fce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -814,7 +814,7 @@ func TestAmqp_BasicNack(t *testing.T) {
 	_, amqp := amqpModForTests()
 
 	data1, err := hex.DecodeString("0100010000000d003c0078000000000000000102ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data1, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -841,7 +841,7 @@ func TestAmqp_GetTable(t *testing.T) {
 		"696d616c440500ec49050568656c6c6f530000001f4869206461726c696e6720c3aac3aa" +
 		"c3aac3aac3aac3aac3aae697a5e69cac06646f75626c656440453e100cbd7da405666c6f" +
 		"6174664124cccd04626f6f6c7401ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -900,7 +900,7 @@ func TestAmqp_TableInception(t *testing.T) {
 		"000006445245414d5306696e6365703253000000064d4152494f4e056c696d626f46" +
 		"00000021066c696d626f315300000004436f6262066c696d626f3253000000055361" +
 		"69746f06626967496e746c00071afd498d0000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -950,7 +950,7 @@ func TestAmqp_ArrayFields(t *testing.T) {
 	//byte array, rabbitMQ specific field
 	data, err := hex.DecodeString("010001000000260028000a0000057465737431057" +
 		"46f706963020000000f05617272617978000000040a007dd2ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -975,7 +975,7 @@ func TestAmqp_ArrayFields(t *testing.T) {
 		"0a66666666666096172726179626f6f6c410000000a740174007400740174010b617272" +
 		"6179737472696e674100000030530000000441414141530000000442424242530000001" +
 		"9d090d0bdd0bdd0b020d09ad0b0d180d0b5d0bdd0b8d0bdd0b0ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream = &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete = amqp.amqpMessageParser(stream)
@@ -1030,7 +1030,7 @@ func TestAmqp_WrongTable(t *testing.T) {
 		"96d616c440500ec49050568656c6c6f530000001f4869206461726c696e6720c3aac3aac" +
 		"3aac3aac3aac3aac3aae697a5e69cac06646f75626c656440453e100cbd7da405666c6f6" +
 		"174664124cccd04626f6f6c7401ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete := amqp.amqpMessageParser(stream)
@@ -1053,7 +1053,7 @@ func TestAmqp_WrongTable(t *testing.T) {
 		"96d616c447600ec49180568036c6c0b536400001f480a2064076e6c696e0520c3aac3aac" +
 		"34613aac3aac3aa01aae697a5e69cac3c780b75626c6564a4453e100cbd7da4320a6c0b0" +
 		"90b664124cc1904626f6f6c7401ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream = &amqpStream{data: data, message: new(amqpMessage)}
 	ok, complete = amqp.amqpMessageParser(stream)
@@ -1101,9 +1101,9 @@ func TestAmqp_ChannelCloseErrorMethod(t *testing.T) {
 		"6f5f64656c6574652720666f722065786368616e676520277465737445786368616e676" +
 		"52720696e2076686f737420272f273a207265636569766564202774727565272062757" +
 		"42063757272656e74206973202766616c7365270028000ace")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("0100010000000400280033ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -1127,9 +1127,9 @@ func TestAmqp_ConnectionCloseNoError(t *testing.T) {
 	amqp.hideConnectionInformation = false
 
 	data, err := hex.DecodeString("01000000000012000a003200c8076b74687862616900000000ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("01000000000004000a0033ce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 
@@ -1161,9 +1161,9 @@ func TestAmqp_MultipleBodyFrames(t *testing.T) {
 		"02000100000021003c0000000000000000002a80400a746578742f706c61696e00000000" +
 		"56a22873ce030001000000202a2a2a68656c6c6f2049206c696b6520746f207075626c69" +
 		"736820626967206dce")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data2, err := hex.DecodeString("0300010000000a657373616765732a2a2ace")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: data}

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -767,7 +767,7 @@ func TestHttpParser_requestURIWithSpace(t *testing.T) {
 	assert.True(t, ok)
 	assert.True(t, complete)
 	path, params, err := http.extractParameters(msg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "/test", path)
 	assert.Equal(t, string(msg.requestURI), "http://localhost:8080/test?password=two secret")
 	assert.False(t, strings.Contains(params, "two secret"))
@@ -802,7 +802,7 @@ func TestHttpParser_censorPasswordURL(t *testing.T) {
 	assert.True(t, ok)
 	assert.True(t, complete)
 	path, params, err := http.extractParameters(msg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "/test", path)
 	assert.False(t, strings.Contains(params, "secret"))
 }
@@ -829,7 +829,7 @@ func TestHttpParser_censorPasswordPOST(t *testing.T) {
 	assert.True(t, complete)
 
 	path, params, err := http.extractParameters(msg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "/users/login", path)
 	assert.True(t, strings.Contains(params, "username=ME"))
 	assert.False(t, strings.Contains(params, "secret"))

--- a/packetbeat/protos/memcache/memcache_test.go
+++ b/packetbeat/protos/memcache/memcache_test.go
@@ -90,7 +90,7 @@ func Test_TryMergeUnmergeableResponses(t *testing.T) {
 	msg2 := textParseNoFail(t, "0\r\n")
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.False(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_TryMergeUnmergeableResponseWithValue(t *testing.T) {
@@ -99,7 +99,7 @@ func Test_TryMergeUnmergeableResponseWithValue(t *testing.T) {
 	msg2 := textParseNoFail(t, "0\r\n")
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.False(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_TryMergeUnmergeableResponseWithStat(t *testing.T) {
@@ -108,7 +108,7 @@ func Test_TryMergeUnmergeableResponseWithStat(t *testing.T) {
 	msg2 := textParseNoFail(t, "0\r\n")
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.False(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_MergeTextValueResponses(t *testing.T) {
@@ -119,12 +119,12 @@ func Test_MergeTextValueResponses(t *testing.T) {
 
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, msg1.isComplete)
 
 	b, err = tryMergeResponses(mct.mc, msg1, msg3)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, msg1.isComplete)
 }
 
@@ -136,12 +136,12 @@ func Test_MergeTextStatsValueResponses(t *testing.T) {
 
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, msg1.isComplete)
 
 	b, err = tryMergeResponses(mct.mc, msg1, msg3)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, msg1.isComplete)
 }
 
@@ -159,12 +159,12 @@ func Test_MergeBinaryStatsValueResponses(t *testing.T) {
 
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, msg1.isComplete)
 
 	b, err = tryMergeResponses(mct.mc, msg1, msg3)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, msg1.isComplete)
 }
 
@@ -179,12 +179,12 @@ func Test_MergeTextValueResponsesNoLimits(t *testing.T) {
 
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, msg1.isComplete)
 
 	b, err = tryMergeResponses(mct.mc, msg1, msg3)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, msg1.isComplete)
 
 	msg := msg1
@@ -206,12 +206,12 @@ func Test_MergeTextValueResponsesWithLimits(t *testing.T) {
 
 	b, err := tryMergeResponses(mct.mc, msg1, msg2)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, msg1.isComplete)
 
 	b, err = tryMergeResponses(mct.mc, msg1, msg3)
 	assert.True(t, b)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, msg1.isComplete)
 
 	msg := msg1

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -88,7 +88,7 @@ func TestSimpleFindLimit1(t *testing.T) {
 			"00000000746573742e72667374617572" +
 			"616e7473000000000001000000050000" +
 			"0000")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	respData, err := hex.DecodeString(
 		"020200004a0000000a00000001000000" +
 			"08000000000000000000000000000000" +
@@ -123,7 +123,7 @@ func TestSimpleFindLimit1(t *testing.T) {
 			"53686f70000272657374617572616e74" +
 			"5f696400090000003330303735343435" +
 			"0000")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
@@ -157,7 +157,7 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 			"00000000746573742e72667374617572" +
 			"616e7473000000000001000000050000" +
 			"0000")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	respData1, err := hex.DecodeString(
 		"020200004a0000000a00000001000000" +
 			"08000000000000000000000000000000" +
@@ -196,7 +196,7 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 			"53686f70000272657374617572616e74" +
 			"5f696400090000003330303735343435" +
 			"0000")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
@@ -381,7 +381,7 @@ func TestDocumentLengthBoundsChecked(t *testing.T) {
 			"06000000" +
 			// Document (1 byte instead of 2)
 			"00")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -519,7 +519,7 @@ func Test_gap_in_response(t *testing.T) {
 	reqData, err := hex.DecodeString(
 		"130000000373656c656374202a20" +
 			"66726f6d2074657374")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	respData, err := hex.DecodeString(
 		"0100000103240000020364656604" +
 			"74657374047465737404746573740161" +
@@ -537,7 +537,7 @@ func Test_gap_in_response(t *testing.T) {
 			"6f6620746865207072696e74696e6720" +
 			"616e64207479706573657474696e6720" +
 			"696e6475737472792e204c6f72656d20")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
@@ -571,7 +571,7 @@ func Test_gap_in_eat_message(t *testing.T) {
 	reqData, err := hex.DecodeString(
 		"130000000373656c656374202a20" +
 			"66726f6d20746573")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := &mysqlStream{data: reqData, message: new(mysqlMessage), isClient: true}
 	ok, complete := mysqlMessageParser(stream)
@@ -589,13 +589,13 @@ func Test_read_length(t *testing.T) {
 	var length int
 
 	_, err = readLength([]byte{}, 0)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	_, err = readLength([]byte{0x00, 0x00}, 0)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	length, err = readLength([]byte{0x01, 0x00, 0x00}, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, length, 1)
 }
 
@@ -662,7 +662,7 @@ func Test_PreparedStatement(t *testing.T) {
 
 	send := func(dir uint8, data string) {
 		rawData, err := hex.DecodeString(data)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		packet := protos.Packet{Payload: rawData}
 
 		var private protos.ProtocolData

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -352,7 +352,7 @@ func Test_gap_in_response(t *testing.T) {
 	reqData, err := hex.DecodeString(
 		"510000001873656c656374202a20" +
 			"66726f6d20746573743b00")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// response is incomplete
 	respData, err := hex.DecodeString(
@@ -365,7 +365,7 @@ func Test_gap_in_response(t *testing.T) {
 			"63440000001e0003000000046d656131" +
 			"000000046d656231000000046d656331" +
 			"440000001e0003000000046d65613200")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tcptuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -153,7 +153,7 @@ func Test_configToPortsMap(t *testing.T) {
 
 	for _, test := range configTests {
 		output, err := buildPortsMap(test.Input)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.Output, output)
 	}
 }
@@ -178,7 +178,7 @@ func Test_configToPortsMap_negative(t *testing.T) {
 
 	for _, test := range tests {
 		_, err := buildPortsMap(test.Input)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Contains(t, err.Error(), test.Err)
 	}
 }

--- a/packetbeat/protos/tls/alerts_test.go
+++ b/packetbeat/protos/tls/alerts_test.go
@@ -36,14 +36,14 @@ func getParser() *parser {
 
 func mkBuf(t *testing.T, s string, length int) *bufferView {
 	bytes, err := hex.DecodeString(s)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return newBufferView(streambuf.New(bytes), 0, length)
 }
 
 func TestParse(t *testing.T) {
 	parser := getParser()
 	err := parser.parseAlert(mkBuf(t, "0102", 2))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, parser.alerts, 1)
 	assert.Equal(t, alertSeverity(1), parser.alerts[0].severity)
 	assert.Equal(t, alertCode(2), parser.alerts[0].code)
@@ -52,17 +52,17 @@ func TestParse(t *testing.T) {
 func TestShortBuffer(t *testing.T) {
 	parser := getParser()
 	err := parser.parseAlert(mkBuf(t, "", 2))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Empty(t, parser.alerts)
 
 	err = parser.parseAlert(mkBuf(t, "01", 2))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Empty(t, parser.alerts)
 }
 
 func TestEncrypted(t *testing.T) {
 	parser := getParser()
 	err := parser.parseAlert(mkBuf(t, "010200000000", 6))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, parser.alerts)
 }

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -114,19 +114,19 @@ const (
 
 func sBuf(t *testing.T, hexString string) *streambuf.Buffer {
 	bytes, err := hex.DecodeString(hexString)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return streambuf.New(bytes)
 }
 
 func mapGet(t *testing.T, m common.MapStr, key string) interface{} {
 	value, err := m.GetValue(key)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return value
 }
 
 func mapInt(t *testing.T, m common.MapStr, key string) uint32 {
 	value, err := m.GetValue(key)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return value.(uint32)
 }
 
@@ -137,17 +137,17 @@ func TestParseRecordHeader(t *testing.T) {
 	}
 
 	_, err := readRecordHeader(sBuf(t, ""))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readRecordHeader(sBuf(t, "11"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readRecordHeader(sBuf(t, "1122"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readRecordHeader(sBuf(t, "112233"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readRecordHeader(sBuf(t, "11223344"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	header, err := readRecordHeader(sBuf(t, "1103024455"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, recordType(0x11), header.recordType)
 	assert.Equal(t, "TLS 1.1", header.version.String())
 	assert.Equal(t, uint16(0x4455), header.length)
@@ -164,13 +164,13 @@ func TestParseHandshakeHeader(t *testing.T) {
 	}
 
 	_, err := readHandshakeHeader(sBuf(t, ""))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readHandshakeHeader(sBuf(t, "11"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readHandshakeHeader(sBuf(t, "112233"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = readHandshakeHeader(sBuf(t, "112233"))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	header, err := readHandshakeHeader(sBuf(t, "11223344"))
 	assert.Equal(t, handshakeType(0x11), header.handshakeType)
 	assert.Equal(t, 0x223344, header.length)

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -116,7 +116,7 @@ func TestAlert(t *testing.T) {
 
 	reqData, err := hex.DecodeString(
 		"1503010002022d")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -151,7 +151,7 @@ func TestInvalidAlert(t *testing.T) {
 
 	reqData, err := hex.DecodeString(
 		"1503010003010203")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -167,7 +167,7 @@ func TestClientHello(t *testing.T) {
 
 	reqData, err := hex.DecodeString(rawClientHello)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -179,7 +179,7 @@ func TestClientHello(t *testing.T) {
 	event := results.events[0]
 
 	b, err := json.Marshal(event.Fields)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedClientHello, string(b))
 }
 
@@ -188,7 +188,7 @@ func TestServerHello(t *testing.T) {
 
 	reqData, err := hex.DecodeString(rawServerHello)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -200,9 +200,9 @@ func TestServerHello(t *testing.T) {
 	event := results.events[0]
 
 	hello, err := event.GetValue("tls.detailed.server_hello")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	b, err := json.Marshal(hello)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedServerHello, string(b))
 }
 
@@ -215,7 +215,7 @@ func TestFragmentedHandshake(t *testing.T) {
 			"ee7570a88b9a7d5d56b3af00001c3a3ac02bc02fc02cc030cca9cca8c013c014" +
 			"009c009d")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -227,7 +227,7 @@ func TestFragmentedHandshake(t *testing.T) {
 		"1603010083002f0035000a01000079dada0000ff0100010000000010000e00000b" +
 			"6578616d706c652e6f72670017000000230000000d0014001204030804040105" +
 			"0308050501080606010201000500050100000000001200000010000e000c0268")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	req = protos.Packet{Payload: reqData}
 	private = tls.Parse(&req, tcpTuple, 0, private)
 
@@ -235,7 +235,7 @@ func TestFragmentedHandshake(t *testing.T) {
 	reqData, err = hex.DecodeString(
 		"3208687474702f312e3175500000000b00020100000a000a00086a6a001d0017" +
 			"0018aaaa000100")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	req = protos.Packet{Payload: reqData}
 	private = tls.Parse(&req, tcpTuple, 0, private)
 
@@ -245,7 +245,7 @@ func TestFragmentedHandshake(t *testing.T) {
 	event := results.events[0]
 
 	b, err := json.Marshal(event.Fields)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedClientHello, string(b))
 }
 
@@ -258,7 +258,7 @@ func TestInterleavedRecords(t *testing.T) {
 			"ee7570a88b9a7d5d56b3af00001c3a3ac02bc02fc02cc030cca9cca8c013c014" +
 			"009c009d")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -268,14 +268,14 @@ func TestInterleavedRecords(t *testing.T) {
 	// Then two records containing one alert each, merged in a single packet
 	reqData, err = hex.DecodeString(
 		"1503010002FFFF15030100020101")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	req = protos.Packet{Payload: reqData}
 	private = tls.Parse(&req, tcpTuple, 0, private)
 
 	// And an application data record
 	reqData, err = hex.DecodeString(
 		"17030100080123456789abcdef")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	req = protos.Packet{Payload: reqData}
 	private = tls.Parse(&req, tcpTuple, 0, private)
 
@@ -286,7 +286,7 @@ func TestInterleavedRecords(t *testing.T) {
 			"0308050501080606010201000500050100000000001200000010000e000c0268" +
 			"3208687474702f312e3175500000000b00020100000a000a00086a6a001d0017" +
 			"0018aaaa000100")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	req = protos.Packet{Payload: reqData}
 	private = tls.Parse(&req, tcpTuple, 0, private)
 
@@ -297,11 +297,11 @@ func TestInterleavedRecords(t *testing.T) {
 
 	// Event contains the client hello
 	_, err = event.GetValue("tls.detailed.client_hello")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// and the alert
 	alerts, err := event.GetValue("tls.detailed.alerts")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Len(t, alerts.([]common.MapStr), 2)
 }
@@ -312,7 +312,7 @@ func TestCompletedHandshake(t *testing.T) {
 	// First, a certificates record
 	reqData, err := hex.DecodeString(certsMsg)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -357,7 +357,7 @@ func TestTLS13VersionNegotiation(t *testing.T) {
 			"d809edfcd417861a3ca83e40cf631616e0791efbcc79a0fdfe0d57c6ede4dd4f" +
 			"8dc54cdb7904a8924f10c55f97e5fcc1f813e6002120720c822a09c99a10b09e" +
 			"de25dded2e4c62eff486bf7827f89613f3038d5a200a")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -391,7 +391,7 @@ func TestTLS13VersionNegotiation(t *testing.T) {
 		"tls.detailed.version": "TLS 1.3",
 	} {
 		version, err := results.events[0].Fields.GetValue(key)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, version)
 	}
 }
@@ -401,7 +401,7 @@ func TestLegacyVersionNegotiation(t *testing.T) {
 
 	// First, a client hello
 	reqData, err := hex.DecodeString(rawClientHello)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tcpTuple := testTCPTuple()
 	req := protos.Packet{Payload: reqData}
 	var private protos.ProtocolData
@@ -430,7 +430,7 @@ func TestLegacyVersionNegotiation(t *testing.T) {
 		"tls.detailed.version": "TLS 1.2",
 	} {
 		version, err := results.events[0].Fields.GetValue(key)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, version)
 	}
 }

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -169,7 +169,7 @@ func Test_buildPortsMap(t *testing.T) {
 
 	for _, test := range configTests {
 		output, err := buildPortsMap(test.Input)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.Output, output)
 	}
 }
@@ -198,7 +198,7 @@ func Test_buildPortsMap_portOverlapError(t *testing.T) {
 
 	for _, test := range tests {
 		_, err := buildPortsMap(test.Input)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Contains(t, err.Error(), test.Err)
 	}
 }

--- a/x-pack/filebeat/input/azureeventhub/file_persister_test.go
+++ b/x-pack/filebeat/input/azureeventhub/file_persister_test.go
@@ -22,9 +22,9 @@ func TestFilePersister_Read(t *testing.T) {
 	partitionID := "0"
 	dir := path.Join(os.TempDir(), "read")
 	persister, err := persist.NewFilePersister(dir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ckp, err := persister.Read(namespace, name, consumerGroup, partitionID)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, persist.NewCheckpointFromStartOfStream(), ckp)
 }
 
@@ -35,12 +35,12 @@ func TestFilePersister_Write(t *testing.T) {
 	partitionID := "0"
 	dir := path.Join(os.TempDir(), "write")
 	persister, err := persist.NewFilePersister(dir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ckp := persist.NewCheckpoint("120", 22, time.Now())
 	err = persister.Write(namespace, name, consumerGroup, partitionID, ckp)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ckp2, err := persister.Read(namespace, name, consumerGroup, partitionID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ckp.Offset, ckp2.Offset)
 	assert.Equal(t, ckp.SequenceNumber, ckp2.SequenceNumber)
 }

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
@@ -35,7 +35,7 @@ func TestCloudwatch(t *testing.T) {
 	assert.Equal(t, 1, len(events))
 
 	expectedTime, err := time.ParseInLocation(time.RFC3339, "2019-08-27T12:24:51.193+00:00", time.UTC)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedEvent := beat.Event{
 		Timestamp: expectedTime,
@@ -139,7 +139,7 @@ ciJ9XX0=`),
 	}
 
 	events, err := CloudwatchKinesisEvent(request, true, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(events))
 
 	envelopeFields := common.MapStr{

--- a/x-pack/libbeat/management/api/enroll_test.go
+++ b/x-pack/libbeat/management/api/enroll_test.go
@@ -101,7 +101,7 @@ func TestEnrollError(t *testing.T) {
 				"thisismyenrollmenttoken",
 			)
 
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 			assert.Equal(t, "", accessToken)
 		})
 	}

--- a/x-pack/metricbeat/module/azure/compute_vm/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/client_helper_test.go
@@ -89,7 +89,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricNamespaces", mock.Anything).Return(insights.MetricNamespaceCollection{}, errors.New("invalid resource ID"))
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "no metric namespaces were found for resource 123: invalid resource ID")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
@@ -101,7 +101,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, nil)
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace namespace.")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
@@ -113,7 +113,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metrics, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, metrics[0].Resource.Id, "123")
 		assert.Equal(t, metrics[0].Resource.Name, "resourceName")
 		assert.Equal(t, metrics[0].Resource.Type, "resourceType")

--- a/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
@@ -53,7 +53,7 @@ func TestFetch(t *testing.T) {
 	module, metricsets, err := mb.NewModule(c, mb.Registry)
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ms, ok := metricsets[0].(*MetricSet)
 	assert.Equal(t, len(ms.Client.Config.Resources), 1)
 	assert.Equal(t, ms.Client.Config.Resources[0].Query, fmt.Sprintf("resourceType eq '%s'", defaultVMNamespace))

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/client_helper_test.go
@@ -75,7 +75,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, errors.New("invalid resource ID"))
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace namespace: invalid resource ID")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
@@ -85,7 +85,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, nil)
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace namespace.")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
@@ -95,7 +95,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metrics, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, len(metrics), 2)
 
 		assert.Equal(t, metrics[0].Resource.Id, "123")

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
@@ -53,7 +53,7 @@ func TestFetch(t *testing.T) {
 	module, metricsets, err := mb.NewModule(c, mb.Registry)
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ms, ok := metricsets[0].(*MetricSet)
 	assert.Equal(t, len(ms.Client.Config.Resources), 1)
 	assert.Equal(t, ms.Client.Config.Resources[0].Query, fmt.Sprintf("resourceType eq '%s'", defaultVMScalesetNamespace))

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
@@ -67,7 +67,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(insights.MetricDefinitionCollection{}, errors.New("invalid resource ID"))
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
 	})
@@ -78,7 +78,7 @@ func TestMapMetric(t *testing.T) {
 		metricConfig.Name = []string{"*"}
 		resourceConfig.Metrics = []azure.MetricConfig{metricConfig}
 		metrics, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, metrics[0].Resource.Id, "123")
 		assert.Equal(t, metrics[0].Resource.Name, "resourceName")
 		assert.Equal(t, metrics[0].Resource.Type, "resourceType")
@@ -97,7 +97,7 @@ func TestMapMetric(t *testing.T) {
 		metricConfig.Aggregations = []string{"Average"}
 		resourceConfig.Metrics = []azure.MetricConfig{metricConfig}
 		metrics, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, len(metrics) > 0)
 		assert.Equal(t, metrics[0].Resource.Id, "123")

--- a/x-pack/metricbeat/module/azure/storage/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_test.go
@@ -98,7 +98,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, nil)
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace Microsoft.Storage/storageAccounts.")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
@@ -108,7 +108,7 @@ func TestMapMetric(t *testing.T) {
 		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metrics, err := mapMetrics(client, []resources.GenericResource{resource}, resourceConfig)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, metrics[0].Resource.Id, "123")
 		assert.Equal(t, metrics[0].Resource.Name, "resourceName")
 		assert.Equal(t, metrics[0].Resource.Type, "resourceType")

--- a/x-pack/metricbeat/module/azure/storage/storage_test.go
+++ b/x-pack/metricbeat/module/azure/storage/storage_test.go
@@ -53,7 +53,7 @@ func TestFetch(t *testing.T) {
 	module, metricsets, err := mb.NewModule(c, mb.Registry)
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ms, ok := metricsets[0].(*MetricSet)
 	assert.Equal(t, len(ms.Client.Config.Resources), 1)
 	assert.Equal(t, ms.Client.Config.Resources[0].Query, fmt.Sprintf("resourceType eq '%s'", defaultStorageAccountNamespace))

--- a/x-pack/metricbeat/module/iis/application_pool/reader_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader_test.go
@@ -18,7 +18,7 @@ import (
 func TestNewReaderValid(t *testing.T) {
 	var config Config
 	reader, err := newReader(config)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, reader)
 	assert.NotNil(t, reader.query)
 	assert.NotNil(t, reader.query.Handle)
@@ -31,7 +31,7 @@ func TestInitCounters(t *testing.T) {
 	var config Config
 	reader, err := newReader(config)
 	assert.NotNil(t, reader)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// if iis is not enabled, the reader.ApplicationPools is empty
 	if len(reader.applicationPools) > 0 {
 		assert.NotZero(t, len(reader.query.Counters))


### PR DESCRIPTION
## What does this PR do?

replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why is it important?

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works


- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`
Im not sure what you are looking for here.

## How to test this PR locally

run go test make sure it still passes.