### PR TITLE
Cherry-pick #20351 to 7.9: Change licence of github.com/gorhill/cronexpr to Apache

### DIFF
--- a/dev-tools/notice/overrides.json
+++ b/dev-tools/notice/overrides.json
@@ -1,5 +1,5 @@
 {"name": "github.com/elastic/elastic-agent-client/v7", "licenceType": "Elastic"}
-{"name": "github.com/gorhill/cronexpr", "licenceType": "GPL-3.0", "licenceFile":"GPLv3"}
+{"name": "github.com/gorhill/cronexpr", "licenceType": "Apache-2.0", "licenceFile":"APLv2"}
 {"name": "github.com/miekg/dns", "licenceType": "BSD"}
 {"name": "github.com/kr/logfmt", "licenceFile": "Readme", "licenceType": "MIT"}
 {"name": "github.com/samuel/go-parser", "licenceType": "BSD-3-Clause"}


### PR DESCRIPTION
Cherry-pick of PR #20351 to 7.9 branch. Original message: 

