### PR TITLE
Fix hints autodiscover docs typo

### DIFF
--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -193,5 +193,5 @@ You can label Docker containers with useful info to spin up {beatname_uc} module
   co.elastic.metrics/period: 10s
 -------------------------------------------------------------------------------------
 
-The above labels would allow {beatname_uc} to configure a Prometheus collector to poll port `9090`
-of the Docker container every 1 minute.
+The above labels would allow {beatname_uc} to run the nginx module and poll port `80`
+of the Docker container every 10 seconds.


### PR DESCRIPTION
Opening a copy of https://github.com/elastic/beats/pull/18157 (which was for `7.6`) against the master.