### PR TITLE
Cherry-pick to 7.8: [docs] Fix minor typo (#20591)

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -7,7 +7,7 @@ experimental[]
 By default {agent} runs in standalone mode to ingest system data and send it to
 a local {es} instance running on port 9200. It uses the demo credentials of the
 `elastic` user. It's also configured to monitor all {beats} managed by the Agent
-and send the {beats} logs and metrics to the same {es) instance.
+and send the {beats} logs and metrics to the same {es} instance.
 
 To alter this behavior, configure the output and other configuration settings:
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [docs] Fix minor typo (#20591)