### PR TITLE
[Elastic Agent] Fix agent control socket path to always be less than 107 characters

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/control/addr.go
+++ b/x-pack/elastic-agent/pkg/agent/control/addr.go
@@ -9,8 +9,6 @@ package control
 import (
 	"crypto/sha256"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 )
@@ -20,6 +18,5 @@ func Address() string {
 	data := paths.Data()
 	// entire string cannot be longer than 107 characters, this forces the
 	// length to always be 88 characters (but unique per data path)
-	path := filepath.Join(os.TempDir(), fmt.Sprintf("elastic-agent-%x.sock", sha256.Sum256([]byte(data))))
-	return fmt.Sprintf(`unix://%s`, path)
+	return fmt.Sprintf(`unix:///tmp/elastic-agent-%x.sock`, sha256.Sum256([]byte(data)))
 }

--- a/x-pack/elastic-agent/pkg/agent/control/addr.go
+++ b/x-pack/elastic-agent/pkg/agent/control/addr.go
@@ -9,6 +9,9 @@ package control
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 )
 
@@ -17,5 +20,6 @@ func Address() string {
 	data := paths.Data()
 	// entire string cannot be longer than 107 characters, this forces the
 	// length to always be 88 characters (but unique per data path)
-	return fmt.Sprintf(`unix:///tmp/elastic-agent-%x.sock`, sha256.Sum256([]byte(data)))
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("elastic-agent-%x.sock", sha256.Sum256([]byte(data))))
+	return fmt.Sprintf(`unix://%s`, path)
 }

--- a/x-pack/elastic-agent/pkg/agent/control/addr.go
+++ b/x-pack/elastic-agent/pkg/agent/control/addr.go
@@ -7,14 +7,15 @@
 package control
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"path/filepath"
-
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 )
 
 // Address returns the address to connect to Elastic Agent daemon.
 func Address() string {
 	data := paths.Data()
-	return fmt.Sprintf("unix://%s", filepath.Join(data, "agent.sock"))
+	// entire string cannot be longer than 107 characters, this forces the
+	// length to always be 88 characters (but unique per data path)
+	return fmt.Sprintf(`unix:///tmp/elastic-agent-%x.sock`, sha256.Sum256([]byte(data)))
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Instead of placing the control socket inside the `paths.Data()` it moves it to be under `/tmp/elastic-agent-{$ hash_of(paths.Data()) $}.sock`. That ensure that the path will always be less than 107 characters, but be unique per Elastic Agent data path.

I was original could to change it to the `/run` directory but that has permission issues, that would always required Elastic Agent to run as root, and we do not want to make that a requirement.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So that running Elastic Agent when it is nested deep into multiple directories doesn't cause an issue with the socket path being longer than 107 characters.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

