### PR TITLE
Cherry-pick #20425 to 7.9: Improve cgroup_regex docs with examples

### DIFF
--- a/libbeat/processors/add_process_metadata/docs/add_process_metadata.asciidoc
+++ b/libbeat/processors/add_process_metadata/docs/add_process_metadata.asciidoc
@@ -72,7 +72,7 @@ field will be present in the output.
 
 `host_path`:: (Optional) By default, the `host_path` field is set to the root
 directory of the host `/`. This is the path where `/proc` is mounted. For
-different runtime configurations of Kubernetes or Docker, the `host_path` can 
+different runtime configurations of Kubernetes or Docker, the `host_path` can
 be set to overwrite the default.
 
 `cgroup_prefixes`:: (Optional) By default, the `cgroup_prefixes` field is set
@@ -80,15 +80,21 @@ to `/kubepods` and `/docker`. This is the prefix where the container ID is
 inside cgroup. For different runtime configurations of Kubernetes or Docker,
 the `cgroup_prefixes` can be set to overwrite the defaults.
 
-`cgroup_regex`:: (Optional) By default, the container id is extracted from 
-cgroup file based on `cgroup_prefixes`. This can be overwritten by specifying 
-regular expression with capture group for capturing container id from cgroup 
-path. For example: `^\/.+\/.+\/.+\/([0-9a-f]{64}).*`
+`cgroup_regex`:: (Optional) By default, the container id is extracted from
+cgroup file based on `cgroup_prefixes`. This can be overwritten by specifying
+regular expression with capture group for capturing container id from cgroup
+path. Examples:
+. `^\/.+\/.+\/.+\/([0-9a-f]{64}).*` will match the container id of a cgroup
+like `/kubepods/besteffort/pod665fb997-575b-11ea-bfce-080027421ddf/b5285682fba7449c86452b89a800609440ecc88a7ba5f2d38bedfb85409b30b1`
+. `^\/.+\/.+\/.+\/docker-([0-9a-f]{64}).scope` will match the container id of a cgroup
+like `/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod69349abe_d645_11ea_9c4c_08002709c05c.slice/docker-80d85a3a585f1575028ebe468d83093c301eda20d37d1671ff2a0be50fc0e460.scope`
+. `^\/.+\/.+\/.+\/crio-([0-9a-f]{64}).scope` will match the container id of a cgroup
+like `/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod69349abe_d645_11ea_9c4c_08002709c05c.slice/crio-80d85a3a585f1575028ebe468d83093c301eda20d37d1671ff2a0be50fc0e460.scope`
 
-`cgroup_cache_expire_time`:: (Optional) By default, the 
+`cgroup_cache_expire_time`:: (Optional) By default, the
 `cgroup_cache_expire_time` is set to 30 seconds. This is the length of time
 before cgroup cache elements expire in seconds. It can be set to 0 to disable
-the cgroup cache. In some container runtimes technology like runc, the 
+the cgroup cache. In some container runtimes technology like runc, the
 container's process is also process in the host kernel, and will be affected by
-PID rollover/reuse. The expire time needs to set smaller than the PIDs wrap 
+PID rollover/reuse. The expire time needs to set smaller than the PIDs wrap
 around time to avoid wrong container id.


### PR DESCRIPTION
Cherry-pick of PR #20425 to 7.9 branch. Original message: 

## What does this PR do?
This PR adds more usage examples for `cgroup_regex` setting of `add_process_metadata`, which was introduced at https://github.com/elastic/beats/pull/17360.

## Why is it important?
To make usage of this setting more clear.
