### PR TITLE
feat(ci): support building docker images for PRs

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -188,9 +188,15 @@ def tagAndPush(name){
   if("${env.SNAPSHOT}" == "true"){
     libbetaVer += "-SNAPSHOT"
   }
+
+  def imageName = "${name}"
+  if (env.CHANGE_ID?.trim()) {
+    imageName = "${name}/pr-${env.CHANGE_ID}"
+  }
+
   def oldName = "${DOCKER_REGISTRY}/beats/${name}:${libbetaVer}"
-  def newName = "${DOCKER_REGISTRY}/observability-ci/${name}:${libbetaVer}"
-  def commitName = "${DOCKER_REGISTRY}/observability-ci/${name}:${env.GIT_BASE_COMMIT}"
+  def newName = "${DOCKER_REGISTRY}/observability-ci/${imageName}:${libbetaVer}"
+  def commitName = "${DOCKER_REGISTRY}/observability-ci/${imageName}:${env.GIT_BASE_COMMIT}"
   dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
   retry(3){
     sh(label:'Change tag and push', script: """

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -189,14 +189,14 @@ def tagAndPush(name){
     libbetaVer += "-SNAPSHOT"
   }
 
-  def imageName = "${name}"
+  def tagName = "${libbetaVer}"
   if (env.CHANGE_ID?.trim()) {
-    imageName = "${name}/pr-${env.CHANGE_ID}"
+    tagName = "pr-${env.CHANGE_ID}"
   }
 
   def oldName = "${DOCKER_REGISTRY}/beats/${name}:${libbetaVer}"
-  def newName = "${DOCKER_REGISTRY}/observability-ci/${imageName}:${libbetaVer}"
-  def commitName = "${DOCKER_REGISTRY}/observability-ci/${imageName}:${env.GIT_BASE_COMMIT}"
+  def newName = "${DOCKER_REGISTRY}/observability-ci/${name}:${tagName}"
+  def commitName = "${DOCKER_REGISTRY}/observability-ci/${name}:${env.GIT_BASE_COMMIT}"
   dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
   retry(3){
     sh(label:'Change tag and push', script: """


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
It uses the PR ID as the new name for the docker images built by the packaging build. This change will only apply to PRs. For any other type of build (merge, branch), the previous behavior will be kept.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We want to generate images for the PRs, without overriding the current snapshot for releases. This way we will be able to consume those images for PRs in other projects, such as the e2e tests for Ingest Manager or integrations.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20317

## Use cases

```gherkin
Scenario: a PR generates its own docker images without overridding the snapshot ones for merge-commits
Given a PR
When the author requests packaging it
Then the docker images are pushed to the observability-ci namespace including the pr ID on its name
   And the snapshot is not overridden
```
<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->