### PR TITLE
Cherry-pick #20397 to 7.x: Disable logging when pulling on python integration tests

### DIFF
--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -1,8 +1,11 @@
+import io
+import logging
 import os
 import sys
 import tarfile
 import time
-import io
+
+from contextlib import contextmanager
 
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
@@ -54,9 +57,12 @@ class ComposeMixin(object):
             return container.inspect()['State']['Health']['Status'] == 'healthy'
 
         project = cls.compose_project()
-        project.pull(
-            ignore_pull_failures=True,
-            service_names=cls.COMPOSE_SERVICES)
+
+        with disabled_logger('compose.service'):
+            project.pull(
+                ignore_pull_failures=True,
+                service_names=cls.COMPOSE_SERVICES)
+
         project.up(
             strategy=ConvergenceStrategy.always,
             service_names=cls.COMPOSE_SERVICES,
@@ -231,3 +237,14 @@ class ComposeMixin(object):
             if line.find(msg.encode("utf-8")) >= 0:
                 counter += 1
         return counter > 0
+
+
+@contextmanager
+def disabled_logger(name):
+    logger = logging.getLogger(name)
+    old_level = logger.getEffectiveLevel()
+    logger.setLevel(logging.CRITICAL)
+    try:
+        yield logger
+    finally:
+        logger.setLevel(old_level)


### PR DESCRIPTION
Cherry-pick of PR #20397 to 7.x branch. Original message: 

Docker compose library is quite verbose, and it prints many messages
when logging is enabled. On integration tests we make a pull before
trying to build the images in case the image is already pre-built. If
this pull doesn't work, the image is built, so we ignore errors on this
pull. But, even when ignoring errors, these errors are logged, and when
investigating problems with tests this may lead to think that the
problem is with the unavailability of some image. Disable logging on the
compose logger while this previous pull is being done.

## What does this PR do?

Disables logging on errors happening when trying to pull images on
integration tests.

Note: Docker compose logging is still too verbose, but this is a collateral effect
of the test runner. This will improve after #16883.

## Why is it important?

Errors when pulling images on integration tests are ignored, because
the image can still be built, but they are still logged, what is misleading.

See for example this thread: https://github.com/elastic/beats/issues/19739#issuecomment-655541424

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Logs

Before, if an image is not available, but it can be built, and the test fails for other reason, this is logged, what is confusing.
```
compose.service: ERROR: 404 Client Error: Not Found ("manifest for docker.elastic.co/integrations-ci/beats-redis:5.0.5-2 not found: manifest unknown: manifest unknown")
```
After this change no errors are logged by the pull if the test fails, logs regarding the later build are still logged:
```
compose.service: WARNING: Image for service redis was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
```