### PR TITLE
Cherry-pick #19864 to 7.x: libbeat/publisher/pipeline: fix Client.Close

### DIFF
--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -271,7 +271,7 @@ func (w *clientCloseWaiter) signalClose() {
 		return
 	}
 
-	w.closing.Store(false)
+	w.closing.Store(true)
 	if w.events.Load() == 0 {
 		w.finishClose()
 		return


### PR DESCRIPTION
Cherry-pick of PR #19864 to 7.x branch. Original message: 

## What does this PR do?

Fix a regression in `clientCloseWaiter`, so that when a `WaitClose` timeout is specified it can be interrupted by all events being acknowledged. Set the "closing" variable to true, not false, upon signalling the waiter to close.

## Why is it important?

Fixes a regression in `WaitClose` behaviour.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

`go test ./libbeat/publisher/pipeline`

## Related issues

https://github.com/elastic/beats/pull/19514