### PR TITLE
[docs] Add x-pack role to relevant metricsets

### DIFF
--- a/metricbeat/docs/modules/activemq/broker.asciidoc
+++ b/metricbeat/docs/modules/activemq/broker.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-activemq-broker]]
+[role="xpack"]
 === ActiveMQ broker metricset
 
 include::../../../../x-pack/metricbeat/module/activemq/broker/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/activemq/queue.asciidoc
+++ b/metricbeat/docs/modules/activemq/queue.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-activemq-queue]]
+[role="xpack"]
 === ActiveMQ queue metricset
 
 include::../../../../x-pack/metricbeat/module/activemq/queue/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/activemq/topic.asciidoc
+++ b/metricbeat/docs/modules/activemq/topic.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-activemq-topic]]
+[role="xpack"]
 === ActiveMQ topic metricset
 
 include::../../../../x-pack/metricbeat/module/activemq/topic/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/appsearch/stats.asciidoc
+++ b/metricbeat/docs/modules/appsearch/stats.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-appsearch-stats]]
+[role="xpack"]
 === App Search stats metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/billing.asciidoc
+++ b/metricbeat/docs/modules/aws/billing.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-billing]]
+[role="xpack"]
 === AWS billing metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/cloudwatch.asciidoc
+++ b/metricbeat/docs/modules/aws/cloudwatch.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-cloudwatch]]
+[role="xpack"]
 === AWS cloudwatch metricset
 
 include::../../../../x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/dynamodb.asciidoc
+++ b/metricbeat/docs/modules/aws/dynamodb.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-dynamodb]]
+[role="xpack"]
 === AWS dynamodb metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/ebs.asciidoc
+++ b/metricbeat/docs/modules/aws/ebs.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-ebs]]
+[role="xpack"]
 === AWS ebs metricset
 
 include::../../../../x-pack/metricbeat/module/aws/ebs/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/ec2.asciidoc
+++ b/metricbeat/docs/modules/aws/ec2.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-ec2]]
+[role="xpack"]
 === AWS ec2 metricset
 
 include::../../../../x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/elb.asciidoc
+++ b/metricbeat/docs/modules/aws/elb.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-elb]]
+[role="xpack"]
 === AWS elb metricset
 
 include::../../../../x-pack/metricbeat/module/aws/elb/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/lambda.asciidoc
+++ b/metricbeat/docs/modules/aws/lambda.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-lambda]]
+[role="xpack"]
 === AWS lambda metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/natgateway.asciidoc
+++ b/metricbeat/docs/modules/aws/natgateway.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-natgateway]]
+[role="xpack"]
 === AWS natgateway metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/rds.asciidoc
+++ b/metricbeat/docs/modules/aws/rds.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-rds]]
+[role="xpack"]
 === AWS rds metricset
 
 include::../../../../x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/s3_daily_storage.asciidoc
+++ b/metricbeat/docs/modules/aws/s3_daily_storage.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-s3_daily_storage]]
+[role="xpack"]
 === AWS s3_daily_storage metricset
 
 include::../../../../x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/s3_request.asciidoc
+++ b/metricbeat/docs/modules/aws/s3_request.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-s3_request]]
+[role="xpack"]
 === AWS s3_request metricset
 
 include::../../../../x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/sns.asciidoc
+++ b/metricbeat/docs/modules/aws/sns.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-sns]]
+[role="xpack"]
 === AWS sns metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/sqs.asciidoc
+++ b/metricbeat/docs/modules/aws/sqs.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-sqs]]
+[role="xpack"]
 === AWS sqs metricset
 
 include::../../../../x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/aws/transitgateway.asciidoc
+++ b/metricbeat/docs/modules/aws/transitgateway.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-transitgateway]]
+[role="xpack"]
 === AWS transitgateway metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/usage.asciidoc
+++ b/metricbeat/docs/modules/aws/usage.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-usage]]
+[role="xpack"]
 === AWS usage metricset
 
 beta[]

--- a/metricbeat/docs/modules/aws/vpn.asciidoc
+++ b/metricbeat/docs/modules/aws/vpn.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-aws-vpn]]
+[role="xpack"]
 === AWS vpn metricset
 
 beta[]

