### PR TITLE
Cherry-pick #20203 to 7.9: [Elastic Agent] Fix Windows powershell install service script

### DIFF
--- a/dev-tools/packaging/templates/windows/install-service-elastic-agent.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service-elastic-agent.ps1.tmpl
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 # Delete and stop the service if it already exists.
 if (Get-Service {{.BeatName}} -ErrorAction SilentlyContinue) {
   $service = Get-WmiObject -Class Win32_Service -Filter "name='{{.BeatName}}'"
@@ -13,8 +15,5 @@ New-Service -name {{.BeatName}} `
   -displayName {{.BeatName | title}} `
   -binaryPathName "`"$workdir\{{.BeatName}}.exe`" --path.home `"$workdir`" --path.data  `"$workdir\data`" run"
 
-# Attempt to set the service to delayed start using sc config.
-Try {
-  Start-Process -FilePath sc.exe -ArgumentList 'config {{.BeatName}} start= delayed-auto'
-}
-Catch { Write-Host -f red "An error occured setting the service to delayed start." }
+# Start the new service.
+Start-Service -name {{.BeatName}}

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@
 - Fix failing unit tests on windows {pull}20127[20127]
 - Prevent closing closed reader {pull}20214[20214]
 - Improve GRPC stop to be more relaxed {pull}20118[20118]
+- Fix Windows service installation script {pull}20203[20203]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
@@ -86,6 +86,7 @@ func getInfoFromStore(s ioStore) (*persistentAgentInfo, error) {
 		return nil, err
 	}
 
+	// reader is closed by this function
 	cfg, err := config.NewConfigFrom(reader)
 	if err != nil {
 		return nil, errors.New(err,
@@ -126,6 +127,7 @@ func updateAgentInfo(s ioStore, agentInfo *persistentAgentInfo) error {
 		return err
 	}
 
+	// reader is closed by this function
 	cfg, err := config.NewConfigFrom(reader)
 	if err != nil {
 		return errors.New(err, fmt.Sprintf("fail to read configuration %s for the agent", agentConfigFile),


### PR DESCRIPTION
Cherry-pick of PR #20203 to 7.9 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the Windows Elastic Agent service installation script to not mark the service as delayed start and to start the service.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So Elastic Agent is started on the host as soon as possible and so the service is started.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20106 
