### PR TITLE
Tests: Ignore timestamp from cylance/protect dataset

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -227,6 +227,7 @@ def clean_keys(obj):
         "cef.log",
         "cisco.asa",
         "cisco.ios",
+        "cylance.protect",
         "fortinet.clientendpoint",
         "haproxy.log",
         "icinga.startup",

--- a/x-pack/filebeat/module/cylance/protect/test/generated.log-expected.json
+++ b/x-pack/filebeat/module/cylance/protect/test/generated.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2016-01-29T08:09:59.000Z",
         "event.action": "ZoneAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -26,7 +25,6 @@
         "rsa.network.alias_host": [
             "nostrud4819.mail.test"
         ],
-        "rsa.time.event_time": "2016-01-29T08:09:59.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -34,7 +32,6 @@
         ]
     },
     {
-        "@timestamp": "2016-02-12T03:12:33.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -59,7 +56,6 @@
         "rsa.network.alias_host": [
             "volup208.invalid"
         ],
-        "rsa.time.event_time": "2016-02-12T03:12:33.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -67,7 +63,6 @@
         ]
     },
     {
-        "@timestamp": "2020-02-26T10:15:08.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -92,7 +87,6 @@
         "rsa.network.alias_host": [
             "eius6159.www5.localhost"
         ],
-        "rsa.time.event_time": "2020-02-26T10:15:08.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -100,7 +94,6 @@
         ]
     },
     {
-        "@timestamp": "2016-03-12T05:17:42.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -125,7 +118,6 @@
         "rsa.network.alias_host": [
             "ratvolup497.www.corp"
         ],
-        "rsa.time.event_time": "2016-03-12T05:17:42.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -133,7 +125,6 @@
         ]
     },
     {
-        "@timestamp": "2016-03-26T12:20:16.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -159,7 +150,6 @@
         "rsa.network.alias_host": [
             "tatno5625.api.local"
         ],
-        "rsa.time.event_time": "2016-03-26T12:20:16.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -167,7 +157,6 @@
         ]
     },
     {
-        "@timestamp": "2016-04-09T07:22:51.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -199,7 +188,6 @@
             "maveniam1399.mail.lan"
         ],
         "rsa.network.eth_host": "01:00:5e:dc:bb:8b",
-        "rsa.time.event_time": "2016-04-09T07:22:51.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.124.61.119"
@@ -211,7 +199,6 @@
         "user.name": "occ"
     },
     {
-        "@timestamp": "2020-04-24T14:25:25.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -236,7 +223,6 @@
         "rsa.network.alias_host": [
             "nimadmin6499.local"
         ],
-        "rsa.time.event_time": "2020-04-24T14:25:25.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -244,7 +230,6 @@
         ]
     },
     {
-        "@timestamp": "2016-05-08T09:27:59.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -270,7 +255,6 @@
         "rsa.network.alias_host": [
             "suntinc4934.www5.test"
         ],
-        "rsa.time.event_time": "2016-05-08T09:27:59.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -278,7 +262,6 @@
         ]
     },
     {
-        "@timestamp": "2016-05-22T04:30:33.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -307,7 +290,6 @@
         "rsa.network.alias_host": [
             "reetdolo2451.www.example"
         ],
-        "rsa.time.event_time": "2016-05-22T04:30:33.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -316,7 +298,6 @@
         "user.name": "usan"
     },
     {
-        "@timestamp": "2016-06-05T11:33:08.000Z",
         "event.action": "Registration",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -337,7 +318,6 @@
         "rsa.network.alias_host": [
             "uis7612.www5.domain"
         ],
-        "rsa.time.event_time": "2016-06-05T11:33:08.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -345,7 +325,6 @@
         ]
     },
     {
-        "@timestamp": "2020-06-20T06:35:42.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -370,7 +349,6 @@
         "rsa.network.alias_host": [
             "admi3749.api.lan"
         ],
-        "rsa.time.event_time": "2020-06-20T06:35:42.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -378,7 +356,6 @@
         ]
     },
     {
-        "@timestamp": "2016-07-04T13:38:16.000Z",
         "event.action": "fullaccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -408,7 +385,6 @@
         "rsa.network.alias_host": [
             "rudexerc703.internal.host"
         ],
-        "rsa.time.event_time": "2016-07-04T13:38:16.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -417,7 +393,6 @@
         "user.name": "isaute"
     },
     {
-        "@timestamp": "2016-07-18T20:40:00.000Z",
         "event.action": "cancel",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -444,7 +419,6 @@
         "rsa.misc.checksum": "itecto",
         "rsa.misc.event_type": "threat_found",
         "rsa.misc.node": "sequatur",
-        "rsa.time.event_time": "2016-07-18T20:40:00.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.199.98.186"
@@ -455,7 +429,6 @@
         ]
     },
     {
-        "@timestamp": "2016-08-02T03:43:25.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -487,7 +460,6 @@
         "rsa.network.alias_host": [
             "estqu1709.internal.example"
         ],
-        "rsa.time.event_time": "2016-08-02T03:43:25.000Z",
         "rsa.web.reputation_num": 145.898,
         "service.type": "cylance",
         "source.ip": [
@@ -499,7 +471,6 @@
         ]
     },
     {
-        "@timestamp": "2016-08-16T10:45:59.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -531,7 +502,6 @@
             "xeac7155.www.localdomain"
         ],
         "rsa.network.eth_host": "01:00:5e:93:1c:9f",
