### PR TITLE
Interpolate beat name

### DIFF
--- a/libbeat/_meta/config/setup.ilm.reference.yml.tmpl
+++ b/libbeat/_meta/config/setup.ilm.reference.yml.tmpl
@@ -18,7 +18,7 @@
 #setup.ilm.pattern: "{now/d}-000001"
 
 # Set the lifecycle policy name. The default policy name is
-# 'beatname'.
+# '{{.BeatName}}'.
 #setup.ilm.policy_name: "mypolicy"
 
 # The path to a JSON file that contains a lifecycle policy configuration. Used


### PR DESCRIPTION
## What does this PR do?

This should change the documented default policy name from 'beatname' to 'filebeat' in the case of Filebeat.

## Why is it important?

The current docs aren't entirely correct:

<img width="624" alt="Screenshot 2020-07-20 at 16 25 58" src="https://user-images.githubusercontent.com/809707/87948991-b8f99380-caa5-11ea-907c-a4f5416be912.png">