### PR TITLE
Cherry-pick #19974 to 7.x: Remove unnecessary restarts of metricsets while using Node autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -173,6 +173,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Server-side TLS config now validates certificate and key are both specified {pull}19584[19584]
 - Fix terminating pod autodiscover issue. {pull}20084[20084]
 - Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
+- Remove unnecessary restarts of metricsets while using Node autodiscover {pull}19974[19974]
 - Output errors when Kibana index pattern setup fails. {pull}20121[20121]
 
 *Auditbeat*

--- a/libbeat/autodiscover/providers/kubernetes/node_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/node_test.go
@@ -278,3 +278,178 @@ func TestEmitEvent_Node(t *testing.T) {
 		})
 	}
 }
+
+func TestNode_isUpdated(t *testing.T) {
+	tests := []struct {
+		old     *kubernetes.Node
+		new     *kubernetes.Node
+		updated bool
+		test    string
+	}{
+		{
+			test:    "one of the objects is nil then its updated",
+			old:     nil,
+			new:     &kubernetes.Node{},
+			updated: true,
+		},
+		{
+			test:    "both empty nodes should return not updated",
+			old:     &kubernetes.Node{},
+			new:     &kubernetes.Node{},
+			updated: false,
+		},
+		{
+			test: "resource version is the same should return not updated",
+			old: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+				},
+			},
+			new: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+				},
+			},
+		},
+		{
+			test: "if meta changes then it should return updated",
+			old: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+					Annotations:     map[string]string{},
+				},
+			},
+			new: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "2",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+			},
+			updated: true,
+		},
+		{
+			test: "if spec changes then it should return updated",
+			old: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: false,
+				},
+			},
+			new: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "2",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: true,
+				},
+			},
+			updated: true,
+		},
+		{
+			test: "if overall status doesn't change then its not an update",
+			old: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: true,
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			new: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "2",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: true,
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			updated: false,
+		},
+		{
+			test: "if node status changes then its an update",
+			old: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: true,
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionFalse,
+						},
+					},
+				},
+			},
+			new: &kubernetes.Node{
+				ObjectMeta: kubernetes.ObjectMeta{
+					ResourceVersion: "2",
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID:    "1",
+					Unschedulable: true,
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			updated: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.test, func(t *testing.T) {
+			assert.Equal(t, test.updated, isUpdated(test.old, test.new))
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #19974 to 7.x branch. Original message: 

Bug

## What does this PR do?

Everytime the kubelet does a check for node health it posts an update to the node status. Each change even if overall status doesnt change then it causes the metricset to restart. This PR adds a watcher option to register a func that checks in detail if the update is valid or not. 

## Why is it important?

This makes sure that the kubelet status updates dont prompt a restart unless the overall status changes. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      in_cluster: false
      kube_config: ${HOME}/.kube/config
      scope: node
      node: ${NODENAME}
      resource: node
      templates:
        - config:
            - module: http
              period: 1m
              metricsets: ["json"]
              namespace: beats
              hosts: "${data.host}:5002"
              path: "/stats"
```

## Related issues

