### PR TITLE
[docs] Add Elastic Agent doc changes for 7.9

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -1,6 +1,10 @@
 [[elastic-agent-cmd-options]]
 [role="xpack"]
-= Command line options
+= {agent} command line options
+
+++++
+<titleabbrev>Command line options</titleabbrev>
+++++
 
 beta[]
 

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -1,3 +1,5 @@
+:release-state: released
+
 [[elastic-agent-installation-configuration]]
 [role="xpack"]
 

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -8,7 +8,7 @@ beta[]
 // tag::agent-install-intro[]
 {agent} is a single, unified agent that you can deploy to hosts or containers to
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the
-{beats} shippers or Endpoint required for your configuration.
+{beats} shippers or Elastic Endpoint required for your configuration.
 // end::agent-install-intro[]
 
 To learn how to install, configure, and run your {agent}s, see:

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -16,6 +16,7 @@ To learn how to install, configure, and run your {agent}s, see:
 * <<elastic-agent-installation>>
 * <<run-elastic-agent>>
 * <<stop-elastic-agent>>
+* <<unenroll-elastic-agent>>
 * <<elastic-agent-cmd-options>>
 * <<elastic-agent-configuration>>
 
@@ -24,6 +25,8 @@ include::install-elastic-agent.asciidoc[leveloffset=+1]
 include::run-elastic-agent.asciidoc[leveloffset=+1]
 
 include::stop-elastic-agent.asciidoc[leveloffset=+1]
+
+include::unenroll-elastic-agent.asciidoc[leveloffset=+1]
 
 include::elastic-agent-command-line.asciidoc[leveloffset=+1]
 

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -16,5 +16,5 @@ include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/install-widget.a
 // end::install-elastic-agent[]
 
 // Add Javascript and CSS for tabbed panels
-include::{code-path}.asciidoc[]
+include::tab-widgets/code.asciidoc[]
 

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -4,82 +4,17 @@
 
 beta[]
 
-Download and install the Agent on each system you want to monitor.
-
-//TODO: Replace with tabbed panel when the code is stable. 
+Download and install {agent} on each system you want to monitor.
 
 // tag::install-elastic-agent[]
 
 To download and install {elastic-agent}, use the commands that work with your
 system:
 
-*mac:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
-----
-
-endif::[]
-
-*linux:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----
-curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
-tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
-----
-
-endif::[]
-
-*win:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {agent} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-. Download the {agent} Windows zip file from the
-https://www.elastic.co/downloads/elastic-agent[downloads page].
-
-. Extract the contents of the zip file into `C:\Program Files`.
-
-. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
-
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
-
-. From the PowerShell prompt, run the following commands to install Filebeat as a
-Windows service:
-+
-[source,shell]
-----
-PS > cd 'C:\Program Files\Elastic-Agent'
-PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
-----
-
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
-
-endif::[]
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc[]
 
 // end::install-elastic-agent[]
+
+// Add Javascript and CSS for tabbed panels
+include::{code-path}.asciidoc[]
 

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -20,13 +20,14 @@ agent to {fleet}.
 
 To enroll an {agent} to {fleet}:
 
-. Stop the agent, if it's already running.
+. Stop {agent}, if it's already running.
 
 . In {ingest-manager}, select **{fleet}**, then click **Add agent** to
-generate an enrollment token. See <<ingest-management-getting-started>> for
+get an enrollment token. See <<ingest-management-getting-started>> for
 detailed steps.
 
-. Enroll the agent:
+. Change to the directory where {agent} is installed, and enroll the agent to
+{fleet}:
 +
 --
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -5,67 +5,60 @@
 beta[]
 
 {agent} runs in two modes: standalone or fleet. The two modes differ in how you
-configure and manage the Agent.
+configure and manage the agent.
 
 [discrete]
 [[fleet-mode]]
 == Run in {fleet} mode
 
-With _fleet mode_, you manage {agent} remotely. The Agent uses a trusted {kib}
-instance to retrieve configurations and report Agent events. This trusted {kib}
+With _fleet mode_, you manage {agent} remotely. The agent uses a trusted {kib}
+instance to retrieve configurations and report agent events. This trusted {kib}
 instance must have {ingest-manager} and {fleet} enabled.
 
 To create a trusted communication channel between {agent} and {kib}, enroll the
-Agent to {fleet}.
+agent to {fleet}.
 
 To enroll an {agent} to {fleet}:
 
