### PR TITLE
[Metricbeat] Use MySQL Host Parser in Query metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -584,6 +584,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Adds support for app insights metrics in the azure module. {issue}18570[18570] {pull}18940[18940]
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
+- Add MySQL host parser to query metricset {pull}20191[20191]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -584,7 +584,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Adds support for app insights metrics in the azure module. {issue}18570[18570] {pull}18940[18940]
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
-- Add MySQL host parser to query metricset {pull}20191[20191]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -59,9 +59,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - "status"
-  #  - "galera_status"
-  #  - performance
-  #  - query
+  # - "galera_status"
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -59,9 +59,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -60,6 +60,8 @@ metricbeat.modules:
   metricsets:
     - "status"
   #  - "galera_status"
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -58,8 +58,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 metricbeat.modules:
 - module: mysql
   metricsets:
-    - "status"
-  # - "galera_status"
+    - status
+  # - galera_status
   # - performance
   # - query
   period: 10s

--- a/metricbeat/docs/modules/mysql/performance.asciidoc
+++ b/metricbeat/docs/modules/mysql/performance.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/mysql/performance/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/docs/modules/mysql/query.asciidoc
+++ b/metricbeat/docs/modules/mysql/query.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/mysql/query/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -648,9 +648,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - "status"
-  #  - "galera_status"
-  #  - performance
-  #  - query
+  # - "galera_status"
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -648,9 +648,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -647,8 +647,8 @@ metricbeat.modules:
 #-------------------------------- MySQL Module --------------------------------
 - module: mysql
   metricsets:
-    - "status"
-  # - "galera_status"
+    - status
+  # - galera_status
   # - performance
   # - query
   period: 10s

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -649,6 +649,8 @@ metricbeat.modules:
   metricsets:
     - "status"
   #  - "galera_status"
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.epr.yml
+++ b/metricbeat/module/mysql/_meta/config.epr.yml
@@ -1,9 +1,9 @@
 - module: mysql
   metricsets:
     - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.epr.yml
+++ b/metricbeat/module/mysql/_meta/config.epr.yml
@@ -1,7 +1,7 @@
 - module: mysql
   metricsets:
-    - "status"
-  # - "galera_status"
+    - status
+  # - galera_status
   # - performance
   # - query
   period: 10s

--- a/metricbeat/module/mysql/_meta/config.epr.yml
+++ b/metricbeat/module/mysql/_meta/config.epr.yml
@@ -1,7 +1,7 @@
 - module: mysql
   metricsets:
     - "status"
-    - "galera_status"
+  # - "galera_status"
   # - performance
   # - query
   period: 10s

--- a/metricbeat/module/mysql/_meta/config.epr.yml
+++ b/metricbeat/module/mysql/_meta/config.epr.yml
@@ -2,6 +2,8 @@
   metricsets:
     - "status"
     - "galera_status"
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -1,9 +1,9 @@
 - module: mysql
   metricsets:
     - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -1,7 +1,7 @@
 - module: mysql
   metricsets:
-    - "status"
-  # - "galera_status"
+    - status
+  # - galera_status
   # - performance
   # - query
   period: 10s

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -2,6 +2,8 @@
   metricsets:
     - "status"
   #  - "galera_status"
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -1,9 +1,9 @@
 - module: mysql
   metricsets:
     - "status"
-  #  - "galera_status"
-  #  - performance
-  #  - query
+  # - "galera_status"
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,9 +1,9 @@
 - module: mysql
   #metricsets:
-  # - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,7 +1,9 @@
 - module: mysql
-  #metricsets:
-  #  - status
+  metricsets:
+    - status
   #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,9 +1,9 @@
 - module: mysql
-  metricsets:
-    - status
-  #  - galera_status
-  #  - performance
-  #  - query
+  #metricsets:
+  # - status
+  # - galera_status
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/performance/manifest.yml
+++ b/metricbeat/module/mysql/performance/manifest.yml
@@ -1,4 +1,4 @@
-default: true
+default: false
 input:
   module: mysql
   metricset: query

--- a/metricbeat/module/mysql/query/query.go
+++ b/metricbeat/module/mysql/query/query.go
@@ -32,11 +32,12 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/metricbeat/helper/sql"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/mysql"
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("mysql", "query", New,
-		mb.DefaultMetricSet(),
+		mb.WithHostParser(mysql.ParseDSN),
 	)
 }
 

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -3,10 +3,10 @@
 
 - module: mysql
   #metricsets:
-  # - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -2,11 +2,11 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
 
 - module: mysql
-  metricsets:
-    - status
-  #  - galera_status
-  #  - performance
-  #  - query
+  #metricsets:
+  # - status
+  # - galera_status
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -2,9 +2,11 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
 
 - module: mysql
-  #metricsets:
-  #  - status
+  metricsets:
+    - status
   #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -969,8 +969,8 @@ metricbeat.modules:
 #-------------------------------- MySQL Module --------------------------------
 - module: mysql
   metricsets:
-    - "status"
-  # - "galera_status"
+    - status
+  # - galera_status
   # - performance
   # - query
   period: 10s

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -970,9 +970,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - "status"
-  #  - "galera_status"
-  #  - performance
-  #  - query
+  # - "galera_status"
+  # - performance
+  # - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -970,9 +970,9 @@ metricbeat.modules:
 - module: mysql
   metricsets:
     - status
-  # - galera_status
-  # - performance
-  # - query
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -971,6 +971,8 @@ metricbeat.modules:
   metricsets:
     - "status"
   #  - "galera_status"
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"


### PR DESCRIPTION
Add Mysql host parser in query metricset instead of using the default.

Relates: https://github.com/elastic/beats/pull/20149