### PR TITLE
Cherry-pick #20245 to 7.8: Cisco ASA: Fix message 106100

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -129,6 +129,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak in tcp and unix input sources. {pull}19459[19459]
 - Fix bug with empty filter values in system/service {pull}19812[19812]
 - Fix millisecond timestamp normalization issues in CrowdStrike module {issue}20035[20035], {pull}20138[20138]
+- Fix support for message code 106100 in Cisco ASA and FTD. {issue}19350[19350] {pull}20245[20245]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
@@ -5,3 +5,5 @@ Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123
 Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123
 Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1
 Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8
+Oct 20 2019 15:42:53: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]
+Oct 20 2019 15:42:54: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\username) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
@@ -219,38 +219,25 @@
         "destination.ip": "127.3.4.5",
         "destination.port": 53,
         "event.action": "firewall-rule",
-        "event.category": [
-            "network"
-        ],
         "event.code": 106100,
         "event.dataset": "cisco.asa",
-        "event.kind": "event",
         "event.module": "cisco",
         "event.original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
         "event.outcome": "allow",
         "event.severity": 6,
         "event.timezone": "-02:00",
-        "event.type": [
-            "info",
-            "allowed"
-        ],
         "fileset.name": "asa",
         "input.type": "log",
         "log.level": "informational",
         "log.offset": 1171,
         "network.iana_number": 17,
         "network.transport": "udp",
-        "related.ip": [
-            "127.2.3.4",
-            "127.3.4.5"
-        ],
         "service.type": "cisco",
         "source.address": "127.2.3.4",
         "source.ip": "127.2.3.4",
         "source.port": 56575,
         "tags": [
-            "cisco-asa",
-            "forwarded"
+            "cisco-asa"
         ]
     },
     {
@@ -262,38 +249,25 @@
         "destination.ip": "127.3.4.5",
         "destination.port": 53,
         "event.action": "firewall-rule",
-        "event.category": [
-            "network"
-        ],
         "event.code": 106100,
         "event.dataset": "cisco.asa",
-        "event.kind": "event",
         "event.module": "cisco",
         "event.original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\\\username) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
         "event.outcome": "allow",
         "event.severity": 6,
         "event.timezone": "-02:00",
-        "event.type": [
-            "info",
-            "allowed"
-        ],
         "fileset.name": "asa",
         "input.type": "log",
         "log.level": "informational",
         "log.offset": 1334,
         "network.iana_number": 17,
         "network.transport": "udp",
-        "related.ip": [
-            "127.2.3.4",
-            "127.3.4.5"
-        ],
         "service.type": "cisco",
         "source.address": "127.2.3.4",
         "source.ip": "127.2.3.4",
         "source.port": 56575,
         "tags": [
-            "cisco-asa",
-            "forwarded"
+            "cisco-asa"
         ]
     }
 ]

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
@@ -209,5 +209,91 @@
         "tags": [
             "cisco-asa"
         ]
+    },
+    {
+        "cisco.asa.destination_interface": "inside",
+        "cisco.asa.message_id": "106100",
+        "cisco.asa.rule_name": "incoming",
+        "cisco.asa.source_interface": "dmz2",
+        "destination.address": "127.3.4.5",
+        "destination.ip": "127.3.4.5",
+        "destination.port": 53,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 106100,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
+        "event.outcome": "allow",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info",
+            "allowed"
+        ],
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 1171,
+        "network.iana_number": 17,
+        "network.transport": "udp",
+        "related.ip": [
+            "127.2.3.4",
+            "127.3.4.5"
+        ],
+        "service.type": "cisco",
+        "source.address": "127.2.3.4",
+        "source.ip": "127.2.3.4",
+        "source.port": 56575,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
+        "cisco.asa.destination_interface": "inside",
+        "cisco.asa.message_id": "106100",
+        "cisco.asa.rule_name": "incoming",
+        "cisco.asa.source_interface": "dmz2",
+        "destination.address": "127.3.4.5",
+        "destination.ip": "127.3.4.5",
+        "destination.port": 53,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 106100,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\\\username) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
+        "event.outcome": "allow",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info",
+            "allowed"
+        ],
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 1334,
+        "network.iana_number": 17,
+        "network.transport": "udp",
+        "related.ip": [
+            "127.2.3.4",
+            "127.3.4.5"
+        ],
+        "service.type": "cisco",
+        "source.address": "127.2.3.4",
+        "source.ip": "127.2.3.4",
+        "source.port": 56575,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
     }
 ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -253,7 +253,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106100'"
       field: "message"
-      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port}) -> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port}) %{}"
+      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106102'"
       field: "message"


### PR DESCRIPTION
Cherry-pick of PR #20245 to 7.8 branch. Original message: 

## What does this PR do?

This updates the parser for Cisco ASA message 106100 so that it doesn't fail when extra information is appended after the port numbers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Fixes #19350

