### PR TITLE
Increase index.max_docvalue_fields_search to 200

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -354,6 +354,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support to trim captured values in the dissect processor. {pull}19464[19464]
 - Added the `max_cached_sessions` option to the script processor. {pull}19562[19562]
 - Add support for DNS over TLS for the dns_processor. {pull}19321[19321]
+- Set index.max_docvalue_fields_search in index template to increase value to 200 fields. {issue}20215[20215]
 
 *Auditbeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -32,9 +32,10 @@ import (
 
 var (
 	// Defaults used in the template
-	defaultDateDetection         = false
-	defaultTotalFieldsLimit      = 10000
-	defaultNumberOfRoutingShards = 30
+	defaultDateDetection           = false
+	defaultTotalFieldsLimit        = 10000
+	defaultNumberOfRoutingShards   = 30
+	defaultMaxDocvalueFieldsSearch = 200
 
 	// Array to store dynamicTemplate parts in
 	dynamicTemplates []common.MapStr
@@ -323,6 +324,10 @@ func buildIdxSettings(ver common.Version, userSettings common.MapStr) common.Map
 		fields = append(fields, "fields.*")
 
 		indexSettings.Put("query.default_field", fields)
+	}
+
+	if ver.Major >= 6 {
+		indexSettings.Put("max_docvalue_fields_search", defaultMaxDocvalueFieldsSearch)
 	}
 
 	indexSettings.DeepUpdate(userSettings)

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -113,6 +113,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings.doc._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 
 	t.Run("for ES 7.x", func(t *testing.T) {
@@ -120,6 +121,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 
 	t.Run("for ES 8.x", func(t *testing.T) {
@@ -127,6 +129,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

The number of docvalue fields in Filebeat went beyond 100 and Discover was not loading.
I added settings.index.max_docvalue_fields_search=200 to the default index template.
In Filebeat there are about 117 fields now.

Fixes #20215

## Why is it important?

It allows Filebeat data to be shown in Kibana.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
