### PR TITLE
[Ingest Manager] Send datastreams fields

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -98,3 +98,4 @@
 - Will retry to enroll if the server return a 429. {pull}19918[19811]
 - Add --staging option to enroll command {pull}20026[20026]
 - Add `event.dataset` to all events {pull}20076[20076]
+- Send datastreams fields {pull}20416[20416]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -234,6 +234,16 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 					},
 					{
 						"add_fields": map[string]interface{}{
+							"target": "datastream",
+							"fields": map[string]interface{}{
+								"type":      "logs",
+								"dataset":   fmt.Sprintf("elastic.agent.%s", name),
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						"add_fields": map[string]interface{}{
 							"target": "event",
 							"fields": map[string]interface{}{
 								"dataset": fmt.Sprintf("elastic.agent.%s", name),
@@ -278,6 +288,16 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 						"fields": map[string]interface{}{
 							"type":      "metrics",
 							"name":      fmt.Sprintf("elastic.agent.%s", name),
+							"namespace": "default",
+						},
+					},
+				},
+				{
+					"add_fields": map[string]interface{}{
+						"target": "datastream",
+						"fields": map[string]interface{}{
+							"type":      "metrics",
+							"dataset":   fmt.Sprintf("elastic.agent.%s", name),
 							"namespace": "default",
 						},
 					},

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -200,6 +200,16 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 				},
 				{
 					"add_fields": map[string]interface{}{
+						"target": "datastream",
+						"fields": map[string]interface{}{
+							"type":      "logs",
+							"dataset":   "elastic.agent",
+							"namespace": "default",
+						},
+					},
+				},
+				{
+					"add_fields": map[string]interface{}{
 						"target": "event",
 						"fields": map[string]interface{}{
 							"dataset": "elastic.agent",

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/constraints_config-filebeat.yml
@@ -13,6 +13,12 @@ filebeat:
             name: generic
             namespace: default
       - add_fields:
+          target: "datastream"
+          fields:
+            type: logs
+            dataset: generic
+            namespace: default
+      - add_fields:
           target: "event"
           fields:
             dataset: generic

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
@@ -13,6 +13,12 @@ filebeat:
             name: generic
             namespace: default
       - add_fields:
+          target: "datastream"
+          fields:
+            type: logs
+            dataset: generic
+            namespace: default
+      - add_fields:
           target: "event"
           fields:
             dataset: generic

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
@@ -14,6 +14,12 @@ filebeat:
             name: generic
             namespace: default
       - add_fields:
+          target: "datastream"
+          fields:
+            type: logs
+            dataset: generic
+            namespace: default
+      - add_fields:
           target: "event"
           fields:
             dataset: generic

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
@@ -15,6 +15,12 @@ filebeat:
             name: generic
             namespace: default
       - add_fields:
+          target: "datastream"
+          fields:
+            type: logs
+            dataset: generic
+            namespace: default
+      - add_fields:
           target: "event"
           fields:
             dataset: generic
@@ -31,6 +37,12 @@ filebeat:
           fields:
             type: testtype
             name: generic
+            namespace: default
+      - add_fields:
+          target: "datastream"
+          fields:
+            type: testtype
+            dataset: generic
             namespace: default
       - add_fields:
           target: "event"

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
@@ -12,6 +12,12 @@ metricbeat:
           name: docker.status
           namespace: default
     - add_fields:
+        target: "datastream"
+        fields:
+          type: metrics
+          dataset: docker.status
+          namespace: default
+    - add_fields:
         target: "event"
         fields:
           dataset: docker.status
@@ -25,6 +31,12 @@ metricbeat:
         fields:
           type: metrics
           name: generic
+          namespace: default
+    - add_fields:
+        target: "datastream"
+        fields:
+          type: metrics
+          dataset: generic
           namespace: default
     - add_fields:
         target: "event"
@@ -43,6 +55,12 @@ metricbeat:
           fields:
             type: metrics
             name: generic
+            namespace: testing
+      - add_fields:
+          target: "datastream"
+          fields:
+            type: metrics
+            dataset: generic
             namespace: testing
       - add_fields:
           target: "event"

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -632,6 +632,7 @@ func (r *InjectStreamProcessorRule) Apply(ast *AST) error {
 				return errors.New("InjectStreamProcessorRule: processors is not a list")
 			}
 
+			// dataset
 			processorMap := &Dict{value: make([]Node, 0)}
 			processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "dataset"}})
 			processorMap.value = append(processorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
@@ -642,6 +643,18 @@ func (r *InjectStreamProcessorRule) Apply(ast *AST) error {
 			addFieldsMap := &Dict{value: []Node{&Key{"add_fields", processorMap}}}
 			processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, addFieldsMap)
 
+			// datastream
+			processorMap = &Dict{value: make([]Node, 0)}
+			processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "datastream"}})
+			processorMap.value = append(processorMap.value, &Key{name: "fields", value: &Dict{value: []Node{
+				&Key{name: "type", value: &StrVal{value: datasetType}},
+				&Key{name: "namespace", value: &StrVal{value: namespace}},
+				&Key{name: "dataset", value: &StrVal{value: dataset}},
+			}}})
+			addFieldsMap = &Dict{value: []Node{&Key{"add_fields", processorMap}}}
+			processorsList.value = mergeStrategy(r.OnConflict).InjectItem(processorsList.value, addFieldsMap)
+
+			// event
 			processorMap = &Dict{value: make([]Node, 0)}
 			processorMap.value = append(processorMap.value, &Key{name: "target", value: &StrVal{value: "event"}})
 			processorMap.value = append(processorMap.value, &Key{name: "fields", value: &Dict{value: []Node{


### PR DESCRIPTION
## What does this PR do?

Adds `datastream.*` fields as for request described here https://github.com/elastic/integrations/pull/213 and https://github.com/elastic/elasticsearch/pull/60592

## Why is it important?

Desciben in an issue here https://github.com/elastic/integrations/pull/213 and https://github.com/elastic/elasticsearch/pull/60592

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @ruflin 