### PR TITLE
Cherry-pick #19984 to 7.x: Ignore missing fields in Zeek module in drop_fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -250,6 +250,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix S3 input to trim delimiter /n from each log line. {pull}19972[19972]
 - Fix Filebeat OOMs on very long lines {issue}19500[19500], {pull}19552[19552]
 - Fix s3 input parsing json file without expand_event_list_from_field. {issue}19902[19902] {pull}19962[19962]
+- Ignore missing in Zeek module when dropping unecessary fields. {pull}19984[19984]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/connection/config/connection.yml
+++ b/x-pack/filebeat/module/zeek/connection/config/connection.yml
@@ -12,6 +12,7 @@ json.keys_under_root: false
 processors:
   - drop_fields:
       fields: ["json.orig_bytes","json.resp_bytes","json.tunnel_parents"]
+      ignore_missing: true
   - rename:
       fields:
         - from: "json"

--- a/x-pack/filebeat/module/zeek/files/config/files.yml
+++ b/x-pack/filebeat/module/zeek/files/config/files.yml
@@ -12,6 +12,7 @@ json.keys_under_root: false
 processors:
   - drop_fields:
       fields: ["json.x509"]
+      ignore_missing: true
   - rename:
       fields:
         - from: "json"

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -12,6 +12,7 @@ json.keys_under_root: false
 processors:
   - drop_fields:
       fields: ["json.actions"]
+      ignore_missing: true
   - rename:
       fields:
         - from: "json"
@@ -79,6 +80,7 @@ processors:
 
   - drop_fields:
       fields: ["zeek.notice.remote_location", "zeek.notice.f"]
+      ignore_missing: true
   - convert:
       fields:
         - {from: "zeek.session_id", to: "event.id"}


### PR DESCRIPTION
Cherry-pick of PR #19984 to 7.x branch. Original message: 

## What does this PR do?

This PR sets `ignore_missing` to `true` in the `drop_fields` processors of the Zeek module.

## Why is it important?

Sometimes the fields that are supposed to be dropped are missing. If the fields are missing, Filebeat cannot apply the processors properly and drops the events.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.