### PR TITLE
Cherry-pick to 7.x: Add ECK doc links to Heartbeat docs (#20284)

### DIFF
--- a/heartbeat/docs/running-on-kubernetes.asciidoc
+++ b/heartbeat/docs/running-on-kubernetes.asciidoc
@@ -4,6 +4,8 @@
 {beatname_uc} <<running-on-docker,Docker images>> can be used on Kubernetes to
 check resources uptime.
 
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-beat.html[Run {beats} on ECK]
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {beatname_uc} has not yet been


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add ECK doc links to Heartbeat docs (#20284)