### PR TITLE
Cherry-pick #20218 to 7.9: Increase index.max_docvalue_fields_search to 200

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -197,6 +197,19 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add keystore support for autodiscover static configurations. {pull]16306[16306]
 - When using the `decode_json_fields` processor, decoded fields are now deep-merged into existing event. {pull}17958[17958]
 - Add keystore support for autodiscover static configurations. {pull]16306[16306]
+- Add backoff configuration options for the Kafka output. {issue}16777[16777] {pull}17808[17808]
+- Add TLS support to Kerberos authentication in Elasticsearch. {pull}18607[18607]
+- Change ownership of files in docker images so they can be used in secured environments. {pull}12905[12905]
+- Upgrade k8s.io/client-go and k8s keystore tests. {pull}18817[18817]
+- Add support for multiple sets of hints on autodiscover {pull}18883[18883]
+- Add a configurable delay between retries when an app metadata cannot be retrieved by `add_cloudfoundry_metadata`. {pull}19181[19181]
+- Add data type conversion in `dissect` processor for converting string values to other basic data types. {pull}18683[18683]
+- Add the `ignore_failure` configuration option to the dissect processor. {pull}19464[19464]
+- Add the `overwrite_keys` configuration option to the dissect processor. {pull}19464[19464]
+- Add support to trim captured values in the dissect processor. {pull}19464[19464]
+- Added the `max_cached_sessions` option to the script processor. {pull}19562[19562]
+- Add support for DNS over TLS for the dns_processor. {pull}19321[19321]
+- Set index.max_docvalue_fields_search in index template to increase value to 200 fields. {issue}20215[20215]
 
 *Auditbeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -32,9 +32,10 @@ import (
 
 var (
 	// Defaults used in the template
-	defaultDateDetection         = false
-	defaultTotalFieldsLimit      = 10000
-	defaultNumberOfRoutingShards = 30
+	defaultDateDetection           = false
+	defaultTotalFieldsLimit        = 10000
+	defaultNumberOfRoutingShards   = 30
+	defaultMaxDocvalueFieldsSearch = 200
 
 	// Array to store dynamicTemplate parts in
 	dynamicTemplates []common.MapStr
@@ -323,6 +324,10 @@ func buildIdxSettings(ver common.Version, userSettings common.MapStr) common.Map
 		fields = append(fields, "fields.*")
 
 		indexSettings.Put("query.default_field", fields)
+	}
+
+	if ver.Major >= 6 {
+		indexSettings.Put("max_docvalue_fields_search", defaultMaxDocvalueFieldsSearch)
 	}
 
 	indexSettings.DeepUpdate(userSettings)

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -113,6 +113,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings.doc._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 
 	t.Run("for ES 7.x", func(t *testing.T) {
@@ -120,6 +121,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 
 	t.Run("for ES 8.x", func(t *testing.T) {
@@ -127,6 +129,7 @@ func TestTemplate(t *testing.T) {
 		template.Assert("index_patterns", []string{"testbeat-" + currentVersion + "-*"})
 		template.Assert("order", 1)
 		template.Assert("mappings._meta", common.MapStr{"beat": "testbeat", "version": currentVersion})
+		template.Assert("settings.index.max_docvalue_fields_search", 200)
 	})
 }
 


### PR DESCRIPTION
Cherry-pick of PR #20218 to 7.9 branch. Original message: 

## What does this PR do?

The number of docvalue fields in Filebeat went beyond 100 and Discover was not loading.
I added settings.index.max_docvalue_fields_search=200 to the default index template.
In Filebeat there are about 117 fields now.

Fixes #20215

## Why is it important?

It allows Filebeat data to be shown in Kibana.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
