### PR TITLE
Add event.ingested to all Filebeat modules

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -501,6 +501,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add event.ingested for CrowdStrike module {pull}20138[20138]
 - Add support for additional fields and FirewallMatchEvent type events in CrowdStrike module {pull}20138[20138]
 - Add event.ingested for Suricata module {pull}20220[20220]
+- Add event.ingested to all Filebeat modules. {pull}20386[20386]
 
 *Heartbeat*
 

--- a/filebeat/module/apache/access/ingest/pipeline.yml
+++ b/filebeat/module/apache/access/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: "Pipeline for parsing Apache HTTP Server access logs. Requires the geoip and user_agent plugins."
 
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/apache/error/ingest/pipeline.yml
+++ b/filebeat/module/apache/error/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing apache error logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/auditd/log/ingest/pipeline.yml
+++ b/filebeat/module/auditd/log/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for parsing Linux auditd logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     pattern_definitions:

--- a/filebeat/module/elasticsearch/audit/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing elasticsearch audit logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/elasticsearch/deprecation/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/deprecation/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing elasticsearch deprecation logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/elasticsearch/gc/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/gc/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing Elasticsearch JVM garbage collection logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing elasticsearch server logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/elasticsearch/slowlog/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/slowlog/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing elasticsearch slow logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/haproxy/log/ingest/pipeline.yml
+++ b/filebeat/module/haproxy/log/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for parsing HAProxy http, tcp and default logs. Requires the
   geoip plugin.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/icinga/debug/ingest/pipeline.yml
+++ b/filebeat/module/icinga/debug/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing icinga debug logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/icinga/main/ingest/pipeline.yml
+++ b/filebeat/module/icinga/main/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing icinga main logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/icinga/startup/ingest/pipeline.yml
+++ b/filebeat/module/icinga/startup/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing icinga startup logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/iis/access/ingest/pipeline.yml
+++ b/filebeat/module/iis/access/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for parsing IIS access logs. Requires the geoip and user_agent
   plugins.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/iis/error/ingest/pipeline.yml
+++ b/filebeat/module/iis/error/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing IIS error logs. Requires the geoip plugin.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/kafka/log/ingest/pipeline.yml
+++ b/filebeat/module/kafka/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing Kafka log messages
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     trace_match: true

--- a/filebeat/module/kibana/log/ingest/pipeline.yml
+++ b/filebeat/module/kibana/log/ingest/pipeline.yml
@@ -4,6 +4,9 @@ on_failure:
     field: error.message
     value: '{{ _ingest.on_failure_message }}'
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/logstash/log/ingest/pipeline.yml
+++ b/filebeat/module/logstash/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing logstash node logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/logstash/slowlog/ingest/pipeline.yml
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing logstash slow logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: '@timestamp'
     target_field: event.created