--- a/metricbeat/docs/modules/azure/app_insights.asciidoc
+++ b/metricbeat/docs/modules/azure/app_insights.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-app_insights]]
+[role="xpack"]
 === Azure app_insights metricset
 
 beta[]

--- a/metricbeat/docs/modules/azure/billing.asciidoc
+++ b/metricbeat/docs/modules/azure/billing.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-billing]]
+[role="xpack"]
 === Azure billing metricset
 
 beta[]

--- a/metricbeat/docs/modules/azure/compute_vm.asciidoc
+++ b/metricbeat/docs/modules/azure/compute_vm.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-compute_vm]]
+[role="xpack"]
 === Azure compute_vm metricset
 
 include::../../../../x-pack/metricbeat/module/azure/compute_vm/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/compute_vm_scaleset.asciidoc
+++ b/metricbeat/docs/modules/azure/compute_vm_scaleset.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-compute_vm_scaleset]]
+[role="xpack"]
 === Azure compute_vm_scaleset metricset
 
 include::../../../../x-pack/metricbeat/module/azure/compute_vm_scaleset/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/container_instance.asciidoc
+++ b/metricbeat/docs/modules/azure/container_instance.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-container_instance]]
+[role="xpack"]
 === Azure container_instance metricset
 
 include::../../../../x-pack/metricbeat/module/azure/container_instance/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/container_registry.asciidoc
+++ b/metricbeat/docs/modules/azure/container_registry.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-container_registry]]
+[role="xpack"]
 === Azure container_registry metricset
 
 include::../../../../x-pack/metricbeat/module/azure/container_registry/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/container_service.asciidoc
+++ b/metricbeat/docs/modules/azure/container_service.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-container_service]]
+[role="xpack"]
 === Azure container_service metricset
 
 include::../../../../x-pack/metricbeat/module/azure/container_service/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/database_account.asciidoc
+++ b/metricbeat/docs/modules/azure/database_account.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-database_account]]
+[role="xpack"]
 === Azure database_account metricset
 
 include::../../../../x-pack/metricbeat/module/azure/database_account/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/monitor.asciidoc
+++ b/metricbeat/docs/modules/azure/monitor.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-monitor]]
+[role="xpack"]
 === Azure monitor metricset
 
 include::../../../../x-pack/metricbeat/module/azure/monitor/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/azure/storage.asciidoc
+++ b/metricbeat/docs/modules/azure/storage.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-azure-storage]]
+[role="xpack"]
 === Azure storage metricset
 
 include::../../../../x-pack/metricbeat/module/azure/storage/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/cloudfoundry/container.asciidoc
+++ b/metricbeat/docs/modules/cloudfoundry/container.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-cloudfoundry-container]]
+[role="xpack"]
 === Cloudfoundry container metricset
 
 beta[]

--- a/metricbeat/docs/modules/cloudfoundry/counter.asciidoc
+++ b/metricbeat/docs/modules/cloudfoundry/counter.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-cloudfoundry-counter]]
+[role="xpack"]
 === Cloudfoundry counter metricset
 
 beta[]

--- a/metricbeat/docs/modules/cloudfoundry/value.asciidoc
+++ b/metricbeat/docs/modules/cloudfoundry/value.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-cloudfoundry-value]]
+[role="xpack"]
 === Cloudfoundry value metricset
 
 beta[]

--- a/metricbeat/docs/modules/cockroachdb/status.asciidoc
+++ b/metricbeat/docs/modules/cockroachdb/status.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-cockroachdb-status]]
+[role="xpack"]
 === CockroachDB status metricset
 
 beta[]

--- a/metricbeat/docs/modules/coredns/stats.asciidoc
+++ b/metricbeat/docs/modules/coredns/stats.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-coredns-stats]]
+[role="xpack"]
 === Coredns stats metricset
 
 include::../../../../x-pack/metricbeat/module/coredns/stats/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/googlecloud/compute.asciidoc
+++ b/metricbeat/docs/modules/googlecloud/compute.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-googlecloud-compute]]
+[role="xpack"]
 === Google Cloud Platform compute metricset
 
 beta[]