-        "rsa.time.event_time": "2016-08-16T10:45:59.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.143.239.210"
@@ -543,7 +513,6 @@
         "user.name": "oinBCSe"
     },
     {
-        "@timestamp": "2016-08-30T05:48:33.000Z",
         "event.action": "accept",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -578,7 +547,6 @@
         "rsa.network.alias_host": [
             "maccusa5126.api.domain"
         ],
-        "rsa.time.event_time": "2016-08-30T05:48:33.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.32.143.134"
@@ -590,7 +558,6 @@
         "user.name": "olupta"
     },
     {
-        "@timestamp": "2019-09-13T12:51:07.000Z",
         "event.action": "DeviceEdit",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -614,7 +581,6 @@
         "rsa.network.alias_host": [
             "llu4718.localhost"
         ],
-        "rsa.time.event_time": "2019-09-13T12:51:07.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -622,7 +588,6 @@
         ]
     },
     {
-        "@timestamp": "2019-09-28T07:53:42.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -645,7 +610,6 @@
         "rsa.misc.event_type": "DeviceRemove",
         "rsa.misc.mail_id": "tincu",
         "rsa.misc.policy_name": "taevit",
-        "rsa.time.event_time": "2019-09-28T07:53:42.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -653,7 +617,6 @@
         ]
     },
     {
-        "@timestamp": "2016-10-12T14:56:16.000Z",
         "event.action": "ZoneAddDevice",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -676,7 +639,6 @@
         "rsa.network.alias_host": [
             "eaq908.api.home"
         ],
-        "rsa.time.event_time": "2016-10-12T14:56:16.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -684,7 +646,6 @@
         ]
     },
     {
-        "@timestamp": "2016-10-26T09:58:50.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -714,7 +675,6 @@
         "rsa.network.alias_host": [
             "mcolab379.internal.home"
         ],
-        "rsa.time.event_time": "2016-10-26T09:58:50.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -723,7 +683,6 @@
         "user.name": "fdeFi"
     },
     {
-        "@timestamp": "2019-11-10T05:01:24.000Z",
         "event.action": "threat_quarantined",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -751,7 +710,6 @@
         "rsa.misc.event_type": "threat_quarantined",
         "rsa.misc.node": "ectio",
         "rsa.network.eth_host": "01:00:5e:3f:c4:6c",
-        "rsa.time.event_time": "2019-11-10T05:01:24.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.237.205.140"
@@ -763,7 +721,6 @@
         "user.name": "uames"
     },
     {
-        "@timestamp": "2019-11-24T12:03:59.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -788,7 +745,6 @@
         "rsa.network.alias_host": [
             "sciun4694.api.lan"
         ],
-        "rsa.time.event_time": "2019-11-24T12:03:59.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -796,7 +752,6 @@
         ]
     },
     {
-        "@timestamp": "2019-12-08T07:06:33.000Z",
         "event.action": "pechange",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -818,7 +773,6 @@
         "rsa.network.alias_host": [
             "mni7200.mail.localdomain"
         ],
-        "rsa.time.event_time": "2019-12-08T07:06:33.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -826,7 +780,6 @@
         ]
     },
     {
-        "@timestamp": "2019-12-23T14:09:07.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -846,7 +799,6 @@
         "rsa.misc.event_type": "Device Policy Assigned",
         "rsa.misc.node": "quinesc",
         "rsa.network.zone": "madmi",
-        "rsa.time.event_time": "2019-12-23T14:09:07.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -854,7 +806,6 @@
         ]
     },
     {
-        "@timestamp": "2017-01-06T09:11:41.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -883,7 +834,6 @@
         "rsa.network.alias_host": [
             "ntoccae1705.internal.invalid"
         ],
-        "rsa.time.event_time": "2017-01-06T09:11:41.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -892,7 +842,6 @@
         "user.name": "aperiame"
     },
     {
-        "@timestamp": "2020-01-20T04:14:16.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -916,7 +865,6 @@
         "rsa.network.alias_host": [
             "etconsec6708.internal.invalid"
         ],
-        "rsa.time.event_time": "2020-01-20T04:14:16.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -924,7 +872,6 @@
         ]
     },
     {
-        "@timestamp": "2017-02-03T11:16:50.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -950,7 +897,6 @@
         "rsa.network.alias_host": [
             "Sedutp7428.internal.home"
         ],
-        "rsa.time.event_time": "2017-02-03T11:16:50.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -958,7 +904,6 @@
         ]
     },
     {
-        "@timestamp": "2017-02-18T06:19:24.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -983,7 +928,6 @@
         "rsa.network.alias_host": [
             "ati4639.www5.home"
         ],
-        "rsa.time.event_time": "2017-02-18T06:19:24.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -991,7 +935,6 @@
         ]
     },
     {
-        "@timestamp": "2017-03-04T13:21:59.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1016,7 +959,6 @@
         "rsa.network.alias_host": [
             "torever662.www5.home"
         ],
-        "rsa.time.event_time": "2017-03-04T13:21:59.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1024,7 +966,6 @@
         ]
     },
     {
-        "@timestamp": "2017-03-18T08:24:33.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1050,7 +991,6 @@
         "rsa.network.alias_host": [
             "emeumfug4387.internal.lan"
         ],
-        "rsa.time.event_time": "2017-03-18T08:24:33.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1058,7 +998,6 @@
         ]
     },
     {
-        "@timestamp": "2017-04-02T03:27:07.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1082,7 +1021,6 @@
         "rsa.network.alias_host": [
             "rumwrit764.www5.local"
         ],
-        "rsa.time.event_time": "2017-04-02T03:27:07.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1090,7 +1028,6 @@
         ]
     },
     {
-        "@timestamp": "2020-04-16T10:29:41.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1113,7 +1050,6 @@
         "rsa.investigations.event_vcat": "luptat",
         "rsa.misc.event_type": "SyslogSettingsSave",
         "rsa.misc.mail_id": "ritt",
-        "rsa.time.event_time": "2020-04-16T10:29:41.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.13.66.97"
@@ -1124,7 +1060,6 @@
         ]
     },
     {
-        "@timestamp": "2017-04-30T05:32:16.000Z",
         "event.action": "threat_quarantined",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1150,7 +1085,6 @@
         "rsa.network.alias_host": [
             "oremi1485.api.localhost"
         ],
-        "rsa.time.event_time": "2017-04-30T05:32:16.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1158,7 +1092,6 @@
         ]
     },
     {
-        "@timestamp": "2020-05-14T12:34:50.000Z",
         "event.action": "threat_found",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1180,7 +1113,6 @@
         "rsa.network.alias_host": [
             "periam126.api.host"
         ],
-        "rsa.time.event_time": "2020-05-14T12:34:50.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1188,7 +1120,6 @@
         ]
     },
     {
-        "@timestamp": "2017-05-29T07:37:24.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1220,7 +1151,6 @@
         "rsa.network.alias_host": [
             "tate6578.api.localdomain"
         ],
-        "rsa.time.event_time": "2017-05-29T07:37:24.000Z",
         "rsa.web.reputation_num": 51.523,
         "service.type": "cylance",
         "source.ip": [
@@ -1232,7 +1162,6 @@
         ]
     },
     {
-        "@timestamp": "2017-06-12T14:39:58.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1263,7 +1192,6 @@
             "midestl1919.host"
         ],
         "rsa.network.eth_host": "01:00:5e:f9:78:c2",
