### PR TITLE
[JJBB] fix credentials with a service account

### DIFF
--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -22,7 +22,7 @@
         notification-context: "beats-ci"
         repo: 'beats'
         repo-owner: 'elastic'
-        credentials-id: github-app-beats-ci
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:


### PR DESCRIPTION
## What does this PR do?

Revert some changes partially of https://github.com/elastic/beats/pull/19852 to fix some misconfiguration with the GH accounts in the golang-crossbuild project

## Why is it important?

To fix

```
No changes detected: master (still at 7fe9c7c0bcde40f473473271f8b807557d74c683)

  1 branches were processed

  Checking pull-requests...

    Checking pull request #65

  Error while processing pull request 65

  Reason: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/elastic/golang-crossbuild/collaborators/kuisathaverat/permission {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-permissions-for-a-user"}

    Checking pull request #62

  Error while processing pull request 62

  Reason: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/elastic/golang-crossbuild/collaborators/kuisathaverat/permission {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-permissions-for-a-user"}

    Checking pull request #43

  Error while processing pull request 43

  Reason: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/elastic/golang-crossbuild/collaborators/null/permission {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-permissions-for-a-user"}

  3 pull requests were processed

  3 pull requests encountered errors and were orphaned.

  Checking tags...

  Getting remote tags...

  0 tags were processed

Finished examining elastic/golang-crossbuild

[Tue Aug 11 06:56:46 UTC 2020] Finished branch indexing. Indexing took 3.3 sec
Finished: SUCCESS
```

## Further details

I did add the `elasticmachine` and `apmmachine` as maintainers of the project with the same outcome. I don't know if the issue could related to some cache inconsistency in the CI side, some plugin misbehaving, or something internal with GH. To workaround this particular issue I've decided to revert partially the changes I did to use the GH app credentials.