### PR TITLE
Cherry-pick to 7.x: Support "cluster" scope in Metricbeat elasticsearch module (#18547)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -692,6 +692,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
+- Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -13,7 +13,16 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Module-specific configuration notes
+
+Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
+This setting can contain a list of entries. The related `scope` setting determines how each entry in
+the `hosts` list is interpreted by the module.
+
+* If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
+  {es} cluster.
+* If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
+  {es} cluster (for example, a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
@@ -45,12 +54,9 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+  #scope: node
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -273,12 +273,9 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+  #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -13,9 +13,6 @@
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+  #scope: node

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -6,7 +6,16 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Module-specific configuration notes
+
+Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
+This setting can contain a list of entries. The related `scope` setting determines how each entry in
+the `hosts` list is interpreted by the module.
+
+* If `scope` is set to `node` (default), each entry in the `hosts` list indicates a distinct node in an
+  {es} cluster.
+* If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
+  {es} cluster (for example, a load-balancing proxy fronting the cluster).
 
 The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -56,14 +56,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each follower shard from the _ccr/stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch ccr stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -18,8 +18,6 @@
 package cluster_stats
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -51,14 +49,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch cluster stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -447,6 +447,28 @@ func IsMLockAllEnabled(http *helper.HTTP, resetURI, nodeID string) (bool, error)
 	return false, fmt.Errorf("could not determine if mlockall is enabled on node ID = %v", nodeID)
 }
 
+// GetMasterNodeID returns the ID of the Elasticsearch cluster's master node
+func GetMasterNodeID(http *helper.HTTP, resetURI string) (string, error) {
+	content, err := fetchPath(http, resetURI, "_nodes/_master", "filter_path=nodes.*.name")
+	if err != nil {
+		return "", err
+	}
+
+	var response struct {
+		Nodes map[string]interface{} `json:"nodes"`
+	}
+
+	if err := json.Unmarshal(content, &response); err != nil {
+		return "", err
+	}
+
+	for nodeID, _ := range response.Nodes {
+		return nodeID, nil
+	}
+
+	return "", errors.New("could not determine master node ID")
+}
+
 // PassThruField copies the field at the given path from the given source data object into
 // the same path in the given target data object.
 func PassThruField(fieldPath string, sourceData, targetData common.MapStr) error {

--- a/metricbeat/module/elasticsearch/enrich/enrich.go
+++ b/metricbeat/module/elasticsearch/enrich/enrich.go
@@ -55,14 +55,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each enrich coordinator node
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch enrich stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -59,15 +59,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch index stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -18,8 +18,6 @@
 package index_recovery
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -67,14 +65,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -62,14 +62,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch index summary stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -18,8 +18,6 @@
 package ml_job
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -54,15 +52,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch machine learning job stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node_stats
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServiceURI(t *testing.T) {
+	tests := map[string]struct {
+		scope       elasticsearch.Scope
+		expectedURI string
+	}{
+		"scope_node": {
+			scope:       elasticsearch.ScopeNode,
+			expectedURI: "/_nodes/_local/stats",
+		},
+		"scope_cluster": {
+			scope:       elasticsearch.ScopeCluster,
+			expectedURI: "/_nodes/_all/stats",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newURI, err := getServiceURI("/foo/bar", test.scope)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedURI, newURI)
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -18,8 +18,6 @@
 package pending_tasks
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -59,14 +57,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch pending tasks from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -18,8 +18,6 @@
 package shard
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
@@ -53,14 +51,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
+	shouldSkip, err := m.ShouldSkipFetch()
 	if err != nil {
-		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		return err
 	}
-
-	// Not master, no event sent
-	if !isMaster {
-		m.Logger().Debug("trying to fetch shard stats from a non-master node")
+	if shouldSkip {
 		return nil
 	}
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -482,12 +482,9 @@ metricbeat.modules:
   #password: "changeme"
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Set to false to fetch all entries
   #index_recovery.active_only: true
-
-  # Set to true to send data collected by module to X-Pack
-  # Monitoring instead of metricbeat-* indices.
   #xpack.enabled: false
+  #scope: node
 
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Support "cluster" scope in Metricbeat elasticsearch module (#18547)