-        "rsa.time.event_time": "2017-06-12T14:39:58.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.124.88.222"
@@ -1275,7 +1203,6 @@
         "user.name": "onu"
     },
     {
-        "@timestamp": "2017-06-26T09:42:33.000Z",
         "event.action": "ZoneAddDevice",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1301,7 +1228,6 @@
         "rsa.network.alias_host": [
             "eiusmod3517.internal.invalid"
         ],
-        "rsa.time.event_time": "2017-06-26T09:42:33.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1309,7 +1235,6 @@
         ]
     },
     {
-        "@timestamp": "2017-07-11T04:45:07.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1341,7 +1266,6 @@
             "ntexpl3889.www.home"
         ],
         "rsa.network.eth_host": "01:00:5e:54:ab:3f",
-        "rsa.time.event_time": "2017-07-11T04:45:07.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.156.34.19"
@@ -1353,7 +1277,6 @@
         "user.name": "imveni"
     },
     {
-        "@timestamp": "2019-07-25T11:47:41.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1384,7 +1307,6 @@
             "ntium4450.www5.localdomain"
         ],
         "rsa.network.eth_host": "01:00:5e:ee:e8:77",
-        "rsa.time.event_time": "2019-07-25T11:47:41.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.22.94.10"
@@ -1396,7 +1318,6 @@
         "user.name": "ssusci"
     },
     {
-        "@timestamp": "2017-08-08T06:50:15.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1420,7 +1341,6 @@
         "rsa.network.alias_host": [
             "erspi5757.local"
         ],
-        "rsa.time.event_time": "2017-08-08T06:50:15.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1428,7 +1348,6 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T13:52:50.000Z",
         "event.action": "threat_found",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1450,7 +1369,6 @@
         "rsa.misc.device_name": "edolo",
         "rsa.misc.event_type": "threat_found",
         "rsa.misc.mail_id": "econs",
-        "rsa.time.event_time": "2019-08-22T13:52:50.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1458,7 +1376,6 @@
         ]
     },
     {
-        "@timestamp": "2017-09-06T08:55:00.000Z",
         "event.action": "allow",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1485,7 +1402,6 @@
         "rsa.misc.checksum": "culpaq",
         "rsa.misc.event_type": "PolicyAdd",
         "rsa.misc.node": "fugits",
-        "rsa.time.event_time": "2017-09-06T08:55:00.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.153.34.43"
@@ -1496,7 +1412,6 @@
         ]
     },
     {
-        "@timestamp": "2017-09-20T03:57:58.000Z",
         "event.action": "threat_found",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1520,7 +1435,6 @@
         "rsa.network.alias_host": [
             "magnid3343.home"
         ],
-        "rsa.time.event_time": "2017-09-20T03:57:58.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1528,7 +1442,6 @@
         ]
     },
     {
-        "@timestamp": "2019-10-04T11:00:32.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1551,7 +1464,6 @@
             "asperna7623.www.home"
         ],
         "rsa.network.zone": "tat",
