### PR TITLE
Cherry-pick #20191 to 7.x: [Metricbeat] Use MySQL Host Parser in Query metricset

### DIFF
--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -58,8 +58,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 metricbeat.modules:
 - module: mysql
   metricsets:
-    - "status"
-  #  - "galera_status"
+    - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/docs/modules/mysql/performance.asciidoc
+++ b/metricbeat/docs/modules/mysql/performance.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/mysql/performance/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/docs/modules/mysql/query.asciidoc
+++ b/metricbeat/docs/modules/mysql/query.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/mysql/query/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -647,8 +647,10 @@ metricbeat.modules:
 #-------------------------------- MySQL Module --------------------------------
 - module: mysql
   metricsets:
-    - "status"
-  #  - "galera_status"
+    - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -1,7 +1,9 @@
 - module: mysql
   metricsets:
-    - "status"
-  #  - "galera_status"
+    - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -2,6 +2,8 @@
   #metricsets:
   #  - status
   #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/mysql/performance/manifest.yml
+++ b/metricbeat/module/mysql/performance/manifest.yml
@@ -1,4 +1,4 @@
-default: true
+default: false
 input:
   module: mysql
   metricset: query

--- a/metricbeat/module/mysql/query/query.go
+++ b/metricbeat/module/mysql/query/query.go
@@ -32,11 +32,12 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/metricbeat/helper/sql"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/mysql"
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("mysql", "query", New,
-		mb.DefaultMetricSet(),
+		mb.WithHostParser(mysql.ParseDSN),
 	)
 }
 

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -5,6 +5,8 @@
   #metricsets:
   #  - status
   #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -970,8 +970,10 @@ metricbeat.modules:
 #-------------------------------- MySQL Module --------------------------------
 - module: mysql
   metricsets:
-    - "status"
-  #  - "galera_status"
+    - status
+  #  - galera_status
+  #  - performance
+  #  - query
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"


### PR DESCRIPTION
Cherry-pick of PR #20191 to 7.x branch. Original message: 

Add Mysql host parser in query metricset instead of using the default.

Relates: https://github.com/elastic/beats/pull/20149