-. Stop the Agent, if it's already running.
+. Stop the agent, if it's already running.
 
 . Go the **{fleet}** tab in {ingest-manager}, and click **Enroll new agent** to
 generate a token. See <<ingest-management-getting-started>> for detailed steps.
 
-. Enroll the Agent:
+. Enroll the agent:
 +
-[source,shell]
-----
-./elastic-agent enroll http://localhost:5601 $token
-----
+--
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc[]
+--
+
+. Start the agent:
 +
-Where `$token` is an enrollment token acquired from {fleet}.
-
-//TODO: Add tabbed panels for platform-specific tabs (waiting for final design)
-
-To start {agent}, run:
-
-// tag::run-agent[]
-[source,shell]
-----
-./elastic-agent run <1>
-----
-<1> On Windows, you must run {agent} under the SYSTEM account if you plan
-to use the {elastic-endpoint} integration.
-// end::run-agent[]
+--
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc[]
+--
 
 [discrete]
 [[standalone-mode]]
 == Run in standalone mode (default)
 
-With _standalone mode_, you manually configure and manage the Agent locally.
-Each Agent is configured to be in standalone mode by default after installation.
+With _standalone mode_, you manually configure and manage {agent} locally on the
+system where the agent is installed. {agent} is configured to run in standalone
+mode by default unless you enroll it in {fleet}. 
 
 If {agent} is installed as an auto-starting service, it will run automatically
 when you restart your system.
 
 To start {agent} manually, run:
 
-include::run-elastic-agent.asciidoc[tag=run-agent]
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc[]
 
