### PR TITLE
[Filebeat] Chmod/Chown seccomp fix

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix config reload metrics (`libbeat.config.module.start/stops/running`). {pull}19168[19168]
 - Fix metrics hints builder to avoid wrong container metadata usage when port is not exposed {pull}18979[18979]
 - Server-side TLS config now validates certificate and key are both specified {pull}19584[19584]
+- Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
 
 *Auditbeat*
 

--- a/libbeat/common/seccomp/policy_linux_386.go
+++ b/libbeat/common/seccomp/policy_linux_386.go
@@ -46,6 +46,7 @@ func init() {
 					"exit_group",
 					"fchdir",
 					"fchmod",
+					"fchmodat",
 					"fchown32",
 					"fcntl",
 					"fcntl64",

--- a/libbeat/common/seccomp/policy_linux_386.go
+++ b/libbeat/common/seccomp/policy_linux_386.go
@@ -48,6 +48,7 @@ func init() {
 					"fchmod",
 					"fchmodat",
 					"fchown32",
+					"fchownat",
 					"fcntl",
 					"fcntl64",
 					"fdatasync",

--- a/libbeat/common/seccomp/policy_linux_amd64.go
+++ b/libbeat/common/seccomp/policy_linux_amd64.go
@@ -51,6 +51,7 @@ func init() {
 					"exit_group",
 					"fchdir",
 					"fchmod",
+					"fchmodat",
 					"fchown",
 					"fcntl",
 					"fdatasync",

--- a/libbeat/common/seccomp/policy_linux_amd64.go
+++ b/libbeat/common/seccomp/policy_linux_amd64.go
@@ -53,6 +53,7 @@ func init() {
 					"fchmod",
 					"fchmodat",
 					"fchown",
+					"fchownat",
 					"fcntl",
 					"fdatasync",
 					"flock",


### PR DESCRIPTION
## What does this PR do?

So, to support changing the file permissions dynamically for the filebeat unix socket input under seccomp, I had previously leveraged the fact that `chmod` was already in our whitelist--corresponding to [this call](https://github.com/golang/go/blob/0951939fd9e4a6bc83f23c42e8ddff02b29c997e/src/os/file_posix.go#L79)--which was initially added in [this commit](https://github.com/elastic/beats/commit/5d9aeb7d81902139ca43b0177fcb925930be4191), and also added a whitelist entry for `chown` to support [`os.Chown`](https://github.com/golang/go/blob/0951939fd9e4a6bc83f23c42e8ddff02b29c997e/src/os/file_posix.go#L104).

However, interestingly enough, on Linux systems `syscall.Chmod` and `syscall.Chown` don't actually call the `chown` or `chmod` syscalls at all (good naming convention, right?). Instead they use `fchownat` and `fchmodat`--see [here](https://github.com/golang/go/blob/0951939fd9e4a6bc83f23c42e8ddff02b29c997e/src/syscall/syscall_linux.go#L26-L32).

Currently filebeat is broken under seccomp without these additional entries.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
