### PR TITLE
Cherry-pick #20586 to 7.9: Use older version of github.com/dop251/goja_nodejs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,6 +188,7 @@ replace (
 	github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
 	github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
+	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
 	github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
 	github.com/google/gopacket => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41


### PR DESCRIPTION
Cherry-pick of PR #20586 to 7.9 branch. Original message: 

## What does this PR do?

This PR pins the version of `github.com/dop251/goja_nodejs`.

## Why is it important?

The recent update of this library leads to the following error when generating custom Beats:

```
mage GenerateCustomBeat
# github.com/dop251/goja_nodejs/require
/home/n/go/pkg/mod/github.com/dop251/goja_nodejs@v0.0.0-20200728182148-d8e650e3b24d/require/resolve.go:169:13: undefined: goja.StackFrame
/home/n/go/pkg/mod/github.com/dop251/goja_nodejs@v0.0.0-20200728182148-d8e650e3b24d/require/resolve.go:170:21: r.runtime.CaptureCallStack undefined (type *goja.Runtime has no field or method CaptureCallStack)
Error: error compiling magefiles
```

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~