-        "rsa.time.event_time": "2019-10-04T11:00:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1559,7 +1471,6 @@
         ]
     },
     {
-        "@timestamp": "2017-10-19T06:03:07.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1588,7 +1499,6 @@
         "rsa.network.alias_host": [
             "undeom845.www5.example"
         ],
-        "rsa.time.event_time": "2017-10-19T06:03:07.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1597,7 +1507,6 @@
         "user.name": "tassita"
     },
     {
-        "@timestamp": "2019-11-02T13:05:41.000Z",
         "event.action": "threat_changed",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1617,7 +1526,6 @@
         "rsa.misc.event_type": "threat_changed",
         "rsa.misc.node": "quira",
         "rsa.network.zone": "rror",
-        "rsa.time.event_time": "2019-11-02T13:05:41.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1625,7 +1533,6 @@
         ]
     },
     {
-        "@timestamp": "2017-11-16T08:08:15.000Z",
         "event.action": "threat_quarantined",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1657,7 +1564,6 @@
         "rsa.network.alias_host": [
             "ons5050.mail.test"
         ],
-        "rsa.time.event_time": "2017-11-16T08:08:15.000Z",
         "rsa.web.reputation_num": 75.498,
         "service.type": "cylance",
         "source.ip": [
@@ -1669,7 +1575,6 @@
         ]
     },
     {
-        "@timestamp": "2019-12-01T03:10:49.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1700,7 +1605,6 @@
             "oloreeu7597.mail.home"
         ],
         "rsa.network.eth_host": "01:00:5e:e8:41:ae",
