### PR TITLE
Cherry-pick to 7.x: [docs] Promote ingest management to beta (#20295)

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Command line options
 
-experimental[]
+beta[]
 
 The `elastic-agent run` command provides flags that alter the behavior of an
 agent:

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Configuration example
 
-experimental[]
+beta[]
 
 The following example shows a full list of configuration options:
 

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Configuration settings
 
-experimental[]
+beta[]
 
 By default {agent} runs in standalone mode to ingest system data and send it to
 a local {es} instance running on port 9200. It uses the demo credentials of the

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -3,7 +3,7 @@
 
 = Manage your {agent}s
 
-experimental[]
+beta[]
 
 // tag::agent-install-intro[]
 {agent} is a single, unified agent that you can deploy to hosts or containers to

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Install {agent}
 
-experimental[]
+beta[]
 
 Download and install the Agent on each system you want to monitor.
 

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Run {agent}
 
-experimental[]
+beta[]
 
 {agent} runs in two modes: standalone or fleet. The two modes differ in how you
 configure and manage the Agent.

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -5,8 +5,6 @@
 To stop {agent} and its related executables, stop the {agent} process. Use the
 commands that work for your system. 
 
-//TODO: Replace with tabbed panel when it's out of experimental phase.
-
 *Windows:*
 
 If you installed the Agent as a service, stop the service. If


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Promote ingest management to beta (#20295)