### PR TITLE
Cherry-pick #20459 to 7.9: [Filebeat][o365 documentation] fixing typo in o365 input documentation

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-o365audit.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-o365audit.asciidoc
@@ -38,6 +38,7 @@ Example configuration:
 
 Multi-tenancy and certificate-based authentication is also supported:
 
+["source","yaml",subs="attributes"]
 ----
 {beatname_lc}.inputs:
 - type: o365audit


### PR DESCRIPTION
Cherry-pick of PR #20459 to 7.9 branch. Original message: 

## What does this PR do?

Configuration example in o365 input documentation was missing the source reference, so the config was not correctly formatted

## Why is it important?

Fixes documentation visualization error.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

