### PR TITLE
Cherry-pick #20241 to 7.9: Disable the option of running setup --machine-learning on its own

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 * Suricata {pull}19107[19107] (`forwarded` tag is not included by default)
 * CoreDNS {pull}19134[19134] (`forwarded` tag is not included by default)
 * Envoy Proxy {pull}19134[19134] (`forwarded` tag is not included by default)
+- Disable the option of running --machine-learning on its own. {pull}20241[20241]
 
 *Heartbeat*
 

--- a/filebeat/tests/system/test_ml.py
+++ b/filebeat/tests/system/test_ml.py
@@ -106,7 +106,7 @@ class Test(BaseTest):
 
         # Skipping dashboard loading to speed up tests
         cmd += ["-E", "setup.dashboards.enabled=false"]
-        cmd += ["setup", "--machine-learning"]
+        cmd += ["setup", "--machine-learning", "--dashboards"]
         if modules_flag:
             cmd += ["--modules=nginx"]
 

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -114,6 +114,13 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 				}
 			}
 
+			// XXX this is a workaround for installing index template patterns
+			// before enabling ML for modules
+			if s.MachineLearning && !s.Dashboard {
+				fmt.Fprintf(os.Stderr, "--dashboards must be specified when choosing --machine-learning\n")
+				os.Exit(1)
+			}
+
 			if err = beat.Setup(settings, beatCreator, s); err != nil {
 				os.Exit(1)
 			}

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -209,7 +209,7 @@ func SetupModule(kibanaClient MLSetupper, module, prefix string) error {
 	prefixPayload := fmt.Sprintf("{\"prefix\": \"%s\"}", prefix)
 	status, response, err := kibanaClient.Request("POST", setupURL, nil, nil, strings.NewReader(prefixPayload))
 	if status != 200 {
-		return errors.Errorf("cannot set up ML with prefix: %s", prefix)
+		return errors.Errorf("cannot set up ML with prefix: %s, response: %s", prefix, string(response))
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry-pick of PR #20241 to 7.9 branch. Original message: 

## What does this PR do?

This PR disables running `setup --machine-learning` on its own. From now on `setup --machine-learning --dashboards` has to be specified to enable ML jobs.

## Why is it important?

ML jobs require an index template pattern in Kibana. If it is not configured, loading the jobs fails. However, loading this asset is done by the dashboards step of setup.

Loading index template patterns are too tightly coupled with Kibana and dashboards and it needs refactoring. As this code is way too complex and going to be removed soon, I opted for a workaround instead of a fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Related issues

Closes #19964
Closes #12998
Closes #20022