### PR TITLE
Cherry-pick #20405 to 7.x: Upgrade elasticsearch client library used in tests

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -8,7 +8,7 @@ docker-compose==1.25.3
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
-elasticsearch==7.1.0
+elasticsearch==7.8.1
 enum34==1.1.6
 idna==2.6
 ipaddress==1.0.19

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -24,7 +24,7 @@ class Test(metricbeat.BaseTest):
     def setUp(self):
         super(Test, self).setUp()
         self.es = Elasticsearch(self.get_hosts())
-        self.ml_es = client.xpack.ml.MlClient(self.es)
+        self.ml_es = client.ml.MlClient(self.es)
 
         es_version = self.get_version()
         if es_version["major"] < 7:


### PR DESCRIPTION
Cherry-pick of PR #20405 to 7.x branch. Original message: 

## What does this PR do?

Upgrade elasticsearch client library used in python tests.

## Why is it important?

Old version uses deprecated Python functions that will be removed in Python 3.9.

## Related issues

- Relates to #20384