### PR TITLE
Cherry-pick to 7.x: feat(ci): support building docker images for PRs (#20323)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -190,7 +190,7 @@ def tagAndPush(name){
   }
 
   def tagName = "${libbetaVer}"
-  if (env.CHANGE_ID?.trim()) {
+  if (isPR()) {
     tagName = "pr-${env.CHANGE_ID}"
   }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -188,8 +188,14 @@ def tagAndPush(name){
   if("${env.SNAPSHOT}" == "true"){
     libbetaVer += "-SNAPSHOT"
   }
+
+  def tagName = "${libbetaVer}"
+  if (env.CHANGE_ID?.trim()) {
+    tagName = "pr-${env.CHANGE_ID}"
+  }
+
   def oldName = "${DOCKER_REGISTRY}/beats/${name}:${libbetaVer}"
-  def newName = "${DOCKER_REGISTRY}/observability-ci/${name}:${libbetaVer}"
+  def newName = "${DOCKER_REGISTRY}/observability-ci/${name}:${tagName}"
   def commitName = "${DOCKER_REGISTRY}/observability-ci/${name}:${env.GIT_BASE_COMMIT}"
   dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
   retry(3){


### PR DESCRIPTION
Backports the following commits to 7.x:
 - feat(ci): support building docker images for PRs (#20323)