### PR TITLE
[Filebeat][Fortinet] Remove pre populated event.timezone

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -225,6 +225,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix s3 input parsing json file without expand_event_list_from_field. {issue}19902[19902] {pull}19962[19962]
 - Fix millisecond timestamp normalization issues in CrowdStrike module {issue}20035[20035], {pull}20138[20138]
 - Fix support for message code 106100 in Cisco ASA and FTD. {issue}19350[19350] {pull}20245[20245]
+- Fix `fortinet` setting `event.timezone` to the system one when no `tz` field present {pull}20273[20273]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -24,7 +24,6 @@ tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
-  - add_locale: ~
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -27,6 +27,9 @@ processors:
 - set:
     field: event.dataset
     value: fortinet.firewall
+- remove:
+    field: event.timezone
+    ignore_missing: true
 - set:
     field: event.timezone
     value: "{{fortinet.firewall.tz}}"

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -27,9 +27,6 @@ processors:
 - set:
     field: event.dataset
     value: fortinet.firewall
-- remove:
-    field: event.timezone
-    ignore_missing: true
 - set:
     field: event.timezone
     value: "{{fortinet.firewall.tz}}"

--- a/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/fortinet.log-expected.json
@@ -96,7 +96,6 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.start": "2020-06-24T01:16:08.000Z",
-        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "end"


### PR DESCRIPTION
## What does this PR do?

Removes the pre populated `event.timezone` field.

## Why is it important?

Some fortinet logs do not have a `tz` field to set as `event.timezone`, for this reason, when this happens, the `event.timezone` was incorrectly set to the system default instead of UTC or none (which represents UTC).

With this change `event.timezone` will only be set when the log has a timezone itself.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```bash
cd x-pack/filebeat
TESTING_FILEBEAT_MODULES=fortinet mage pythonIntegTest
```

