### PR TITLE
Cherry-pick #20435 to 7.x: [Filebeat][http_endpoint input] Adds support for custom auth header names and secret

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -601,8 +601,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add event.ingested for Suricata module {pull}20220[20220]
 - Add event.ingested for Suricata module {pull}20220[20220]
 - Add support for custom header and headersecret for filebeat http_endpoint input {pull}20435[20435]
-- Add event.ingested to all Filebeat modules. {pull}20386[20386]
-- Return error when log harvester tries to open a named pipe. {issue}18682[18682] {pull}20450[20450]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -599,7 +599,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support for additional fields and FirewallMatchEvent type events in CrowdStrike module {pull}20138[20138]
 - Add event.ingested to all Filebeat modules. {pull}20386[20386]
 - Add event.ingested for Suricata module {pull}20220[20220]
-- Add event.ingested for Suricata module {pull}20220[20220]
 - Add support for custom header and headersecret for filebeat http_endpoint input {pull}20435[20435]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -599,6 +599,10 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add support for additional fields and FirewallMatchEvent type events in CrowdStrike module {pull}20138[20138]
 - Add event.ingested to all Filebeat modules. {pull}20386[20386]
 - Add event.ingested for Suricata module {pull}20220[20220]
+- Add event.ingested for Suricata module {pull}20220[20220]
+- Add support for custom header and headersecret for filebeat http_endpoint input {pull}20435[20435]
+- Add event.ingested to all Filebeat modules. {pull}20386[20386]
+- Return error when log harvester tries to open a named pipe. {issue}18682[18682] {pull}20450[20450]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -70,6 +70,18 @@ Basic auth and SSL example:
   password: somepassword
 ----
 
+Authentication or checking that a specific header includes a specific value
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: http_endpoint
+  enabled: true
+  listen_address: 192.168.1.1
+  listen_port: 8080
+  secret.header: someheadername
+  secret.value: secretheadertoken
+----
+
 
 ==== Configuration options
 
@@ -90,6 +102,16 @@ If `basic_auth` is enabled, this is the username used for authentication against
 ==== `password`
 
 If `basic_auth` is eanbled, this is the password used for authentication against the HTTP listener. Requires `username` to also be set.
+
+[float]
+==== `secret.header`
+
+The header to check for a specific value specified by `secret.value`. Certain webhooks provide the possibility to include a special header and secret to identify the source.
+
+[float]
+==== `secret.value`
+
+The secret stored in the header name specified by `secret.header`. Certain webhooks provide the possibility to include a special header and secret to identify the source.
 
 [float]
 ==== `content_type`

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -24,6 +24,8 @@ type config struct {
 	URL           string                  `config:"url"`
 	Prefix        string                  `config:"prefix"`
 	ContentType   string                  `config:"content_type"`
+	SecretHeader  string                  `config:"secret.header"`
+	SecretValue   string                  `config:"secret.value"`
 }
 
 func defaultConfig() config {
@@ -38,6 +40,8 @@ func defaultConfig() config {
 		URL:           "/",
 		Prefix:        "json",
 		ContentType:   "application/json",
+		SecretHeader:  "",
+		SecretValue:   "",
 	}
 }
 
