### PR TITLE
Cherry-pick #20522 to 7.x: Fix ECS fields in Elastic Log Driver, change index prefix

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -740,6 +740,7 @@ field. You can revert this change by configuring tags for the module and omittin
 
 *Elastic Log Driver*
 - Add support for `docker logs` command {pull}19531[19531]
+- Add support to change beat name, and support for Kibana Logs. {pull}20522[20522]
 
 ==== Deprecated
 

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -76,6 +76,11 @@ indices. For example: +"dockerlogs-%{+yyyy.MM.dd}"+.
 
 3+|*Advanced:*
 
+|`name`
+|`testbeat`
+| A custom value that will be inserted into the document as `agent.name`.
+If not set, it will be the hostname of Docker host.
+
 |`backoff_init`
 |`1s`
 |The number of seconds to wait before trying to reconnect to {es} after

--- a/x-pack/dockerlogbeat/main.go
+++ b/x-pack/dockerlogbeat/main.go
@@ -73,7 +73,13 @@ func main() {
 	if err != nil {
 		fatal("DESTROY_LOGS_ON_STOP must be 'true' or 'false': %s", err)
 	}
-	pipelines := pipelinemanager.NewPipelineManager(logDestroy)
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		fatal("Error fetching hostname: %s", err)
+	}
+
+	pipelines := pipelinemanager.NewPipelineManager(logDestroy, hostname)
 
 	sdkHandler := sdk.NewHandler(`{"Implements": ["LoggingDriver"]}`)
 	// Create handlers for startup and shutdown of the log driver

--- a/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/clientLogReader_test.go
@@ -76,15 +76,7 @@ func setupTestReader(t *testing.T, logString string, containerConfig logger.Info
 }
 
 // createNewClient sets up the "write side" of the pipeline, creating a log event to write and send back into the test.
-func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector, containerConfig logger.Info) *ClientLogger {
-	// an example container metadata struct
-	cfgObject := logger.Info{
-		Config:             map[string]string{"output.elasticsearch": "localhost:9200"},
-		ContainerLabels:    map[string]string{"test.label": "test"},
-		ContainerID:        "3acc92989a97c415905eba090277b8a8834d087e58a95bed55450338ce0758dd",
-		ContainerName:      "testContainer",
-		ContainerImageName: "TestImage",
-	}
+func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock.MockPipelineConnector, cfgObject logger.Info) *ClientLogger {
 
 	// create a new pipeline reader for use with the libbeat client
 	reader, err := pipereader.NewReaderFromReadCloser(pipelinemock.CreateTestInputFromLine(t, logString))
@@ -100,7 +92,7 @@ func createNewClient(t *testing.T, logString string, mockConnector *pipelinemock
 	localLog, err := jsonfilelog.New(info)
 	assert.NoError(t, err)
 
-	client, err := newClientFromPipeline(mockConnector, reader, 123, cfgObject, localLog)
+	client, err := newClientFromPipeline(mockConnector, reader, 123, cfgObject, localLog, "test")
 	require.NoError(t, err)
 
 	return client

--- a/x-pack/dockerlogbeat/pipelinemanager/config.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/config.go
@@ -27,6 +27,7 @@ type ContainerOutputConfig struct {
 	CloudID     string   `struct:"cloud.id,omitempty"`
 	CloudAuth   string   `struct:"cloud.auth,omitempty"`
 	ProxyURL    string   `struct:"output.elasticsearch.proxy_url,omitempty"`
+	BeatName    string   `struct:"-"`
 }
 
 // NewCfgFromRaw returns a ContainerOutputConfig based on a raw config we get from the API
@@ -53,6 +54,7 @@ func NewCfgFromRaw(input map[string]string) (ContainerOutputConfig, error) {
 	newCfg.Timeout = input["timeout"]
 	newCfg.BackoffInit = input["backoff_init"]
 	newCfg.BackoffMax = input["backoff_max"]
+	newCfg.BeatName = input["name"]
 
 	return newCfg, nil
 }

--- a/x-pack/dockerlogbeat/readme.md
+++ b/x-pack/dockerlogbeat/readme.md
@@ -9,7 +9,7 @@ To build and install, just run `mage Package`. The build process happens entire 
 
 ## Running
 
-`docker run --log-driver=elastic-logging-plugin:8.0.0 --log-opt output.elasticsearch.hosts="172.18.0.2:9200" --log-opt output.elasticsearch.index="dockerbeat-test" -it debian:jessie /bin/bash`
+`docker run --log-driver=elastic/elastic-logging-plugin:8.0.0 --log-opt hosts="172.18.0.2:9200" -it debian:jessie /bin/bash`
 
 
 ## Config Options


### PR DESCRIPTION
Cherry-pick of PR #20522 to 7.x branch. Original message: 

## What does this PR do?

- Report the correct hostname and properly separated container names in ECS fields
- Change the prefix to `logs-docker` so documents show up in the Kibana logs UI

## Why is it important?

Although the ECS fields themselves are an issue, we also want Log Driver documents to be easily discoverable in Kibana with little additional configuration. The Logs UI will look for `logs-*` index patterns by default.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

- Checkout PR locally
- Run `mage BuildAndInstall`
- Run the plugin using the examples provided in the docs
- Make sure any `host.*` and `container.*` fields are correct, and that logs show up in the Kibana log UI
- The end result should look something like this: 

```
{
  "_index": ".ds-logs-docker-8.0.0-2020.08.10-000001",
  "_type": "_doc",
  "_id": "_p2a2nMBsYRBGP3GiK5-",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2020-08-10T23:00:26.046Z",
    "container": {
      "labels": {},
      "id": "6abc8bcd301162fe156d0d560362501a9215c8e9e24e582247ad49dfa9ed1872",
      "name": "awesome_heisenberg",
      "image": {
        "name": "redis",
        "tag": "latest"
      }
    },
    "host": {
      "name": "buzzard.nest"
    },
    "ecs": {
      "version": "1.5.0"
    },
    "agent": {
      "type": "elastic-log-driver",
      "version": "8.0.0",
      "ephemeral_id": "617bcc47-3640-4866-8725-6f22546d53ba",
      "id": "a5308b40-344e-41ab-a985-212075a9762a",
      "name": "buzzard.nest"
    },
    "message": "1:M 10 Aug 2020 23:00:26.045 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect."
  },
  "fields": {
    "@timestamp": [
      "2020-08-10T23:00:26.046Z"
    ]
  },
  "sort": [
    1597100426046
  ]
}
```