### PR TITLE
Cherry-pick #20077 to 7.x: Collect cloud.instance.name in ec2 metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -675,6 +675,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Adds support for app insights metrics in the azure module. {issue}18570[18570] {pull}18940[18940]
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
+- Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/ec2/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/data.json
@@ -3,12 +3,12 @@
     "aws": {
         "ec2": {
             "cpu": {
-                "credit_balance": 576,
-                "credit_usage": 0.217777,
+                "credit_balance": 144,
+                "credit_usage": 0.061395,
                 "surplus_credit_balance": 0,
                 "surplus_credits_charged": 0,
                 "total": {
-                    "pct": 2.1374965268131265
+                    "pct": 1.1651199407241788
                 }
             },
             "diskio": {
@@ -27,21 +27,21 @@
             },
             "instance": {
                 "core": {
-                    "count": 2
+                    "count": 1
                 },
                 "image": {
-                    "id": "ami-f920cd94"
+                    "id": "ami-04bc3da8f14823e88"
                 },
                 "monitoring": {
                     "state": "disabled"
                 },
                 "private": {
-                    "dns_name": "ip-10-0-0-148.ec2.internal",
-                    "ip": "10.0.0.148"
+                    "dns_name": "ip-172-31-9-119.us-west-1.compute.internal",
+                    "ip": "172.31.9.119"
                 },
                 "public": {
-                    "dns_name": "ec2-54-226-109-162.compute-1.amazonaws.com",
-                    "ip": "54.226.109.162"
+                    "dns_name": "ec2-13-52-163-56.us-west-1.compute.amazonaws.com",
+                    "ip": "13.52.163.56"
                 },
                 "state": {
                     "code": 16,
@@ -51,16 +51,16 @@
             },
             "network": {
                 "in": {
-                    "bytes": 1510123.4,
-                    "bytes_per_sec": 5033.7446666666665,
-                    "packets": 3126.4,
-                    "packets_per_sec": 10.421333333333333
+                    "bytes": 7375.4,
+                    "bytes_per_sec": 24.584666666666667,
+                    "packets": 49,
+                    "packets_per_sec": 0.16333333333333333
                 },
                 "out": {
-                    "bytes": 464863,
-                    "bytes_per_sec": 1549.5433333333333,
-                    "packets": 3031.2,
-                    "packets_per_sec": 10.104
+                    "bytes": 11567,
+                    "bytes_per_sec": 38.556666666666665,
+                    "packets": 44.8,
+                    "packets_per_sec": 0.14933333333333332
                 }
             },
             "status": {
@@ -70,24 +70,25 @@
             }
         },
         "tags": {
-            "Cost": "$614.01",
-            "Name": "container-registry-test-ui.elastic.co"
+            "Name": "mysql-test",
+            "created-by": "ks"
         }
     },
     "cloud": {
         "account": {
-            "id": "627959692251",
-            "name": "elastic-test"
+            "id": "428152502467",
+            "name": "elastic-beats"
         },
-        "availability_zone": "us-east-1b",
+        "availability_zone": "us-west-1b",
         "instance": {
-            "id": "i-77f84332"
+            "id": "i-0516ddaca5c1d231f",
+            "name": "mysql-test"
         },
         "machine": {
-            "type": "t2.medium"
+            "type": "t2.micro"
         },
         "provider": "aws",
-        "region": "us-east-1"
+        "region": "us-west-1"
     },
     "event": {
         "dataset": "aws.ec2",

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -201,6 +201,10 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 				// Note: tag values are not dedotted.
 				for _, tag := range tags {
 					events[instanceID].ModuleFields.Put("tags."+common.DeDot(*tag.Key), *tag.Value)
+					// add cloud.instance.name and host.name into ec2 events
+					if *tag.Key == "Name" {
+						events[instanceID].RootFields.Put("cloud.instance.name", *tag.Value)
+					}
 				}
 
 				machineType, err := instanceOutput[instanceID].InstanceType.MarshalValue()


### PR DESCRIPTION
Cherry-pick of PR #20077 to 7.x branch. Original message: 

This PR is to add ECS field `cloud.instance.name` for `ec2` metricset.

EC2 instance name is optional in AWS and if it's given by user, it will show as tag value of tag key `Name`.