### PR TITLE
Cherry-pick #20512 to 7.x: Add k8s manifest leveraging leaderelection

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -14,12 +14,47 @@ data:
       # Reload module configs as they change:
       reload.enabled: false
 
-    # To enable hints based autodiscover uncomment this:
-    #metricbeat.autodiscover:
-    #  providers:
-    #    - type: kubernetes
-    #      node: ${NODE_NAME}
-    #      hints.enabled: true
+    metricbeat.autodiscover:
+      providers:
+        # To enable hints based autodiscover uncomment this:
+        #- type: kubernetes
+        #  node: ${NODE_NAME}
+        #  hints.enabled: true
+        # Uncomment the following to enable leader election provider that handles
+        # singleton instance configuration across the Daemonset Pods of the whole cluster
+        # in order to monitor some unique data sources, like kube-state-metrics.
+        # When enabling this remember to also delete the Deployment or just set the replicas of the
+        # Deployment to 0.
+        #- type: kubernetes
+        #  scope: cluster
+        #  node: ${NODE_NAME}
+        #  unique: true
+        #  # identifier: <lease_lock_name>
+        #  templates:
+        #    - config:
+        #        - module: kubernetes
+        #          hosts: ["kube-state-metrics:8080"]
+        #          period: 10s
+        #          add_metadata: true
+        #          metricsets:
+        #            - state_node
+        #            - state_deployment
+        #            - state_replicaset
+        #            - state_pod
+        #            - state_container
+        #            - state_cronjob
+        #            - state_resourcequota
+        #            - state_statefulset
+        #            # Uncomment this to get k8s events:
+        #            #- event
+        #        - module: kubernetes
+        #          metricsets:
+        #            - apiserver
+        #          hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
+        #          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        #          ssl.certificate_authorities:
+        #            - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        #          period: 30s
 
     processors:
       - add_cloud_metadata:
@@ -258,6 +293,8 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  # Set to 0 if using leader election provider with the Daemonset
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: metricbeat

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -14,12 +14,47 @@ data:
       # Reload module configs as they change:
       reload.enabled: false
 
-    # To enable hints based autodiscover uncomment this:
-    #metricbeat.autodiscover:
-    #  providers:
-    #    - type: kubernetes
-    #      node: ${NODE_NAME}
-    #      hints.enabled: true
+    metricbeat.autodiscover:
+      providers:
+        # To enable hints based autodiscover uncomment this:
+        #- type: kubernetes
+        #  node: ${NODE_NAME}
+        #  hints.enabled: true
+        # Uncomment the following to enable leader election provider that handles
+        # singleton instance configuration across the Daemonset Pods of the whole cluster
+        # in order to monitor some unique data sources, like kube-state-metrics.
+        # When enabling this remember to also delete the Deployment or just set the replicas of the
+        # Deployment to 0.
+        #- type: kubernetes
+        #  scope: cluster
+        #  node: ${NODE_NAME}
+        #  unique: true
+        #  # identifier: <lease_lock_name>
+        #  templates:
+        #    - config:
+        #        - module: kubernetes
+        #          hosts: ["kube-state-metrics:8080"]
+        #          period: 10s
+        #          add_metadata: true
+        #          metricsets:
+        #            - state_node
+        #            - state_deployment
+        #            - state_replicaset
+        #            - state_pod
+        #            - state_container
+        #            - state_cronjob
+        #            - state_resourcequota
+        #            - state_statefulset
+        #            # Uncomment this to get k8s events:
+        #            #- event
+        #        - module: kubernetes
+        #          metricsets:
+        #            - apiserver
+        #          hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
+        #          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        #          ssl.certificate_authorities:
+        #            - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        #          period: 30s
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  # Set to 0 if using leader election provider with the Daemonset
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: metricbeat

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -182,3 +182,44 @@ metricbeat                1         1         1            1           1m
 ------------------------------------------------
 
 Metrics should start flowing to Elasticsearch.
