### PR TITLE
Cherry-pick #20281 to 7.x: Add leader election for autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -432,6 +432,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support to trim captured values in the dissect processor. {pull}19464[19464]
 - Added the `max_cached_sessions` option to the script processor. {pull}19562[19562]
 - Set index.max_docvalue_fields_search in index template to increase value to 200 fields. {issue}20215[20215]
+- Add leader election for Kubernetes autodiscover. {pull}20281[20281]
 - Add capability of enriching process metadata with contianer id also for non-privileged containers in `add_process_metadata` processor. {pull}19767[19767]
 
 *Auditbeat*

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -366,6 +366,12 @@ rules:
   - "/metrics"
   verbs:
   - get
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -32,3 +32,9 @@ rules:
   - "/metrics"
   verbs:
   - get
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - '*'

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	golang.org/x/tools v0.0.0-20200701041122-1837592efa10
+	golang.org/x/tools v0.0.0-20200806022845-90696ccdc692
 	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb
 	google.golang.org/grpc v1.29.1

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -83,7 +83,7 @@ func NewAutodiscover(
 	// Init providers
 	var providers []Provider
 	for _, providerCfg := range config.Providers {
-		provider, err := Registry.BuildProvider(bus, providerCfg, keystore)
+		provider, err := Registry.BuildProvider(name, bus, providerCfg, keystore)
 		if err != nil {
 			return nil, errors.Wrap(err, "error in autodiscover provider settings")
 		}

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -140,7 +140,7 @@ func TestAutodiscover(t *testing.T) {
 	// Register mock autodiscover provider
 	busChan := make(chan bus.Bus, 1)
 	Registry = NewRegistry()
-	Registry.AddProvider("mock", func(b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
+	Registry.AddProvider("mock", func(beatName string, b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
 		// intercept bus to mock events
 		busChan <- b
 
@@ -259,7 +259,7 @@ func TestAutodiscoverHash(t *testing.T) {
 	busChan := make(chan bus.Bus, 1)
 
 	Registry = NewRegistry()
-	Registry.AddProvider("mock", func(b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
+	Registry.AddProvider("mock", func(beatName string, b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
 		// intercept bus to mock events
 		busChan <- b
 
@@ -323,7 +323,7 @@ func TestAutodiscoverWithConfigCheckFailures(t *testing.T) {
 	// Register mock autodiscover provider
 	busChan := make(chan bus.Bus, 1)
 	Registry = NewRegistry()
-	Registry.AddProvider("mock", func(b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
+	Registry.AddProvider("mock", func(beatName string, b bus.Bus, uuid uuid.UUID, c *common.Config, k keystore.Keystore) (Provider, error) {
 		// intercept bus to mock events
 		busChan <- b
 

--- a/libbeat/autodiscover/provider.go
+++ b/libbeat/autodiscover/provider.go
@@ -35,7 +35,7 @@ type Provider interface {
 }
 
 // ProviderBuilder creates a new provider based on the given config and returns it
-type ProviderBuilder func(bus.Bus, uuid.UUID, *common.Config, keystore.Keystore) (Provider, error)
+type ProviderBuilder func(string, bus.Bus, uuid.UUID, *common.Config, keystore.Keystore) (Provider, error)
 
 // AddProvider registers a new ProviderBuilder
 func (r *registry) AddProvider(name string, provider ProviderBuilder) error {
@@ -70,7 +70,7 @@ func (r *registry) GetProvider(name string) ProviderBuilder {
 }
 
 // BuildProvider reads provider configuration and instantiate one
-func (r *registry) BuildProvider(bus bus.Bus, c *common.Config, keystore keystore.Keystore) (Provider, error) {
+func (r *registry) BuildProvider(beatName string, bus bus.Bus, c *common.Config, keystore keystore.Keystore) (Provider, error) {
 	var config ProviderConfig
 	err := c.Unpack(&config)
 	if err != nil {
@@ -87,5 +87,5 @@ func (r *registry) BuildProvider(bus bus.Bus, c *common.Config, keystore keystor
 		return nil, err
 	}
 
-	return builder(bus, uuid, c, keystore)
+	return builder(beatName, bus, uuid, c, keystore)
 }

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -59,7 +59,13 @@ type Provider struct {
 }
 
 // AutodiscoverBuilder builds and returns an autodiscover provider
-func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config, keystore keystore.Keystore) (autodiscover.Provider, error) {
+func AutodiscoverBuilder(
+	beatName string,
+	bus bus.Bus,
+	uuid uuid.UUID,
+	c *common.Config,
+	keystore keystore.Keystore,
+) (autodiscover.Provider, error) {
 	logger := logp.NewLogger("docker")
 
 	errWrap := func(err error) error {

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -56,7 +56,7 @@ func TestDockerStart(t *testing.T) {
 	s := &template.MapperSettings{nil, nil}
 	config.Templates = *s
 	k, _ := keystore.NewFileKeystore("test")
-	provider, err := AutodiscoverBuilder(bus, UUID, common.MustNewConfigFrom(config), k)
+	provider, err := AutodiscoverBuilder("mockBeat", bus, UUID, common.MustNewConfigFrom(config), k)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/autodiscover/providers/jolokia/jolokia.go
+++ b/libbeat/autodiscover/providers/jolokia/jolokia.go
@@ -53,7 +53,13 @@ type Provider struct {
 
 // AutodiscoverBuilder builds a Jolokia Discovery autodiscover provider, it fails if
 // there is some problem with the configuration
-func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config, keystore keystore.Keystore) (autodiscover.Provider, error) {
+func AutodiscoverBuilder(
+	beatName string,
+	bus bus.Bus,
+	uuid uuid.UUID,
+	c *common.Config,
+	keystore keystore.Keystore,
+) (autodiscover.Provider, error) {
 	errWrap := func(err error) error {
 		return errors.Wrap(err, "error setting up jolokia autodiscover provider")
 	}

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -44,6 +44,9 @@ type Config struct {
 	// Scope can be either node or cluster.
 	Scope    string `config:"scope"`
 	Resource string `config:"resource"`
+	// Unique identifies if this provider enables its templates only when it is elected as leader in a k8s cluster
+	Unique      bool   `config:"unique"`
+	LeaderLease string `config:"leader_lease"`
 
 	Prefix    string                  `config:"prefix"`
 	Hints     *common.Config          `config:"hints"`
@@ -60,6 +63,7 @@ func defaultConfig() *Config {
 		Resource:       "pod",
 		CleanupTimeout: 60 * time.Second,
 		Prefix:         "co.elastic",
+		Unique:         false,
 	}
 }
 
@@ -97,6 +101,9 @@ func (c *Config) Validate() error {
 
 	if c.Scope != "node" && c.Scope != "cluster" {
 		return fmt.Errorf("invalid `scope` configured. supported values are `node` and `cluster`")
+	}
+	if c.Unique && c.Scope != "cluster" {
+		logp.L().Warnf("can only set `unique` when scope is `cluster`")
 	}
 
 	return nil

--- a/libbeat/autodiscover/providers/kubernetes/node_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/node_test.go
@@ -246,8 +246,9 @@ func TestEmitEvent_Node(t *testing.T) {
 			}
 
 			metaGen := metadata.NewNodeMetadataGenerator(common.NewConfig(), nil)
+			config := defaultConfig()
 			p := &Provider{
-				config:    defaultConfig(),
+				config:    config,
 				bus:       bus.New(logp.NewLogger("bus"), "test"),
 				templates: mapper,
 				logger:    logp.NewLogger("kubernetes"),
@@ -261,7 +262,7 @@ func TestEmitEvent_Node(t *testing.T) {
 				logger:  logp.NewLogger("kubernetes.no"),
 			}
 
-			p.eventer = no
+			p.eventManager = NewMockNodeEventerManager(no)
 
 			listener := p.bus.Subscribe()
 
@@ -277,6 +278,12 @@ func TestEmitEvent_Node(t *testing.T) {
 			}
 		})
 	}
+}
+
+func NewMockNodeEventerManager(no *node) EventManager {
+	em := &eventerManager{}
+	em.eventer = no
+	return em
 }
 
 func TestNode_isUpdated(t *testing.T) {

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -1013,7 +1013,7 @@ func TestEmitEvent(t *testing.T) {
 				logger:  logp.NewLogger("kubernetes.pod"),
 			}
 
-			p.eventer = pod
+			p.eventManager = NewMockPodEventerManager(pod)
 
 			listener := p.bus.Subscribe()
 
@@ -1032,6 +1032,12 @@ func TestEmitEvent(t *testing.T) {
 
 		})
 	}
+}
+
+func NewMockPodEventerManager(pod *pod) EventManager {
+	em := &eventerManager{}
+	em.eventer = pod
+	return em
 }
 
 func getNestedAnnotations(in common.MapStr) common.MapStr {

--- a/libbeat/autodiscover/providers/kubernetes/service_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/service_test.go
@@ -414,8 +414,7 @@ func TestEmitEvent_Service(t *testing.T) {
 				logger:  logp.NewLogger("kubernetes.service"),
 			}
 
-			p.eventer = service
-
+			p.eventManager = NewMockServiceEventerManager(service)
 			listener := p.bus.Subscribe()
 
 			service.emit(test.Service, test.Flag)
@@ -430,4 +429,10 @@ func TestEmitEvent_Service(t *testing.T) {
 			}
 		})
 	}
+}
+
+func NewMockServiceEventerManager(svc *service) EventManager {
+	em := &eventerManager{}
+	em.eventer = svc
+	return em
 }

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -241,6 +241,38 @@ running configuration for a container, 60s by default.
           include_labels: ["nodelabel2"]
 -------------------------------------------------------------------------------------
 
+`unique`:: (Optional) Defaults to `false`. Marking an autodiscover provider as unique results into
+  making the provider to enable the provided templates only when it will gain the leader lease.
+  This setting can only be combined with `cluster` scope. When `unique` is enabled enabled, `resource`
+  and `add_resource_metadata` settings are not taken into account.
+`leader_lease`:: (Optional) Defaults to `{beatname_lc}-cluster-leader`. This will be name of the lock lease.
+  One can monitor the status of the lease with `kubectl describe lease beats-cluster-leader`.
+  Different Beats that refer to the same leader lease will be competetitors in holding the lease
+  and only one will be elected as leader each time. Example:
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+metricbeat.autodiscover:
+  providers:
+    - type: kubernetes
+      scope: cluster
+      node: ${NODE_NAME}
+      unique: true
+      identifier: leader-election-metricbeat
+      templates:
+        - config:
+            - module: kubernetes
+              hosts: ["kube-state-metrics:8080"]
+              period: 10s
+              add_metadata: true
+              metricsets:
+                - state_node
+-------------------------------------------------------------------------------------
+
+The above configuration when deployed on one or more Metribceat instances will enable `state_node`
+metricset only for the Metricbeat instance that will gain the leader lease/lock. With this deployment
+strategy we can ensure that cluster-wide metricsets are only enabled by one Beat instance when
+deploying a Beat as Daemonset.
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 

--- a/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
@@ -37,7 +37,13 @@ type Provider struct {
 }
 
 // AutodiscoverBuilder is the main builder for this provider.
-func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config, keystore keystore.Keystore) (autodiscover.Provider, error) {
+func AutodiscoverBuilder(
+	beatName string,
+	bus bus.Bus,
+	uuid uuid.UUID,
+	c *common.Config,
+	keystore keystore.Keystore,
+) (autodiscover.Provider, error) {
 	cfgwarn.Experimental("aws_ec2 autodiscover is experimental")
 
 	config := awsauto.DefaultConfig()

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -39,7 +39,13 @@ type Provider struct {
 }
 
 // AutodiscoverBuilder is the main builder for this provider.
-func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config, keystore keystore.Keystore) (autodiscover.Provider, error) {
+func AutodiscoverBuilder(
+	beatName string,
+	bus bus.Bus,
+	uuid uuid.UUID,
+	c *common.Config,
+	keystore keystore.Keystore,
+) (autodiscover.Provider, error) {
 	cfgwarn.Experimental("aws_elb autodiscover is experimental")
 
 	config := awsauto.DefaultConfig()


### PR DESCRIPTION
Cherry-pick of PR #20281 to 7.x branch. Original message: 

## What does this PR do?
Implements leader election as part of kubernetes autodiscover provider. With this, when the beat is elected as leader it will start cluster scope metricsets.

Under the hood, all leader candidates will try to gain the lock on Lease object (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io). When the lock is gained then the configured cluster wide mericsets will get started.

## Why is it important?
To get rid of `Deployment` procedure for the singleton Metricbeat instance which is needed for the cluster scope metricsets.
Sample configuration that will start `state_node` metricset when a leadership is gained:

```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      node: ${NODE_NAME}
      unique: true
      identifier: leaderelectionmetricbeat
      templates:
        - config:
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_node
```

Then we can monitor the `lease` to check which provider holds the lock:
```console
kubectl describe lease beats-cluster-leader
Name:         beats-cluster-leader
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  coordination.k8s.io/v1
Kind:         Lease
Metadata:
  Creation Timestamp:  2020-07-30T14:48:16Z
  Resource Version:    357033
  Self Link:           /apis/coordination.k8s.io/v1/namespaces/default/leases/beats-cluster-leader
  UID:                 ef255352-3d30-42f9-b27a-3a3e5dcb80dd
Spec:
  Acquire Time:            2020-07-30T14:51:00.592028Z
  Holder Identity:         beats-leader-leaderelectionmetricbeat
  Lease Duration Seconds:  15
  Lease Transitions:       2
  Renew Time:              2020-07-30T14:51:00.597852Z
Events:                    <none>
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally
1. Prepare a multinode k8s cluster (for instance on gke)
2. Deploy Metricbeat as a Daemonset on the cluster with leader election config:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      node: ${NODE_NAME}
      unique: true
      leader_lease: leaderelectionmetricbeat
      templates:
        - config:
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_node
```
3. Make sure that events for `state_node` are being collected from only one metricbeat instance. You can the in the logs and verify that only one metricbeat has gained the lock so far.
4. Monitor the `lease` object to keep track of the lock holder: `watch kubectl describe lease beats-cluster-leader`
5. Stop the Metricbeat instance that currently holds the lock and make sure that another one takes over and we keep getting events from `state-node`. Make sure that the `lease` changed holder (logs will also let us know that a new metricset is getting started)
6. Also test without setting `identifier` and check that it takes the default value properly like `metricbeat-cluster-leader`.

7. Check with old autodiscover (template based/hints based) for possible regressions.

## Related issues

- Relates https://github.com/elastic/beats/issues/19731

