### PR TITLE
Agent entrypoint fix

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -49,6 +49,7 @@ function enroll(){
       if [ $exitCode -ne 0 ]; then
         exit $exitCode
       fi
+      
       apikey=$(echo $enrollResp | jq -r '.item.api_key')
     fi
     echo $apikey

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -49,8 +49,8 @@ function enroll(){
       if [ $exitCode -ne 0 ]; then
         exit $exitCode
       fi
+      apikey=$(echo $enrollResp | jq -r '.item.api_key')
     fi
-    apikey=$(echo $enrollResp | jq -r '.item.api_key')
     echo $apikey
 
     ./{{ .BeatName }} enroll ${KIBANA_HOST:-http://localhost:5601} $apikey -f


### PR DESCRIPTION
## What does this PR do?
Fixes `docker-entrypoint` for Agent. Without this change `FLEET_ENROLLMENT_TOKEN` was always ignored and hence the startup script cannot start agent.

## Why is it important?
To make dockerized agent work for `7.9`. 

Related to https://github.com/elastic/beats/pull/19727#issuecomment-662941435.