### PR TITLE
Cherry-pick #20440 to 7.x: [Filebeat][ATP Module]Setting user agent field required by the API

### DIFF
--- a/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
@@ -11,7 +11,7 @@ url: {{ .url }}
 oauth2: {{ .oauth2 | tojson }}
 oauth2.provider: azure
 oauth2.azure.resource: https://api.securitycenter.windows.com/
-
+http_headers: {{ .http_headers | tojson }}
 date_cursor.field: lastUpdateTime
 date_cursor.url_field: '$filter'
 date_cursor.value_template: {{ .date_cursor.value_template }}

--- a/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
@@ -6,14 +6,17 @@ var:
   - name: interval
     default: 5m
   - name: date_cursor
-    default: 
+    default:
       value_template: "lastUpdateTime gt {{.}}"
   - name: tags
     default: [defender-atp, forwarded]
+  - name: http_headers
+    default:
+      User-Agent: MdatpPartner-Elastic-Filebeat/1.0.0
   - name: url
     default: "https://api.securitycenter.windows.com/api/alerts?$expand=evidence"
   - name: oauth2
-      
+
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/atp.yml


### PR DESCRIPTION
Cherry-pick of PR #20440 to 7.x branch. Original message: 

## What does this PR do?

Vendor modules are required to include a header for tracking purposes

## Why is it important?

The header set is a requirement to use the ATP/MTP API.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
