### PR TITLE
Cherry-pick #19981 to 7.x: [Filebeat][Gsuite] Make GSuite docs more clear

### DIFF
--- a/filebeat/docs/modules/gsuite.asciidoc
+++ b/filebeat/docs/modules/gsuite.asciidoc
@@ -21,18 +21,25 @@ include::../include/gs-link.asciidoc[]
 
 It is compatible with a subset of applications under the https://developers.google.com/admin-sdk/reports/v1/get-start/getting-started[Google Reports API v1]. As of today it supports:
 
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/saml[SAML Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/user-accounts[User Accounts Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login[Login Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/admin-application-settings[Admin Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/drive[Drive Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[Groups Audit Activity Events]
+[options="header"]
+|===========================================================================================================================================================================================================================
+| GSuite Service                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                               |
+| SAML https://developers.google.com/admin-sdk/reports/v1/appendix/activity/saml[api docs] https://support.google.com/a/answer/7007375?hl=en&ref_topic=9027054[help]                        | View users’ successful and failed sign-ins to SAML applications.                                                                                                            |
+| User Accounts https://developers.google.com/admin-sdk/reports/v1/appendix/activity/user-accounts[api docs] https://support.google.com/a/answer/9022875?hl=en&ref_topic=9027054[help]      | Audit actions carried out by users on their own accounts including password changes, account recovery details and 2-Step Verification enrollment.                                                    |
+| Login https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login[api docs] https://support.google.com/a/answer/4580120?hl=en&ref_topic=9027054[help]                      | Track user sign-in activity to your domain.                                                                                                                  |
+| Admin https://developers.google.com/admin-sdk/reports/v1/appendix/activity/admin-application-settings[api docs] https://support.google.com/a/answer/4579579?hl=en&ref_topic=9027054[help] | View administrator activity performed within the Google Admin console.                                                                                                                 |
+| Drive https://developers.google.com/admin-sdk/reports/v1/appendix/activity/drive[api docs] https://support.google.com/a/answer/4579696?hl=en&ref_topic=9027054[help]                      | Record user activity within Google Drive including content creation in such as Google Docs, as well as content created elsewhere that your users upload to Drive such as PDFs and Microsoft Word files. |
+| Groups https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[api docs] https://support.google.com/a/answer/6270454?hl=en&ref_topic=9027054[help]                    | Track changes to groups, group memberships and group messages.                                                                                                                |
+|===========================================================================================================================================================================================================================
 
 === Configure the module
 
-In order for filebeat to ingest data from the Google Reports API you must set up a `ServiceAccount` that has access to the `Admin SDK API`. Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+In order for filebeat to ingest data from the Google Reports API you must https://support.google.com/gsuitemigrate/answer/9222993?hl=en[set up a ServiceAccount] that https://support.google.com/gsuitemigrate/answer/9222865?hl=en[has access to the Admin SDK API].
 
-This module will make use of the following `oauth2 scope`:
+
+Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+
+This module will make use of the following *oauth2 scope*:
 
 - `https://www.googleapis.com/auth/admin.reports.audit.readonly`
 
@@ -57,6 +64,18 @@ you can set up your module:
     enabled: true
     var.jwt_file: "./credentials_file.json"
     var.delegated_account: "user@example.com"
+  admin:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
+  drive:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
+  groups:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
 ----
 
 Every fileset has the following configuration options:
@@ -76,11 +95,18 @@ Duration of the time limit on HTTP requests made by the module. Defaults to
 
 *`var.interval`*::
 
-Duration between requests to the API. Defaults to `60s`.
+Duration between requests to the API. Defaults to `2h`.
+
+NOTE: GSuite defaults to a 2 hour polling interval because Google reports can go from
+some minutes up to 3 days of delay. For more details on this, you can read more https://support.google.com/a/answer/7061566[here].
 
 *`var.user_key`*::
 
 Specifies the user key to fetch reports from. Defaults to `all`.
+
+*`var.initial_interval`*::
+
+It will poll events up to this time period when the module starts. This is to prevent polling too many or repeated events on module restarts. Defaults to `24h`.
 
 [float]
 ==== GSuite Reports ECS fields
@@ -88,22 +114,19 @@ Specifies the user key to fetch reports from. Defaults to `all`.
 This is a list of GSuite Reports fields that are mapped to ECS.
 
 [options="header"]
-|=======================================================================================
-| GSuite Reports             | ECS Fields                                              |
-| items[].id.time            | @timestamp                                              |
-| items[].id.uniqueQualifier | event.id                                                |
-| items[].id.applicationName | event.provider                                          |
-| items[].events[].name      | event.action                                            |
-| items[].customerId         | organization.id                                         |
-| items[].ipAddress          | source.ip, related.ip, source.as.*, source.geo.*        |
-| items[].actor.email        | source.user.email, source.user.name, source.user.domain |
-| items[].actor.profileId    | source.user.id                                          |
-|=======================================================================================
+|===============================================================================================
+| GSuite Reports               | ECS Fields                                                    |
+| `items[].id.time`            | `@timestamp`                                                  |
+| `items[].id.uniqueQualifier` | `event.id`                                                    |
+| `items[].id.applicationName` | `event.provider`                                              |
+| `items[].events[].name`      | `event.action`                                                |
+| `items[].customerId`         | `organization.id`                                             |
+| `items[].ipAddress`          | `source.ip`, related.ip`, `source.as.*`, `source.geo.*`       |
+| `items[].actor.email`        | `source.user.email`, `source.user.name`, `source.user.domain` |
+| `items[].actor.profileId`    | `source.user.id`                                              |
+|===============================================================================================
 
 These are the common ones to all filesets.
-
-Note: GSuite defaults to a 2 hours polling interval because Google admin lag times can go from
-some minutes up to 3 days. For more details on this, please read more https://support.google.com/a/answer/7061566[here].
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -699,7 +699,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   user_accounts:
     enabled: true
     # var.jwt_file: credentials.json
@@ -707,7 +707,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   login:
     enabled: true
     # var.jwt_file: credentials.json
@@ -715,7 +715,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   admin:
     enabled: true
     # var.jwt_file: credentials.json
@@ -723,7 +723,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   drive:
     enabled: true
     # var.jwt_file: credentials.json
@@ -731,7 +731,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   groups:
     enabled: true
     # var.jwt_file: credentials.json
@@ -739,7 +739,7 @@ filebeat.modules:
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
 
 #------------------------------- HAProxy Module -------------------------------
 - module: haproxy

--- a/x-pack/filebeat/module/gsuite/_meta/config.yml
+++ b/x-pack/filebeat/module/gsuite/_meta/config.yml
@@ -6,7 +6,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   user_accounts:
     enabled: true
     # var.jwt_file: credentials.json
@@ -14,7 +14,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   login:
     enabled: true
     # var.jwt_file: credentials.json
@@ -22,7 +22,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   admin:
     enabled: true
     # var.jwt_file: credentials.json
@@ -30,7 +30,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   drive:
     enabled: true
     # var.jwt_file: credentials.json
@@ -38,7 +38,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   groups:
     enabled: true
     # var.jwt_file: credentials.json
@@ -46,4 +46,4 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h

--- a/x-pack/filebeat/module/gsuite/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/gsuite/_meta/docs.asciidoc
@@ -16,18 +16,25 @@ include::../include/gs-link.asciidoc[]
 
 It is compatible with a subset of applications under the https://developers.google.com/admin-sdk/reports/v1/get-start/getting-started[Google Reports API v1]. As of today it supports:
 
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/saml[SAML Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/user-accounts[User Accounts Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login[Login Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/admin-application-settings[Admin Audit Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/drive[Drive Activity Events]
-- https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[Groups Audit Activity Events]
+[options="header"]
+|===========================================================================================================================================================================================================================
+| GSuite Service                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                               |
+| SAML https://developers.google.com/admin-sdk/reports/v1/appendix/activity/saml[api docs] https://support.google.com/a/answer/7007375?hl=en&ref_topic=9027054[help]                        | View users’ successful and failed sign-ins to SAML applications.                                                                                                            |
+| User Accounts https://developers.google.com/admin-sdk/reports/v1/appendix/activity/user-accounts[api docs] https://support.google.com/a/answer/9022875?hl=en&ref_topic=9027054[help]      | Audit actions carried out by users on their own accounts including password changes, account recovery details and 2-Step Verification enrollment.                                                    |
+| Login https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login[api docs] https://support.google.com/a/answer/4580120?hl=en&ref_topic=9027054[help]                      | Track user sign-in activity to your domain.                                                                                                                  |
+| Admin https://developers.google.com/admin-sdk/reports/v1/appendix/activity/admin-application-settings[api docs] https://support.google.com/a/answer/4579579?hl=en&ref_topic=9027054[help] | View administrator activity performed within the Google Admin console.                                                                                                                 |
+| Drive https://developers.google.com/admin-sdk/reports/v1/appendix/activity/drive[api docs] https://support.google.com/a/answer/4579696?hl=en&ref_topic=9027054[help]                      | Record user activity within Google Drive including content creation in such as Google Docs, as well as content created elsewhere that your users upload to Drive such as PDFs and Microsoft Word files. |
+| Groups https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[api docs] https://support.google.com/a/answer/6270454?hl=en&ref_topic=9027054[help]                    | Track changes to groups, group memberships and group messages.                                                                                                                |
+|===========================================================================================================================================================================================================================
 
 === Configure the module
 
-In order for filebeat to ingest data from the Google Reports API you must set up a `ServiceAccount` that has access to the `Admin SDK API`. Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+In order for filebeat to ingest data from the Google Reports API you must https://support.google.com/gsuitemigrate/answer/9222993?hl=en[set up a ServiceAccount] that https://support.google.com/gsuitemigrate/answer/9222865?hl=en[has access to the Admin SDK API].
 
-This module will make use of the following `oauth2 scope`:
+
+Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+
+This module will make use of the following *oauth2 scope*:
 
 - `https://www.googleapis.com/auth/admin.reports.audit.readonly`
 
@@ -52,6 +59,18 @@ you can set up your module:
     enabled: true
     var.jwt_file: "./credentials_file.json"
     var.delegated_account: "user@example.com"
+  admin:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
+  drive:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
+  groups:
+    enabled: true
+    var.jwt_file: "./credentials_file.json"
+    var.delegated_account: "user@example.com"
 ----
 
 Every fileset has the following configuration options:
@@ -71,11 +90,18 @@ Duration of the time limit on HTTP requests made by the module. Defaults to
 
 *`var.interval`*::
 
-Duration between requests to the API. Defaults to `60s`.
+Duration between requests to the API. Defaults to `2h`.
+
+NOTE: GSuite defaults to a 2 hour polling interval because Google reports can go from
+some minutes up to 3 days of delay. For more details on this, you can read more https://support.google.com/a/answer/7061566[here].
 
 *`var.user_key`*::
 
 Specifies the user key to fetch reports from. Defaults to `all`.
+
+*`var.initial_interval`*::
+
+It will poll events up to this time period when the module starts. This is to prevent polling too many or repeated events on module restarts. Defaults to `24h`.
 
 [float]
 ==== GSuite Reports ECS fields
@@ -83,22 +109,19 @@ Specifies the user key to fetch reports from. Defaults to `all`.
 This is a list of GSuite Reports fields that are mapped to ECS.
 
 [options="header"]
-|=======================================================================================
-| GSuite Reports             | ECS Fields                                              |
-| items[].id.time            | @timestamp                                              |
-| items[].id.uniqueQualifier | event.id                                                |
-| items[].id.applicationName | event.provider                                          |
-| items[].events[].name      | event.action                                            |
-| items[].customerId         | organization.id                                         |
-| items[].ipAddress          | source.ip, related.ip, source.as.*, source.geo.*        |
-| items[].actor.email        | source.user.email, source.user.name, source.user.domain |
-| items[].actor.profileId    | source.user.id                                          |
-|=======================================================================================
+|===============================================================================================
+| GSuite Reports               | ECS Fields                                                    |
+| `items[].id.time`            | `@timestamp`                                                  |
+| `items[].id.uniqueQualifier` | `event.id`                                                    |
+| `items[].id.applicationName` | `event.provider`                                              |
+| `items[].events[].name`      | `event.action`                                                |
+| `items[].customerId`         | `organization.id`                                             |
+| `items[].ipAddress`          | `source.ip`, related.ip`, `source.as.*`, `source.geo.*`       |
+| `items[].actor.email`        | `source.user.email`, `source.user.name`, `source.user.domain` |
+| `items[].actor.profileId`    | `source.user.id`                                              |
+|===============================================================================================
 
 These are the common ones to all filesets.
-
-Note: GSuite defaults to a 2 hours polling interval because Google admin lag times can go from
-some minutes up to 3 days. For more details on this, please read more https://support.google.com/a/answer/7061566[here].
 
 :has-dashboards!:
 

--- a/x-pack/filebeat/modules.d/gsuite.yml.disabled
+++ b/x-pack/filebeat/modules.d/gsuite.yml.disabled
@@ -9,7 +9,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   user_accounts:
     enabled: true
     # var.jwt_file: credentials.json
@@ -17,7 +17,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   login:
     enabled: true
     # var.jwt_file: credentials.json
@@ -25,7 +25,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   admin:
     enabled: true
     # var.jwt_file: credentials.json
@@ -33,7 +33,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   drive:
     enabled: true
     # var.jwt_file: credentials.json
@@ -41,7 +41,7 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h
   groups:
     enabled: true
     # var.jwt_file: credentials.json
@@ -49,4 +49,4 @@
     # var.initial_interval: 24h
     # var.http_client_timeout: 60s
     # var.user_key: all
-    # var.interval: 5s
+    # var.interval: 2h


### PR DESCRIPTION
Cherry-pick of PR #19981 to 7.x branch. Original message: 

## What does this PR do?

After reading Gsuite docs for 7.9 I thought some things might benefit of a bit more info.

## Why is it important?

Docs need to be as clear as possible for people who sets up the module.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

