### PR TITLE
[CI] MacOS stages for branches/tags and PRs when certain conditions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\/test(\W+macos)?$)')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test(\W+macos)?$)')
   }
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,6 @@ pipeline {
             mageTarget(context: "Elastic Agent x-pack Linux", directory: "x-pack/elastic-agent", target: "build test")
           }
         }
-
         stage('Elastic Agent x-pack Windows'){
           agent { label 'windows-immutable && windows-2019' }
           options { skipDefaultCheckout() }
@@ -121,7 +120,6 @@ pipeline {
             mageTargetWin(context: "Elastic Agent x-pack Windows Unit test", directory: "x-pack/elastic-agent", target: "build unitTest")
           }
         }
-
         stage('Elastic Agent Mac OS X'){
           agent { label 'macosx' }
           options { skipDefaultCheckout() }
@@ -140,7 +138,6 @@ pipeline {
             }
           }
         }
-
         stage('Filebeat oss'){
           agent { label 'ubuntu && immutable' }
           options { skipDefaultCheckout() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test(\W+macos)?$)')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test(\\W+macos)?$)')
   }
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1350,11 +1350,11 @@ def loadConfigEnvVars(){
   // Skip all the stages for changes only related to the documentation
   env.ONLY_DOCS = isDocChangedOnly()
 
-  // Enable MacOSX when required:
-  //  - UI parameter is set
-  //  - by default for branches and tags
-  //  - if GH comment that contains `for macos`
-  env.BUILD_ON_MACOS = params.macosTest || !isPR() || (env.GITHUB_COMMENT?.contains('for macos'))
+  // Enable macOS builds when required
+  env.BUILD_ON_MACOS = params.macosTest                 // UI Input parameter is set to true
+                      || !isPR()                        // For branches and tags
+                      || matchesPrLabel(label: 'macOS') // If `macOS` GH label (Case-Sensitive)
+                      || (env.GITHUB_COMMENT?.toLowerCase().contains('for macos')) // If `for macos` in the GH comment (Case-Insensitive)
 }
 
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests\\W+(?:for\\W+macos)?(?:\\W+please)?.*')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\/test(\W+macos)?$)')
   }
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')
@@ -1351,10 +1351,10 @@ def loadConfigEnvVars(){
   env.ONLY_DOCS = isDocChangedOnly()
 
   // Enable macOS builds when required
-  env.BUILD_ON_MACOS = (params.macosTest                 // UI Input parameter is set to true
+  env.BUILD_ON_MACOS = (params.macosTest                  // UI Input parameter is set to true
                         || !isPR()                        // For branches and tags
                         || matchesPrLabel(label: 'macOS') // If `macOS` GH label (Case-Sensitive)
-                        || (env.GITHUB_COMMENT?.toLowerCase().contains('for macos'))) // If `for macos` in the GH comment (Case-Insensitive)
+                        || (env.GITHUB_COMMENT?.toLowerCase().contains('/test macos'))) // If `/test macos` in the GH comment (Case-Insensitive)
 }
 
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,12 +55,10 @@ pipeline {
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')
     booleanParam(name: 'windowsTest', defaultValue: true, description: 'Allow Windows stages.')
-    booleanParam(name: 'macosTest', defaultValue: true, description: 'Allow macOS stages.')
-
+    booleanParam(name: 'macosTest', defaultValue: false, description: 'Allow macOS stages.')
     booleanParam(name: 'allCloudTests', defaultValue: false, description: 'Run all cloud integration tests.')
     booleanParam(name: 'awsCloudTests', defaultValue: false, description: 'Run AWS cloud integration tests.')
     string(name: 'awsRegion', defaultValue: 'eu-central-1', description: 'Default AWS region to use for testing.')
-
     booleanParam(name: 'debug', defaultValue: false, description: 'Allow debug logging for Jenkins steps')
     booleanParam(name: 'dry_run', defaultValue: false, description: 'Skip build steps, it is for testing pipeline flow')
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests\\W+(?:for\\W+macos)?(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')
@@ -126,7 +126,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_ELASTIC_AGENT_XPACK != "false" && params.macosTest
+              return env.BUILD_ELASTIC_AGENT_XPACK != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -170,7 +170,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_FILEBEAT != "false" && params.macosTest
+              return env.BUILD_FILEBEAT != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -188,7 +188,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_FILEBEAT_XPACK != "false" && params.macosTest
+              return env.BUILD_FILEBEAT_XPACK != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -247,7 +247,7 @@ pipeline {
               when {
                 beforeAgent true
                 expression {
-                  return params.macosTest
+                  return env.BUILD_ON_MACOS != 'false'
                 }
               }
               steps {
@@ -306,7 +306,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_AUDITBEAT != "false" && params.macosTest
+              return env.BUILD_AUDITBEAT != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -350,7 +350,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_AUDITBEAT_XPACK != "false" && params.macosTest
+              return env.BUILD_AUDITBEAT_XPACK != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -503,7 +503,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_METRICBEAT != "false" && params.macosTest
+              return env.BUILD_METRICBEAT != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -516,7 +516,7 @@ pipeline {
           when {
             beforeAgent true
             expression {
-              return env.BUILD_METRICBEAT_XPACK != "false" && params.macosTest
+              return env.BUILD_METRICBEAT_XPACK != "false" && env.BUILD_ON_MACOS != 'false'
             }
           }
           steps {
@@ -575,7 +575,7 @@ pipeline {
               when {
                 beforeAgent true
                 expression {
-                  return params.macosTest
+                  return env.BUILD_ON_MACOS != 'false'
                 }
               }
               steps {
@@ -686,7 +686,7 @@ pipeline {
               when {
                 beforeAgent true
                 expression {
-                  return params.macosTest
+                  return env.BUILD_ON_MACOS != 'false'
                 }
               }
               steps {
@@ -758,7 +758,7 @@ pipeline {
               when {
                 beforeAgent true
                 expression {
-                  return params.macosTest
+                  return env.BUILD_ON_MACOS != 'false'
                 }
               }
               steps {
@@ -776,7 +776,7 @@ pipeline {
               when {
                 beforeAgent true
                 expression {
-                  return params.macosTest
+                  return env.BUILD_ON_MACOS != 'false'
                 }
               }
               steps {
@@ -1342,6 +1342,12 @@ def loadConfigEnvVars(){
 
   // Skip all the stages for changes only related to the documentation
   env.ONLY_DOCS = isDocChangedOnly()
+
+  // Enable MacOSX when required:
+  //  - UI parameter is set
+  //  - by default for branches and tags
+  //  - if GH comment that contains `for macos`
+  env.BUILD_ON_MACOS = params.macosTest || !isPR() || (env.GITHUB_COMMENT?.contains('for macos'))
 }
 
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1351,10 +1351,10 @@ def loadConfigEnvVars(){
   env.ONLY_DOCS = isDocChangedOnly()
 
   // Enable macOS builds when required
-  env.BUILD_ON_MACOS = params.macosTest                 // UI Input parameter is set to true
-                      || !isPR()                        // For branches and tags
-                      || matchesPrLabel(label: 'macOS') // If `macOS` GH label (Case-Sensitive)
-                      || (env.GITHUB_COMMENT?.toLowerCase().contains('for macos')) // If `for macos` in the GH comment (Case-Insensitive)
+  env.BUILD_ON_MACOS = (params.macosTest                 // UI Input parameter is set to true
+                        || !isPR()                        // For branches and tags
+                        || matchesPrLabel(label: 'macOS') // If `macOS` GH label (Case-Sensitive)
+                        || (env.GITHUB_COMMENT?.toLowerCase().contains('for macos'))) // If `for macos` in the GH comment (Case-Insensitive)
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ It is possible to trigger some jobs by putting a comment on a GitHub PR.
 (This service is only available for users affiliated with Elastic and not for open-source contributors.)
 
 * [beats][]
-  * `jenkins run the tests please`
-  * `jenkins run tests`
+  * `jenkins run the tests please` or `jenkins run tests` or `/test` will kick off a default build.
+  * `/test macos` will kick off a default build with also the `macos` stages.
 * [apm-beats-update][]
   * `/run apm-beats-update`
 


### PR DESCRIPTION
## What

- Run the MacOS stages for all the branches/tags builds.
- Run the MacOS stages for PRs that 
  - were built manually with the UI parameter `macosTest`
  - got a GitHub comment with `/test macos`
  - got a GitHub label `macOS`

## Why is it important?

As long as MacOS workers are not fungible/ephemerals we got a restriction in the number of physical workers we got for such we need to disable the macOS by default for all the PRs.

## Issues

Closes https://github.com/elastic/beats/issues/19754

## Tasks

- [x] Test
- [x] Label based

## Tests

- Comment based

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/88035219-bd6f8c00-cb39-11ea-92e1-7676f52b8b2b.png)

</p>
</details>

- UI params based

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/88035352-edb72a80-cb39-11ea-8726-811518ce638c.png)

caused

![image](https://user-images.githubusercontent.com/2871786/88039302-489f5080-cb3f-11ea-8d6f-165df84aa4fa.png)

</p>
</details>

- GH label based

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/88039362-5ead1100-cb3f-11ea-949c-4fc047d3b863.png)

and a push event caused 

![image](https://user-images.githubusercontent.com/2871786/88042823-73d86e80-cb44-11ea-8e4b-23c16ec5dff5.png)

</p>
</details>


## Tasks

- [ ] Agree in https://github.com/elastic/beats/issues/19754