### PR TITLE
[ITs] Revert healthcheck for elasticsearchssl service to the previous behaviour

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl -u admin:changeme -f http://localhost:9200/_cat/health?h=status --insecure | grep -q green"]
+      test: ["CMD", "curl", "-u", "admin:changeme", "-f", "https://localhost:9200", "--insecure"]
       retries: 1200
       interval: 5s
       start_period: 60s


### PR DESCRIPTION
## What does this PR do?

Fix ES with SSL docker container

## Why is it important?

To fix the ITs when running in the CI

## Issues

Supersedes https://github.com/elastic/beats/pull/20557

## Tests

```bash
cd libbeat
mage build test
```


```
>> Building docker images
elasticsearch uses an image, skipping
elasticsearch_monitoring uses an image, skipping
elasticsearchssl uses an image, skipping
logstash uses an image, skipping
kibana uses an image, skipping
proxy_dep uses an image, skipping
Building redis
Building sredis
Building kafka
Building elasticsearch_kerberos.elastic
Building beat
Creating libbeat_8_0_0_3f33563ed9-snapshot_elasticsearch_monitoring_1       ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_kafka_1                          ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_elasticsearchssl_1               ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_kibana_1                         ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_redis_1                          ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_elasticsearch_1                  ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_elasticsearch_kerberos.elastic_1 ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_sredis_1                         ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_logstash_1                       ... done
Creating libbeat_8_0_0_3f33563ed9-snapshot_proxy_dep_1                      ... done
>> go test: Integration Testing

SUMMARY:
  Fail:     0
  Skip:     10
  Pass:     1919
  Packages: 114
  Duration: 5m5.242727402s
  JUnit Report: /go/src/github.com/elastic/beats/libbeat/build/TEST-go-integration.xml
  Output File:  /go/src/github.com/elastic/beats/libbeat/build/TEST-go-integration.out
>> go test: Integration Test Passed


```