### PR TITLE
Cherry-pick #20084 to 7.x: Fix terminating pod autodiscover issue

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,6 +169,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix config reload metrics (`libbeat.config.module.start/stops/running`). {pull}19168[19168]
 - Fix metrics hints builder to avoid wrong container metadata usage when port is not exposed {pull}18979[18979]
 - Server-side TLS config now validates certificate and key are both specified {pull}19584[19584]
+- Fix terminating pod autodiscover issue. {pull}20084[20084]
 - Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
 
 *Auditbeat*


### PR DESCRIPTION
Cherry-pick of PR #20084 to 7.x branch. Original message: 

## What does this PR do?
This addition handles the case when a Pod is in `Terminating` phase. 
In this case the pod is neither `PodSucceeded` nor `PodFailed` and
hence requires special handling.
In this, we check all Pod's containers' statuses and if we find a at least
one still running we ignore this update event. With this, we make sure
that all containers are stopped before stopping Filebeat.


## Why is it important?
To collect any leftover logs when the pod is going in Terminating state.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
Use replication steps of https://github.com/elastic/beats/issues/17396#issue-591883875 and expect to see that the issue is fixed. The screenshot below provides the fixed case.


```
filebeat.autodiscover:
      providers:
        - type: kubernetes
          node: ${NODE_NAME}
          templates:
            - condition:
                equals:
                  kubernetes.pod.name: "mytargetpod"
              config:
                - type: container
                  paths:
                    - /var/log/containers/*${data.kubernetes.container.id}.log
```

## Related issues

- Closes https://github.com/elastic/beats/issues/17396
- Relates https://github.com/elastic/beats/pull/14259



## Screenshots
![Screenshot 2020-07-21 at 12 17 45](https://user-images.githubusercontent.com/11754898/88037866-1fd28780-cb4e-11ea-94d8-9a8e114f2f49.png)
