### PR TITLE
Bumping up version of MarkupSafe dependency

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -14,7 +14,7 @@ idna==2.6
 ipaddress==1.0.19
 Jinja2==2.10.1
 jsonschema==2.6.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0


### PR DESCRIPTION
## What does this PR do?

Bumps up the version of the `MarkupSafe` Python package dependency.

## Why is it important?

Starting from a clean checkout of the Beats repo, when `mage update` is run in the `metricbeat` folder, it results in the following error:
```
$ mage update
Generated fields.yml for metricbeat to /Users/shaunak/development/github/beats/metricbeat/fields.yml
>> Building metricbeat.yml for linux/amd64
>> Building metricbeat.reference.yml for linux/amd64
>> Building metricbeat.docker.yml for linux/amd64
Generated fields.yml for metricbeat to /Users/shaunak/development/github/beats/metricbeat/build/fields/fields.all.yml
    ERROR: Command errored out with exit status 1:
     command: /Users/shaunak/development/github/beats/build/ve/darwin/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/0b/vxz4y9xd6c92xqf060bdnp340000gn/T/pip-install-mthg408b/MarkupSafe/setup.py'"'"'; __file__='"'"'/private/var/folders/0b/vxz4y9xd6c92xqf060bdnp340000gn/T/pip-install-mthg408b/MarkupSafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/0b/vxz4y9xd6c92xqf060bdnp340000gn/T/pip-pip-egg-info-0meyrnk6
         cwd: /private/var/folders/0b/vxz4y9xd6c92xqf060bdnp340000gn/T/pip-install-mthg408b/MarkupSafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/0b/vxz4y9xd6c92xqf060bdnp340000gn/T/pip-install-mthg408b/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature' from 'setuptools' (/Users/shaunak/development/github/beats/build/ve/darwin/lib/python3.8/site-packages/setuptools/__init__.py)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Error: running "/Users/shaunak/development/github/beats/build/ve/darwin/bin/pip install --quiet -Ur /Users/shaunak/development/github/beats/libbeat/tests/system/requirements.txt" failed with exit code 1
```

I traced this error back to https://github.com/pallets/markupsafe/issues/116. Per the directions in that issue, this PR fixes the error by bumping up the version of `MarkupSafe`.
