### PR TITLE
Cherry-pick #19962 to 7.9: [Filebeat] Fix s3 input parsing json file without expand_event_list_from_field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -120,6 +120,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
 - Fix S3 input to trim delimiter /n from each log line. {pull}19972[19972]
+- Ignore missing in Zeek module when dropping unecessary fields. {pull}19984[19984]
+- Fix Filebeat OOMs on very long lines {issue}19500[19500], {pull}19552[19552]
+- Fix s3 input parsing json file without expand_event_list_from_field. {issue}19902[19902] {pull}19962[19962]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -120,8 +120,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
 - Fix S3 input to trim delimiter /n from each log line. {pull}19972[19972]
-- Ignore missing in Zeek module when dropping unecessary fields. {pull}19984[19984]
-- Fix Filebeat OOMs on very long lines {issue}19500[19500], {pull}19552[19552]
 - Fix s3 input parsing json file without expand_event_list_from_field. {issue}19902[19902] {pull}19962[19962]
 
 *Heartbeat*

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -455,17 +455,10 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 		gzipReader.Close()
 	}
 
-	// Check if expand_event_list_from_field is given with document content-type = "application/json"
-	if resp.ContentType != nil && *resp.ContentType == "application/json" && p.config.ExpandEventListFromField == "" {
-		err := errors.New("expand_event_list_from_field parameter is missing in config for application/json content-type file")
-		p.logger.Error(err)
-		return err
-	}
-
-	// Decode JSON documents when expand_event_list_from_field is given in config
-	if p.config.ExpandEventListFromField != "" {
+	// Decode JSON documents when content-type is "application/json" or expand_event_list_from_field is given in config
+	if resp.ContentType != nil && *resp.ContentType == "application/json" || p.config.ExpandEventListFromField != "" {
 		decoder := json.NewDecoder(reader)
-		err := p.decodeJSONWithKey(decoder, objectHash, info, s3Ctx)
+		err := p.decodeJSON(decoder, objectHash, info, s3Ctx)
 		if err != nil {
 			err = errors.Wrapf(err, "decodeJSONWithKey failed for '%s' from S3 bucket '%s'", info.key, info.name)
 			p.logger.Error(err)
@@ -512,32 +505,19 @@ func (p *s3Input) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info, s3C
 	return nil
 }
 
-func (p *s3Input) decodeJSONWithKey(decoder *json.Decoder, objectHash string, s3Info s3Info, s3Ctx *s3Context) error {
+func (p *s3Input) decodeJSON(decoder *json.Decoder, objectHash string, s3Info s3Info, s3Ctx *s3Context) error {
 	offset := 0
 	for {
-		var jsonFields map[string][]interface{}
+		var jsonFields interface{}
 		err := decoder.Decode(&jsonFields)
 		if jsonFields == nil {
 			return nil
 		}
 
 		if err == io.EOF {
-			// create event for last line
-			// get logs from expand_event_list_from_field
-			textValues, ok := jsonFields[p.config.ExpandEventListFromField]
-			if !ok {
-				err = errors.Wrapf(err, "key '%s' not found", p.config.ExpandEventListFromField)
-				p.logger.Error(err)
+			offset, err = p.jsonFieldsType(jsonFields, offset, objectHash, s3Info, s3Ctx)
+			if err != nil {
 				return err
-			}
-
-			for _, v := range textValues {
-				err := p.convertJSONToEvent(v, offset, objectHash, s3Info, s3Ctx)
-				if err != nil {
-					err = errors.Wrapf(err, "convertJSONToEvent failed for '%s' from S3 bucket '%s'", s3Info.key, s3Info.name)
-					p.logger.Error(err)
-					return err
-				}
 			}
 		} else if err != nil {
 			// decode json failed, skip this log file
@@ -546,25 +526,46 @@ func (p *s3Input) decodeJSONWithKey(decoder *json.Decoder, objectHash string, s3
 			return nil
 		}
 
-		textValues, ok := jsonFields[p.config.ExpandEventListFromField]
-		if !ok {
-			err = errors.Wrapf(err, "Key '%s' not found", p.config.ExpandEventListFromField)
-			p.logger.Error(err)
+		offset, err = p.jsonFieldsType(jsonFields, offset, objectHash, s3Info, s3Ctx)
+		if err != nil {
 			return err
-		}
-
-		for _, v := range textValues {
-			err := p.convertJSONToEvent(v, offset, objectHash, s3Info, s3Ctx)
-			if err != nil {
-				err = errors.Wrapf(err, "Key '%s' not found", p.config.ExpandEventListFromField)
-				p.logger.Error(err)
-				return err
-			}
 		}
 	}
 }
 
-func (p *s3Input) convertJSONToEvent(jsonFields interface{}, offset int, objectHash string, s3Info s3Info, s3Ctx *s3Context) error {
+func (p *s3Input) jsonFieldsType(jsonFields interface{}, offset int, objectHash string, s3Info s3Info, s3Ctx *s3Context) (int, error) {
+	switch f := jsonFields.(type) {
+	case map[string][]interface{}:
+		if p.config.ExpandEventListFromField != "" {
+			textValues, ok := f[p.config.ExpandEventListFromField]
+			if !ok {
+				err := errors.Errorf("key '%s' not found", p.config.ExpandEventListFromField)
+				p.logger.Error(err)
+				return offset, err
+			}
+			for _, v := range textValues {
+				offset, err := p.convertJSONToEvent(v, offset, objectHash, s3Info, s3Ctx)
+				if err != nil {
+					err = errors.Wrapf(err, "convertJSONToEvent failed for '%s' from S3 bucket '%s'", s3Info.key, s3Info.name)
+					p.logger.Error(err)
+					return offset, err
+				}
+			}
+			return offset, nil
+		}
+	case map[string]interface{}:
+		offset, err := p.convertJSONToEvent(f, offset, objectHash, s3Info, s3Ctx)
+		if err != nil {
+			err = errors.Wrapf(err, "convertJSONToEvent failed for '%s' from S3 bucket '%s'", s3Info.key, s3Info.name)
+			p.logger.Error(err)
+			return offset, err
+		}
+		return offset, nil
+	}
+	return offset, nil
+}
+
+func (p *s3Input) convertJSONToEvent(jsonFields interface{}, offset int, objectHash string, s3Info s3Info, s3Ctx *s3Context) (int, error) {
 	vJSON, err := json.Marshal(jsonFields)
 	logOriginal := string(vJSON)
 	log := trimLogDelimiter(logOriginal)
@@ -575,9 +576,9 @@ func (p *s3Input) convertJSONToEvent(jsonFields interface{}, offset int, objectH
 	if err != nil {
 		err = errors.Wrap(err, "forwardEvent failed")
 		p.logger.Error(err)
-		return err
+		return offset, err
 	}
-	return nil
+	return offset, nil
 }
 
 func (p *s3Input) forwardEvent(event beat.Event) error {


### PR DESCRIPTION
Cherry-pick of PR #19962 to 7.9 branch. Original message: 

## What does this PR do?

This PR is to fix s3 input when parsing json files without `expand_event_list_from_field` config parameter.
During testing I found `offset` is not working properly for s3 input events, this PR also fix it.

## Why is it important?

For some logs, such as Cloudflare, json looks like:
```
{"id": "0001", "hey": "there", "how": {"are": "you"}}
{"id": "0002", "hope": "you", "are": {"doing": "well"}}
{"id": "0003", "I": "am", "doing": {"O": "K"}}
```
instead of with a head field like:
```
{
  "Records": [
    {
      "eventVersion": "1.05",
      "userIdentity": {
        "type": "AssumedRole",
        "principalId": "AROAJ3UFBPIHDEKKCOI2G:AssumeRoleSession",
        "arn": "arn:aws:sts::123456789012:assumed-role/CloudHealth/AssumeRoleSession",
        "accountId": "123456789012"
      }
]
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Create a test log file:
```
$ cat s3filebeat.log 
{"id": "0001", "hey": "there", "how": {"are": "you"}}
{"id": "0002", "hope": "you", "are": {"doing": "well"}}
{"id": "0003", "I": "am", "doing": {"O": "K"}}
```

Gzip the log file:
```
gzip s3filebeat.log 
```

Upload the file to S3 bucket and add property:
```
$ aws --profile PROFILE s3api put-object --body ./s3filebeat.log.gz --bucket lucas-test-filebeat-s3 --content-encoding gzip --content-type application/json --key s3filebeat.log.gz
{
    "ETag": "\"955ed9f01b6ee38dbba167daab9ebbbb\""
}
```
or manually upload this file to s3 bucket and change the property there.

Change filebeat input to s3 in `filebeat.yml`
```
filebeat.inputs:
- type: s3
  queue_url: https://sqs.us-east-1.amazonaws.com/428152502467/test-fb-ks
  credential_profile_name: elastic-beats
```

Run `./filebeat -e`

## Related issues
- Closes elastic/beats#19902
