### PR TITLE
Cherry-pick #20407 to 7.x: Remove pillow from testing requirements.txt

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -19,7 +19,6 @@ nose==1.3.7
 nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==4.2b1
-Pillow==7.0.0
 redis==2.10.6
 requests==2.20.0
 six==1.11.0


### PR DESCRIPTION
Cherry-pick of PR #20407 to 7.x branch. Original message: 

## What does this PR do?

Remove Pillow from `requirements.txt`.

## Why is it important?

It contains deprecated code to support older versions of Python, and it doesn't seem to be used in Beats. I introduced it on the migration to Python 3 (#14798), not sure why.

## Related issues

- Relates with #20384.