### PR TITLE
Cherry-pick to 7.x: [ITs] change healthcheck for elasticsearch (#20514)(#20558)

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cat/health?h=status --insecure | grep -q green"]
+      test: ["CMD", "curl", "-u", "admin:changeme", "-f", "https://localhost:9200", "--insecure"]
       retries: 1200
       interval: 5s
       start_period: 60s

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -65,14 +65,13 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
-
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
   elasticsearchssl:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD", "curl", "-u", "admin:changeme", "-f", "https://localhost:9200", "--insecure"]
+      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cat/health?h=status --insecure | grep -q green"]
       retries: 1200
       interval: 5s
       start_period: 60s

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0-SNAPSHOT
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
       interval: 1s
     environment:

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl http://myelastic:changeme@localhost:9200/_cat/health?h=status | grep -q green"]
+      test: ["CMD-SHELL", "curl -u myelastic:changeme -f http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 1200
       interval: 5s
       start_period: 60s


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ITs] change healthcheck for elasticsearch (#20514)
 - [ITs] Revert healthcheck for elasticsearchssl service to the previous behaviour (#20558)