-        "rsa.time.event_time": "2019-12-01T03:10:49.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.7.99.47"
@@ -1712,7 +1616,6 @@
         "user.name": "evolupta"
     },
     {
-        "@timestamp": "2017-12-15T10:13:24.000Z",
         "event.action": "Device Updated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1735,7 +1638,6 @@
         "rsa.network.alias_host": [
             "ueip5847.api.test"
         ],
-        "rsa.time.event_time": "2017-12-15T10:13:24.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1743,7 +1645,6 @@
         ]
     },
     {
-        "@timestamp": "2017-12-29T05:15:58.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1773,7 +1674,6 @@
         "rsa.network.alias_host": [
             "uid3520.www.home"
         ],
-        "rsa.time.event_time": "2017-12-29T05:15:58.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1782,7 +1682,6 @@
         "user.name": "ici"
     },
     {
-        "@timestamp": "2020-01-12T12:18:32.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1801,7 +1700,6 @@
         "rsa.investigations.event_vcat": "iduntu",
         "rsa.misc.event_type": "SyslogSettingsSave",
         "rsa.misc.node": "inibusB",
-        "rsa.time.event_time": "2020-01-12T12:18:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1809,7 +1707,6 @@
         ]
     },
     {
-        "@timestamp": "2020-01-27T07:21:06.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1829,7 +1726,6 @@
         "rsa.misc.event_type": "SyslogSettingsSave",
         "rsa.misc.node": "imavenia",
         "rsa.network.zone": "expli",
-        "rsa.time.event_time": "2020-01-27T07:21:06.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1837,7 +1733,6 @@
         ]
     },
     {
-        "@timestamp": "2018-02-10T14:23:41.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1862,7 +1757,6 @@
         "rsa.network.alias_host": [
             "teir7585.www5.localdomain"
         ],
-        "rsa.time.event_time": "2018-02-10T14:23:41.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1870,7 +1764,6 @@
         ]
     },
     {
-        "@timestamp": "2020-02-24T09:26:15.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1891,7 +1784,6 @@
         "rsa.misc.event_type": "SyslogSettingsSave",
         "rsa.misc.node": "quunt",
         "rsa.misc.serial_number": "volup",
-        "rsa.time.event_time": "2020-02-24T09:26:15.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1899,7 +1791,6 @@
         ]
     },
     {
-        "@timestamp": "2020-03-11T04:28:49.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1921,7 +1812,6 @@
         "rsa.misc.device_name": "oreeu",
         "rsa.misc.event_type": "Alert",
         "rsa.misc.mail_id": "tassita",
-        "rsa.time.event_time": "2020-03-11T04:28:49.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1929,7 +1819,6 @@
         ]
     },
     {
-        "@timestamp": "2018-03-25T11:31:24.000Z",
         "event.action": "ZoneAddDevice",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1952,7 +1841,6 @@
         "rsa.network.alias_host": [
             "serrorsi1096.www5.localdomain"
         ],
-        "rsa.time.event_time": "2018-03-25T11:31:24.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1960,7 +1848,6 @@
         ]
     },
     {
-        "@timestamp": "2018-04-08T06:33:58.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -1984,7 +1871,6 @@
         "rsa.network.alias_host": [
             "prehen4807.mail.invalid"
         ],
-        "rsa.time.event_time": "2018-04-08T06:33:58.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -1992,7 +1878,6 @@
         ]
     },
     {
-        "@timestamp": "2018-04-22T13:36:32.000Z",
         "event.action": "ZoneAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2018,7 +1903,6 @@
         "rsa.network.alias_host": [
             "sit1400.www.lan"
         ],
-        "rsa.time.event_time": "2018-04-22T13:36:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2026,7 +1910,6 @@
         ]
     },
     {
-        "@timestamp": "2018-05-07T08:39:06.000Z",
         "event.action": "Device Updated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2047,7 +1930,6 @@
         "rsa.network.alias_host": [
             "sectetu7182.localdomain"
         ],
-        "rsa.time.event_time": "2018-05-07T08:39:06.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2055,7 +1937,6 @@
         ]
     },
     {
-        "@timestamp": "2018-05-21T03:41:41.000Z",
         "event.action": "ZoneAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2080,7 +1961,6 @@
         "rsa.network.alias_host": [
             "officiad4982.www5.domain"
         ],
-        "rsa.time.event_time": "2018-05-21T03:41:41.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2088,7 +1968,6 @@
         ]
     },
     {
-        "@timestamp": "2018-06-04T10:44:15.000Z",
         "event.action": "pechange",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2111,7 +1990,6 @@
         "rsa.network.alias_host": [
             "consequa1486.internal.localdomain"
         ],
-        "rsa.time.event_time": "2018-06-04T10:44:15.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2119,7 +1997,6 @@
         ]
     },
     {
-        "@timestamp": "2018-06-19T05:46:49.000Z",
         "event.action": "fullaccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2150,7 +2027,6 @@
             "its6443.mail.example"
         ],
         "rsa.network.eth_host": "01:00:5e:bc:c1:21",
