### PR TITLE
[Ingest Manager] Fixed unzip on older windows 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@
 - Remove support for logs type and use logfile {pull}19761[19761]
 - Avoid comparing uncomparable types on enroll {issue}19976[19976]
 - Fix issues with merging of elastic-agent.yml and fleet.yml {pull}20026[20026]
+- Unzip failures on Windows 8/Windows server 2012 {pull}20088[20088]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
@@ -11,9 +11,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
-	"github.com/hashicorp/go-multierror"
 )
 
 const (

--- a/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
@@ -7,13 +7,13 @@ package zip
 import (
 	"archive/zip"
 	"context"
-	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -47,7 +47,7 @@ func (i *Installer) Install(_ context.Context, programName, version, installDir 
 		os.RemoveAll(installDir)
 	}
 
-	if err := i.unzip(artifactPath, programName, version); err != nil {
+	if err := i.unzip(artifactPath); err != nil {
 		return err
 	}
 
@@ -67,14 +67,59 @@ func (i *Installer) Install(_ context.Context, programName, version, installDir 
 	return nil
 }
 
-func (i *Installer) unzip(artifactPath, programName, version string) error {
-	if _, err := os.Stat(artifactPath); err != nil {
-		return errors.New(fmt.Sprintf("artifact for '%s' version '%s' could not be found at '%s'", programName, version, artifactPath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, artifactPath))
+func (i *Installer) unzip(artifactPath string) error {
+	r, err := zip.OpenReader(artifactPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := os.MkdirAll(i.config.InstallPath, 0755); err != nil && !os.IsExist(err) {
+		// failed to create install dir
+		return err
 	}
 
-	powershellArg := fmt.Sprintf("Expand-Archive -LiteralPath \"%s\" -DestinationPath \"%s\"", artifactPath, i.config.InstallPath)
-	installCmd := exec.Command("powershell", "-command", powershellArg)
-	return installCmd.Run()
+	unpackFile := func(f *zip.File) (err error) {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if cerr := rc.Close(); cerr != nil {
+				err = multierror.Append(err, cerr)
+			}
+		}()
+
+		path := filepath.Join(i.config.InstallPath, f.Name)
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, f.Mode())
+		} else {
+			os.MkdirAll(filepath.Dir(path), f.Mode())
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if cerr := f.Close(); cerr != nil {
+					err = multierror.Append(err, cerr)
+				}
+			}()
+
+			if _, err = io.Copy(f, rc); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, f := range r.File {
+		if err := unpackFile(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // retrieves root directory from zip archive


### PR DESCRIPTION
## What does this PR do?

We used Expand_Archive function provided by powershell to unpack zip archives on windows. this is not available on PowerShell 4. Strategy is changed not to use powershell functionaliry but rather the approach taken with tars - walking and expanding the archive.

## Why is it important?

Supporting windows 8 and server 2012

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
