### PR TITLE
Cherry-pick #20570 to 7.x: Stop Heartbeat monitor jobs on cancelation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -281,6 +281,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misuse. {pull}16397[16397]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
 - Add support for new `service_name` option to all monitors. {pull}19932[19932].
+- Stop rescheduling tasks of stopped monitors. {pull}20570[20570]
 
 *Journalbeat*
 

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -188,6 +188,12 @@ func (s *Scheduler) Add(sched Schedule, id string, entrypoint TaskFunc) (removeF
 	var taskFn timerqueue.TimerTaskFn
 
 	taskFn = func(_ time.Time) {
+		select {
+		case <-jobCtx.Done():
+			debugf("Job '%v' canceled", id)
+			return
+		default:
+		}
 		s.stats.activeJobs.Inc()
 		lastRanAt = s.runRecursiveJob(jobCtx, entrypoint)
 		s.stats.activeJobs.Dec()


### PR DESCRIPTION
Cherry-pick of PR #20570 to 7.x branch. Original message: 

If a monitor is stopped, for example when using autodiscover, the
scheduled tasks should be stopped too. Scheduler was rescheduling tasks
forever once started, though these tasks were not being executed because
they are also aware of the context.

This change avoids the execution and rescheduling of tasks once its job
context is done.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Start heartbeat with autodiscover enabled and `-d scheduler`.
- Start some container/pod.
- Wait for the monitor to be configured and executed.
- Stop the container/pod.
- Messages about jobs execution like the following one should eventually stop appearing:
```
2020-08-12T13:13:43.705+0200	DEBUG	[scheduler]	scheduler/scheduler.go:201	Job 'auto-http-0X2C5537D51C1B9524' returned at 2020-08-12 13:13:43.70518639 +0200 CEST m=+66.010433861
```

## Related issues

- Closes #20544