### PR TITLE
[CI] runbld project name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1422,22 +1422,15 @@ def junitAndStore(Map params = [:]){
 def runbld() {
   catchError(buildResult: 'SUCCESS', message: 'runbld post build action failed.') {
     if (stashedTestReports) {
-      def jobName = 'elastic+beats'
-      if (isPR()) {
-        jobName = 'elastic+beats+pull-request'
-      }
+      def jobName = isPR() ? 'elastic+beats+pull-request' : 'elastic+beats'
       deleteDir()
       unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-      // Unstash the test reports
-      stashedTestReports.each { k, v ->
-        dir(k) {
-          unstash(v)
-        }
-      }
-      // Unstash the test reports
-      stashedTestReports.each { k, v ->
-        dir(k) {
-          unstash(v)
+      dir("${env.BASE_DIR}") {
+        // Unstash the test reports
+        stashedTestReports.each { k, v ->
+          dir(k) {
+            unstash(v)
+          }
         }
       }
       sh(label: 'Process JUnit reports with runbld',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1422,11 +1422,14 @@ def junitAndStore(Map params = [:]){
 def runbld() {
   catchError(buildResult: 'SUCCESS', message: 'runbld post build action failed.') {
     if (stashedTestReports) {
-      def jobName = 'elastic+beats-new'
+      def jobName = 'elastic+beats'
+      // TODO: change ansible/roles/runbld/templates/runbld.conf.j2
+      def where = ''
       if (isPR()) {
-        jobName = 'elastic+beats-new+pull-request'
+        jobName = 'elastic+beats+pull-request'
+        where = env.BASE_DIR
       }
-      dir("${env.BASE_DIR}") {
+      dir("${where}") {
         sh(label: 'Prepare workspace context',
            script: 'find . -type f -name "TEST*.xml" -path "*/build/*" -delete')
         // Unstash the test reports

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1422,6 +1422,10 @@ def junitAndStore(Map params = [:]){
 def runbld() {
   catchError(buildResult: 'SUCCESS', message: 'runbld post build action failed.') {
     if (stashedTestReports) {
+      def jobName = 'elastic+beats-new'
+      if (isPR()) {
+        jobName = 'elastic+beats-new+pull-request'
+      }
       dir("${env.BASE_DIR}") {
         sh(label: 'Prepare workspace context',
            script: 'find . -type f -name "TEST*.xml" -path "*/build/*" -delete')
@@ -1432,12 +1436,12 @@ def runbld() {
           }
         }
         sh(label: 'Process JUnit reports with runbld',
-          script: '''\
+          script: """\
           cat >./runbld-script <<EOF
           echo "Processing JUnit reports with runbld..."
           EOF
-          /usr/local/bin/runbld ./runbld-script
-          '''.stripIndent())  // stripIdent() requires '''/
+          /usr/local/bin/runbld ./runbld-script --job-name ${jobName}
+          """.stripIndent())  // stripIdent() requires '''/
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Set the project name when running the runbld post-build stage otherwise the project and organisation fields are empty.

## Why is it important?

Because the current implementation does not populate certain fields that are required to keep the dashboards intact and therefore don't change the people's process to monitor the build status

## Tests

![image](https://user-images.githubusercontent.com/2871786/89754642-041f2900-dadd-11ea-9d1e-946ebd323b92.png)

![image](https://user-images.githubusercontent.com/2871786/89754733-42b4e380-dadd-11ea-9c37-74a62122a949.png)

