### PR TITLE
Cherry-pick #20121 to 7.9: [libbeat] Don't swallow Kibana index pattern errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -90,6 +90,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
 - Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
+- Output errors when Kibana index pattern setup fails. {pull}20121[20121]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -300,7 +300,9 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 
 	// Loads the internal index pattern
 	if imp.fields != nil {
-		imp.loader.ImportIndex(imp.fields)
+		if err = imp.loader.ImportIndex(imp.fields); err != nil {
+			return errw.Wrap(err, "failed to import Kibana index pattern")
+		}
 	}
 
 	dir = path.Join(dir, versionPath)


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#20121 to 7.9 branch. Original message: 

## What does this PR do?

While running 'beat setup --dashboads' any errors that occur while importing the generated Kibana index pattern or silently ignored.
This changes that by causing the dashboard setup to stop and return the error. Dashboards won't work without the index pattern anyways.

## Why is it important?

Errors with the Kibana index pattern were undetected. The only hint of an error is that the index pattern doesn't exist in Kibana after setup.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

`2020-07-21T18:26:27.006-0400	ERROR	instance/beat.go:935	Exiting: 1 error: error loading index pattern: returned 413 to import file: <nil>. Response: {"statusCode":413,"error":"Request Entity Too Large","message":"Payload content length greater than maximum allowed: 1048576"}`
