### PR TITLE
Make implementing Close required by reader.Reader

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -51,7 +51,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `common.MapStrPointer` parameter from `cfgfile.Runnerfactory` interface. {pull}19135[19135]
 - Replace `ACKCount`, `ACKEvents`, and `ACKLastEvent` callbacks with `ACKHandler` and interface in `beat.ClientConfig`. {pull}19632[19632]
 - Remove global ACK handler support via `SetACKHandler` from publisher pipeline. {pull}19632[19632]
-- Make implementing `Close` for `reader.Reader` interfaces. {pull}20455[20455] 
+- Make implementing `Close` required for `reader.Reader` interfaces. {pull}20455[20455]
 
 ==== Bugfixes
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -51,6 +51,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `common.MapStrPointer` parameter from `cfgfile.Runnerfactory` interface. {pull}19135[19135]
 - Replace `ACKCount`, `ACKEvents`, and `ACKLastEvent` callbacks with `ACKHandler` and interface in `beat.ClientConfig`. {pull}19632[19632]
 - Remove global ACK handler support via `SetACKHandler` from publisher pipeline. {pull}19632[19632]
+- Make implementing `Close` for `reader.Reader` interfaces. {pull}20455[20455] 
 
 ==== Bugfixes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -520,6 +520,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for custom header and headersecret for filebeat http_endpoint input {pull}20435[20435]
 - Add event.ingested to all Filebeat modules. {pull}20386[20386]
 - Return error when log harvester tries to open a named pipe. {issue}18682[18682] {pull}20450[20450]
+- Avoid goroutine leaks in Filebeat readers. {issue}19193[19193] {pull}20455[20455]
 
 
 *Heartbeat*

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -291,7 +291,7 @@ func (h *Harvester) Run() error {
 		}
 
 		h.stop()
-		h.log.Close()
+		h.reader.Close()
 	}(h.state.Source)
 
 	logp.Info("Harvester started for file: %s", h.state.Source)

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -291,7 +291,10 @@ func (h *Harvester) Run() error {
 		}
 
 		h.stop()
-		h.reader.Close()
+		err := h.reader.Close()
+		if err != nil {
+			logp.Err("Failed to stop harvester for file %s: %v", h.state.Source, err)
+		}
 	}(h.state.Source)
 
 	logp.Info("Harvester started for file: %s", h.state.Source)

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -208,7 +208,8 @@ func (f *Log) wait() {
 }
 
 // Close closes the done channel but no th the file handler
