### PR TITLE
Cherry-pick #20305 to 7.9: [Autodiscovery] Ignore ErrInputNotFinished errors in autodiscover config checks

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -93,6 +93,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix terminating pod autodiscover issue. {pull}20084[20084]
 - Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
 - Output errors when Kibana index pattern setup fails. {pull}20121[20121]
+- Fix issue in autodiscover that kept inputs stopped after config updates. {pull}20305[20305]
+- Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,7 +94,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix seccomp policy for calls to `chmod` and `chown`. {pull}20054[20054]
 - Output errors when Kibana index pattern setup fails. {pull}20121[20121]
 - Fix issue in autodiscover that kept inputs stopped after config updates. {pull}20305[20305]
-- Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
 
 *Auditbeat*
 

--- a/filebeat/input/errors.go
+++ b/filebeat/input/errors.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input
+
+import (
+	"fmt"
+)
+
+// ErrInputNotFinished struct for reporting errors related to not finished inputs
+type ErrInputNotFinished struct {
+	State string
+}
+
+// Error method of ErrInputNotFinished
+func (e *ErrInputNotFinished) Error() string {
+	return fmt.Sprintf("Can only start an input when all related states are finished: %+v", e.State)
+}

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -18,6 +18,7 @@
 package file
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -65,4 +66,20 @@ func NewState(fileInfo os.FileInfo, path string, t string, meta map[string]strin
 // IsEqual checks if the two states point to the same file.
 func (s *State) IsEqual(c *State) bool {
 	return s.Id == c.Id
+}
+
+// String returns string representation of the struct
+func (s *State) String() string {
+	return fmt.Sprintf(
+		"{Id: %v, Finished: %v, Fileinfo: %v, Source: %v, Offset: %v, Timestamp: %v, TTL: %v, Type: %v, Meta: %v, FileStateOS: %v}",
+		s.Id,
+		s.Finished,
+		s.Fileinfo,
+		s.Source,
+		s.Offset,
+		s.Timestamp,
+		s.TTL,
+		s.Type,
+		s.Meta,
+		s.FileStateOS)
 }

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -175,7 +175,7 @@ func (p *Input) loadStates(states []file.State) error {
 
 			// In case a input is tried to be started with an unfinished state matching the glob pattern
 			if !state.Finished {
-				return fmt.Errorf("Can only start an input when all related states are finished: %+v", state)
+				return &input.ErrInputNotFinished{State: state.String()}
 			}
 
 			// Convert state to current identifier if different

--- a/filebeat/input/runnerfactory.go
+++ b/filebeat/input/runnerfactory.go
@@ -59,5 +59,9 @@ func (r *RunnerFactory) Create(
 
 func (r *RunnerFactory) CheckConfig(cfg *common.Config) error {
 	_, err := r.Create(pipeline.NewNilPipeline(), cfg)
+	if _, ok := err.(*ErrInputNotFinished); ok {
+		// error is related to state, and hence config can be considered valid
+		return nil
+	}
 	return err
 }

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -160,6 +160,7 @@ func (p *pod) OnUpdate(obj interface{}) {
 			}
 		}
 		time.AfterFunc(p.config.CleanupTimeout, func() { p.emit(pod, "stop") })
+		return
 	}
 
 	p.logger.Debugf("Watcher Pod update: %+v", obj)


### PR DESCRIPTION
Cherry-pick of PR #20305 to 7.9 branch. Original message: 

## What does this PR do?
This PR ignores `ErrInputNotFinished` error occur in autodiscover stop/start process. This is required in order to avoid having stoped configs that never come back since the start event fails due to this error on first attempt if the previous state is not cleaned yet.

Currently configs that fail due to `ErrInputNotFinished` are skipped at https://github.com/elastic/beats/blob/fb52d26932b038d0af67cfa660f0d6b3a25bf0f3/libbeat/autodiscover/autodiscover.go#L212. However, this is not a config error but a state error and in that case we need to add them in the list of configs at https://github.com/elastic/beats/blob/fb52d26932b038d0af67cfa660f0d6b3a25bf0f3/libbeat/autodiscover/autodiscover.go#L223 so as to be handled properly by the retry mechanism of autodiscover at https://github.com/elastic/beats/blob/fb52d26932b038d0af67cfa660f0d6b3a25bf0f3/libbeat/autodiscover/autodiscover.go#L164

## Why is it important?
In order to resolve a permanent issue with updated Pods, which makes Filebeat stop collecting logs after a Pod is updated.

## How to test this PR locally
1. Deploy Filebeat on k8s using the following config for autodiscover (set a valid output too so as to ship logs to ES):
```
filebeat.autodiscover:
  providers:
    - type: kubernetes
      node: ${NODE_NAME}
      templates:
        - condition:
            equals:
              kubernetes.pod.name: "mytarget3"
          config:
            - type: container
              paths:
                - /var/log/containers/*${data.kubernetes.container.id}.log
```
2. While Filebeat is up and running deploy a target pod to be autodiscovered and make Filebeat collects its logs:

```
---
apiVersion: v1
kind: Pod
metadata:
  name: mytarget3
  labels:
    app: test
spec:
  containers:
    - name: test
      image: ubuntu:latest
      command:
        - bash
        - -c
        - |
          #!/bin/bash
          echo "$(date): started the process"

          while :
          do
                 echo "$(date): sleeping 5 seconds"
                 sleep 5
          done
```
3. Update the target Pod's manifest by adding an extra label like `team: qa`
4. apply the Pod's update with `kubectl apply -f <manifest_filename>.yml`
5. Make sure that after a while, Filebeat continues collecting logs after the update of the Pod.