### PR TITLE
Cherry-pick #20406 to 7.9: Makes `metrics` config option required in app_insights

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,6 +171,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - Modify doc for app_insights metricset to contain example of config. {pull}20185[20185]
+- Add required option for `metrics` in app_insights. {pull}20406[20406]
 - Groups same timestamp metric values to one event in the app_insights metricset. {pull}20403[20403]
 
 *Packetbeat*

--- a/metricbeat/docs/modules/azure.asciidoc
+++ b/metricbeat/docs/modules/azure.asciidoc
@@ -241,7 +241,8 @@ metricbeat.modules:
   period: 300s
   application_id: ''
   api_key: ''
-
+  metrics:
+    - id: ["requests/count", "requests/duration"]
 ----
 
 [float]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -340,7 +340,8 @@ metricbeat.modules:
   period: 300s
   application_id: ''
   api_key: ''
-
+  metrics:
+    - id: ["requests/count", "requests/duration"]
 
 #--------------------------------- Beat Module ---------------------------------
 - module: beat

--- a/x-pack/metricbeat/module/azure/_meta/config.reference.yml
+++ b/x-pack/metricbeat/module/azure/_meta/config.reference.yml
@@ -100,4 +100,5 @@
   period: 300s
   application_id: ''
   api_key: ''
-
+  metrics:
+    - id: ["requests/count", "requests/duration"]

--- a/x-pack/metricbeat/module/azure/_meta/config.yml
+++ b/x-pack/metricbeat/module/azure/_meta/config.yml
@@ -109,3 +109,5 @@
 #  period: 300s
 #  application_id: ''
 #  api_key: ''
+#  metrics:
+#   - id: ["requests/count", "requests/duration"]

--- a/x-pack/metricbeat/module/azure/app_insights/app_insights.go
+++ b/x-pack/metricbeat/module/azure/app_insights/app_insights.go
@@ -22,7 +22,7 @@ type Config struct {
 	ApplicationId string        `config:"application_id"    validate:"required"`
 	ApiKey        string        `config:"api_key" validate:"required"`
 	Period        time.Duration `config:"period" validate:"nonzero,required"`
-	Metrics       []Metric      `config:"metrics"`
+	Metrics       []Metric      `config:"metrics" validate:"required"`
 }
 
 // Metric struct used for configuration options

--- a/x-pack/metricbeat/modules.d/azure.yml.disabled
+++ b/x-pack/metricbeat/modules.d/azure.yml.disabled
@@ -112,3 +112,5 @@
 #  period: 300s
 #  application_id: ''
 #  api_key: ''
+#  metrics:
+#   - id: ["requests/count", "requests/duration"]


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#20406 to 7.9 branch. Original message:

## What does this PR do?

Makes `metrics` config option required.

## Why is it important?

Validation

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

