### PR TITLE
[Filebeat] Add export tests to x-pack/filebeat

### DIFF
--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -18,7 +18,7 @@ class BaseTest(TestCase):
         if not hasattr(self, "beat_name"):
             self.beat_name = "filebeat"
         if not hasattr(self, "beat_path"):
-            self.beat_path = os.path.abspath(os.path.join(curdir, "../../"))
+            self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 
         super(BaseTest, self).setUpClass()
 

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -56,6 +56,10 @@ class TestExportsMixin:
         output = self.run_export_cmd("index-pattern")
         js = json.loads(output)
         assert "objects" in js
+        size = len(output.encode('utf-8'))
+        assert size < 1024*1024, "Kibana index pattern must be less than 1MiB " \
+                                 "to keep the Beat setup request size below " \
+                                 "Kibana's server.maxPayloadBytes."
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_export_config(self):

--- a/x-pack/filebeat/tests/system/test_filebeat_xpack.py
+++ b/x-pack/filebeat/tests/system/test_filebeat_xpack.py
@@ -1,0 +1,30 @@
+import jinja2
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../filebeat/tests/system')))
+
+from filebeat import BaseTest as FilebeatTest
+from beat import common_tests
+
+
+class FilebeatXPackTest(FilebeatTest, common_tests.TestExportsMixin):
+
+    @classmethod
+    def setUpClass(self):
+        self.beat_name = "filebeat"
+        self.beat_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../../"))
+
+        super(FilebeatTest, self).setUpClass()
+
+    def setUp(self):
+        super(FilebeatTest, self).setUp()
+
+        # Hack to make jinja2 have the right paths
+        self.template_env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader([
+                os.path.abspath(os.path.join(self.beat_path, "../../filebeat")),
+                os.path.abspath(os.path.join(self.beat_path, "../../libbeat"))
+            ])
+        )


### PR DESCRIPTION

## What does this PR do?

Add export sub-command tests to x-pack/filebeat and add an assertion for the
size the Kibana index-pattern due to the Kibana API limiting payloads to 1 MiB.

## Why is it important?

Kibana as a maximum request payload size. If our index pattern document goes above this limit then we cannot setup dashboards.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #19965
