### PR TITLE
Update elasticsearch.asciidoc

### DIFF
--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -30,7 +30,7 @@ For example:
 ["source","yaml",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 output.elasticsearch:
-  hosts: ["https://myEShost:9200"]
+  hosts: ["http://myEShost:9200"]
   username: "{beat_default_index_prefix}_writer" <1>
   password: "{pwd}" <2>
 ----------------------------------------------------------------------

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -12,7 +12,7 @@ Example configuration:
 ["source","yaml",subs="attributes"]
 ----
 output.elasticsearch:
-  hosts: ["https://myEShost:9200"] <1>
+  hosts: ["http://myEShost:9200"] <1>
 ----
 <1> To enable SSL, add `https` to all URLs defined under __hosts__.
 
@@ -28,7 +28,7 @@ output, {beatname_uc} can use any of the following authentication methods:
 ["source","yaml",subs="attributes,callouts"]
 ----
 output.elasticsearch:
-  hosts: ["https://myEShost:9200"]
+  hosts: ["http://myEShost:9200"]
   username: "{beat_default_index_prefix}_writer"
   password: "{pwd}"
 ----


### PR DESCRIPTION
I changed `https` to `http` in the original and the Basic authentication example because `https` alone with `username` and `password` is not sufficient to authenticate. If one chooses `https`, they must either use API key authentication or PKI certificate authentication?

This is related to https://github.com/elastic/elasticsearch/pull/60857