### PR TITLE
[Elastic Agent] Fix service application stop timeout issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ x-pack/dockerlogbeat/temproot.tar
 x-pack/elastic-agent/elastic_agent
 x-pack/elastic-agent/fleet.yml
 x-pack/elastic-agent/pkg/agent/operation/tests/scripts/configurable-1.0-darwin-x86_64/configurable
+x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/serviceable
 
 # Editor swap files
 *.swp

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@
 - Improve GRPC stop to be more relaxed {pull}20118[20118]
 - Prevent closing closed reader {pull}20214[20214]
 - Fix Windows service installation script {pull}20203[20203]
+- Fix timeout issue stopping service applications {pull}20256[20256]
 
 ==== New features
 

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -167,12 +167,15 @@ func (Build) Clean() {
 func (Build) TestBinaries() error {
 	p := filepath.Join("pkg", "agent", "operation", "tests", "scripts")
 
-	binaryName := "configurable"
+	configurableName := "configurable"
+	serviceableName := "serviceable"
 	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
+		configurableName += ".exe"
+		serviceableName += ".exe"
 	}
 	return combineErr(
-		RunGo("build", "-o", filepath.Join(p, "configurable-1.0-darwin-x86_64", binaryName), filepath.Join(p, "configurable-1.0-darwin-x86_64", "main.go")),
+		RunGo("build", "-o", filepath.Join(p, "configurable-1.0-darwin-x86_64", configurableName), filepath.Join(p, "configurable-1.0-darwin-x86_64", "main.go")),
+		RunGo("build", "-o", filepath.Join(p, "serviceable-1.0-darwin-x86_64", serviceableName), filepath.Join(p, "serviceable-1.0-darwin-x86_64", "main.go")),
 	)
 }
 

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -94,15 +94,13 @@ func getLogger() *logger.Logger {
 }
 
 func getProgram(binary, version string) *app.Descriptor {
+	spec := program.SupportedMap[binary]
 	downloadCfg := &artifact.Config{
 		InstallPath:     installPath,
 		OperatingSystem: "darwin",
 		Architecture:    "32",
 	}
-	return app.NewDescriptor(program.Spec{
-		Name: binary,
-		Cmd:  binary,
-	}, version, downloadCfg, nil)
+	return app.NewDescriptor(spec, version, downloadCfg, nil)
 }
 
 func getAbsPath(path string) string {

--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -35,9 +35,9 @@ func TestMain(m *testing.M) {
 	}
 	serviceSpec := program.Spec{
 		ServicePort: port,
-		Name: "serviceable",
-		Cmd:  "serviceable",
-		Args: []string{fmt.Sprintf("%d", port)},
+		Name:        "serviceable",
+		Cmd:         "serviceable",
+		Args:        []string{fmt.Sprintf("%d", port)},
 	}
 
 	program.Supported = append(program.Supported, configurableSpec, serviceSpec)
@@ -389,7 +389,7 @@ func TestConfigurableService(t *testing.T) {
 
 	// emulating a service, so we need to start the binary here in the test
 	spec := p.Spec()
-	cmd := exec.Command(spec.BinaryPath, spec.Args...)
+	cmd := exec.Command(spec.BinaryPath, fmt.Sprintf("%d", p.ServicePort()))
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Dir = filepath.Dir(spec.BinaryPath)
 	cmd.Stdout = os.Stdout
@@ -435,15 +435,6 @@ func TestConfigurableService(t *testing.T) {
 	if err := operator.stop(p); err != nil {
 		t.Fatalf("Failed to stop service: %v", err)
 	}
-
-	waitFor(t, func() error {
-		items := operator.State()
-		_, ok := items[p.ID()]
-		if ok {
-			return fmt.Errorf("state for process, should be removed")
-		}
-		return nil
-	})
 
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("Process failed: %v", err)

--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -7,7 +7,9 @@ package operation
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -27,17 +29,26 @@ func TestMain(m *testing.M) {
 		Cmd:  "configurable",
 		Args: []string{},
 	}
-
-	program.Supported = append(program.Supported, configurableSpec)
-
-	p := getProgram("configurable", "1.0")
-	spec := p.Spec()
-	path := spec.BinaryPath
-	if runtime.GOOS == "windows" {
-		path += ".exe"
+	port, err := getFreePort()
+	if err != nil {
+		panic(err)
 	}
-	if s, err := os.Stat(path); err != nil || s == nil {
-		panic(fmt.Errorf("binary not available %s", spec.BinaryPath))
+	serviceSpec := program.Spec{
+		ServicePort: port,
+		Name: "serviceable",
+		Cmd:  "serviceable",
+		Args: []string{fmt.Sprintf("%d", port)},
+	}
+
+	program.Supported = append(program.Supported, configurableSpec, serviceSpec)
+	program.SupportedMap["configurable"] = configurableSpec
+	program.SupportedMap["serviceable"] = serviceSpec
+
+	if err := isAvailable("configurable", "1.0"); err != nil {
+		panic(err)
+	}
+	if err := isAvailable("serviceable", "1.0"); err != nil {
+		panic(err)
 	}
 
 	os.Exit(m.Run())
@@ -365,4 +376,103 @@ func TestConfigurableStartStop(t *testing.T) {
 			return nil
 		})
 	}
+}
+
+func TestConfigurableService(t *testing.T) {
+	p := getProgram("serviceable", "1.0")
+
+	operator := getTestOperator(t, downloadPath, installPath, p)
+	if err := operator.start(p, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer operator.stop(p) // failure catch, to ensure no sub-process stays running
+
+	// emulating a service, so we need to start the binary here in the test
+	spec := p.Spec()
+	cmd := exec.Command(spec.BinaryPath, spec.Args...)
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Dir = filepath.Dir(spec.BinaryPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, func() error {
+		items := operator.State()
+		item, ok := items[p.ID()]
+		if !ok {
+			return fmt.Errorf("no state for process")
+		}
+		if item.Status != state.Running {
+			return fmt.Errorf("process never went to running")
+		}
+		return nil
+	})
+
+	// try to configure
+	cfg := make(map[string]interface{})
+	tstFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("tmp%d", rand.Uint32()))
+	cfg["TestFile"] = tstFilePath
+	if err := operator.pushConfig(p, cfg); err != nil {
+		t.Fatalf("failed to config: %v", err)
+	}
+
+	waitFor(t, func() error {
+		if s, err := os.Stat(tstFilePath); err != nil || s == nil {
+			return fmt.Errorf("failed to create a file using Config call %s", tstFilePath)
+		}
+		return nil
+	})
+
+	items := operator.State()
+	item0, ok := items[p.ID()]
+	if !ok || item0.Status != state.Running {
+		t.Fatalf("Process no longer running after config %#v", items)
+	}
+
+	// stop the process
+	if err := operator.stop(p); err != nil {
+		t.Fatalf("Failed to stop service: %v", err)
+	}
+
+	waitFor(t, func() error {
+		items := operator.State()
+		_, ok := items[p.ID()]
+		if ok {
+			return fmt.Errorf("state for process, should be removed")
+		}
+		return nil
+	})
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+}
+
+func isAvailable(name, version string) error {
+	p := getProgram(name, version)
+	spec := p.Spec()
+	path := spec.BinaryPath
+	if runtime.GOOS == "windows" {
+		path += ".exe"
+	}
+	if s, err := os.Stat(path); err != nil || s == nil {
+		return fmt.Errorf("binary not available %s", spec.BinaryPath)
+	}
+	return nil
+}
+
+// getFreePort finds a free port.
+func getFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }

--- a/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/configurable-1.0-darwin-x86_64/README.md
+++ b/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/configurable-1.0-darwin-x86_64/README.md
@@ -1,1 +1,1 @@
-Testing program emulating tool which is configurable using GRPC communication channel.
+Testing program emulating tool which is configurable using GRPC communication channel when running as a sub-process.

--- a/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/README.md
+++ b/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/README.md
@@ -1,0 +1,1 @@
+Testing program emulating tool which is configurable using GRPC communication channel when running as an external service.

--- a/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/main.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/main.go
@@ -1,0 +1,155 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	protobuf "github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+)
+
+func main() {
+	srvPort, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	f, _ := os.OpenFile(filepath.Join(os.TempDir(), "testing.out"), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	f.WriteString("starting \n")
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &configServer{
+		f:      f,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	f.WriteString(fmt.Sprintf("reading creds from port: %d\n", srvPort))
+	client, err := clientFromNet(srvPort, s)
+	if err != nil {
+		f.WriteString(err.Error())
+		panic(err)
+	}
+	s.client = client
+	err = client.Start(ctx)
+	if err != nil {
+		f.WriteString(err.Error())
+		panic(err)
+	}
+	<-ctx.Done()
+	f.WriteString("finished \n")
+}
+
+type configServer struct {
+	f      *os.File
+	ctx    context.Context
+	cancel context.CancelFunc
+	client client.Client
+}
+
+func (s *configServer) OnConfig(cfgString string) {
+	s.client.Status(proto.StateObserved_CONFIGURING, "Writing config file", nil)
+
+	testCfg := &TestConfig{}
+	if err := yaml.Unmarshal([]byte(cfgString), &testCfg); err != nil {
+		s.client.Status(proto.StateObserved_FAILED, fmt.Sprintf("Failed to unmarshall config: %s", err), nil)
+		return
+	}
+
+	if testCfg.TestFile != "" {
+		tf, err := os.Create(testCfg.TestFile)
+		if err != nil {
+			s.client.Status(proto.StateObserved_FAILED, fmt.Sprintf("Failed to create file %s: %s", testCfg.TestFile, err), nil)
+			return
+		}
+
+		err = tf.Close()
+		if err != nil {
+			s.client.Status(proto.StateObserved_FAILED, fmt.Sprintf("Failed to close file %s: %s", testCfg.TestFile, err), nil)
+			return
+		}
+	}
+
+	if testCfg.Crash {
+		os.Exit(2)
+	}
+
+	if testCfg.Status != nil {
+		s.client.Status(*testCfg.Status, "Custom status", map[string]interface{}{
+			"status":  *testCfg.Status,
+			"message": "Custom status",
+		})
+	} else {
+		s.client.Status(proto.StateObserved_HEALTHY, "Running", map[string]interface{}{
+			"status":  proto.StateObserved_HEALTHY,
+			"message": "Running",
+		})
+	}
+}
+
+func (s *configServer) OnStop() {
+	s.client.Status(proto.StateObserved_STOPPING, "Stopping", nil)
+	s.cancel()
+}
+
+func (s *configServer) OnError(err error) {
+	s.f.WriteString(err.Error())
+}
+
+// TestConfig is a configuration for testing Config calls
+type TestConfig struct {
+	TestFile string                      `config:"TestFile" yaml:"TestFile"`
+	Status   *proto.StateObserved_Status `config:"Status" yaml:"Status"`
+	Crash    bool                        `config:"Crash" yaml:"Crash"`
+}
+
+func getCreds(port int) (*proto.ConnInfo, error) {
+	c, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	buf := make([]byte, 0, 8192)
+	n, err := c.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(os.Stdout, "reading: %d\n", n)
+	var connInfo proto.ConnInfo
+	err = protobuf.Unmarshal(buf[:n], &connInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &connInfo, nil
+}
+
+func clientFromNet(port int, impl client.StateInterface, actions ...client.Action) (client.Client, error) {
+	connInfo, err := getCreds(port)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.X509KeyPair(connInfo.PeerCert, connInfo.PeerKey)
+	if err != nil {
+		return nil, err
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(connInfo.CaCert)
+	trans := credentials.NewTLS(&tls.Config{
+		ServerName:   connInfo.ServerName,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	})
+	return client.New(connInfo.Addr, connInfo.Token, impl, actions, grpc.WithTransportCredentials(trans)), nil
+}

--- a/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/main.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/tests/scripts/serviceable-1.0-darwin-x86_64/main.go
@@ -9,14 +9,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	protobuf "github.com/golang/protobuf/proto"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	protobuf "github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
@@ -82,21 +82,10 @@ func (s *configServer) OnConfig(cfgString string) {
 		}
 	}
 
-	if testCfg.Crash {
-		os.Exit(2)
-	}
-
-	if testCfg.Status != nil {
-		s.client.Status(*testCfg.Status, "Custom status", map[string]interface{}{
-			"status":  *testCfg.Status,
-			"message": "Custom status",
-		})
-	} else {
-		s.client.Status(proto.StateObserved_HEALTHY, "Running", map[string]interface{}{
-			"status":  proto.StateObserved_HEALTHY,
-			"message": "Running",
-		})
-	}
+	s.client.Status(proto.StateObserved_HEALTHY, "Running", map[string]interface{}{
+		"status":  proto.StateObserved_HEALTHY,
+		"message": "Running",
+	})
 }
 
 func (s *configServer) OnStop() {
@@ -110,23 +99,20 @@ func (s *configServer) OnError(err error) {
 
 // TestConfig is a configuration for testing Config calls
 type TestConfig struct {
-	TestFile string                      `config:"TestFile" yaml:"TestFile"`
-	Status   *proto.StateObserved_Status `config:"Status" yaml:"Status"`
-	Crash    bool                        `config:"Crash" yaml:"Crash"`
+	TestFile string `config:"TestFile" yaml:"TestFile"`
 }
 
 func getCreds(port int) (*proto.ConnInfo, error) {
-	c, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+	c, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, err
 	}
 	defer c.Close()
-	buf := make([]byte, 0, 8192)
+	buf := make([]byte, 1024*1024)
 	n, err := c.Read(buf)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Fprintf(os.Stdout, "reading: %d\n", n)
 	var connInfo proto.ConnInfo
 	err = protobuf.Unmarshal(buf[:n], &connInfo)
 	if err != nil {

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -123,20 +123,26 @@ func (a *Application) Started() bool {
 // Stop stops the current application.
 func (a *Application) Stop() {
 	a.appLock.Lock()
-	defer a.appLock.Unlock()
+	status := a.state.Status
+	srvState := a.srvState
+	a.appLock.Unlock()
 
-	if a.state.Status == state.Stopped {
+	if status == state.Stopped {
 		return
 	}
 
 	stopSig := os.Interrupt
-	if a.srvState != nil {
-		if err := a.srvState.Stop(a.processConfig.StopTimeout); err != nil {
+	if srvState != nil {
+		if err := srvState.Stop(a.processConfig.StopTimeout); err != nil {
 			// kill the process if stop through GRPC doesn't work
 			stopSig = os.Kill
 		}
-		a.srvState = nil
 	}
+
+	a.appLock.Lock()
+	defer a.appLock.Unlock()
+
+	a.srvState = nil
 	if a.state.ProcessInfo != nil {
 		if err := a.state.ProcessInfo.Process.Signal(stopSig); err == nil {
 			// no error on signal, so wait for it to stop


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where stopping a service based application always resulted in the stop timeout always occurring.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows a service application to stop correctly and quickly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20244
