### PR TITLE
Cherry-pick #19975 to 7.x: Fix starttime of metricsets on dataset endpoint for metricbeat

### DIFF
--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -142,7 +142,7 @@ func (mw *Wrapper) Start(done <-chan struct{}) <-chan beat.Event {
 			defer msw.close()
 
 			registry.Add(metricsPath, msw.Metrics(), monitoring.Full)
-			monitoring.NewString(msw.Metrics(), "starttime").Set(common.Time{}.String())
+			monitoring.NewString(msw.Metrics(), "starttime").Set(common.Time(time.Now()).String())
 
 			msw.run(done, out)
 		}(msw)


### PR DESCRIPTION
Cherry-pick of PR #19975 to 7.x branch. Original message: 

Bug

## What does this PR do?

Starttime of all metricsets on the `/dataset` endpoint is always ` "0001-01-01T00:00:00.000Z"`. This PR fixes that. 

## Why is it important?

Helps better debugging. 

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