-func (f *Log) Close() {
+func (f *Log) Close() error {
 	close(f.done)
 	// Note: File reader is not closed here because that leads to race conditions
+	return nil
 }

--- a/libbeat/reader/multiline/counter.go
+++ b/libbeat/reader/multiline/counter.go
@@ -131,3 +131,7 @@ func (cr *counterReader) resetState() {
 func (cr *counterReader) setState(next func(cr *counterReader) (reader.Message, error)) {
 	cr.state = next
 }
+
+func (cr *counterReader) Close() error {
+	return cr.reader.Close()
+}

--- a/libbeat/reader/multiline/counter.go
+++ b/libbeat/reader/multiline/counter.go
@@ -18,6 +18,8 @@
 package multiline
 
 import (
+	"io"
+
 	"github.com/elastic/beats/v7/libbeat/reader"
 )
 
@@ -133,5 +135,10 @@ func (cr *counterReader) setState(next func(cr *counterReader) (reader.Message, 
 }
 
 func (cr *counterReader) Close() error {
+	cr.setState((*counterReader).readClosed)
 	return cr.reader.Close()
+}
+
+func (cr *counterReader) readClosed() (reader.Message, error) {
+	return reader.Message{}, io.EOF
 }

--- a/libbeat/reader/multiline/multiline_test.go
+++ b/libbeat/reader/multiline/multiline_test.go
@@ -22,6 +22,7 @@ package multiline
 import (
 	"bytes"
 	"errors"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -375,7 +376,7 @@ func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg Config) reade
 	}
 
 	var r reader.Reader
-	r, err = readfile.NewEncodeReader(in, readfile.Config{
+	r, err = readfile.NewEncodeReader(ioutil.NopCloser(in), readfile.Config{
 		Codec:      enc,
 		BufferSize: 4096,
 		Terminator: readfile.LineFeed,

--- a/libbeat/reader/multiline/pattern.go
+++ b/libbeat/reader/multiline/pattern.go
@@ -20,6 +20,7 @@ package multiline
 import (
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/match"
@@ -255,7 +256,12 @@ func (pr *patternReader) setState(next func(pr *patternReader) (reader.Message, 
 }
 
 func (pr *patternReader) Close() error {
+	pr.setState((*patternReader).readClosed)
 	return pr.reader.Close()
+}
+
+func (pr *patternReader) readClosed() (reader.Message, error) {
+	return reader.Message{}, io.EOF
 }
 
 // matchers

--- a/libbeat/reader/multiline/pattern.go
+++ b/libbeat/reader/multiline/pattern.go
@@ -254,6 +254,10 @@ func (pr *patternReader) setState(next func(pr *patternReader) (reader.Message, 
 	pr.state = next
 }
 
+func (pr *patternReader) Close() error {
+	return pr.reader.Close()
+}
+
 // matchers
 func afterMatcher(pat match.Matcher) (matcher, error) {
 	return genPatternMatcher(pat, func(last, current []byte) []byte {

--- a/libbeat/reader/multiline/while.go
+++ b/libbeat/reader/multiline/while.go
@@ -18,6 +18,8 @@
 package multiline
 
 import (
+	"io"
+
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/reader"
@@ -225,5 +227,10 @@ func negatedLineMatcher(m lineMatcherFunc) lineMatcherFunc {
 }
 
 func (pr *whilePatternReader) Close() error {
+	pr.setState((*whilePatternReader).readClosed)
 	return pr.reader.Close()
+}
+
+func (pr *whilePatternReader) readClosed() (reader.Message, error) {
+	return reader.Message{}, io.EOF
 }

--- a/libbeat/reader/multiline/while.go
+++ b/libbeat/reader/multiline/while.go
@@ -223,3 +223,7 @@ func negatedLineMatcher(m lineMatcherFunc) lineMatcherFunc {
 		return !m(content)
 	}
 }
+
+func (pr *whilePatternReader) Close() error {
+	return pr.reader.Close()
+}

--- a/libbeat/reader/reader.go
+++ b/libbeat/reader/reader.go
@@ -19,6 +19,7 @@ package reader
 
 import (
 	"errors"
+	"io"
 )
 
 // Reader is the interface that wraps the basic Next method for
@@ -26,6 +27,7 @@ import (
 // Next returns the message being read or and error. EOF is returned
 // if reader will not return any new message on subsequent calls.
 type Reader interface {
+	io.Closer
 	Next() (Message, error)
 }
 

--- a/libbeat/reader/readfile/encode.go
+++ b/libbeat/reader/readfile/encode.go
@@ -43,7 +43,7 @@ type Config struct {
 
 // New creates a new Encode reader from input reader by applying
 // the given codec.
-func NewEncodeReader(r io.Reader, config Config) (EncoderReader, error) {
+func NewEncodeReader(r io.ReadCloser, config Config) (EncoderReader, error) {
 	eReader, err := NewLineReader(r, config)
 	return EncoderReader{eReader}, err
 }
@@ -58,4 +58,8 @@ func (r EncoderReader) Next() (reader.Message, error) {
 		Content: bytes.Trim(c, "\xef\xbb\xbf"),
 		Bytes:   sz,
 	}, err
+}
+
+func (r EncoderReader) Close() error {
+	return r.reader.Close()
 }

--- a/libbeat/reader/readfile/encode_test.go
+++ b/libbeat/reader/readfile/encode_test.go
@@ -19,6 +19,7 @@ package readfile
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,7 @@ func TestEncodeLines(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			r := bytes.NewReader(testCase.Input)
+			r := ioutil.NopCloser(bytes.NewReader(testCase.Input))
 			codec, err := encFactory(r)
 			assert.Nil(t, err, "failed to initialize encoding: %v", err)
 

--- a/libbeat/reader/readfile/limit.go
+++ b/libbeat/reader/readfile/limit.go
@@ -49,3 +49,7 @@ func (r *LimitReader) Next() (reader.Message, error) {
 	}
 	return message, err
 }
+
+func (r *LimitReader) Close() error {
+	return r.reader.Close()
+}

--- a/libbeat/reader/readfile/limit_test.go
+++ b/libbeat/reader/readfile/limit_test.go
@@ -37,6 +37,8 @@ func (m *mockReader) Next() (reader.Message, error) {
 	}, nil
 }
 
+func (m *mockReader) Close() error { return nil }
+
 var limitTests = []struct {
 	line      string
 	maxBytes  int

--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -34,7 +34,7 @@ const unlimited = 0
 // using the configured codec. The reader keeps track of bytes consumed
 // from raw input stream for every decoded line.
 type LineReader struct {
-	reader     io.Reader
+	reader     io.ReadCloser
 	bufferSize int
 	maxBytes   int // max bytes per line limit to avoid OOM with malformatted files
 	nl         []byte
@@ -48,7 +48,7 @@ type LineReader struct {
 }
 
 // New creates a new reader object
-func NewLineReader(input io.Reader, config Config) (*LineReader, error) {
+func NewLineReader(input io.ReadCloser, config Config) (*LineReader, error) {
 	encoder := config.Codec.NewEncoder()
 
 	// Create newline char based on encoding
@@ -270,4 +270,8 @@ func (r *LineReader) decode(end int) (int, error) {
 
 	r.byteCount += start
 	return start, err
+}
+
+func (r *LineReader) Close() error {
+	return r.reader.Close()
 }

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"strings"
 	"testing"
@@ -97,7 +98,7 @@ func TestReaderEncodings(t *testing.T) {
 		}
 
 		// create line reader
-		reader, err := NewLineReader(buffer, Config{codec, 1024, LineFeed, unlimited})
+		reader, err := NewLineReader(ioutil.NopCloser(buffer), Config{codec, 1024, LineFeed, unlimited})
 		if err != nil {
 			t.Fatal("failed to initialize reader:", err)
 		}
@@ -157,7 +158,7 @@ func TestLineTerminators(t *testing.T) {
 		buffer.Write([]byte("this is my second line"))
 		buffer.Write(nl)
 
-		reader, err := NewLineReader(buffer, Config{codec, 1024, terminator, unlimited})
+		reader, err := NewLineReader(ioutil.NopCloser(buffer), Config{codec, 1024, terminator, unlimited})
 		if err != nil {
 			t.Errorf("failed to initialize reader: %v", err)
 			continue
@@ -229,7 +230,7 @@ func testReadLines(t *testing.T, inputLines [][]byte) {
 	// initialize reader
 	buffer := bytes.NewBuffer(inputStream)
 	codec, _ := encoding.Plain(buffer)
-	reader, err := NewLineReader(buffer, Config{codec, buffer.Len(), LineFeed, unlimited})
+	reader, err := NewLineReader(ioutil.NopCloser(buffer), Config{codec, buffer.Len(), LineFeed, unlimited})
 	if err != nil {
 		t.Fatalf("Error initializing reader: %v", err)
 	}
@@ -349,7 +350,7 @@ func TestMaxBytesLimit(t *testing.T) {
 	}
 
 	// Create line reader
-	reader, err := NewLineReader(strings.NewReader(input), Config{codec, bufferSize, LineFeed, lineMaxLimit})
+	reader, err := NewLineReader(ioutil.NopCloser(strings.NewReader(input)), Config{codec, bufferSize, LineFeed, lineMaxLimit})
 	if err != nil {
 		t.Fatal("failed to initialize reader:", err)
 	}

--- a/libbeat/reader/readfile/strip_newline.go
+++ b/libbeat/reader/readfile/strip_newline.go
@@ -81,3 +81,7 @@ func (p *StripNewline) autoLineEndingChars(l []byte) int {
 	}
 	return 1
 }
+
+func (p *StripNewline) Close() error {
+	return p.reader.Close()
+}

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -92,7 +92,7 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 	case <-timer.C:
 		return reader.Message{}, r.signal
 	case <-r.done:
-		return reader.Message{}, nil
+		return reader.Message{}, io.EOF
 	}
 }
 

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -19,6 +19,7 @@ package readfile
 
 import (
 	"errors"
+	"io"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/reader"

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -75,7 +75,7 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 					return
 				case r.ch <- lineMessage{message, err}:
 					if err != nil {
-						break
+						return
 					}
 				}
 			}

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -69,11 +69,11 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 		r.running = true
 		go func() {
 			for {
+				message, err := r.reader.Next()
 				select {
 				case <-r.done:
 					return
-				case message, err := r.reader.Next():
-					r.ch <- lineMessage{message, err}
+				case r.ch <- lineMessage{message, err}:
 					if err != nil {
 						break
 					}

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -72,12 +72,11 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 				select {
 				case <-r.done:
 					return
-				default:
-				}
-				message, err := r.reader.Next()
-				r.ch <- lineMessage{message, err}
-				if err != nil {
-					break
+				case message, err := r.reader.Next():
+					r.ch <- lineMessage{message, err}
+					if err != nil {
+						break
+					}
 				}
 			}
 		}()

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -244,3 +244,7 @@ func stripNewLineWin(msg *reader.Message) {
 		return r == '\n' || r == '\r'
 	})
 }
+
+func (p *DockerJSONReader) Close() error {
+	return p.reader.Close()
+}

--- a/libbeat/reader/readjson/docker_json_test.go
+++ b/libbeat/reader/readjson/docker_json_test.go
@@ -365,3 +365,5 @@ func (m *mockReader) Next() (reader.Message, error) {
 		Bytes:   len(message),
 	}, nil
 }
+
+func (m *mockReader) Close() error { return nil }

--- a/libbeat/reader/readjson/json.go
+++ b/libbeat/reader/readjson/json.go
@@ -111,6 +111,10 @@ func (r *JSONReader) Next() (reader.Message, error) {
 	return message, nil
 }
 
+func (r *JSONReader) Close() error {
+	return r.reader.Close()
+}
+
 func createJSONError(message string) common.MapStr {
 	return common.MapStr{"message": message, "type": "json"}
 }


### PR DESCRIPTION
## What does this PR do?

This PR changes the `reader.Reader` interface to require readers implement a `Close` function.

## Why is it important?

This lets Filebeat clean-up the goroutine in `TimeoutReader`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #19193
