### PR TITLE
Call host parser only once when building light metricsets

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -55,6 +55,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 ==== Bugfixes
 
 - Stop using `mage:import` in community beats. This was ignoring the vendorized beats directory for some mage targets, using the code available in GOPATH, this causes inconsistencies and compilation problems if the version of the code in the GOPATH is different to the vendored one. Use of `mage:import` will continue to be unsupported in custom beats till beats is migrated to go modules, or mage supports vendored dependencies. {issue}13998[13998] {pull}14162[14162]
+- Metricbeat module builders call host parser only once when instantiating light modules. {pull}20149[20149]
 
 ==== Added
 

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -62,8 +62,7 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 	// - Override defaults
 	// - Call module factory if registered (it wouldn't have been called
 	//   if light module is really a registered mixed module)
-	// - Call host parser if defined (it would have already been called
-	//   without the light module defaults)
+	// - Call host parser if there was one defined
 	// - Finally, call the original factory for the registered metricset
 	registration.Factory = func(base BaseMetricSet) (MetricSet, error) {
 		// Override default config on base module and metricset
@@ -85,7 +84,7 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 			base.module = module
 		}
 
-		// Run the host parser if there was any
+		// Run the host parser if there was anyone defined
 		if originalHostParser != nil {
 			base.hostData, err = originalHostParser(base.module, base.host)
 			if err != nil {

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -52,7 +52,8 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 	originalFactory := registration.Factory
 	registration.IsDefault = m.Default
 
-	// Disable the host parser, we will call it as part of the factory
+	// Disable the host parser, we will call it as part of the factory so the original
+	// host in the base module is not modified.
 	originalHostParser := registration.HostParser
 	registration.HostParser = nil
 


### PR DESCRIPTION
## What does this PR do?

Call host parser only once on Metricbeat light modules.

## Why is it important?

When using light modules, host parser is called twice. First by the actual implementation
of the metricset, and second after adding the configuration defined in the light module
manifest. Second call might be missing data as the original host is modified after the first
call, causing problems as the ones described in #16205 and #19849.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (Covered by tests from https://github.com/elastic/beats/pull/16205).
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- There should be no changes in addresses included in metricbeat events, check specially on modules using custom host parsers as the sql ones.
- Check that steps described in #19849 don't cause any issue.

## Related issues

- Closes #19849
- Replaces #16205
- Relates #18955

## Use cases

- Implement light modules based on native modules with custom host parsers.