@@ -50,6 +54,10 @@ func (c *config) Validate() error {
 		if c.Username == "" || c.Password == "" {
 			return errors.New("Username and password required when basicauth is enabled")
 		}
+	}
+
+	if (c.SecretHeader != "" && c.SecretValue == "") || (c.SecretHeader == "" && c.SecretValue != "") {
+		return errors.New("Both secret.header and secret.value must be set")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -83,11 +83,13 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 	log := ctx.Logger.With("address", e.addr)
 
 	validator := &apiValidator{
-		basicAuth:   e.config.BasicAuth,
-		username:    e.config.Username,
-		password:    e.config.Password,
-		method:      http.MethodPost,
-		contentType: e.config.ContentType,
+		basicAuth:    e.config.BasicAuth,
+		username:     e.config.Username,
+		password:     e.config.Password,
+		method:       http.MethodPost,
+		contentType:  e.config.ContentType,
+		secretHeader: e.config.SecretHeader,
+		secretValue:  e.config.SecretValue,
 	}
 
 	handler := &httpHandler{

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -21,15 +21,24 @@ type apiValidator struct {
 	username, password string
 	method             string
 	contentType        string
+	secretHeader       string
+	secretValue        string
 }
 
 var errIncorrectUserOrPass = errors.New("Incorrect username or password")
+var errIncorrectHeaderSecret = errors.New("Incorrect header or header secret")
 
 func (v *apiValidator) ValidateHeader(r *http.Request) (int, error) {
 	if v.basicAuth {
 		username, password, _ := r.BasicAuth()
 		if v.username != username || v.password != password {
 			return http.StatusUnauthorized, errIncorrectUserOrPass
+		}
+	}
+
+	if v.secretHeader != "" && v.secretValue != "" {
+		if v.secretValue != r.Header.Get(v.secretHeader) {
+			return http.StatusUnauthorized, errIncorrectHeaderSecret
 		}
 	}
 

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -79,6 +79,8 @@ class Test(BaseTest):
 
         output = self.read_output()
 
+        print("response:", r.status_code, r.text)
+
         assert r.text == '{"message": "success"}'
         assert output[0]["input.type"] == "http_endpoint"
         assert output[0]["json.{}".format(self.prefix)] == message
@@ -97,6 +99,8 @@ class Test(BaseTest):
         r = requests.post(self.url, headers=headers, data=json.dumps(payload))
 
         filebeat.check_kill_and_wait()
+
+        print("response:", r.status_code, r.text)
 
         assert r.status_code == 415
         assert r.text == '{"message": "Wrong Content-Type header, expecting application/json"}'
@@ -135,8 +139,58 @@ class Test(BaseTest):
 
         filebeat.check_kill_and_wait()
 
+        print("response:", r.status_code, r.text)
+
         assert r.status_code == 401
         assert r.text == '{"message": "Incorrect username or password"}'
+
+    def test_http_endpoint_wrong_auth_header(self):
+        """
+        Test http_endpoint input with wrong auth header and secret.
+        """
+        options = """
+  secret.header: Authorization
+  secret.value: 123password
+"""
+        self.get_config(options)
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.log_contains("Starting HTTP server on {}:{}".format(self.host, self.port)))
+
+        message = "somerandommessage"
+        payload = {self.prefix: message}
+        headers = {"Content-Type": "application/json", "Authorization": "password123"}
+        r = requests.post(self.url, headers=headers, data=json.dumps(payload))
+
+        filebeat.check_kill_and_wait()
+
+        print("response:", r.status_code, r.text)
+
+        assert r.status_code == 401
+        assert r.text == '{"message": "Incorrect header or header secret"}'
+
+    def test_http_endpoint_correct_auth_header(self):
+        """
+        Test http_endpoint input with correct auth header and secret.
+        """
+        options = """
+  secret.header: Authorization
+  secret.value: 123password
+"""
+        self.get_config(options)
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.log_contains("Starting HTTP server on {}:{}".format(self.host, self.port)))
+
+        message = "somerandommessage"
+        payload = {self.prefix: message}
+        headers = {"Content-Type": "application/json", "Authorization": "123password"}
+        r = requests.post(self.url, headers=headers, data=json.dumps(payload))
+
+        filebeat.check_kill_and_wait()
+        output = self.read_output()
+
+        assert r.text == '{"message": "success"}'
+        assert output[0]["input.type"] == "http_endpoint"
+        assert output[0]["json.{}".format(self.prefix)] == message
 
     def test_http_endpoint_empty_body(self):
         """
@@ -150,6 +204,8 @@ class Test(BaseTest):
         r = requests.post(self.url, headers=headers, data="")
 
         filebeat.check_kill_and_wait()
+
+        print("response:", r.status_code, r.text)
 
         assert r.status_code == 406
         assert r.text == '{"message": "Body cannot be empty"}'
@@ -169,6 +225,7 @@ class Test(BaseTest):
         filebeat.check_kill_and_wait()
 
         print("response:", r.status_code, r.text)
+
         assert r.status_code == 400
         assert r.text.startswith('{"message": "Malformed JSON body:')
 
@@ -184,8 +241,9 @@ class Test(BaseTest):
         payload = {self.prefix: message}
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
         r = requests.get(self.url, headers=headers, data=json.dumps(payload))
-        print("response:", r.status_code, r.text)
         filebeat.check_kill_and_wait()
+
+        print("response:", r.status_code, r.text)
 
         assert r.status_code == 405
         assert r.text == '{"message": "Only POST requests supported"}'


### PR DESCRIPTION
Cherry-pick of PR #20435 to 7.x branch. Original message: 

## What does this PR do?

Certain webhooks offers functionality to add a custom header and defined secret to each request to identify the source. This PR adds the possibility to configure the header name and secret that needs to be confirmed for every request, similar but not the same as basic auth.

## Why is it important?

Required for certain modules like Zoom #20414 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Updated docs
- [x] Updated nosetests

Added nosetest for wrong configuration option, ensuring that anything not matching header+secret is dropped and that a successful match allows the request with the correct responses.
Tested with:
```
> INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false nosetests -v -s tests/system/test_http_endpoint.py 
Test http_endpoint input with correct auth header and secret. ... ok
Test http_endpoint input with empty body. ... ok
Test http_endpoint input with GET request. ... ok
Test http_endpoint input with malformed body. ... ok
Test http_endpoint input with missing basic auth values. ... ok
Test http_endpoint input with HTTP events. ... ok
Test http_endpoint input with wrong auth header and secret. ... ok
Test http_endpoint input with wrong basic auth values. ... ok
Test http_endpoint input with wrong content header. ... ok
```