### PR TITLE
Cherry-pick #20232 to 7.x: [Filebeat Input][HTTP_endpoint] Add possibility to override content-type header

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -41,6 +41,17 @@ Custom response example:
   prefix: "json"
 ----
 
+Disable Content-Type checks
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: http_endpoint
+  enabled: true
+  listen_address: 192.168.1.1
+  content_type: ""
+  prefix: "json"
+----
+
 Basic auth and SSL example:
 ["source","yaml",subs="attributes"]
 ----
@@ -79,6 +90,12 @@ If `basic_auth` is enabled, this is the username used for authentication against
 ==== `password`
 
 If `basic_auth` is eanbled, this is the password used for authentication against the HTTP listener. Requires `username` to also be set.
+
+[float]
+==== `content_type`
+
+By default the input expects the incoming POST to include a Content-Type of `application/json` to try to enforce the incoming data to be valid JSON.
+In certain scenarios when the source of the request is not able to do that, it can be overwritten with another value or set to null
 
 [float]
 ==== `response_code`

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -23,6 +23,7 @@ type config struct {
 	ListenPort    string                  `config:"listen_port"`
 	URL           string                  `config:"url"`
 	Prefix        string                  `config:"prefix"`
+	ContentType   string                  `config:"content_type"`
 }
 
 func defaultConfig() config {
@@ -36,6 +37,7 @@ func defaultConfig() config {
 		ListenPort:    "8000",
 		URL:           "/",
 		Prefix:        "json",
+		ContentType:   "application/json",
 	}
 }
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -87,7 +87,7 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 		username:    e.config.Username,
 		password:    e.config.Password,
 		method:      http.MethodPost,
-		contentType: "application/json",
+		contentType: e.config.ContentType,
 	}
 
 	handler := &httpHandler{


### PR DESCRIPTION
Cherry-pick of PR #20232 to 7.x branch. Original message: 

## What does this PR do?

Webhooks like Zoom does not add any content-type headers on incoming requests, the content type now defaults to application/json but is possible to set to another value or null.

This is a preliminary change needed before adding some more validation steps, which will be created in separate PR's

## Why is it important?

Adds support for webhooks which does not set content-type headers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
