### PR TITLE
[docs] Indicate that SYSTEM user is required on Windows to use Endpoint

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -15,6 +15,7 @@ To learn how to install, configure, and run your {agent}s, see:
 
 * <<elastic-agent-installation>>
 * <<run-elastic-agent>>
+* <<stop-elastic-agent>>
 * <<elastic-agent-cmd-options>>
 * <<elastic-agent-configuration>>
 

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -34,11 +34,18 @@ generate a token. See <<ingest-management-getting-started>> for detailed steps.
 +
 Where `$token` is an enrollment token acquired from {fleet}.
 
+//TODO: Add tabbed panels for platform-specific tabs (waiting for final design)
+
 To start {agent}, run:
+
+// tag::run-agent[]
 [source,shell]
 ----
-./elastic-agent run
+./elastic-agent run <1>
 ----
+<1> On Windows, you must run {agent} under the SYSTEM account if you plan
+to use the {elastic-endpoint} integration.
+// end::run-agent[]
 
 [discrete]
 [[standalone-mode]]
@@ -52,10 +59,7 @@ when you restart your system.
 
 To start {agent} manually, run:
 
-[source,shell]
-----
-./elastic-agent run
-----
+include::run-elastic-agent.asciidoc[tag=run-agent]
 
 If no configuration file is specified, {agent} uses the default configuration,
 `elastic-agent.yml`, which is located in the same directory as {agent}. Specify


### PR DESCRIPTION
## What does this PR do?

Updates Elastic Agent docs to indicate that the agent must be run under the SYSTEM user to use the Endpoint integration.

## Why is it important?

Users will run into a "Agent process is not root/admin or validation failed" error on Win if they don't run under SYSTEM.

## Related issues

- Closes elastic/beats#19955 

(I'm also writing a troubleshooting topic with more detail. I'll add the link here when it's ready.)

Note that the current docs do not show platform-specific commands. I will fix that...just waiting for the final design of our tabbed panel widget to avoid having to redo the work.