### PR TITLE
Cherry-pick #19727 to 7.9: Elastic agent on k8s

### DIFF
--- a/deploy/kubernetes/elastic-agent-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-kubernetes.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-ingest-management-nodescope
+  namespace: kube-system
+  labels:
+    app: agent-ingest-management-nodescope
+    group: ingest-management
+spec:
+  selector:
+    matchLabels:
+      app: agent-ingest-management-nodescope
+  template:
+    metadata:
+      labels:
+        app: agent-ingest-management-nodescope
+        group: ingest-management
+    spec:
+      serviceAccountName: agent-ingest-management
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: agent-ingest-management-nodescope
+          image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
+          env:
+            - name: FLEET_ENROLL
+              value: "1"
+            # Use enrollment key of node scope configuration to distinguish node scope datasets
+            - name: FLEET_ENROLLMENT_TOKEN
+              value:
+            - name: KIBANA_HOST
+              value: "http://kibana:5601"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-ingest-management-clusterscope
+  namespace: kube-system
+  labels:
+    app: agent-ingest-management-clusterscope
+    group: ingest-management
+spec:
+  selector:
+    matchLabels:
+      app: agent-ingest-management-clusterscope
+  template:
+    metadata:
+      labels:
+        app: agent-ingest-management-clusterscope
+        group: ingest-management
+    spec:
+      serviceAccountName: agent-ingest-management
+      containers:
+        - name: agent-ingest-management-clusterscope
+          image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
+          env:
+            - name: FLEET_ENROLL
+              value: "1"
+            # Use enrollment key of cluster scope configuration to distinguish node scope datasets
+            - name: FLEET_ENROLLMENT_TOKEN
+              value:
+            - name: KIBANA_HOST
+              value: "http://kibana:5601"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-ingest-management
+subjects:
+  - kind: ServiceAccount
+    name: agent-ingest-management
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: agent-ingest-management
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-ingest-management
+  labels:
+    k8s-app: agent-ingest-management
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - secrets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  # required for apiserver
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-ingest-management
+  namespace: kube-system
+  labels:
+    k8s-app: agent-ingest-management
+---

--- a/deploy/kubernetes/elastic-agent/elastic-agent-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent/elastic-agent-daemonset.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-ingest-management-nodescope
+  namespace: kube-system
+  labels:
+    app: agent-ingest-management-nodescope
+    group: ingest-management
+spec:
+  selector:
+    matchLabels:
+      app: agent-ingest-management-nodescope
+  template:
+    metadata:
+      labels:
+        app: agent-ingest-management-nodescope
+        group: ingest-management
+    spec:
+      serviceAccountName: agent-ingest-management
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: agent-ingest-management-nodescope
+          image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
+          env:
+            - name: FLEET_ENROLL
+              value: "1"
+            # Use enrollment key of node scope configuration to distinguish node scope datasets
+            - name: FLEET_ENROLLMENT_TOKEN
+              value:
+            - name: KIBANA_HOST
+              value: "http://kibana:5601"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy/kubernetes/elastic-agent/elastic-agent-deployment.yaml
+++ b/deploy/kubernetes/elastic-agent/elastic-agent-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-ingest-management-clusterscope
+  namespace: kube-system
+  labels:
+    app: agent-ingest-management-clusterscope
+    group: ingest-management
+spec:
+  selector:
+    matchLabels:
+      app: agent-ingest-management-clusterscope
+  template:
+    metadata:
+      labels:
+        app: agent-ingest-management-clusterscope
+        group: ingest-management
+    spec:
+      serviceAccountName: agent-ingest-management
+      containers:
+        - name: agent-ingest-management-clusterscope
+          image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
+          env:
+            - name: FLEET_ENROLL
+              value: "1"
+            # Use enrollment key of cluster scope configuration to distinguish node scope datasets
+            - name: FLEET_ENROLLMENT_TOKEN
+              value:
+            - name: KIBANA_HOST
+              value: "http://kibana:5601"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy/kubernetes/elastic-agent/elastic-agent-role-binding.yaml
+++ b/deploy/kubernetes/elastic-agent/elastic-agent-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-ingest-management
+subjects:
+  - kind: ServiceAccount
+    name: agent-ingest-management
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: agent-ingest-management
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/elastic-agent/elastic-agent-role.yaml
+++ b/deploy/kubernetes/elastic-agent/elastic-agent-role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-ingest-management
+  labels:
+    k8s-app: agent-ingest-management
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - secrets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  # required for apiserver
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/deploy/kubernetes/elastic-agent/elastic-agent-service-account.yaml
+++ b/deploy/kubernetes/elastic-agent/elastic-agent-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-ingest-management
+  namespace: kube-system
+  labels:
+    k8s-app: agent-ingest-management