-        "rsa.time.event_time": "2018-06-19T05:46:49.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.139.80.71"
@@ -2162,7 +2038,6 @@
         "user.name": "orem"
     },
     {
-        "@timestamp": "2018-07-03T12:49:23.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2194,7 +2069,6 @@
         "rsa.network.alias_host": [
             "tconsec7604.corp"
         ],
-        "rsa.time.event_time": "2018-07-03T12:49:23.000Z",
         "rsa.web.reputation_num": 105.845,
         "service.type": "cylance",
         "source.ip": [
@@ -2206,7 +2080,6 @@
         ]
     },
     {
-        "@timestamp": "2018-07-17T07:51:58.000Z",
         "event.action": "threat_found",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2232,7 +2105,6 @@
         "rsa.network.alias_host": [
             "tuser2694.internal.invalid"
         ],
-        "rsa.time.event_time": "2018-07-17T07:51:58.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2240,7 +2112,6 @@
         ]
     },
     {
-        "@timestamp": "2018-08-01T14:54:32.000Z",
         "event.action": "pechange",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2263,7 +2134,6 @@
         "rsa.network.alias_host": [
             "gnaaliq5240.api.test"
         ],
-        "rsa.time.event_time": "2018-08-01T14:54:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2271,7 +2141,6 @@
         ]
     },
     {
-        "@timestamp": "2019-08-15T09:57:06.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2293,7 +2162,6 @@
         "rsa.network.alias_host": [
             "illum2625.test"
         ],
-        "rsa.time.event_time": "2019-08-15T09:57:06.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2301,7 +2169,6 @@
         ]
     },
     {
-        "@timestamp": "2018-08-29T16:59:40.000Z",
         "event.action": "deny",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2332,7 +2199,6 @@
         "rsa.network.alias_host": [
             "nulamc5617.mail.host"
         ],
-        "rsa.time.event_time": "2018-08-29T16:59:40.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.134.137.205"
@@ -2343,7 +2209,6 @@
         ]
     },
     {
-        "@timestamp": "2018-09-12T12:02:15.000Z",
         "event.action": "threat_found",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2369,7 +2234,6 @@
         "rsa.network.alias_host": [
             "tatem4713.internal.host"
         ],
-        "rsa.time.event_time": "2018-09-12T12:02:15.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2377,7 +2241,6 @@
         ]
     },
     {
-        "@timestamp": "2018-09-27T07:04:49.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2409,7 +2272,6 @@
             "ugits5961.www5.local"
         ],
         "rsa.network.eth_host": "01:00:5e:42:41:00",
-        "rsa.time.event_time": "2018-09-27T07:04:49.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.91.2.225"
@@ -2421,7 +2283,6 @@
         "user.name": "rsp"
     },
     {
-        "@timestamp": "2018-10-11T14:07:23.000Z",
         "event.action": "block",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2456,7 +2317,6 @@
         "rsa.network.alias_host": [
             "prehende5460.mail.localdomain"
         ],
-        "rsa.time.event_time": "2018-10-11T14:07:23.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.191.99.14"
@@ -2468,7 +2328,6 @@
         "user.name": "lapa"
     },
     {
-        "@timestamp": "2019-10-25T09:09:57.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2495,7 +2354,6 @@
         "rsa.network.alias_host": [
             "velites1745.api.corp"
         ],
-        "rsa.time.event_time": "2019-10-25T09:09:57.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2503,7 +2361,6 @@
         ]
     },
     {
-        "@timestamp": "2019-11-09T04:12:32.000Z",
         "event.action": "LoginSuccess",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2525,7 +2382,6 @@
         "rsa.network.alias_host": [
             "Duis583.api.local"
         ],
-        "rsa.time.event_time": "2019-11-09T04:12:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2533,7 +2389,6 @@
         ]
     },
     {
-        "@timestamp": "2018-11-23T11:15:06.000Z",
         "event.action": "DeviceEdit",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2560,7 +2415,6 @@
         "rsa.network.alias_host": [
             "velitess2401.www.lan"
         ],
-        "rsa.time.event_time": "2018-11-23T11:15:06.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2568,7 +2422,6 @@
         ]
     },
     {
-        "@timestamp": "2018-12-07T06:17:40.000Z",
         "event.action": "pechange",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2595,7 +2448,6 @@
         "rsa.network.alias_host": [
             "sequines3991.mail.local"
         ],
-        "rsa.time.event_time": "2018-12-07T06:17:40.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2603,7 +2455,6 @@
         ]
     },
     {
-        "@timestamp": "2018-12-21T13:20:14.000Z",
         "event.action": "pechange",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2635,7 +2486,6 @@
         "rsa.network.alias_host": [
             "iatquo2815.mail.host"
         ],
-        "rsa.time.event_time": "2018-12-21T13:20:14.000Z",
         "rsa.web.reputation_num": 38.593,
         "service.type": "cylance",
         "source.ip": [
@@ -2647,7 +2497,6 @@
         ]
     },
     {
-        "@timestamp": "2020-01-05T08:22:49.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2669,7 +2518,6 @@
         "rsa.misc.device_name": "atevelit",
         "rsa.misc.event_type": "Device Policy Assigned",
         "rsa.misc.mail_id": "uptate",
-        "rsa.time.event_time": "2020-01-05T08:22:49.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2677,7 +2525,6 @@
         ]
     },
     {
-        "@timestamp": "2020-01-19T03:25:23.000Z",
         "event.action": "ZoneAddDevice",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2704,7 +2551,6 @@
         "rsa.network.alias_host": [
             "issusci7005.mail.host"
         ],
-        "rsa.time.event_time": "2020-01-19T03:25:23.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2712,7 +2558,6 @@
         ]
     },
     {
-        "@timestamp": "2019-02-02T22:27:57.000Z",
         "event.action": "accept",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2743,7 +2588,6 @@
         "rsa.network.alias_host": [
             "umq7428.invalid"
         ],
-        "rsa.time.event_time": "2019-02-02T22:27:57.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.164.59.219"
@@ -2754,7 +2598,6 @@
         ]
     },
     {
-        "@timestamp": "2020-02-17T05:30:32.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2776,7 +2619,6 @@
         "rsa.misc.device_name": "rem",
         "rsa.misc.event_type": "PolicyAdd",
         "rsa.misc.mail_id": "rinci",
-        "rsa.time.event_time": "2020-02-17T05:30:32.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2784,7 +2626,6 @@
         ]
     },
     {
-        "@timestamp": "2019-03-03T12:33:06.000Z",
         "event.action": "block",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2815,7 +2656,6 @@
         "rsa.network.alias_host": [
             "epteurs5503.www5.home"
         ],
-        "rsa.time.event_time": "2019-03-03T12:33:06.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.1.193.187"
@@ -2826,7 +2666,6 @@
         ]
     },
     {
-        "@timestamp": "2020-03-17T07:35:40.000Z",
         "event.action": "DeviceRemove",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2849,7 +2688,6 @@
         "rsa.misc.event_type": "DeviceRemove",
         "rsa.misc.mail_id": "riat",
         "rsa.misc.policy_name": "umdo",
-        "rsa.time.event_time": "2020-03-17T07:35:40.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2857,7 +2695,6 @@
         ]
     },
     {
-        "@timestamp": "2020-04-01T14:38:14.000Z",
         "event.action": "DeviceEdit",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2881,7 +2718,6 @@
         "rsa.network.alias_host": [
             "omnisis5339.www5.local"
         ],
-        "rsa.time.event_time": "2020-04-01T14:38:14.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2889,7 +2725,6 @@
         ]
     },
     {
-        "@timestamp": "2019-04-15T09:40:49.000Z",
         "event.action": "SystemSecurity",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2914,7 +2749,6 @@
         "rsa.network.alias_host": [
             "ction491.www5.local"
         ],
-        "rsa.time.event_time": "2019-04-15T09:40:49.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -2922,7 +2756,6 @@
         ]
     },
     {
-        "@timestamp": "2019-04-29T04:43:23.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2954,7 +2787,6 @@
             "undeom7847.api.corp"
         ],
         "rsa.network.eth_host": "01:00:5e:9a:f3:b9",
