### PR TITLE
[ITs] change healthcheck for elasticsearch

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -65,14 +65,13 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
-
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
   elasticsearchssl:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cluster/health --insecure | grep -vq '\"status\":\"red\"'"]
+      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cat/health?h=status --insecure | grep -q green"]
       retries: 1200
       interval: 5s
       start_period: 60s

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -65,14 +65,14 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
 
   elasticsearchssl:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD", "curl", "-u", "admin:changeme", "-f", "https://localhost:9200", "--insecure"]
+      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cluster/health --insecure | grep -vq '\"status\":\"red\"'"]
       retries: 1200
       interval: 5s
       start_period: 60s

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:9200/_cluster/health"); data = json.loads(response.read()); exit(1) if data["status"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", "curl -s http://myelastic:changeme@localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
       retries: 1200
       interval: 5s
       start_period: 60s

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://myelastic:changeme@localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      test: ["CMD-SHELL", "curl -u myelastic:changeme -f http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 1200
       interval: 5s
       start_period: 60s


### PR DESCRIPTION
## What does this PR do?

Elasticsearch docker image is based on centos:8 but it doesn't have python installed.

## Why is it important?

Healthcheck with the python approach are not supported anymore since python is not installed. curl is the less intrusive approach instead.


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this

```bash
gvm install go1.14.4
gvm use go1.14.4
make mage
cd x-pack/libbeat
mage build test

...
-------------------------------------------------- generated xml file: /go/src/github.com/elastic/beats/x-pack/libbeat/build/TEST-python-integration.xml ---------------------------------------------------
=========================================================================================== slowest 20 durations ===========================================================================================
14.83s call     x-pack/libbeat/tests/system/test_management.py::TestManagement::test_fetch_configs
12.87s call     x-pack/libbeat/tests/system/test_management.py::TestManagement::test_configs_cache
1.94s call     x-pack/libbeat/tests/system/test_management.py::TestManagement::test_enroll
0.42s call     x-pack/libbeat/tests/system/test_management.py::TestManagement::test_enroll_bad_pw

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================================ 4 passed in 33.36s ============================================================================================
>> python test: Integration Testing Complete
```

## Logs

```
docker inspect $(docker ps | grep docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT | cut -f1 -d' ') --format "{{json .State.Health }}" | jq

{
  "Status": "starting",
  "FailingStreak": 752,
  "Log": [
    {
      "Start": "2020-08-10T08:00:34.210390517Z",
      "End": "2020-08-10T08:00:34.315594515Z",
      "ExitCode": 127,
      "Output": "/bin/sh: python: command not found\n"
    },

```

### Issues

Duplicates https://github.com/elastic/beats/pull/20511