### PR TITLE
Cherry-pick #20511 to 7.x: Fix healthcheck in ES compose service

### DIFF
--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:9200/_cluster/health"); data = json.loads(response.read()); exit(1) if data["status"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", "curl http://myelastic:changeme@localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 1200
       interval: 5s
       start_period: 60s


### PR DESCRIPTION
Cherry-pick of PR #20511 to 7.x branch. Original message: 

Python is not included anymore on Elasticsearch images, change the
healthcheck to be based on curl and the easier to parse cat API.

This fixes failures in CI with master branch.