### PR TITLE
Fix versions in requirements.txt for python 3.5 and 3.9

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -25,7 +25,6 @@ more-itertools==8.4.0
 ordered-set==3.1.1
 packaging==20.4
 parameterized==0.7.0
-Pillow==7.2.0
 pluggy==0.13.1
 py==1.9.0
 pycodestyle==2.4.0
@@ -45,4 +44,4 @@ toml==0.10.1
 urllib3==1.24.2
 wcwidth==0.2.5
 websocket-client==0.47.0
-zipp==3.1.0
+zipp>=1.2.0,<=3.1.0

--- a/script/check_python_requirements.sh
+++ b/script/check_python_requirements.sh
@@ -14,10 +14,10 @@ set -e
 
 function abspath() {
 	local path=$1
-	if [ -d $path ]; then
-		cd $path; pwd; cd - > /dev/null
+	if [ -d "$path" ]; then
+		cd "$path"; pwd; cd - > /dev/null
 	else
-		echo $(abspath $(dirname $path))/$(basename $path)
+		echo $(abspath "$(dirname "$path")")/$(basename "$path")
 	fi
 }
 
@@ -26,12 +26,12 @@ BEATS_PATH=$(abspath $(dirname ${BASH_SOURCE[0]})/..)
 VERSIONS=${VERSIONS:-3.5 3.6 3.7 3.8 3.9-rc}
 REQUIREMENTS=${1:-${BEATS_PATH}/libbeat/tests/system/requirements.txt}
 
-if [ ! -f $REQUIREMENTS ]; then
+if [ ! -f "$REQUIREMENTS" ]; then
 	echo "Requirements file doesn't exist: $REQUIREMENTS"
 	exit -1
 fi
 
-REQUIREMENTS=$(abspath $REQUIREMENTS)
+REQUIREMENTS=$(abspath "$REQUIREMENTS")
 
 echo "Versions: $VERSIONS"
 echo "Requirements file: $REQUIREMENTS"
@@ -39,7 +39,7 @@ echo "Requirements file: $REQUIREMENTS"
 for version in $VERSIONS; do
 	echo "==== Version: $version"
 
-	docker run -it --rm -v $REQUIREMENTS:/requirements.txt python:$version \
+	docker run -it --rm -v "$REQUIREMENTS":/requirements.txt python:$version \
 		python -m pip install -q -r /requirements.txt
 
 	echo "==== OK"

--- a/script/check_python_requirements.sh
+++ b/script/check_python_requirements.sh
@@ -21,7 +21,7 @@ function abspath() {
 	fi
 }
 
-BEATS_PATH=$(abspath $(dirname ${BASH_SOURCE[0]})/..)
+BEATS_PATH=$(abspath "$(dirname "${BASH_SOURCE[0]}")"/..)
 
 VERSIONS=${VERSIONS:-3.5 3.6 3.7 3.8 3.9-rc}
 REQUIREMENTS=${1:-${BEATS_PATH}/libbeat/tests/system/requirements.txt}

--- a/script/check_python_requirements.sh
+++ b/script/check_python_requirements.sh
@@ -12,7 +12,16 @@
 
 set -e
 
-BEATS_PATH=$(realpath $(dirname ${BASH_SOURCE[0]})/..)
+function abspath() {
+	local path=$1
+	if [ -d $path ]; then
+		cd $path; pwd; cd - > /dev/null
+	else
+		echo $(abspath $(dirname $path))/$(basename $path)
+	fi
+}
+
+BEATS_PATH=$(abspath $(dirname ${BASH_SOURCE[0]})/..)
 
 VERSIONS=${VERSIONS:-3.5 3.6 3.7 3.8 3.9-rc}
 REQUIREMENTS=${1:-${BEATS_PATH}/libbeat/tests/system/requirements.txt}
@@ -22,7 +31,7 @@ if [ ! -f $REQUIREMENTS ]; then
 	exit -1
 fi
 
-REQUIREMENTS=$(realpath $REQUIREMENTS)
+REQUIREMENTS=$(abspath $REQUIREMENTS)
 
 echo "Versions: $VERSIONS"
 echo "Requirements file: $REQUIREMENTS"

--- a/script/check_python_requirements.sh
+++ b/script/check_python_requirements.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Helper script to check that packages defined in a requirements.txt
+# file can be installed in different Python versions, it checks by
+# default the requirements.txt file for libbeat tests.
+#
+#    Usage: check_python_requirements.sh /path/to/requirements.txt
+#
+# VERSIONS environment variable can be set to a space-separated list
+# of versions of python to test with.
+#
+
+set -e
+
+BEATS_PATH=$(realpath $(dirname ${BASH_SOURCE[0]})/..)
+
+VERSIONS=${VERSIONS:-3.5 3.6 3.7 3.8 3.9-rc}
+REQUIREMENTS=${1:-${BEATS_PATH}/libbeat/tests/system/requirements.txt}
+
+if [ ! -f $REQUIREMENTS ]; then
+	echo "Requirements file doesn't exist: $REQUIREMENTS"
+	exit -1
+fi
+
+REQUIREMENTS=$(realpath $REQUIREMENTS)
+
+echo "Versions: $VERSIONS"
+echo "Requirements file: $REQUIREMENTS"
+
+for version in $VERSIONS; do
+	echo "==== Version: $version"
+
+	docker run -it --rm -v $REQUIREMENTS:/requirements.txt python:$version \
+		python -m pip install -q -r /requirements.txt
+
+	echo "==== OK"
+done


### PR DESCRIPTION
## What does this PR do?

Fix versions of packages in `requirements.txt` file so they can be installed in all python versions from 3.5 to 3.9.

Added a cleaned-up version of a one-liner I was using to check the `requirements.txt` file with different versions.

## Why is it important?

Packages listed in current `requirements.txt` file cannot be installed in python 3.5 and 3.9:
* Pillow package doesn't have a candidate for 3.9, it was removed in #20407, but added again by mistake in #16883.
* `zipp` package needed by `pytest` works with different versions depending the version of python, version that works with python 3.5 doesn't work with other versions.

We still need to support python 3.5 because it is used in some CI workers.