### PR TITLE
Removed spurious query from Filebeat postgresql slowlogs dashboard

### DIFF
--- a/filebeat/module/postgresql/_meta/kibana/7/dashboard/Filebeat-Postgresql-slowlogs.json
+++ b/filebeat/module/postgresql/_meta/kibana/7/dashboard/Filebeat-Postgresql-slowlogs.json
@@ -229,7 +229,7 @@
                         "highlightAll": true, 
                         "query": {
                             "language": "kuery",
-                            "query": "postgresql.log.query:*"
+                            "query": ""
                         }, 
                         "version": true
                     }


### PR DESCRIPTION
## What does this PR do?

Fixes the `[Filebeat PostgreSQL] Query Duration Overview` dashboard

## Why is it important?

Otherwise, the dashboard is empty

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- [ ] Check to make sure dashboard isn't empty after deleting saved query

## Related issues

- Closes https://github.com/elastic/beats/issues/20321

## Screenshots

Empty dashboard:
<img width="1980" alt="Screen Shot 2020-07-23 at 7 51 33 PM" src="https://user-images.githubusercontent.com/4145612/88818537-d22ccf00-d18c-11ea-955e-adcc3753f5d0.png">