--- a/filebeat/module/mongodb/log/ingest/pipeline.yml
+++ b/filebeat/module/mongodb/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing MongoDB logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/mysql/error/ingest/pipeline.yml
+++ b/filebeat/module/mysql/error/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing MySQL error logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/mysql/slowlog/ingest/pipeline.json
+++ b/filebeat/module/mysql/slowlog/ingest/pipeline.json
@@ -1,6 +1,11 @@
 {
   "description": "Pipeline for parsing MySQL slow logs.",
   "processors": [{
+    "set": {
+      "field": "event.ingested",
+      "value": "{{_ingest.timestamp}}"
+    }
+  }, {
     "grok": {
       "field": "message",
       "patterns":[

--- a/filebeat/module/nats/log/ingest/pipeline.yml
+++ b/filebeat/module/nats/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing nats log logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/nginx/access/ingest/pipeline.yml
+++ b/filebeat/module/nginx/access/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for parsing Nginx access logs. Requires the geoip and user_agent
   plugins.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:
@@ -145,7 +148,7 @@ processors:
 - set:
     field: event.outcome
     value: failure
-    if: "ctx?.http?.response?.status_code != null && ctx.http.response.status_code >= 400"      
+    if: "ctx?.http?.response?.status_code != null && ctx.http.response.status_code >= 400"
 - append:
     field: related.ip
     value: "{{source.ip}}"

--- a/filebeat/module/nginx/error/ingest/pipeline.yml
+++ b/filebeat/module/nginx/error/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing the Nginx error logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
+++ b/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for parsing Nginx ingress controller access logs. Requires the
   geoip and user_agent plugins.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/osquery/result/ingest/pipeline.json
+++ b/filebeat/module/osquery/result/ingest/pipeline.json
@@ -2,6 +2,11 @@
   "description": "Pipeline for parsing osquery result logs",
   "processors": [
     {
+      "set":{
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }, {
       "rename": {
         "field": "@timestamp",
         "target_field": "event.created"

--- a/filebeat/module/postgresql/log/ingest/pipeline.yml
+++ b/filebeat/module/postgresql/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing PostgreSQL logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     ignore_missing: true

--- a/filebeat/module/redis/log/ingest/pipeline.yml
+++ b/filebeat/module/redis/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing redis logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/santa/log/ingest/pipeline.yml
+++ b/filebeat/module/santa/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing Google Santa logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/system/auth/ingest/pipeline.yml
+++ b/filebeat/module/system/auth/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing system authorisation/secure logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     ignore_missing: true

--- a/filebeat/module/system/syslog/ingest/pipeline.yml
+++ b/filebeat/module/system/syslog/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing Syslog messages.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/filebeat/module/traefik/access/ingest/pipeline.yml
+++ b/filebeat/module/traefik/access/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for parsing Traefik access logs. Requires the geoip and user_agent
   plugins.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - dissect:
     field: message
     pattern: '%{source.address} %{traefik.access.user_identifier} %{user.name} [%{traefik.access.time}]

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -161,6 +161,10 @@ class Test(BaseTest):
             assert obj["event"]["module"] == module, "expected event.module={} but got {}".format(
                 module, obj["event"]["module"])
 
+            # All modules must include a set processor that adds the time that
+            # the event was ingested to Elasticsearch
+            assert "ingested" in obj["event"], "missing event.ingested timestamp"
+
             assert "error" not in obj, "not error expected but got: {}".format(
                 obj)
 

--- a/x-pack/filebeat/module/activemq/audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/activemq/audit/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for parsing ActiveMQ audit logs.
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       pattern_definitions:

--- a/x-pack/filebeat/module/activemq/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/activemq/log/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for parsing ActiveMQ logs.
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       pattern_definitions:

--- a/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for AWS CloudTrail Logs
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - rename:
       field: "message"
       target_field: "event.original"
@@ -614,7 +617,7 @@ processors:
         if (ctx.event.action == 'ConsoleLogin' && ctx?.aws?.cloudtrail?.flattened?.response_elements.ConsoleLogin != null) {
             ctx.event.outcome = Processors.lowercase(ctx.aws.cloudtrail.flattened.response_elements.ConsoleLogin);
         }
-        
+
         def hm = new HashMap(params.get(ctx.event.action));
         hm.forEach((k, v) -> ctx.event[k] = v);
 

--- a/x-pack/filebeat/module/aws/cloudwatch/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: "Pipeline for CloudWatch logs"
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       patterns:

--- a/x-pack/filebeat/module/aws/ec2/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/ec2/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: "Pipeline for EC2 logs in CloudWatch"
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       patterns:

--- a/x-pack/filebeat/module/aws/elb/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/elb/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: "Pipeline for ELB logs"
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       # Classic ELB patterns documented in https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html

--- a/x-pack/filebeat/module/aws/s3access/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/s3access/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: "Pipeline for s3 server access logs"
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - grok:
       field: message
       patterns:

--- a/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
@@ -1,6 +1,10 @@
 description: Pipeline for AWS VPC Flow Logs
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+
   # Convert Unix epoch to timestamp
   - date:
       field: "aws.vpcflow.end"

--- a/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing azure activity logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: azure
     target_field: azure-eventhub

--- a/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing azure activity logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: azure
     target_field: azure-eventhub

--- a/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing azure signin logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - rename:
     field: azure
     target_field: azure-eventhub

--- a/x-pack/filebeat/module/barracuda/waf/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/barracuda/waf/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Barracuda Web Application Firewall
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/bluecoat/director/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/bluecoat/director/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Blue Coat Director
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/cef/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cef/log/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Filebeat CEF
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
         field: source.ip

--- a/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing checkpoint firewall logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:
@@ -157,7 +160,7 @@ processors:
     target_field: source.nat.port
     type: long
     ignore_failure: true
-    ignore_missing: true 
+    ignore_missing: true
     if: "ctx.checkpoint?.xlatesport != '0'"
 - rename:
     field: checkpoint.mac_source_address
@@ -691,7 +694,7 @@ processors:
     field: client.nat.port
     type: long
     ignore_failure: true
-    ignore_missing: true 
+    ignore_missing: true
 - convert:
     field: client.bytes
     type: long
@@ -711,7 +714,7 @@ processors:
     field: server.nat.port
     type: long
     ignore_failure: true
-    ignore_missing: true 
+    ignore_missing: true
 - convert:
     field: server.bytes
     type: long
@@ -721,7 +724,7 @@ processors:
     field: server.packets
     type: long
     ignore_failure: true
-    ignore_missing: true 
+    ignore_missing: true
 - script:
     lang: painless
     source: "ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes"

--- a/x-pack/filebeat/module/cisco/ios/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cisco/ios/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for Cisco IOS logs.
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   # IP Geolocation Lookup
   - geoip:
       field: source.ip

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: "Pipeline for Cisco {< .internal_PREFIX >} logs"
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   #
   # Parse the syslog header
   #

--- a/x-pack/filebeat/module/coredns/log/ingest/pipeline-entry.yml
+++ b/x-pack/filebeat/module/coredns/log/ingest/pipeline-entry.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for normalizing Kubernetes CoreDNS logs.
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - pipeline:
       if: ctx.message.charAt(0) == (char)("{")
       name: '{< IngestPipeline "pipeline-json" >}'

--- a/x-pack/filebeat/module/cylance/protect/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cylance/protect/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for CylanceProtect
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-entry.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/ingest/pipeline-entry.yml
@@ -1,5 +1,8 @@
 description: Pipeline for normalizing envoyproxy logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - pipeline:
     if: ctx.message.charAt(0) != (char)("{")
     name: '{< IngestPipeline "pipeline-plaintext" >}'

--- a/x-pack/filebeat/module/f5/bigipapm/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/f5/bigipapm/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Big-IP Access Policy Manager
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/fortinet/clientendpoint/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/clientendpoint/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Fortinet FortiClient Endpoint Security
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing fortinet firewall logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/x-pack/filebeat/module/googlecloud/audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/googlecloud/audit/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for Google Cloud audit logs
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - user_agent:
       field: user_agent.original
       ignore_missing: true

--- a/x-pack/filebeat/module/googlecloud/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/googlecloud/firewall/ingest/pipeline.yml
@@ -1,6 +1,10 @@
 description: Pipeline for Google Cloud Firewall Logs
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
       field: source.ip

--- a/x-pack/filebeat/module/googlecloud/vpcflow/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/googlecloud/vpcflow/ingest/pipeline.yml
@@ -1,6 +1,10 @@
 description: Pipeline for Google Cloud VPC Flow Logs
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
       field: source.ip

--- a/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing MQ error logs.
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - gsub:
     field: message
     pattern: ^[\-]{5}[a-z0-9\. :]*[\-]{5,}

--- a/x-pack/filebeat/module/imperva/securesphere/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/imperva/securesphere/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Imperva SecureSphere
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/infoblox/nios/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/infoblox/nios/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Infoblox NIOS
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for IPTables
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/x-pack/filebeat/module/microsoft/defender_atp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for parsing microsoft atp logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - remove:
     field:
       - message
@@ -76,9 +79,6 @@ processors:
 - set:
     field: event.provider
     value: defender_atp
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
     value: '{{json.alertCreationTime}}'
@@ -284,7 +284,7 @@ processors:
 ## Cleanup ##
 #############
 - remove:
-    field: 
+    field:
       - json.alertCreationTime
       - json.severity
       - json.relatedUser

--- a/x-pack/filebeat/module/microsoft/dhcp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/microsoft/dhcp/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Microsoft DHCP
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/misp/threat/ingest/pipeline.json
+++ b/x-pack/filebeat/module/misp/threat/ingest/pipeline.json
@@ -2,6 +2,12 @@
     "description": "Pipeline for normalizing MISP threat",
     "processors": [
       {
+        "set": {
+          "field": "event.ingested",
+          "value": "{{_ingest.timestamp}}"
+        }
+      },
+      {
         "geoip": {
           "field": "destination.ip",
           "target_field": "destination.geo",

--- a/x-pack/filebeat/module/mssql/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/mssql/log/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline to parse MSSQL logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/x-pack/filebeat/module/netscout/sightline/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/netscout/sightline/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Arbor Peakflow SP
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/o365/audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/o365/audit/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for Office 365 Audit logs
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - user_agent:
       field: user_agent.original
       ignore_missing: true

--- a/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for Okta system logs.
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
   - user_agent:
       field: user_agent.original
       ignore_missing: true
@@ -44,7 +47,7 @@ processors:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
-  
+
 on_failure:
   - set:
       field: error.message

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: "Pipeline for Palo Alto Networks PAN-OS Logs"
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
 
 # keep message as log.original.
  - rename:

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -1,8 +1,8 @@
 description: "Pipeline for Palo Alto Networks PAN-OS Logs"
 processors:
-  - set:
-      field: event.ingested
-      value: '{{_ingest.timestamp}}'
+ - set:
+     field: event.ingested
+     value: '{{_ingest.timestamp}}'
 
 # keep message as log.original.
  - rename:

--- a/x-pack/filebeat/module/rabbitmq/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/rabbitmq/log/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for parsing RabbitMQ logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     pattern_definitions:

--- a/x-pack/filebeat/module/rapid7/nexpose/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/rapid7/nexpose/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Rapid7 NeXpose
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/sonicwall/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/sonicwall/firewall/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Sonicwall-FW
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/sophos/xg/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/sophos/xg/ingest/pipeline.yml
@@ -1,5 +1,8 @@
 description: Pipeline for parsing sophosxg firewall logs
 processors:
+- set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
 - grok:
     field: message
     patterns:

--- a/x-pack/filebeat/module/squid/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/squid/log/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Squid
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/tomcat/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/tomcat/log/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Apache Tomcat
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/zeek/capture_loss/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/capture_loss/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.capture_loss.ts
     formats:

--- a/x-pack/filebeat/module/zeek/capture_loss/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/capture_loss/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek capture_loss.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.connection.ts
     formats:

--- a/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek conn.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/dce_rpc/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek dce_rpc.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/dce_rpc/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.dce_rpc.ts
     formats:

--- a/x-pack/filebeat/module/zeek/dhcp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek dhcp.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/dhcp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.dhcp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.dnp3.ts
     formats:

--- a/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek dnp3.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/dns/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dns/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Filebeat Zeek dns.log
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
         field: source.ip

--- a/x-pack/filebeat/module/zeek/dpd/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dpd/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.dpd.ts
     formats:

--- a/x-pack/filebeat/module/zeek/dpd/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dpd/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek dpd.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/files/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/files/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.files.ts
     formats:

--- a/x-pack/filebeat/module/zeek/files/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/files/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek files.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:
@@ -47,7 +50,7 @@ processors:
 - set:
     field: client.ip
     value: "{{zeek.files.rx_host}}"
-    if: "ctx?.zeek?.files?.rx_host != null"    
+    if: "ctx?.zeek?.files?.rx_host != null"
 - append:
     field: related.hash
     value: "{{file.hash.md5}}"

--- a/x-pack/filebeat/module/zeek/ftp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ftp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek ftp.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/ftp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ftp/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.ftp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/http/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/http/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.http.ts
     formats:

--- a/x-pack/filebeat/module/zeek/http/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/http/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek http.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/intel/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/intel/ingest/pipeline.yml
@@ -2,6 +2,9 @@
 description: Pipeline for normalizing Zeek intel.log.
 processors:
   - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+  - set:
       field: event.created
       value: "{{_ingest.timestamp}}"
 

--- a/x-pack/filebeat/module/zeek/intel/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/intel/ingest/pipeline.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: event.created
-      value: "{{_ingest.timestamp}}"
+      value: '{{@timestamp}}'
 
   # IP Geolocation Lookup
   - geoip:

--- a/x-pack/filebeat/module/zeek/irc/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/irc/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek irc.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/irc/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/irc/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.irc.ts
     formats:

--- a/x-pack/filebeat/module/zeek/kerberos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek kerberos.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/kerberos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.kerberos.ts
     formats:

--- a/x-pack/filebeat/module/zeek/modbus/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/modbus/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek modbus.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/modbus/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/modbus/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.modbus.ts
     formats:

--- a/x-pack/filebeat/module/zeek/mysql/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/mysql/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek mysql.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/mysql/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/mysql/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.mysql.ts
     formats:

--- a/x-pack/filebeat/module/zeek/notice/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/notice/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek notice.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/notice/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/notice/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.notice.ts
     formats:

--- a/x-pack/filebeat/module/zeek/ntlm/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek ntlm.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/ntlm/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.ntlm.ts
     formats:

--- a/x-pack/filebeat/module/zeek/ocsp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ocsp/ingest/pipeline.yml
@@ -1,8 +1,11 @@
 description: Pipeline for normalizing Zeek ocsp.log
 processors:
 - set:
-    field: event.created
+    field: event.ingested
     value: '{{_ingest.timestamp}}'
+- set:
+    field: event.created
+    value: '{{@timestamp}}'
 - date:
     field: zeek.ocsp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/pe/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/pe/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.pe.ts
     formats:

--- a/x-pack/filebeat/module/zeek/pe/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/pe/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek pe.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/radius/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/radius/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek radius.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/radius/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/radius/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.radius.ts
     formats:

--- a/x-pack/filebeat/module/zeek/rdp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/rdp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek rdp.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/rdp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/rdp/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.rdp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/rfb/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/rfb/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.rfb.ts
     formats:

--- a/x-pack/filebeat/module/zeek/rfb/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/rfb/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek rfb.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/sip/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/sip/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.sip.ts
     formats:

--- a/x-pack/filebeat/module/zeek/sip/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/sip/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek sip.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/smb_cmd/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.smb_cmd.ts
     formats:

--- a/x-pack/filebeat/module/zeek/smb_cmd/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek smb_cmd.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/smb_files/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek smb_files.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/smb_files/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.smb_files.ts
     formats:

--- a/x-pack/filebeat/module/zeek/smb_mapping/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek smb_mapping.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/smb_mapping/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.smb_mapping.ts
     formats:

--- a/x-pack/filebeat/module/zeek/smtp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smtp/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.smtp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/smtp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/smtp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek smtp.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/snmp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/snmp/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek snmp.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/snmp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/snmp/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.snmp.ts
     formats:

--- a/x-pack/filebeat/module/zeek/socks/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/socks/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek socks.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/socks/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/socks/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.socks.ts
     formats:

--- a/x-pack/filebeat/module/zeek/ssh/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ssh/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek ssh.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/ssh/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ssh/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.ssh.ts
     formats:

--- a/x-pack/filebeat/module/zeek/ssl/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ssl/ingest/pipeline.yml
@@ -2,6 +2,9 @@
 description: Pipeline for normalizing Zeek ssl.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/ssl/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/ssl/ingest/pipeline.yml
@@ -6,7 +6,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.ssl.ts
     formats:

--- a/x-pack/filebeat/module/zeek/stats/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/stats/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.stats.ts
     formats:

--- a/x-pack/filebeat/module/zeek/stats/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/stats/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek stats.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/syslog/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/syslog/ingest/pipeline.yml
@@ -1,8 +1,11 @@
 description: Pipeline for normalizing Zeek syslog.log
 processors:
 - set:
-    field: event.created
+    field: event.ingested
     value: '{{_ingest.timestamp}}'
+- set:
+    field: event.created
+    value: '{{@timestamp}}'
 - date:
     field: zeek.syslog.ts
     formats:

--- a/x-pack/filebeat/module/zeek/traceroute/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/traceroute/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek traceroute.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/traceroute/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/traceroute/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.traceroute.ts
     formats:

--- a/x-pack/filebeat/module/zeek/tunnel/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/tunnel/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.tunnel.ts
     formats:

--- a/x-pack/filebeat/module/zeek/tunnel/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/tunnel/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek tunnel.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/weird/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/weird/ingest/pipeline.yml
@@ -5,7 +5,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: event.created
-    value: '{{_ingest.timestamp}}'
+    value: '{{@timestamp}}'
 - date:
     field: zeek.weird.ts
     formats:

--- a/x-pack/filebeat/module/zeek/weird/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/weird/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for normalizing Zeek weird.log
 processors:
 - set:
+    field: event.ingested
+    value: '{{_ingest.timestamp}}'
+- set:
     field: event.created
     value: '{{_ingest.timestamp}}'
 - date:

--- a/x-pack/filebeat/module/zeek/x509/ingest/pipeline.json
+++ b/x-pack/filebeat/module/zeek/x509/ingest/pipeline.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "event.created",
-        "value": "{{_ingest.timestamp}}"
+        "value": "{{@timestamp}}"
       }
     },
     {

--- a/x-pack/filebeat/module/zeek/x509/ingest/pipeline.json
+++ b/x-pack/filebeat/module/zeek/x509/ingest/pipeline.json
@@ -3,6 +3,12 @@
   "processors": [
     {
       "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    },
+    {
+      "set": {
         "field": "event.created",
         "value": "{{_ingest.timestamp}}"
       }

--- a/x-pack/filebeat/module/zscaler/zia/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zscaler/zia/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Zscaler NSS
 
 processors:
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
+
   # User agent
   - user_agent:
         field: user_agent.original


### PR DESCRIPTION


## What does this PR do?

The event.ingested field defines time at which the event was ingested to Elasticsearch
and it added by the Ingest Node pipeline. 

This adds a test to ensure all modules create event.ingested.



## Why is it important?

This field is important when trying to build
alerts for activities that may have been reported long after they occurred (@timestamp is
much older than event.ingested). This might happen if an agent was offline for a period
of time or the processing was delayed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Verify that no pipelines have duplicate `set` processors for event.ingested


## Related issues


- Closes #20073

