### PR TITLE
[CI] Update README.md with CI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![Build Status](https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/job/master/badge/icon)](https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/job/master/)
+[![Build Status](https://beats-ci.elastic.co/job/Beats/job/beats/job/master/badge/icon)](https://beats-ci.elastic.co/job/Beats/job/beats/job/master/)
 [![Travis](https://travis-ci.org/elastic/beats.svg?branch=master)](https://travis-ci.org/elastic/beats)
 [![GoReportCard](http://goreportcard.com/badge/elastic/beats)](http://goreportcard.com/report/elastic/beats)
-[![codecov.io](https://codecov.io/github/elastic/beats/coverage.svg?branch=master)](https://codecov.io/github/elastic/beats?branch=master)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 # Beats - The Lightweight Shippers of the Elastic Stack
@@ -98,7 +97,9 @@ It is possible to trigger some jobs by putting a comment on a GitHub PR.
   * `/test macos` will kick off a default build with also the `macos` stages.
 * [apm-beats-update][]
   * `/run apm-beats-update`
+* [apm-beats-packaging][]
+  * `/package` or `/packaging` will kick of a build to generate the packages for beats.
 
-
-[beats]: https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/
+[beats]: https://beats-ci.elastic.co/job/Beats/job/beats/
 [apm-beats-update]: https://beats-ci.elastic.co/job/Beats/job/apm-beats-update/
+[apm-beats-packaging]: https://beats-ci.elastic.co/job/Beats/job/packaging/


### PR DESCRIPTION
## What does this PR do?

Update the references to the CI jobs and how to trigger them

## Why is it important?

Deprecated MBP was removed, in addition codecov, therefore the badges were not pointing correctly.