--- a/metricbeat/docs/modules/googlecloud/loadbalancing.asciidoc
+++ b/metricbeat/docs/modules/googlecloud/loadbalancing.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-googlecloud-loadbalancing]]
+[role="xpack"]
 === Google Cloud Platform loadbalancing metricset
 
 beta[]

--- a/metricbeat/docs/modules/googlecloud/metrics.asciidoc
+++ b/metricbeat/docs/modules/googlecloud/metrics.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-googlecloud-metrics]]
+[role="xpack"]
 === Google Cloud Platform metrics metricset
 
 beta[]

--- a/metricbeat/docs/modules/googlecloud/pubsub.asciidoc
+++ b/metricbeat/docs/modules/googlecloud/pubsub.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-googlecloud-pubsub]]
+[role="xpack"]
 === Google Cloud Platform pubsub metricset
 
 beta[]

--- a/metricbeat/docs/modules/googlecloud/storage.asciidoc
+++ b/metricbeat/docs/modules/googlecloud/storage.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-googlecloud-storage]]
+[role="xpack"]
 === Google Cloud Platform storage metricset
 
 beta[]

--- a/metricbeat/docs/modules/ibmmq/qmgr.asciidoc
+++ b/metricbeat/docs/modules/ibmmq/qmgr.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-ibmmq-qmgr]]
+[role="xpack"]
 === IBM MQ qmgr metricset
 
 beta[]

--- a/metricbeat/docs/modules/iis/application_pool.asciidoc
+++ b/metricbeat/docs/modules/iis/application_pool.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-iis-application_pool]]
+[role="xpack"]
 === IIS application_pool metricset
 
 beta[]

--- a/metricbeat/docs/modules/iis/webserver.asciidoc
+++ b/metricbeat/docs/modules/iis/webserver.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-iis-webserver]]
+[role="xpack"]
 === IIS webserver metricset
 
 beta[]

--- a/metricbeat/docs/modules/iis/website.asciidoc
+++ b/metricbeat/docs/modules/iis/website.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-iis-website]]
+[role="xpack"]
 === IIS website metricset
 
 beta[]

--- a/metricbeat/docs/modules/istio/citadel.asciidoc
+++ b/metricbeat/docs/modules/istio/citadel.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-istio-citadel]]
+[role="xpack"]
 === Istio citadel metricset
 
 beta[]

--- a/metricbeat/docs/modules/istio/galley.asciidoc
+++ b/metricbeat/docs/modules/istio/galley.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-istio-galley]]
+[role="xpack"]
 === Istio galley metricset
 
 beta[]

--- a/metricbeat/docs/modules/istio/mesh.asciidoc
+++ b/metricbeat/docs/modules/istio/mesh.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-istio-mesh]]
+[role="xpack"]
 === Istio mesh metricset
 
 beta[]

--- a/metricbeat/docs/modules/istio/mixer.asciidoc
+++ b/metricbeat/docs/modules/istio/mixer.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-istio-mixer]]
+[role="xpack"]
 === Istio mixer metricset
 
 beta[]

--- a/metricbeat/docs/modules/istio/pilot.asciidoc
+++ b/metricbeat/docs/modules/istio/pilot.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-istio-pilot]]
+[role="xpack"]
 === Istio pilot metricset
 
 beta[]

--- a/metricbeat/docs/modules/mssql/performance.asciidoc
+++ b/metricbeat/docs/modules/mssql/performance.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-mssql-performance]]
+[role="xpack"]
 === MSSQL performance metricset
 
 include::../../../../x-pack/metricbeat/module/mssql/performance/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/mssql/transaction_log.asciidoc
+++ b/metricbeat/docs/modules/mssql/transaction_log.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-mssql-transaction_log]]
+[role="xpack"]
 === MSSQL transaction_log metricset
 
 include::../../../../x-pack/metricbeat/module/mssql/transaction_log/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/openmetrics/collector.asciidoc
+++ b/metricbeat/docs/modules/openmetrics/collector.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-openmetrics-collector]]
+[role="xpack"]
 === Openmetrics collector metricset
 
 beta[]

