### PR TITLE
Cherry-pick #19899 to 7.x: Update container name for the azure filesets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -253,6 +253,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix tls mapping in suricata module {issue}19492[19492] {pull}19494[19494]
 - Fix memory leak in tcp and unix input sources. {pull}19459[19459]
 - Fix Cisco ASA dissect pattern for 313008 & 313009 messages. {pull}19149[19149]
+- Update container name for the azure filesets. {pull}19899[19899]
 - Fix bug with empty filter values in system/service {pull}19812[19812]
 - Fix S3 input to trim delimiter /n from each log line. {pull}19972[19972]
 - Fix auditd module syscall table for ppc64 and ppc64le. {pull}20052[20052]

--- a/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
@@ -5,6 +5,7 @@ consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
 resource_manager_endpoint: {{ .resource_manager_endpoint }}
+storage_account_container: filebeat-activitylogs-{{ .eventhub }}
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
@@ -5,6 +5,7 @@ consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
 resource_manager_endpoint: {{ .resource_manager_endpoint }}
+storage_account_container: filebeat-auditlogs-{{ .eventhub }}
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:

--- a/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
@@ -5,6 +5,7 @@ consumer_group: {{ .consumer_group }}
 storage_account: {{ .storage_account }}
 storage_account_key: {{ .storage_account_key }}
 resource_manager_endpoint: {{ .resource_manager_endpoint }}
+storage_account_container: filebeat-signinlogs-{{ .eventhub }}
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#19899 to 7.x branch. Original message:

## What does this PR do?

creates a specific container name based on the azure fileset and the eventhub name

## Why is it important?

Users could use same eventhub to export different types of logs, that would mean the same container name would be used for multiple azure input instances. This would avoid the case.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
