### PR TITLE
Cherry-pick #20392 to 7.x: [Packetbeat] add "network" to event.category

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -364,6 +364,7 @@ field. You can revert this change by configuring tags for the module and omittin
 
 - Enable setting promiscuous mode automatically. {pull}11366[11366]
 - Fix process monitoring when ipv6 is disabled under Linux. {issue}19941[19941] {pull}19945[19945]
+- Add "network" to event.category {issue}20364[20364] {pull}20392[20392]
 
 *Winlogbeat*
 

--- a/packetbeat/_meta/sample_outputs/flow.json
+++ b/packetbeat/_meta/sample_outputs/flow.json
@@ -70,6 +70,13 @@
         "end": "2018-11-30T01:16:45.645Z",
         "duration": 3965826800,
         "type": "flow",
-        "start": "2018-11-30T01:16:41.679Z"
+        "start": "2018-11-30T01:16:41.679Z",
+        "dataset": "flow",
+        "kind": "event",
+        "action": "network_flow",
+        "category": [
+            "network_traffic",
+            "network"
+        ]
     }
 }

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -213,7 +213,7 @@ func createEvent(
 		"duration": f.ts.Sub(f.createTS),
 		"dataset":  "flow",
 		"kind":     "event",
-		"category": "network_traffic",
+		"category": []string{"network_traffic", "network"},
 		"action":   "network_flow",
 	}
 	flow := common.MapStr{

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -100,6 +100,9 @@ func TestCreateEvent(t *testing.T) {
 			"end":      isdef.KeyPresent,
 			"duration": isdef.KeyPresent,
 			"dataset":  "flow",
+			"kind":     "event",
+			"category": []string{"network_traffic", "network"},
+			"action":   "network_flow",
 		},
 		"type": "flow",
 	})


### PR DESCRIPTION
Cherry-pick of PR #20392 to 7.x branch. Original message: 

## What does this PR do?

adds "network" to event.category for flows

## Why is it important?

adds ECS allowed value to event.category

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
mage test
```

## Related issues

- Closes #20364