--- a/metricbeat/docs/modules/oracle/performance.asciidoc
+++ b/metricbeat/docs/modules/oracle/performance.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-oracle-performance]]
+[role="xpack"]
 === Oracle performance metricset
 
 include::../../../../x-pack/metricbeat/module/oracle/performance/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/oracle/tablespace.asciidoc
+++ b/metricbeat/docs/modules/oracle/tablespace.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-oracle-tablespace]]
+[role="xpack"]
 === Oracle tablespace metricset
 
 include::../../../../x-pack/metricbeat/module/oracle/tablespace/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/redisenterprise/node.asciidoc
+++ b/metricbeat/docs/modules/redisenterprise/node.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-redisenterprise-node]]
+[role="xpack"]
 === Redis Enterprise node metricset
 
 beta[]

--- a/metricbeat/docs/modules/redisenterprise/proxy.asciidoc
+++ b/metricbeat/docs/modules/redisenterprise/proxy.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-redisenterprise-proxy]]
+[role="xpack"]
 === Redis Enterprise proxy metricset
 
 beta[]

--- a/metricbeat/docs/modules/sql/query.asciidoc
+++ b/metricbeat/docs/modules/sql/query.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-sql-query]]
+[role="xpack"]
 === SQL query metricset
 
 beta[]

--- a/metricbeat/docs/modules/stan/channels.asciidoc
+++ b/metricbeat/docs/modules/stan/channels.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-stan-channels]]
+[role="xpack"]
 === Stan channels metricset
 
 include::../../../../x-pack/metricbeat/module/stan/channels/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/stan/stats.asciidoc
+++ b/metricbeat/docs/modules/stan/stats.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-stan-stats]]
+[role="xpack"]
 === Stan stats metricset
 
 include::../../../../x-pack/metricbeat/module/stan/stats/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/stan/subscriptions.asciidoc
+++ b/metricbeat/docs/modules/stan/subscriptions.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-stan-subscriptions]]
+[role="xpack"]
 === Stan subscriptions metricset
 
 include::../../../../x-pack/metricbeat/module/stan/subscriptions/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/statsd/server.asciidoc
+++ b/metricbeat/docs/modules/statsd/server.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-statsd-server]]
+[role="xpack"]
 === Statsd server metricset
 
 include::../../../../x-pack/metricbeat/module/statsd/server/_meta/docs.asciidoc[]

--- a/metricbeat/docs/modules/tomcat/cache.asciidoc
+++ b/metricbeat/docs/modules/tomcat/cache.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-tomcat-cache]]
+[role="xpack"]
 === Tomcat cache metricset
 
 beta[]

--- a/metricbeat/docs/modules/tomcat/memory.asciidoc
+++ b/metricbeat/docs/modules/tomcat/memory.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-tomcat-memory]]
+[role="xpack"]
 === Tomcat memory metricset
 
 beta[]

--- a/metricbeat/docs/modules/tomcat/requests.asciidoc
+++ b/metricbeat/docs/modules/tomcat/requests.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-tomcat-requests]]
+[role="xpack"]
 === Tomcat requests metricset
 
 beta[]

--- a/metricbeat/docs/modules/tomcat/threading.asciidoc
+++ b/metricbeat/docs/modules/tomcat/threading.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-metricset-tomcat-threading]]
+[role="xpack"]
 === Tomcat threading metricset
 
 beta[]

--- a/metricbeat/scripts/mage/template/metricsetDoc.tmpl
+++ b/metricbeat/scripts/mage/template/metricsetDoc.tmpl
@@ -3,6 +3,8 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[{{getBeatName}}-metricset-{{.Mod.Base}}-{{.Metricset.Title}}]]
+{{- if .Mod.IsXpack}}
+[role="xpack"]{{end}}
 === {{.Mod.Title}} {{.Metricset.Title}} metricset
 
 {{if not ( eq .Metricset.Release "ga") -}}


### PR DESCRIPTION
## What does this PR do?
Adds x-pack label to docs for all metricsets that live under x-pack.

## Why is it important?

The x-pack flag must appear on all topics that describe licensed functionality. This is especially critical now that the Integrations page on the website points directly to these docs.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes https://github.com/elastic/beats/issues/19307