### PR TITLE
Ensure install scripts only install if needed

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -2,9 +2,23 @@
 
 set -exuo pipefail
 
-MSG="parameter missing."
+MSG="environment variable missing: DOCKER_COMPOSE_VERSION."
 DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:?$MSG}
 HOME=${HOME:?$MSG}
+
+if command -v docker-compose
+then
+    echo "Found docker-compose. Checking version.."
+    FOUND_DOCKER_COMPOSE_VERSION=$(docker-compose --version|awk '{print $3}'|sed s/\,//)
+    if [ $FOUND_DOCKER_COMPOSE_VERSION == $DOCKER_COMPOSE_VERSION ]
+    then
+        echo "Versions match. No need to install docker-compose. Exiting."
+        exit 0
+    fi
+fi
+
+echo "Installing docker-compose"
+
 DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"

--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -17,7 +17,7 @@ then
     fi
 fi
 
-echo "Installing docker-compose"
+echo "UNMET DEP: Installing docker-compose"
 
 DC_CMD="${HOME}/bin/docker-compose"
 

--- a/.ci/scripts/install-go.sh
+++ b/.ci/scripts/install-go.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-MSG="parameter missing."
+MSG="environment variable missing"
 GO_VERSION=${GO_VERSION:?$MSG}
 PROPERTIES_FILE=${PROPERTIES_FILE:-"go_env.properties"}
 HOME=${HOME:?$MSG}
 ARCH=$(uname -s| tr '[:upper:]' '[:lower:]')
 GVM_CMD="${HOME}/bin/gvm"
 
+if command -v go
+then
+    echo "Found Go. Checking version.."
+    FOUND_GO_VERSION=$(go version|awk '{print $3}'|sed s/go//)
+    if [ $FOUND_GO_VERSION == $GO_VERSION ]
+    then
+        echo "Versions match. No need to install Go. Exiting."
+        exit 0
+    fi
+fi
+
+echo "Installing Go"
 mkdir -p "${HOME}/bin"
 
 curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-${ARCH}-amd64"

--- a/.ci/scripts/install-go.sh
+++ b/.ci/scripts/install-go.sh
@@ -19,7 +19,7 @@ then
     fi
 fi
 
-echo "Installing Go"
+echo "UNMET DEP: Installing Go"
 mkdir -p "${HOME}/bin"
 
 curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-${ARCH}-amd64"

--- a/.ci/scripts/install-kind.sh
+++ b/.ci/scripts/install-kind.sh
@@ -18,7 +18,7 @@ then
     fi
 fi
 
-echo "Installing Kind"
+echo "UNMET DEP: Installing Kind"
 
 mkdir -p "${HOME}/bin"
 

--- a/.ci/scripts/install-kind.sh
+++ b/.ci/scripts/install-kind.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-MSG="parameter missing."
+MSG="environment variable missing."
 DEFAULT_HOME="/usr/local"
 KIND_VERSION=${KIND_VERSION:?$MSG}
 HOME=${HOME:?$DEFAULT_HOME}
 KIND_CMD="${HOME}/bin/kind"
+
+if command -v kind
+then
+    echo "Found Kind. Checking version.."
+    FOUND_KIND_VERSION=$(kind --version 2>&1 >/dev/null | awk '{print $3}')
+    if [ $FOUND_KIND_VERSION == $KIND_VERSION ]
+    then
+        echo "Versions match. No need to install Kind. Exiting."
+        exit 0
+    fi
+fi
+
+echo "Installing Kind"
 
 mkdir -p "${HOME}/bin"
 

--- a/.ci/scripts/install-terraform.sh
+++ b/.ci/scripts/install-terraform.sh
@@ -2,12 +2,25 @@
 
 set -exuo pipefail
 
-MSG="parameter missing."
+MSG="environment variable missing."
 TERRAFORM_VERSION=${TERRAFORM_VERSION:?$MSG}
 HOME=${HOME:?$MSG}
 TERRAFORM_CMD="${HOME}/bin/terraform"
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+if command -v terraform
+then
+    echo "Found Terraform. Checking version.."
+    FOUND_TERRAFORM_VERSION=$(terraform --version | awk '{print $2}' | sed s/v//)
+    if [ $FOUND_TERRAFORM_VERSION == $TERRAFORM_VERSION ]
+    then
+        echo "Versions match. No need to install Terraform. Exiting."
+        exit 0
+    fi
+fi
+
+echo "Installing Terraform"
 
 mkdir -p "${HOME}/bin"
 

--- a/.ci/scripts/install-terraform.sh
+++ b/.ci/scripts/install-terraform.sh
@@ -20,7 +20,7 @@ then
     fi
 fi
 
-echo "Installing Terraform"
+echo "UNMET DEP: Installing Terraform"
 
 mkdir -p "${HOME}/bin"
 


### PR DESCRIPTION

## What does this PR do?
There are a series of scripts which are used by the CI. 

In some cases, the workers already have the requisite software and so we don't need to bother downloading it. In other cases, we need to detect that we don't have an appropriate version installed on an image, so we can open an issue to get that done. This introduces an easy way to do by checking logs for the string `UNMET DEP`. 

## Why is it important?

Reduce pre-provsioning errors in testing. 