+
+
+[float]
+==== Deploying Metricbeat Daemonset with Leader Election enabled
+
+In some cases users may want to avoid deploying both a Deployment and a Daemonset
+to collect cluser-wide metrics and node-level metrics.
+For this case, we provide the option to deploy Metricbeat only as a Daemonset
+and leverage the leader election feature which allows to define configurations
+that are enabled only by the leader Pod. The leader Pod is automatically chosen
+between the Pods of the Daemonset.
+Here is an example of a configuration that enables leader election:
+[source,yaml]
+-----
+metricbeat.autodiscover:
+  providers:
+  - type: kubernetes
+    scope: cluster
+    node: ${NODE_NAME}
+    unique: true
+    identifier: leaderelectionmetricbeat
+    templates:
+      - config:
+          - module: kubernetes
+            hosts: ["kube-state-metrics:8080"]
+            period: 10s
+            add_metadata: true
+            metricsets:
+              - state_node
+-----
+Users can find more info about the `unique` and `identifier` options at <<configuration-autodiscover>>.
+
+Users can enable the respective parts the Daemonset ConfigMap and
+set the `replicas` of the Deployment to `0` in order to only deploy
+the Daemonset on the cluster with the leader election provider enabled
+in order to collect cluster-wide metrics:
+["source", "sh", subs="attributes"]
+------------------------------------------------
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/metricbeat-kubernetes.yaml
+kubectl create -f metricbeat-kubernetes.yaml
+------------------------------------------------


### PR DESCRIPTION
Cherry-pick of PR #20512 to 7.x branch. Original message: 

## What does this PR do?
This PR proposes new Kubernetes manifests for shake of https://github.com/elastic/beats/issues/19731, leveraging unique Autodiscover provider implemented at https://github.com/elastic/beats/pull/20281.

With these manifests, only Metricbeat's Deamonset will be able to monitor whole k8s cluster since one Deamonset Pod each time will hold the leadership being responsible to coordinate metricsets that collect cluster wide metrics.

We will might need a meta issue to keep track of deprecating Deployment manifests (if needed). 

- [x] Add an extra section within https://www.elastic.co/guide/en/beats/metricbeat/7.x/running-on-kubernetes.html

## Why is it important?
To get rid of the requirement to maintain/handle two different deployment strategies.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
Test the manifests similarly to the testing steps of https://github.com/elastic/beats/pull/20281#issue-457865292.

1. Prepare a multinode cluster (ie on GKE)
2. Edit `metricbeat-leaderelection-kubernetes.yml` properly to set the proper image (ie `docker.elastic.co/beats/metricbeat:7.10.0-SNAPSHOT`) and the proper ES output (ie on Elastic Cloud)
3. Deploy the `metricbeat-leaderelection-kubernetes.yml` manifest and make sure that all the desired metricsets are shipping events and that k8s related Dashboards are populated with data correctly.
4. `kubectl delete` the leader pod and make sure that the leadership is either transfered to another Pod or it is gained again by the new replacement Pod.
5. Add static or hints-based autodiscovery configs/providers and make sure that work all together.
Example:
```
metricbeat.autodiscover:
      providers:
        # To enable hints based autodiscover uncomment this:
        #- type: kubernetes
        #  node: ${NODE_NAME}
        #  hints.enabled: true
        - type: kubernetes
          node: ${NODE_NAME}
          templates:
            - condition:
                contains:
                  kubernetes.pod.name: "nats"
              config:
                - module: nats
                  hosts: "${data.host}:${data.port}"
        - type: kubernetes
          scope: cluster
          node: ${NODE_NAME}
          unique: true
          identifier: gke-lease
          templates:
            - config:
                - module: kubernetes
                  hosts: ["kube-state-metrics:8080"]
                  period: 10s
                  add_metadata: true
                  metricsets:
                    - state_node
                    - state_deployment
                    - state_replicaset
```

## Related issues
- Closes https://github.com/elastic/beats/issues/19731
