### PR TITLE
Cherry-pick to 7.x: [docs] Fix Windows download link for agent (#20258)

### DIFF
--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -60,7 +60,7 @@ endif::[]
 ifeval::["{release-state}"!="unreleased"]
 
 . Download the {agent} Windows zip file from the
-https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
+https://www.elastic.co/downloads/elastic-agent[downloads page].
 
 . Extract the contents of the zip file into `C:\Program Files`.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Fix Windows download link for agent (#20258)