-If no configuration file is specified, {agent} uses the default configuration,
-`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
-the `-c` flag to use a different configuration file.
+Use the `-c` flag to specify the configuration file. If no configuration file is
+specified, {agent} uses the default configuration, `elastic-agent.yml`, which is
+located in the same directory as {agent}.
 
 For configuration options, see <<elastic-agent-configuration>>.
 
 //<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
 
+// Add Javascript and CSS for tabbed panels
+include::{code-path}.asciidoc[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -62,4 +62,4 @@ For configuration options, see <<elastic-agent-configuration>>.
 //<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
 
 // Add Javascript and CSS for tabbed panels
-include::{code-path}.asciidoc[]
+include::tab-widgets/code.asciidoc[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -22,8 +22,9 @@ To enroll an {agent} to {fleet}:
 
 . Stop the agent, if it's already running.
 
-. Go the **{fleet}** tab in {ingest-manager}, and click **Enroll new agent** to
-generate a token. See <<ingest-management-getting-started>> for detailed steps.
+. In {ingest-manager}, select **{fleet}**, then click **Add agent** to
+generate an enrollment token. See <<ingest-management-getting-started>> for
+detailed steps.
 
 . Enroll the agent:
 +
@@ -31,7 +32,7 @@ generate a token. See <<ingest-management-getting-started>> for detailed steps.
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc[]
 --
 
-. Start the agent:
+. Run the agent:
 +
 --
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc[]

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -51,7 +51,7 @@ when you restart your system.
 
 To start {agent} manually, run:
 
-include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc[]
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-standalone-widget.asciidoc[]
 
 Use the `-c` flag to specify the configuration file. If no configuration file is
 specified, {agent} uses the default configuration, `elastic-agent.yml`, which is

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -5,37 +5,7 @@
 To stop {agent} and its related executables, stop the {agent} process. Use the
 commands that work for your system. 
 
-*Windows:*
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc[]
 
-If you installed the Agent as a service, stop the service. If
-necessary, use Task Manager on Windows to stop {agent}. This will kill the
-{agent} process and any sub-processes it created (such as {beats}).
-
-*Linux or macOS:*
-
-Run the following command to get the ID of the `elastic-agent` process:
-
-[source,shell]
-----
-ps | grep elastic-agent
-----
-
-Then kill the process:
-
-[source,shell]
-----
-kill -9 PID
-----
-
-Where `PID` is the ID of the `elastic-agent` process.
-
-*Systemd:*
-
-The DEB and RPM packages include a service unit for Linux systems with systemd.
-On these systems, you can manage {agent} by using systemd commands. Use
-`systemctl` to stop the Agent:
-
-[source,shell]
-----
-systemctl stop elastic-agent
-----
+// Add Javascript and CSS for tabbed panels
+include::{code-path}.asciidoc[]

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -8,4 +8,4 @@ commands that work for your system.
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc[]
 
 // Add Javascript and CSS for tabbed panels
-include::{code-path}.asciidoc[]
+include::tab-widgets/code.asciidoc[]

--- a/x-pack/elastic-agent/docs/tab-widgets/code.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/code.asciidoc
@@ -1,0 +1,166 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+  
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+  
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+  
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+  
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc
@@ -1,0 +1,92 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Enroll">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-enroll"
+            id="deb-enroll">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-enroll"
+            id="rpm-enroll">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-enroll"
+            id="mac-enroll">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-enroll"
+            id="linux-enroll"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-enroll"
+            id="win-enroll"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-enroll"
+       aria-labelledby="deb-enroll">
+++++
+
+include::enroll.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-enroll"
+       aria-labelledby="rpm-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-enroll"
+       aria-labelledby="mac-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-enroll"
+       aria-labelledby="linux-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-enroll"
+       aria-labelledby="win-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
@@ -1,4 +1,10 @@
 // tag::deb[]
+
+// tag::enroll-tip[]
+TIP: We recommend that you run this command as the root user because some
+integrations require root privileges to collect sensitive data.
+
+// end::enroll-tip[]
 [source,shell]
 ----
 elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
@@ -8,6 +14,9 @@ include::enroll.asciidoc[tag=where-description]
 // end::deb[]
 
 // tag::rpm[]
+
+include::enroll.asciidoc[tag=enroll-tip]
+
 [source,shell]
 ----
 elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
@@ -17,6 +26,9 @@ include::enroll.asciidoc[tag=where-description]
 // end::rpm[]
 
 // tag::mac[]
+
+include::enroll.asciidoc[tag=enroll-tip]
+
 [source,shell]
 ----
 ./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
@@ -26,6 +38,9 @@ include::enroll.asciidoc[tag=where-description]
 // end::mac[]
 
 // tag::linux[]
+
+include::enroll.asciidoc[tag=enroll-tip]
+
 [source,shell]
 ----
 ./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
@@ -1,0 +1,55 @@
+// tag::deb[]
+[source,shell]
+----
+elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where-description]
+// end::deb[]
+
+// tag::rpm[]
+[source,shell]
+----
+elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where-description]
+// end::rpm[]
+
+// tag::mac[]
+[source,shell]
+----
+./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where-description]
+// end::mac[]
+
+// tag::linux[]
+[source,shell]
+----
+./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where-description]
+// end::linux[]
+
+// tag::win[]
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select **Run As Administrator**).
+
+From the PowerShell prompt, change to the directory where you installed {agent},
+and run:
+
+[source,shell]
+----
+.\elastic-agent.exe enroll KIBANA_URL ENROLLMENT_KEY
+----
+
+include::enroll.asciidoc[tag=where-description]
+// end::win[]
+
+// tag::where-description[]
+Where `KIBANA_URL` is the {kib} URL where {fleet} is running, and
+`ENROLLMENT_KEY` is the enrollment token acquired from {fleet}.
+// end::where-description[]

--- a/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc
@@ -1,0 +1,92 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install"
+            id="deb-install">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install"
+            id="rpm-install">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install"
+            id="mac-install">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install"
+            id="linux-install"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install"
+            id="win-install"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install"
+       aria-labelledby="deb-install">
+++++
+
+include::install.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install"
+       aria-labelledby="rpm-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install"
+       aria-labelledby="mac-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install"
+       aria-labelledby="linux-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install"
+       aria-labelledby="win-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
@@ -1,0 +1,102 @@
+// tag::deb[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-amd64.deb
+sudo dpkg -i elastic-agent-{version}-amd64.deb
+----
+
+endif::[]
+// end::deb[]
+
+// tag::rpm[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-x86_64.rpm
+sudo rpm -vi elastic-agent-{version}-x86_64.rpm
+----
+endif::[]
+// end::rpm[]
+
+// tag::mac[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
+----
+
+endif::[]
+// end::mac[]
+
+// tag::linux[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
+----
+
+endif::[]
+// end::linux[]
+
+// tag::win[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {agent} Windows zip file from the
+https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install {agent} as a
+Windows service:
++
+[source,shell]
+----
+cd 'C:\Program Files\Elastic-Agent'
+.\install-service-elastic-agent.ps1
+----
+
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
+
+endif::[]
+// end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
@@ -66,6 +66,10 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-ag
 tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
 ----
 
+NOTE: We recommend that you use the DEB or RPM distribution, instead of the
+tarball, to ensure that {agent} restarts automatically if the system is
+rebooted.
+
 endif::[]
 // end::linux[]
 
@@ -84,19 +88,6 @@ https://www.elastic.co/downloads/beats/elastic-agent[downloads page].
 . Extract the contents of the zip file into `C:\Program Files`.
 
 . Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
-
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
-
-. From the PowerShell prompt, run the following commands to install {agent} as a
-Windows service:
-+
-[source,shell]
-----
-cd 'C:\Program Files\Elastic-Agent'
-.\install-service-elastic-agent.ps1
-----
-
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
 
 endif::[]
 // end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/run-standalone-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run-standalone-widget.asciidoc
@@ -1,0 +1,92 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Run the agent">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-run-standalone"
+            id="deb-run-standalone">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-run-standalone"
+            id="rpm-run-standalone">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-run-standalone"
+            id="mac-run-standalone">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-run-standalone"
+            id="linux-run-standalone"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-run-standalone"
+            id="win-run-standalone"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-run-standalone"
+       aria-labelledby="deb-run-standalone">
+++++
+
+include::run.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-run-standalone"
+       aria-labelledby="rpm-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-run-standalone"
+       aria-labelledby="mac-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-run-standalone"
+       aria-labelledby="linux-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-run-standalone"
+       aria-labelledby="win-run-standalone"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run-widget.asciidoc
@@ -1,0 +1,92 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Run the agent">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-run"
+            id="deb-run">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-run"
+            id="rpm-run">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-run"
+            id="mac-run">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-run"
+            id="linux-run"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-run"
+            id="win-run"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-run"
+       aria-labelledby="deb-run">
+++++
+
+include::run.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-run"
+       aria-labelledby="rpm-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-run"
+       aria-labelledby="mac-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-run"
+       aria-labelledby="linux-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-run"
+       aria-labelledby="win-run"
+       hidden="">
+++++
+
+include::run.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
@@ -1,0 +1,76 @@
+// tag::deb[]
+
+The DEB package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands:
+
+[source,shell]
+----
+systemctl enable elastic-agent
+systemctl start elastic-agent
+----
+
+Otherwise, use:
+
+[source,shell]
+----
+sudo service elastic-agent start
+----
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
+// end::deb[]
+
+// tag::rpm[]
+The RPM package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands:
+
+[source,shell]
+----
+systemctl enable elastic-agent
+systemctl start elastic-agent
+----
+
+Otherwise, use:
+
+[source,shell]
+----
+sudo service elastic-agent start
+----
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
+// end::rpm[]
+
+// tag::mac[]
+[source,shell]
+----
+./elastic-agent run
+----
+
+NOTE: You must restart {agent} manually if the agent terminates or the system is
+rebooted.
+
+// end::mac[]
+
+// tag::linux[]
+[source,shell]
+----
+./elastic-agent run
+----
+
+NOTE: You must restart {agent} manually if the agent terminates or the system is
+rebooted.
+
+// end::linux[]
+
+// tag::win[]
+[source,shell]
+----
+Start-Service elastic-agent <1>
+----
+<1> On Windows, you must run {agent} under the SYSTEM account if you plan
+to use the {elastic-endpoint} integration.
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
+// end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
@@ -64,12 +64,33 @@ rebooted.
 // end::linux[]
 
 // tag::win[]
+The first time you run {agent}, you need to install it as auto-starting Windows
+service. To do this, run the PowerShell script provided in the archive you
+downloaded:
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install {agent} as
+an service and start the service:
++
 [source,shell]
 ----
-Start-Service elastic-agent <1>
+cd 'C:\Program Files\Elastic-Agent'
+.\install-service-elastic-agent.ps1 <1> <2>
 ----
-<1> On Windows, you must run {agent} under the SYSTEM account if you plan
+<1> You must run {agent} under the SYSTEM account if you plan
 to use the {elastic-endpoint} integration.
+<2> If script execution is disabled on your system, set the execution policy for
+the current session to allow the script to run. For example:
+`PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
++
+If the service stops and you need to restart it manually, run:
++
+[source,shell]
+----
+Start-Service elastic-agent
+----
 
 NOTE: {agent} will restart automatically if the system is rebooted.
 

