### PR TITLE
Cherry-pick to 7.x: [CI] do not update go.mod during linting (#19824)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,10 @@ pipeline {
     }
     stage('Lint'){
       options { skipDefaultCheckout() }
+      environment {
+        // See https://github.com/elastic/beats/pull/19823
+        GOFLAGS = '-mod=readonly'
+      }
       steps {
         makeTarget(context: "Lint", target: "check")
       }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] do not update go.mod during linting (#19824)