### PR TITLE
Filebeat log.input scan_offset feature to predictably schedule the time for new log scans

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -59,6 +59,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 ==== Added
 
+- Add configuration for filebeat input log scan_offset. {pull}20520[17938]
 - Add configuration for APM instrumentation and expose the tracer trough the Beat object. {pull}17938[17938]
 - Make the behavior of clientWorker and netClientWorker consistent when error is returned from publisher pipeline
 - Metricset generator generates beta modules by default now. {pull}10657[10657]

--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -276,6 +276,25 @@ constantly polls your files.
 The default setting is 10s.
 
 [float]
+[id="{beatname_lc}-input-{type}-scan-offset"]
+===== `scan_offset`
+
+The absolute UTC time that {beatname_uc} checks for new files in the paths that
+are specified for harvesting.
+For example, if you specify a duration value like `0h5m`, the
+directory is scanned for files at 00:05 UTC.
+This setting can be used in conjunction with scan_frequency to periodically check
+for new files precisely after a known time of log rotation. This facilitates
+using much longer scan_frequency periods, with more timely and fruitful harvesting of
+new files, than using scan_freqwuency alone.
+
+If you require log lines to be sent in near real time do not use a very low
+`scan_frequency` but adjust `close_inactive` so the file handler stays open and
+constantly polls your files.
+
+The default setting is 0.
+
+[float]
 [id="{beatname_lc}-input-{type}-scan-sort"]
 ===== `scan.sort`
 

--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -286,11 +286,7 @@ directory is scanned for files at 00:05 UTC.
 This setting can be used in conjunction with scan_frequency to periodically check
 for new files precisely after a known time of log rotation. This facilitates
 using much longer scan_frequency periods, with more timely and fruitful harvesting of
-new files, than using scan_freqwuency alone.
-
-If you require log lines to be sent in near real time do not use a very low
-`scan_frequency` but adjust `close_inactive` so the file handler stays open and
-constantly polls your files.
+new files, than using scan_frequency alone.
 
 The default setting is 0.
 

--- a/filebeat/input/config.go
+++ b/filebeat/input/config.go
@@ -26,12 +26,14 @@ import (
 
 var (
 	defaultConfig = inputConfig{
+		ScanOffset:    0 * time.Second,
 		ScanFrequency: 10 * time.Second,
 		Type:          cfg.DefaultType,
 	}
 )
 
 type inputConfig struct {
+	ScanOffset time.Duration `config:"scan_offset" validate:"min=0"`
 	ScanFrequency time.Duration `config:"scan_frequency" validate:"min=0,nonzero"`
 	Type          string        `config:"type"`
 	InputType     string        `config:"input_type"`

--- a/filebeat/input/input.go
+++ b/filebeat/input/input.go
@@ -31,6 +31,8 @@ import (
 
 var (
 	inputList = monitoring.NewUniqueList()
+	scanDay, _ = time.ParseDuration("24h")
+	utc, _ = time.LoadLocation("UTC")
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/beats/v7
+module github.com/richard-mauri/beats/v7
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/richard-mauri/beats/v7
+module github.com/elastic/beats/v7
 
 go 1.14
 


### PR DESCRIPTION
Enhancement

## What does this PR do?

The filebeat log input already has scan_frequency configuration option. There was no way to schedule a precise time to perform the scans. With the new scan_offset we can now schedule an absolute UTC time so that settings like scan_offset:0h5m and scan_frequency:24 would be sufficient to discover logs after a midnight rotation. 


## Why is it important?

Without scan_offset, then you were forcd to have much more frequent (and unproductive) scan_frequency settings; wasting cpu,io....

## Checklist



- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
I will add some tests

- [ x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

