### PR TITLE
Cherry-pick #20389 to 7.x: [Filebeat] Improve validation check for Azure configuration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -266,6 +266,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix `fortinet` setting `event.timezone` to the system one when no `tz` field present {pull}20273[20273]
 - Fix `okta` geoip lookup in pipeline for `destination.ip` {pull}20454[20454]
 - Fix `cisco` asa and ftd parsing of messages 106102 and 106103. {pull}20469[20469]
+- Improve validation checks for Azure configuration {issue}20369[20369] {pull}20389[20389]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -7,6 +7,7 @@ package azureeventhub
 import (
 	"errors"
 	"fmt"
+	"unicode"
 )
 
 type azureInputConfig struct {
@@ -36,6 +37,32 @@ func (conf *azureInputConfig) Validate() error {
 	}
 	if conf.SAContainer == "" {
 		conf.SAContainer = fmt.Sprintf("%s-%s", ephContainerName, conf.EventHubName)
+
+	}
+	err := storageContainerValidate(conf.SAContainer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func storageContainerValidate(name string) error {
+	runes := []rune(name)
+	length := len(runes)
+	if length < 3 {
+		return fmt.Errorf("storage_account_container (%s) must be 3 or more characters", name)
+	}
+	if length > 63 {
+		return fmt.Errorf("storage_account_container (%s) must be less than 63 characters", name)
+	}
+	if !unicode.IsLower(runes[0]) && !unicode.IsNumber(runes[0]) {
+		return fmt.Errorf("storage_account_container (%s) must start with a lowercase letter or number", name)
+	}
+	for i := 0; i < length; i++ {
+		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && !('-' == runes[i]) {
+			return fmt.Errorf("rune %d of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
+		}
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package azureeventhub
+
+import (
+	"testing"
+)
+
+func TestStorageContainerValidate(t *testing.T) {
+	var tests = []struct {
+		input    string
+		errIsNil bool
+	}{
+		{"a-valid-name", true},
+		{"a", false},
+		{"a-name-that-is-really-too-long-to-be-valid-and-should-never-be-used-no-matter-what", false},
+		{"-not-valid", false},
+		{"capital-A-not-valid", false},
+		{"no_underscores_either", false},
+	}
+	for _, test := range tests {
+		err := storageContainerValidate(test.input)
+		if (err == nil) != test.errIsNil {
+			t.Errorf("storageContainerValidate(%s) = %v", test.input, err)
+		}
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #20389 to 7.x branch. Original message: 

## What does this PR do?

An Azure blob container name must be between 3 and 63 characters in
length; start with a letter or number; and contain only letters,
numbers, and the hyphen. All letters used in blob container names must
be lowercase.  Added validation to make sure the storage container
name meets those requirements.


## Why is it important?

The default storage container name is made by appending "filebeat-" to
the eventhub name.  But the eventhub name may contain invalid
characters or prepending "filebeat-" may make the name too long.  If
either of those occur the user receives an error that the resource
name is invalid but no clear indication as to what is wrong or how to
fix.  This validation will help guide the user to a valid storage
container name.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```
go test
```

## Related issues
- Closes #20369