--- a/x-pack/elastic-agent/docs/running-on-kubernetes.asciidoc
+++ b/x-pack/elastic-agent/docs/running-on-kubernetes.asciidoc
@@ -1,0 +1,109 @@
+[[running-on-kubernetes]]
+[role="xpack"]
+=== Run {agent} on Kubernetes
+
+You can use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to
+retrieve cluster metrics.
+
+ifeval::["{release-state}"=="unreleased"]
+
+However, version {version} of {agent} has not yet been
+released, so no Docker image is currently available for this version.
+
+endif::[]
+
+
+[float]
+==== Kubernetes deploy manifests
+
+You deploy {agent} in two different ways at the same time:
+
+* As a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
+to ensure that there's a running instance on each node of the cluster. These
+instances are used to retrieve most metrics from the host, such as system
+metrics, Docker stats, and metrics from all the services running on top of
+Kubernetes.
+
+* As a single {agent} instance created using a https://kubernetes.io/docs/concepts/workloads/controllers/Deployment/[Deployment].
+This instance is used to retrieve metrics that are unique for the whole
+cluster, such as Kubernetes events or
+https://github.com/kubernetes/kube-state-metrics[kube-state-metrics].
+
+Everything is deployed under the `kube-system` namespace by default. To change
+the namespace, modify the manifest file.
+
+To download the manifest file, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/elastic-agent-kubernetes.yaml
+------------------------------------------------
+
+[float]
+==== Settings
+
+By default, {agent} is enrolled to an existing Kibana deployment,
+if present using the specified credentials. FLEET_ENROLLMENT_TOKEN parameter is used to connect Agent to the
+corresponding Ingest Management configuration. It is suggested to connect Daemonset Agents to a node scope configuration
+and Deployment Agent to a cluster scope configuration. Then Kubernetes package will be deployed enabling cluster scope
+datasets using cluster scope configuration while node scope datasets will be enabled under node scope configuration.
+
+To specify different destination/credentials,
+change the following parameters in the manifest file:
+
+[source,yaml]
+------------------------------------------------
+- name: FLEET_ENROLLMENT_TOKEN
+  value: "abcdf_token"
+- name: KIBANA_HOST
+  value: "http://kibana:5601"
+- name: KIBANA_USERNAME
+  value: "elastic"
+- name: KIBANA_PASSWORD
+  value: "changeme"
+------------------------------------------------
+
+[float]
+===== Running {agent} on master nodes
+
+Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {agent} on master nodes you may need to
+update the Daemonset spec to include proper tolerations:
+
+[source,yaml]
+------------------------------------------------
+spec:
+ tolerations:
+ - key: node-role.kubernetes.io/master
+   effect: NoSchedule
+------------------------------------------------
+
+
+[float]
+==== Deploy
+
+If planing to deploy `state_*` datasets of Kubernetes package,
+https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics] is needed to be already deployed
+in the cluster. If `kube-state-metrics` is not already running, deploy it now (see the
+https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[Kubernetes
+deployment] docs).
+
+To deploy to Kubernetes, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+kubectl create -f elastic-agent-kubernetes.yaml
+------------------------------------------------
+
+To check the status, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+$ kubectl --namespace=kube-system get pods -l group=ingest-management
+
+NAME                                                    READY   STATUS    RESTARTS   AGE
+agent-ingest-management-clusterscope-574dbfc48f-sfrdt   1/1     Running     3        8d
+agent-ingest-management-nodescope-jt9zj                 1/1     Running     3        8d
+------------------------------------------------
+
+Agents should be enrolled to Fleet and user should be able to deploy Kubernetes package accordingly.


### PR DESCRIPTION
Cherry-pick of PR #19727 to 7.9 branch. Original message: 

## What does this PR do?
Add manifests and docs regarding running Agent on k8s.

## Why is it important?
It's a suggested way to run Agent on k8s environments in oder to deploy Kubernetes Package (https://github.com/elastic/integrations/pull/70) efficiently.


cc: @exekias 