### PR TITLE
Cherry-pick #20541 to 7.x: Fix typo in Prometheus module docs

### DIFF
--- a/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/remote_write/_meta/docs.asciidoc
@@ -166,4 +166,4 @@ metricbeat.modules:
 
 Note that when using `types_patterns`, the provided patterns have higher priority than the default patterns.
 For instance if `_histogram_total` is a defined histogram pattern, then a metric like `network_bytes_histogram_total`
-will be handled as a histogram even of it has the suffix `_total` which is a default pattern for counters.
+will be handled as a histogram, even if it has the suffix `_total` which is a default pattern for counters.


### PR DESCRIPTION
Cherry-pick of PR #20541 to 7.x branch. Original message: 

## What does this PR do?
Fixes small typo in Prometheus `remote_write` docs.