### PR TITLE
[Filebeat][nosetests] Printing error message when test_modules.py returns an error message from ES

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -165,8 +165,8 @@ class Test(BaseTest):
             # the event was ingested to Elasticsearch
             assert "ingested" in obj["event"], "missing event.ingested timestamp"
 
-            assert "error" not in obj, "not error expected but got: {}".format(
-                obj)
+            assert "error" not in obj, "not error expected but got: {}.\n The related error message is: {}".format(
+                obj, obj["error"]["message"])
 
             if (module == "auditd" and fileset == "log") \
                     or (module == "osquery" and fileset == "result"):

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -166,7 +166,7 @@ class Test(BaseTest):
             assert "ingested" in obj["event"], "missing event.ingested timestamp"
 
             assert "error" not in obj, "not error expected but got: {}.\n The related error message is: {}".format(
-                obj, obj["error"]["message"])
+                obj, obj["error"].get("message"))
 
             if (module == "auditd" and fileset == "log") \
                     or (module == "osquery" and fileset == "result"):


### PR DESCRIPTION
## What does this PR do?

When working a lot with pipelines and continously run nosetests, if one of the test logs for a module returns an error it only prints the whole JSON. In large documents trying to find the error message over and over again can be tedious.

This PR adds a second line, printing only the error message as well.

Is this something we could add in? Would it break any sort of other tests that might expect a specific amount of lines back?

## Why is it important?

Quality of life addition.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Example output with the changes:
```
FAIL: test_fileset_file_8_zoom (test_xpack_modules.XPackTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/marius/go/src/github.com/P1llus/beats/x-pack/filebeat/venv/lib/python3.8/site-packages/parameterized/parameterized.py", line 531, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/home/marius/go/src/github.com/P1llus/beats/x-pack/filebeat/tests/system/../../../../filebeat/tests/system/test_modules.py", line 95, in test_fileset_file
    self.run_on_file(
  File "/home/marius/go/src/github.com/P1llus/beats/x-pack/filebeat/tests/system/../../../../filebeat/tests/system/test_modules.py", line 164, in run_on_file
    assert "error" not in obj, "not error expected but got: {}.\n The related error message is: {}".format(
AssertionError: not error expected but got: {'agent': {'name': 'Hades', 'id': '30daf028-e321-4a1c-82e2-8d43a59b5e50', 'type': 'filebeat', 'ephemeral_id': '833dbed7-c419-490c-a222-f2ac88622acc', 'version': '8.0.0'}, 'log': {'file': {'path': '/home/marius/go/src/github.com/P1llus/beats/x-pack/filebeat/module/zoom/webhook/test/meeting.ndjson.log'}, 'offset': 0}, 'zoom': {'meeting': {'duration': 60, 'start_time': '2019-07-16T17:14:39Z', 'timezone': 'America/Los_Angeles', 'topic': 'My Meeting', 'id': '6962400003', 'type': 2, 'uuid': '4118UHIiRCAAAtBlDkcVyw==', 'issues': 'Unstable audio quality', 'host_id': 'z8yCxTTTTSiw02QgCAp8uQ'}}, 'fileset': {'name': 'webhook'}, 'error': {'message': 'Cannot cast java.lang.Integer to java.lang.String'}, 'tags': ['zoom-webhook', 'forwarded'], 'input': {'type': 'log'}, 'observer': {'product': 'Webhook', 'vendor': 'Zoom'}, '@timestamp': '2020-08-05T23:56:03.503Z', 'ecs': {'version': '1.5.0'}, 'related': {'user': ['z8yCxTTTTSiw02QgCAp8uQ']}, 'service': {'type': 'zoom'}, 'event': {'ingested': '2020-08-05T23:56:04.613450Z', 'timezone': '-02:00', 'kind': ['event'], 'module': 'zoom', 'action': 'meeting.alert', 'type': ['error'], 'dataset': 'zoom.webhook'}}.
 The related error message is: Cannot cast java.lang.Integer to java.lang.String
```


