### PR TITLE
Cherry-pick #20095 to 7.x: Eliminate panic due to nil pointer dereference in Journalbeat

### DIFF
--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -76,6 +76,7 @@ func newReader(path string, c Config, done chan struct{}, state checkpoint.Journ
 	instance.AddJournalToMonitor(c.Path, journal)
 
 	return &Reader{
+		r:       r,
 		journal: journal,
 		config:  c,
 		done:    done,


### PR DESCRIPTION
Cherry-pick of PR #20095 to 7.x branch. Original message: 

## What does this PR do?

* Fix nil pointer dereference in Journalbeat

## Why is it important?

The current 7.9 snapshot panics with the default configuration.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes #20089