### PR TITLE
Update system tests dependency

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -19,7 +19,7 @@ nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==4.2b1
-Pillow==7.0.0
+Pillow>=7.1.0
 redis==2.10.6
 requests==2.20.0
 six==1.11.0


### PR DESCRIPTION
## What does this PR do?

Updates a dependency used in system tests.

## Why is it important?

To avoid a warning about an unsecure dependency.
