### PR TITLE
Avoid modifications of base module host when building metricsets

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -97,3 +97,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove vendor folder from repository. {pull}18655[18655]
 - Added SQL helper that can be used from any Metricbeat module {pull}18955[18955]
 - Update Go version to 1.14.4. {pull}19753[19753]
+- Metricbeat module builders don't modify the base module host, so host parsers can be called multiple times with the original host. {pull}20143[20143]

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -125,7 +125,7 @@ func initMetricSets(r *Register, m Module) ([]MetricSet, error) {
 		}
 
 		bm.registration = registration
-		bm.hostData = HostData{URI: bm.host}
+		bm.hostData = HostData{URI: bm.host, Host: bm.host}
 		if registration.HostParser != nil {
 			bm.hostData, err = registration.HostParser(bm.Module(), bm.host)
 			if err != nil {
@@ -133,7 +133,6 @@ func initMetricSets(r *Register, m Module) ([]MetricSet, error) {
 					bm.Module().Name(), bm.Name()))
 				continue
 			}
-			bm.host = bm.hostData.Host
 		}
 
 		metricSet, err := registration.Factory(bm)

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -18,9 +18,6 @@
 package mb
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -86,30 +83,16 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 		// At this point host parser was already run, we need to run this again
 		// with the overriden defaults
 		if registration.HostParser != nil {
-			host := m.useHostURISchemeIfPossible(base.host, base.hostData.URI)
-			base.hostData, err = registration.HostParser(base.module, host)
+			base.hostData, err = registration.HostParser(base.module, base.host)
 			if err != nil {
 				return nil, errors.Wrapf(err, "host parser failed on light metricset factory for '%s/%s'", m.Module, m.Name)
 			}
-			base.host = base.hostData.Host
 		}
 
 		return originalFactory(base)
 	}
 
 	return registration, nil
-}
-
-// useHostURISchemeIfPossible method parses given URI to extract protocol scheme and prepend it to the host.
-// It prevents from skipping protocol scheme (e.g. https) while executing HostParser.
-func (m *LightMetricSet) useHostURISchemeIfPossible(host, uri string) string {
-	u, err := url.ParseRequestURI(uri)
-	if err == nil {
-		if u.Scheme != "" {
-			return fmt.Sprintf("%s://%s", u.Scheme, u.Host)
-		}
-	}
-	return host
 }
 
 // baseModule does the configuration overrides in the base module configuration

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -283,7 +283,6 @@ type HostData struct {
 	SanitizedURI string // A sanitized version of the URI without credentials.
 
 	// Parts of the URI.
-
 	Host     string // The host and possibly port.
 	User     string // Username
 	Password string // Password
@@ -357,7 +356,7 @@ func (b *BaseMetricSet) Module() Module {
 // Host returns the hostname or other module specific value that identifies a
 // specific host or service instance from which to collect metrics.
 func (b *BaseMetricSet) Host() string {
-	return b.host
+	return b.hostData.Host
 }
 
 // HostData returns the parsed host data.

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -236,7 +236,7 @@ func TestNewModulesHostParser(t *testing.T) {
 
 		// The URI is passed through in the Host() and HostData().URI.
 		assert.Equal(t, uri, ms.Host())
-		assert.Equal(t, HostData{URI: uri}, ms.HostData())
+		assert.Equal(t, HostData{URI: uri, Host: uri}, ms.HostData())
 	})
 
 	t.Run("MetricSet with HostParser", func(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Avoid modifying the host in Metricbeat module builders.

## Why is it important?

When using light modules, host parser is called twice. First by the actual implementation
of the metricset, and second after adding the configuration defined in the light module
manifest. Without this change we may lose information as the scheme (#16205), or some
other elements in the url (#19849) and parsers will fail or will generate incorrect host data
objects.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (Covered by tests from https://github.com/elastic/beats/pull/16205).
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- There should be no changes in addresses included in metricbeat events, check specially on modules using custom host parsers as the sql ones.
- Check that steps described in #19849 don't cause any issue.

## Related issues

- Closes #19849
- Replaces #16205
- Relates #18955

## Use cases

- Implement light modules based on native modules with custom host parsers.