### PR TITLE
Add service resource in k8s cluster role

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Output errors when Kibana index pattern setup fails. {pull}20121[20121]
 - Fix issue in autodiscover that kept inputs stopped after config updates. {pull}20305[20305]
 - Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
+- Add service resource in k8s cluster role. {pull}20546[20546]
 
 *Auditbeat*
 

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -346,6 +346,7 @@ rules:
   - events
   - pods
   - secrets
+  - services
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -12,6 +12,7 @@ rules:
   - events
   - pods
   - secrets
+  - services
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources:


### PR DESCRIPTION
## What does this PR do?
Trying to investigate https://github.com/elastic/beats/issues/20544 I hit:
```
E0811 12:35:43.768618      90 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.3/tools/cache/reflector.go:125: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "services" in API group "" at the cluster scope
```


## Why is it important?
To make service watcher work on cluster scope.