--- a/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc
@@ -1,0 +1,92 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Stop the agent">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-stop"
+            id="deb-stop">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-stop"
+            id="rpm-stop">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-stop"
+            id="mac-stop">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-stop"
+            id="linux-stop"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-stop"
+            id="win-stop"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-stop"
+       aria-labelledby="deb-stop">
+++++
+
+include::stop.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-stop"
+       aria-labelledby="rpm-stop"
+       hidden="">
+++++
+
+include::stop.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-stop"
+       aria-labelledby="mac-stop"
+       hidden="">
+++++
+
+include::stop.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-stop"
+       aria-labelledby="linux-stop"
+       hidden="">
+++++
+
+include::stop.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-stop"
+       aria-labelledby="win-stop"
+       hidden="">
+++++
+
+include::stop.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
@@ -34,21 +34,20 @@ include::stop.asciidoc[tag=stop-command]
 
 // tag::mac[]
 // tag::kill-process[]
-Run the following command to get the ID of the `elastic-agent` process:
+Get the process ID (PID) of the `elastic-agent` process:
 
 [source,shell]
 ----
 ps | grep elastic-agent
 ----
 
-Then kill the process:
+Then kill the process, replacing the PID in this example with the PID from
+the grep command:
 
 [source,shell]
 ----
-kill -9 PID
+kill -9 90682
 ----
