### PR TITLE
Cherry-pick #20454 to 7.8: [Filebeat] Fix Okta ingest pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -132,7 +132,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bug with empty filter values in system/service {pull}19812[19812]
 - Fix millisecond timestamp normalization issues in CrowdStrike module {issue}20035[20035], {pull}20138[20138]
 - Fix support for message code 106100 in Cisco ASA and FTD. {issue}19350[19350] {pull}20245[20245]
-- Fix `fortinet` setting `event.timezone` to the system one when no `tz` field present {pull}20273[20273]
 - Fix `okta` geoip lookup in pipeline for `destination.ip` {pull}20454[20454]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -132,6 +132,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bug with empty filter values in system/service {pull}19812[19812]
 - Fix millisecond timestamp normalization issues in CrowdStrike module {issue}20035[20035], {pull}20138[20138]
 - Fix support for message code 106100 in Cisco ASA and FTD. {issue}19350[19350] {pull}20245[20245]
+- Fix `fortinet` setting `event.timezone` to the system one when no `tz` field present {pull}20273[20273]
+- Fix `okta` geoip lookup in pipeline for `destination.ip` {pull}20454[20454]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
@@ -1,6 +1,9 @@
 description: Pipeline for Okta system logs.
 
 processors:
+  - set:
+      field: event.ingested
+      value: "{{_ingest.timestamp}}"
   - user_agent:
       field: user_agent.original
       ignore_missing: true
@@ -10,7 +13,7 @@ processors:
       ignore_missing: true
   - geoip:
       field: destination.ip
-      target_field: source.geo
+      target_field: destination.geo
       ignore_missing: true
   - geoip:
       database_file: GeoLite2-ASN.mmdb
@@ -48,4 +51,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: "{{ _ingest.on_failure_message }}"

--- a/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
@@ -1,9 +1,6 @@
 description: Pipeline for Okta system logs.
 
 processors:
-  - set:
-      field: event.ingested
-      value: "{{_ingest.timestamp}}"
   - user_agent:
       field: user_agent.original
       ignore_missing: true


### PR DESCRIPTION
Cherry-pick of PR #20454 to 7.8 branch. Original message: 

## What does this PR do?

The okta pipeline was clobbering geo ip data for the source by accidentally overwriting it with the result of a lookup on `destination.ip` this fixes the field

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.