### PR TITLE
Cherry-pick #20469 to 7.9: Fix cisco asa/ftd parsing of msgs 106102/106103

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,6 +134,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `fortinet` setting `event.timezone` to the system one when no `tz` field present {pull}20273[20273]
 - Fix `okta` geoip lookup in pipeline for `destination.ip` {pull}20454[20454]
 - Fix mapping exception in the `googlecloud/audit` dataset pipeline. {issue}18465[18465] {pull}20465[20465]
+- Fix `cisco` asa and ftd parsing of messages 106102 and 106103. {pull}20469[20469]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log
@@ -7,3 +7,5 @@ Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134,
 Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8
 Oct 20 2019 15:42:53: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]
 Oct 20 2019 15:42:54: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\username) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]
+Aug  6 2020 11:01:37: %ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -> inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]
+Aug  6 2020 11:01:38: %ASA-1-106103: access-list filter denied icmp for user joe inside/10.1.2.3(64321) -> outside/1.2.33.40(8080) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]

--- a/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/asa-fix.log-expected.json
@@ -385,5 +385,106 @@
             "cisco-asa",
             "forwarded"
         ]
+    },
+    {
+        "cisco.asa.destination_interface": "inside",
+        "cisco.asa.message_id": "106102",
+        "cisco.asa.rule_name": "dev_inward_client",
+        "cisco.asa.source_interface": "outside",
+        "cisco.asa.suffix": "session",
+        "destination.address": "10.223.223.40",
+        "destination.ip": "10.223.223.40",
+        "destination.port": 53,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 106102,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -> inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
+        "event.outcome": "allow",
+        "event.severity": 3,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info",
+            "allowed"
+        ],
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.level": "error",
+        "log.offset": 1514,
+        "network.iana_number": 17,
+        "network.transport": "udp",
+        "related.ip": [
+            "10.123.123.20",
+            "10.223.223.40"
+        ],
+        "related.user": [
+            "redacted"
+        ],
+        "service.type": "cisco",
+        "source.address": "10.123.123.20",
+        "source.ip": "10.123.123.20",
+        "source.port": 49721,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ],
+        "user.name": "redacted"
+    },
+    {
+        "cisco.asa.destination_interface": "outside",
+        "cisco.asa.message_id": "106103",
+        "cisco.asa.rule_name": "filter",
+        "cisco.asa.source_interface": "inside",
+        "destination.address": "1.2.33.40",
+        "destination.geo.continent_name": "Asia",
+        "destination.geo.country_iso_code": "CN",
+        "destination.geo.location.lat": 23.1167,
+        "destination.geo.location.lon": 113.25,
+        "destination.geo.region_iso_code": "CN-GD",
+        "destination.geo.region_name": "Guangdong",
+        "destination.ip": "1.2.33.40",
+        "destination.port": 8080,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 106103,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-1-106103: access-list filter denied icmp for user joe inside/10.1.2.3(64321) -> outside/1.2.33.40(8080) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
+        "event.outcome": "deny",
+        "event.severity": 1,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info",
+            "denied"
+        ],
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.level": "alert",
+        "log.offset": 1723,
+        "network.iana_number": 1,
+        "network.transport": "icmp",
+        "related.ip": [
+            "10.1.2.3",
+            "1.2.33.40"
+        ],
+        "related.user": [
+            "joe"
+        ],
+        "service.type": "cisco",
+        "source.address": "10.1.2.3",
+        "source.ip": "10.1.2.3",
+        "source.port": 64321,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ],
+        "user.name": "joe"
     }
 ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -255,13 +255,9 @@ processors:
       field: "message"
       pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
   - dissect:
-      if: "ctx._temp_.cisco.message_id == '106102'"
+      if: "ctx._temp_.cisco.message_id == '106102' || ctx._temp_.cisco.message_id == '106103'"
       field: "message"
-      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} for user %{_temp_.cisco.username} %{_temp_.cisco.source_interface}/%{source.address} %{source.port} %{_temp_.cisco.destination_interface}/%{destination.address} %{destination.port} %{}"
-  - dissect:
-      if: "ctx._temp_.cisco.message_id == '106103'"
-      field: "message"
-      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} for user %{_temp_.cisco.username} %{_temp_.cisco.source_interface}/%{source.address} %{source.port} %{_temp_.cisco.destination_interface}/%{destination.address} %{destination.port} %{}"
+      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} for user %{user.name} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '304001'"
       field: "message"


### PR DESCRIPTION
Cherry-pick of PR #20469 to 7.9 branch. Original message: 

## What does this PR do?

Updates the parsers for messages 106102 and 106103 in the shared Cisco asa/ftd pipeline.

## Why is it important?

The documentation on messages 106102 and 106103 didn't match the actual format used by devices. This is causing errors when trying to ingest those messages.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

The error this fixes:

```
(status=400): {
    "type":"mapper_parsing_exception",
    "reason":"failed to parse field [destination.port] of type [long] in document with id '4lFGv3MBi145cg_j1NOE'. Preview of field's value: 'hit-cnt'",
    "caused_by":{
      "type":"illegal_argument_exception",
      "reason":"For input string: \"hit-cnt\""
    }
  }
```