-        "rsa.time.event_time": "2019-04-29T04:43:23.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.146.228.234"
@@ -2966,7 +2798,6 @@
         "user.name": "susc"
     },
     {
-        "@timestamp": "2019-05-13T11:45:57.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -2992,7 +2823,6 @@
         "rsa.network.alias_host": [
             "dolo6230.mail.invalid"
         ],
-        "rsa.time.event_time": "2019-05-13T11:45:57.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.59.232.97"
@@ -3003,7 +2833,6 @@
         ]
     },
     {
-        "@timestamp": "2019-05-28T06:48:31.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3029,7 +2858,6 @@
         "rsa.network.alias_host": [
             "nvolup6280.api.home"
         ],
-        "rsa.time.event_time": "2019-05-28T06:48:31.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3037,7 +2865,6 @@
         ]
     },
     {
-        "@timestamp": "2019-06-11T13:51:06.000Z",
         "event.action": "PolicyAdd",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3063,7 +2890,6 @@
         "rsa.network.alias_host": [
             "urautodi3892.www5.example"
         ],
-        "rsa.time.event_time": "2019-06-11T13:51:06.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3071,7 +2897,6 @@
         ]
     },
     {
-        "@timestamp": "2020-06-25T08:53:40.000Z",
         "event.action": "allow",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3102,7 +2927,6 @@
         "rsa.misc.device_name": "isciveli",
         "rsa.misc.event_type": "Alert",
         "rsa.misc.policy_name": "ing",
-        "rsa.time.event_time": "2020-06-25T08:53:40.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.36.18.24"
@@ -3114,7 +2938,6 @@
         "user.name": "nsequ"
     },
     {
-        "@timestamp": "2019-07-10T03:56:14.000Z",
         "event.action": "block",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3149,7 +2972,6 @@
         "rsa.network.alias_host": [
             "uraut3756.www5.test"
         ],
-        "rsa.time.event_time": "2019-07-10T03:56:14.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.127.30.119"
@@ -3161,7 +2983,6 @@
         "user.name": "stenatus"
     },
     {
-        "@timestamp": "2020-07-24T10:58:48.000Z",
         "event.action": "Alert",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3186,7 +3007,6 @@
         "rsa.network.alias_host": [
             "squ2213.www.test"
         ],
-        "rsa.time.event_time": "2020-07-24T10:58:48.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3194,7 +3014,6 @@
         ]
     },
     {
-        "@timestamp": "2019-08-07T06:01:23.000Z",
         "event.action": "threat_changed",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3216,7 +3035,6 @@
         "rsa.misc.device_name": "utod",
         "rsa.misc.event_type": "threat_changed",
         "rsa.misc.mail_id": "orinrep",
-        "rsa.time.event_time": "2019-08-07T06:01:23.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3224,7 +3042,6 @@
         ]
     },
     {
-        "@timestamp": "2019-08-21T13:03:57.000Z",
         "event.action": "deny",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3259,7 +3076,6 @@
         "rsa.network.alias_host": [
             "umet5891.api.localdomain"
         ],
-        "rsa.time.event_time": "2019-08-21T13:03:57.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.8.150.213"
@@ -3271,7 +3087,6 @@
         "user.name": "ugiatnul"
     },
     {
-        "@timestamp": "2019-09-05T08:06:31.000Z",
         "event.action": "DeviceEdit",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3297,7 +3112,6 @@
         "rsa.network.alias_host": [
             "umquam5574.internal.test"
         ],
-        "rsa.time.event_time": "2019-09-05T08:06:31.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.108.59.10"
@@ -3308,7 +3122,6 @@
         ]
     },
     {
-        "@timestamp": "2019-09-19T03:09:05.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3335,7 +3148,6 @@
         "rsa.network.alias_host": [
             "volupt6822.api.invalid"
         ],
-        "rsa.time.event_time": "2019-09-19T03:09:05.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3343,7 +3155,6 @@
         ]
     },
     {
-        "@timestamp": "2019-10-03T10:11:40.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3364,7 +3175,6 @@
         "rsa.misc.event_type": "Device Policy Assigned",
         "rsa.misc.node": "stl",
         "rsa.misc.serial_number": "eumfugi",
-        "rsa.time.event_time": "2019-10-03T10:11:40.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3372,7 +3182,6 @@
         ]
     },
     {
-        "@timestamp": "2019-10-18T05:14:14.000Z",
         "event.action": "SyslogSettingsSave",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3393,7 +3202,6 @@
         "rsa.misc.event_type": "SyslogSettingsSave",
         "rsa.misc.node": "tutlabo",
         "rsa.misc.serial_number": "ateveli",
-        "rsa.time.event_time": "2019-10-18T05:14:14.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3401,7 +3209,6 @@
         ]
     },
     {
-        "@timestamp": "2019-11-01T12:16:48.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3430,7 +3237,6 @@
         "rsa.network.alias_host": [
             "amvol4075.mail.localhost"
         ],
-        "rsa.time.event_time": "2019-11-01T12:16:48.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3439,7 +3245,6 @@
         "user.name": "pta"
     },
     {
-        "@timestamp": "2019-11-15T07:19:22.000Z",
         "event.action": "Registration",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3464,7 +3269,6 @@
         "rsa.network.alias_host": [
             "asi4651.api.test"
         ],
-        "rsa.time.event_time": "2019-11-15T07:19:22.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",
@@ -3472,7 +3276,6 @@
         ]
     },
     {
-        "@timestamp": "2019-11-30T14:21:57.000Z",
         "event.action": "Device Policy Assigned",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3498,7 +3301,6 @@
         "rsa.network.alias_host": [
             "perna6751.internal.home"
         ],
-        "rsa.time.event_time": "2019-11-30T14:21:57.000Z",
         "service.type": "cylance",
         "source.ip": [
             "10.138.85.233"
@@ -3509,7 +3311,6 @@
         ]
     },
     {
-        "@timestamp": "2019-12-14T09:24:31.000Z",
         "event.action": "ThreatUpdated",
         "event.code": "CylancePROTECT",
         "event.dataset": "cylance.protect",
@@ -3535,7 +3336,6 @@
         "rsa.network.alias_host": [
             "evolupta7790.internal.local"
         ],
-        "rsa.time.event_time": "2019-12-14T09:24:31.000Z",
         "service.type": "cylance",
         "tags": [
             "cylance.protect",


### PR DESCRIPTION
## What does this PR do?

Updates the modules test to ignore timestamps from cylance/protect dataset

## Why is it important?

Avoid test failures