-
-Where `PID` is the ID of the `elastic-agent` process.
 
 NOTE: {agent} will NOT restart automatically if the system is rebooted.
 

--- a/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
@@ -1,0 +1,75 @@
+// tag::deb[]
+
+The DEB package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands.
+
+// tag::stop-command[]
+Use `systemctl` to stop the agent:
+
+[source,shell]
+----
+systemctl stop elastic-agent
+----
+
+Otherwise, use:
+
+[source,shell]
+----
+sudo service elastic-agent stop
+----
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
+// end::stop-command[]
+
+// end::deb[]
+
+// tag::rpm[]
+The RPM package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands.
+
+include::stop.asciidoc[tag=stop-command]
+
+// end::rpm[]
+
+// tag::mac[]
+// tag::kill-process[]
+Run the following command to get the ID of the `elastic-agent` process:
+
+[source,shell]
+----
+ps | grep elastic-agent
+----
+
+Then kill the process:
+
+[source,shell]
+----
+kill -9 PID
+----
+
+Where `PID` is the ID of the `elastic-agent` process.
+
+NOTE: {agent} will NOT restart automatically if the system is rebooted.
+
+// end::kill-process[]
+// end::mac[]
+
+// tag::linux[]
+include::stop.asciidoc[tag=kill-process]
+// end::linux[]
+
+// tag::win[]
+
+If you installed {agent} as a service, stop the service. 
+[source,shell]
+----
+Stop-Service elastic-agent
+----
+
+If necessary, use Task Manager on Windows to stop {agent}. This will kill the
+`elastic-agent` process and any sub-processes it created (such as {beats}).
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
+// end::win[]

--- a/x-pack/elastic-agent/docs/unenroll-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/unenroll-elastic-agent.asciidoc
@@ -4,10 +4,10 @@
 
 You can unenroll an agent to invalidate the API key used to connect to {es}.
 
-. In {ingest-manager}, select {fleet}.
+. In {ingest-manager}, select **{fleet}**.
 
-. Under Agents, choose **Unenroll** from the **Actions** next to the agent you
-want to unenroll.
+. Under Agents, choose **Unenroll** from the **Actions** menu next to the agent
+you want to unenroll.
 
 . Click **Unenroll**. 
 +

--- a/x-pack/elastic-agent/docs/unenroll-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/unenroll-elastic-agent.asciidoc
@@ -1,0 +1,19 @@
+[[unenroll-elastic-agent]]
+[role="xpack"]
+= Unenroll {agent}
+
+You can unenroll an agent to invalidate the API key used to connect to {es}.
+
+. In {ingest-manager}, select {fleet}.
+
+. Under Agents, choose **Unenroll** from the **Actions** next to the agent you
+want to unenroll.
+
+. Click **Unenroll**. 
++
+The agent will continue to run, but will not be able to send data. It will show
+this error instead: `invalid api key to authenticate with fleet`.
+
+TIP: If unenrollment hangs, select **Force unenroll** to invalidate all API
+keys related to the agent and change the status to `inactive` so that the agent
+no longer appears in {fleet}.


### PR DESCRIPTION
Adds beats-related ingest management changes for 7.9. Preview: https://beats_20437.docs-preview.app.elstc.co/guide/en/ingest-management/master/elastic-agent-installation-configuration.html (look at Elastic Agent changes only)

Requires https://github.com/elastic/observability-docs/pull/80

REVIEWERS: Our tabbed panels are evolving. We need to inject the HTML directly into the build right now, but that will change in the future. For now, the best way to review the content there is to look at the rendered content in the preview.

Please don't review the javascript or css (that's already been reviewed--I'm just copying it here).