### PR TITLE
[docs] Add ECK doc links to Heartbeat docs

### DIFF
--- a/heartbeat/docs/running-on-kubernetes.asciidoc
+++ b/heartbeat/docs/running-on-kubernetes.asciidoc
@@ -4,6 +4,8 @@
 {beatname_uc} <<running-on-docker,Docker images>> can be used on Kubernetes to
 check resources uptime.
 
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK]
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {beatname_uc} has not yet been


### PR DESCRIPTION
Adds link that points to ECK docs about running on K8s.

@exekias Looks like we're only backporting to 7.10.0, right?