### PR TITLE
[Ingest Manager] Prevent closing closed reader

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@
 - Unzip failures on Windows 8/Windows server 2012 {pull}20088[20088]
 - Fix failing unit tests on windows {pull}20127[20127]
 - Improve GRPC stop to be more relaxed {pull}20118[20118]
+- Prevent closing closed reader {pull}20214[20214]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
@@ -94,10 +94,6 @@ func getInfoFromStore(s ioStore) (*persistentAgentInfo, error) {
 			errors.M(errors.MetaKeyPath, agentConfigFile))
 	}
 
-	if err := reader.Close(); err != nil {
-		return nil, err
-	}
-
 	configMap, err := cfg.ToMapStr()
 	if err != nil {
 		return nil, errors.New(err,
@@ -135,10 +131,6 @@ func updateAgentInfo(s ioStore, agentInfo *persistentAgentInfo) error {
 		return errors.New(err, fmt.Sprintf("fail to read configuration %s for the agent", agentConfigFile),
 			errors.TypeFilesystem,
 			errors.M(errors.MetaKeyPath, agentConfigFile))
-	}
-
-	if err := reader.Close(); err != nil {
-		return err
 	}
 
 	configMap := make(map[string]interface{})


### PR DESCRIPTION
## What does this PR do?

With #20127 config reader is closed on read. no need to do that in code. removes all occurences of close

## Why is it important?


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
