### PR TITLE
Fix python deprecation warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1125,6 +1125,7 @@ def isChangedOSSCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
     "^go.mod",
+    "^pytest.ini",
     "^libbeat/.*",
     "^testing/.*",
     "^dev-tools/.*",
@@ -1138,6 +1139,7 @@ def isChangedXPackCode(patterns) {
   def allPatterns = [
     "^Jenkinsfile",
     "^go.mod",
+    "^pytest.ini",
     "^libbeat/.*",
     "^dev-tools/.*",
     "^testing/.*",

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ clean: mage
 .PHONY: check
 check: python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) check || exit 1;)
-	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -exec $(PYTHON_ENV)/bin/autopep8 -a -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
+	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
 	@$(FIND) -name *.py -not -path "*/build/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
 	# check if vendor folder does not exists
 	[ ! -d vendor ]
@@ -134,7 +134,7 @@ misspell:
 fmt: add-headers python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) fmt || exit 1;)
 	@# Cleans also python files which are not part of the beats
-	@$(FIND) -name "*.py" -exec $(PYTHON_ENV)/bin/autopep8 -a --in-place --max-line-length 120 {} \;
+	@$(FIND) -name "*.py" -exec $(PYTHON_ENV)/bin/autopep8 --in-place --max-line-length 120 {} \;
 
 ## lint : TBD.
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ clean: mage
 .PHONY: check
 check: python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) check || exit 1;)
-	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -exec $(PYTHON_ENV)/bin/autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
+	@$(FIND) -name *.py -name *.py -not -path "*/build/*" -exec $(PYTHON_ENV)/bin/autopep8 -a -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
 	@$(FIND) -name *.py -not -path "*/build/*" | xargs $(PYTHON_ENV)/bin/pylint --py3k -E || (echo "Code is not compatible with Python 3" && false)
 	# check if vendor folder does not exists
 	[ ! -d vendor ]
@@ -134,7 +134,7 @@ misspell:
 fmt: add-headers python-env
 	@$(foreach var,$(PROJECTS) dev-tools $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) fmt || exit 1;)
 	@# Cleans also python files which are not part of the beats
-	@$(FIND) -name "*.py" -exec $(PYTHON_ENV)/bin/autopep8 --in-place --max-line-length 120 {} \;
+	@$(FIND) -name "*.py" -exec $(PYTHON_ENV)/bin/autopep8 -a --in-place --max-line-length 120 {} \;
 
 ## lint : TBD.
 .PHONY: lint
@@ -167,7 +167,7 @@ notice:
 .PHONY: python-env
 python-env:
 	@test -d $(PYTHON_ENV) || ${PYTHON_EXE} -m venv $(VENV_PARAMS) $(PYTHON_ENV)
-	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8==1.3.5 pylint==2.4.4
+	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8==1.5.4 pylint==2.4.4
 	@# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 

--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -31,7 +31,7 @@ def file_events(objs, path, expected):
     evts = set()
     for obj in objs:
         if 'file.path' in obj and 'event.action' in obj and obj['file.path'].lower() == path.lower():
-            if type(obj['event.action']) == list:
+            if isinstance(obj['event.action'], list):
                 evts = evts.union(set(obj['event.action']))
             else:
                 evts.add(obj['event.action'])

--- a/dev-tools/cmd/dashboards/export_5x_dashboards.py
+++ b/dev-tools/cmd/dashboards/export_5x_dashboards.py
@@ -13,7 +13,7 @@ def ExportDashboards(es, regex, kibana_index, output_directory):
 
     try:
         reg_exp = re.compile(regex, re.IGNORECASE)
-    except:
+    except BaseException:
         print("Wrong regex {}".format(regex))
         return
 

--- a/dev-tools/mage/fmt.go
+++ b/dev-tools/mage/fmt.go
@@ -107,7 +107,7 @@ func PythonAutopep8() error {
 	}
 
 	args := append(
-		[]string{"-a", "--in-place", "--max-line-length", "120"},
+		[]string{"--in-place", "--max-line-length", "120"},
 		pyFiles...,
 	)
 

--- a/dev-tools/mage/fmt.go
+++ b/dev-tools/mage/fmt.go
@@ -107,7 +107,7 @@ func PythonAutopep8() error {
 	}
 
 	args := append(
-		[]string{"--in-place", "--max-line-length", "120"},
+		[]string{"-a", "--in-place", "--max-line-length", "120"},
 		pyFiles...,
 	)
 

--- a/filebeat/scripts/docs_collector.py
+++ b/filebeat/scripts/docs_collector.py
@@ -61,7 +61,7 @@ For a description of each field in the module, see the
 """
 
         # Write module docs
-        docs_path = os.path.join(os.path.abspath("docs"), "modules",  module + ".asciidoc")
+        docs_path = os.path.join(os.path.abspath("docs"), "modules", module + ".asciidoc")
         with open(docs_path, 'w', encoding='utf_8') as f:
             f.write(module_file)
 

--- a/filebeat/tests/open-file-handlers/log_stdout.py
+++ b/filebeat/tests/open-file-handlers/log_stdout.py
@@ -18,5 +18,5 @@ line_length = len(str(total_lines)) + 1
 # Setup python log handler
 handler = logging.handlers.RotatingFileHandler(
     log_file, maxBytes=line_length * lines_per_file + 1,
-    backupCount=int(total_lines/lines_per_file) + 1)
+    backupCount=int(total_lines / lines_per_file) + 1)
 logger.addHandler(handler)

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -176,7 +176,7 @@ class LogState:
         if ignore_case:
             msg = msg.lower()
 
-        if type(msg) == REGEXP_TYPE:
+        if isinstance(msg, REGEXP_TYPE):
             def match(x): return msg.search(x) is not None
         else:
             def match(x): return x.find(msg) >= 0

--- a/filebeat/tests/system/test_container.py
+++ b/filebeat/tests/system/test_container.py
@@ -28,7 +28,7 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
 
-        self.wait_until(lambda:  self.output_has(lines=21))
+        self.wait_until(lambda: self.output_has(lines=21))
 
         filebeat.check_kill_and_wait()
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -105,7 +105,7 @@ class Test(BaseTest):
 
         try:
             self.es.indices.delete(index=self.index_name)
-        except:
+        except BaseException:
             pass
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 

--- a/filebeat/tests/system/test_multiline.py
+++ b/filebeat/tests/system/test_multiline.py
@@ -18,7 +18,7 @@ class Test(BaseTest):
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after"
         )
@@ -126,7 +126,7 @@ connection <0.23893.109>, channel 3 - soft error:
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after",
             max_lines=3
@@ -165,7 +165,7 @@ connection <0.23893.109>, channel 3 - soft error:
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after",
         )
@@ -210,7 +210,7 @@ connection <0.23893.109>, channel 3 - soft error:
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after",
             max_bytes=60
@@ -247,7 +247,7 @@ connection <0.23893.109>, channel 3 - soft error:
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after",
             close_timeout="2s",
@@ -303,7 +303,7 @@ connection <0.23893.109>, channel 3 - soft error:
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             multiline_type="pattern",
-            pattern="^\[",
+            pattern=r"^\[",
             negate="true",
             match="after",
             close_timeout="2s",

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -41,7 +41,7 @@ class Test(BaseTest):
         index_name = "filebeat-test-input"
         try:
             self.es.indices.delete(index=index_name)
-        except:
+        except BaseException:
             pass
         self.wait_until(lambda: not self.es.indices.exists(index_name))
 
@@ -83,7 +83,7 @@ class Test(BaseTest):
                 res = self.es.search(index=index_name,
                                      body={"query": {"match_all": {}}})
                 return [o["_source"] for o in res["hits"]["hits"]]
-            except:
+            except BaseException:
                 return []
 
         self.wait_until(lambda: len(search_objects()) > 0, max_timeout=20)

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -347,7 +347,7 @@ class Test(BaseTest):
         self.wait_until(lambda: self.output_has(lines=1))
         filebeat.check_kill_and_wait()
 
-        assert self.has_registry(data_path=self.working_dir+"/datapath")
+        assert self.has_registry(data_path=self.working_dir + "/datapath")
 
     def test_rotating_file_inode(self):
         """
@@ -770,7 +770,8 @@ class Test(BaseTest):
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path1))["offset"] == 9
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path2))["offset"] == 8
 
-    @unittest.skipIf(os.name == 'nt' or platform.system() == "Darwin", 'flaky test https://github.com/elastic/beats/issues/8102')
+    @unittest.skipIf(os.name == 'nt' or platform.system() == "Darwin",
+                     'flaky test https://github.com/elastic/beats/issues/8102')
     def test_clean_inactive(self):
         """
         Checks that states are properly removed after clean_inactive
@@ -930,8 +931,8 @@ class Test(BaseTest):
             ignore_older="2000ms",
         )
 
-        init_files = ["test"+str(i)+".log" for i in range(3)]
-        restart_files = ["test"+str(i+3)+".log" for i in range(1)]
+        init_files = ["test" + str(i) + ".log" for i in range(3)]
+        restart_files = ["test" + str(i + 3) + ".log" for i in range(1)]
 
         for name in init_files:
             self.input_logs.write(name, "Hello World\n")

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -61,10 +61,8 @@ class Test(BaseTest):
         logfile_abs_path = os.path.abspath(testfile_path)
         record = self.get_registry_entry_by_path(logfile_abs_path)
 
-        self.assertDictContainsSubset({
-            "source": logfile_abs_path,
-            "offset": iterations * line_len,
-        }, record)
+        self.assertEqual(logfile_abs_path, record.get('source'))
+        self.assertEqual(iterations * line_len, record.get('offset'))
         self.assertTrue("FileStateOS" in record)
         self.assertTrue("meta" not in record)
         file_state_os = record["FileStateOS"]
@@ -82,10 +80,8 @@ class Test(BaseTest):
             self.assertTrue("device" in file_state_os)
         else:
             stat = os.stat(logfile_abs_path)
-            self.assertDictContainsSubset({
-                "inode": stat.st_ino,
-                "device": stat.st_dev,
-            }, file_state_os)
+            self.assertEqual(stat.st_ino, file_state_os.get('inode'))
+            self.assertEqual(stat.st_dev, file_state_os.get('device'))
 
     def test_registrar_files(self):
         """
@@ -1319,10 +1315,8 @@ class Test(BaseTest):
         logfile_abs_path = os.path.abspath(testfile_path1)
         record = self.get_registry_entry_by_path(logfile_abs_path)
 
-        self.assertDictContainsSubset({
-            "source": logfile_abs_path,
-            "offset": iterations * (len("hello world") + len(os.linesep)),
-        }, record)
+        self.assertEqual(logfile_abs_path, record.get('source'))
+        self.assertEqual(iterations * (len("hello world") + len(os.linesep)), record.get('offset'))
         self.assertTrue("FileStateOS" in record)
         file_state_os = record["FileStateOS"]
 
@@ -1339,10 +1333,8 @@ class Test(BaseTest):
             self.assertTrue("device" in file_state_os)
         else:
             stat = os.stat(logfile_abs_path)
-            self.assertDictContainsSubset({
-                "inode": stat.st_ino,
-                "device": stat.st_dev,
-            }, file_state_os)
+            self.assertEqual(stat.st_ino, file_state_os.get('inode'))
+            self.assertEqual(stat.st_dev, file_state_os.get('device'))
 
     def test_registrar_meta(self):
         """

--- a/filebeat/tests/system/test_setup.py
+++ b/filebeat/tests/system/test_setup.py
@@ -60,4 +60,8 @@ class Test(BaseTest):
                 os.mkdir(directory)
 
         copytree(self.beat_path + "/tests/system/input/template-test-module", modules_path + "/template-test-module")
-        copyfile(self.beat_path + "/tests/system/input/template-test-module/_meta/config.yml", modules_d_path + "/test.yml")
+        copyfile(
+            self.beat_path +
+            "/tests/system/input/template-test-module/_meta/config.yml",
+            modules_d_path +
+            "/test.yml")

--- a/heartbeat/scripts/generate_imports_helper.py
+++ b/heartbeat/scripts/generate_imports_helper.py
@@ -1,10 +1,10 @@
+from os import listdir
+from os.path import abspath, isdir, join
+
 comment = """Package defaults imports all Monitor packages so that they
 register with the global monitor registry. This package can be imported in the
 main package to automatically register all of the standard supported Heartbeat
 modules."""
-
-from os.path import abspath, isdir, join
-from os import listdir
 
 
 blacklist = [

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -134,7 +134,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
         heartbeat_proc.check_kill_and_wait()
 
         doc = self.read_output()[0]
-        self.assertDictContainsSubset(expected, doc)
+        assert expected.items() <= doc.items()
         return doc
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")

--- a/heartbeat/tests/system/test_telemetry.py
+++ b/heartbeat/tests/system/test_telemetry.py
@@ -63,7 +63,7 @@ class Test(BaseTest):
                     "Start job 'tcp-tcp@{}".format(tcp_host)))
 
             init_lines = self.output_lines()
-            self.wait_until(lambda: self.output_has(lines=init_lines+2))
+            self.wait_until(lambda: self.output_has(lines=init_lines + 2))
 
             self.assert_stats({
                 "http": {

--- a/libbeat/scripts/generate_makefile_doc.py
+++ b/libbeat/scripts/generate_makefile_doc.py
@@ -63,11 +63,11 @@ def parse_line(line, regexp, categories, categories_set):
         try:
             name = matches.group("varname")
             is_variable = True
-        except:
+        except BaseException:
             pass
         try:
             default = matches.group("default").strip()
-        except:
+        except BaseException:
             default = ""
 
         if not name:

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -109,12 +109,12 @@ class Proc(object):
         try:
             self.proc.terminate()
             self.proc.kill()
-        except:
+        except BaseException:
             pass
         # Ensure the output is closed.
         try:
             self.output.close()
-        except:
+        except BaseException:
             pass
 
 
@@ -180,7 +180,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         proc = self.start_beat(cmd=cmd, config=config, output=output,
                                logging_args=logging_args,
                                extra_args=extra_args, env=env)
-        if exit_code != None:
+        if exit_code is not None:
             return proc.check_wait(exit_code)
 
         return proc.wait()
@@ -276,7 +276,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 try:
                     jsons.append(self.flatten_object(json.loads(
                         line, object_pairs_hook=self.json_raise_on_duplicates), []))
-                except:
+                except BaseException:
                     print("Fail to load the json {}".format(line))
                     raise
 
@@ -342,7 +342,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 os.unlink(self.build_path + "last_run")
             os.symlink(self.build_path + "run/{}".format(self.id()),
                        self.build_path + "last_run")
-        except:
+        except BaseException:
             # symlink is best effort and can fail when
             # running tests in parallel
             pass
@@ -409,7 +409,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         """
         Returns the number of appearances of the given string in the log file
         """
-        is_regexp = type(msg) == REGEXP_TYPE
+        is_regexp = isinstance(msg, REGEXP_TYPE)
 
         counter = 0
         if ignore_case:
@@ -755,7 +755,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             # the file make that difficult
             with open(path) as fhandle:
                 for line in fhandle:
-                    if re.search("ecs\.version", line):
+                    if re.search(r"ecs\.version", line):
                         return True
             return False
 

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -56,9 +56,9 @@ class TestExportsMixin:
         js = json.loads(output)
         assert "objects" in js
         size = len(output.encode('utf-8'))
-        assert size < 1024*1024, "Kibana index pattern must be less than 1MiB " \
-                                 "to keep the Beat setup request size below " \
-                                 "Kibana's server.maxPayloadBytes."
+        assert size < 1024 * 1024, "Kibana index pattern must be less than 1MiB " \
+            "to keep the Beat setup request size below " \
+            "Kibana's server.maxPayloadBytes."
 
     def test_export_index_pattern_migration(self):
         """
@@ -68,9 +68,9 @@ class TestExportsMixin:
         js = json.loads(output)
         assert "objects" in js
         size = len(output.encode('utf-8'))
-        assert size < 1024*1024, "Kibana index pattern must be less than 1MiB " \
-                                 "to keep the Beat setup request size below " \
-                                 "Kibana's server.maxPayloadBytes."
+        assert size < 1024 * 1024, "Kibana index pattern must be less than 1MiB " \
+            "to keep the Beat setup request size below " \
+            "Kibana's server.maxPayloadBytes."
 
     def test_export_config(self):
         """

--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -202,7 +202,7 @@ class ComposeMixin(object):
         basename = os.path.basename(cls.find_compose_path())
 
         def positivehash(x):
-            return hash(x) % ((sys.maxsize+1) * 2)
+            return hash(x) % ((sys.maxsize + 1) * 2)
 
         return "%s_%X" % (basename, positivehash(frozenset(cls.COMPOSE_ENV.items())))
 

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -1,5 +1,5 @@
 attrs==19.3.0
-autopep8==1.3.5
+autopep8==1.5.4
 backports.ssl-match-hostname==3.5.0.1
 cached-property==1.4.2
 certifi==2018.1.18
@@ -27,7 +27,7 @@ packaging==20.4
 parameterized==0.7.0
 pluggy==0.13.1
 py==1.9.0
-pycodestyle==2.4.0
+pycodestyle==2.6.0
 pyparsing==2.4.7
 pyrsistent==0.16.0
 pytest==6.0.1

--- a/libbeat/tests/system/test_cmd_setup_index_management.py
+++ b/libbeat/tests/system/test_cmd_setup_index_management.py
@@ -159,7 +159,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                   extra_args=["setup", self.cmd,
                                               "-E", "setup.ilm.enabled=true",
                                               "-E", "setup.ilm.overwrite=false",
-                                              "-E", "setup.ilm.policy_name="+policy_name])
+                                              "-E", "setup.ilm.policy_name=" + policy_name])
         assert exit_code == 0
         resp = self.es.transport.perform_request('GET', '/_ilm/policy/' + policy_name)
         assert "delete" in resp[policy_name]["policy"]["phases"]
@@ -170,7 +170,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                   extra_args=["setup", self.cmd,
                                               "-E", "setup.ilm.enabled=true",
                                               "-E", "setup.ilm.overwrite=true",
-                                              "-E", "setup.ilm.policy_name="+policy_name])
+                                              "-E", "setup.ilm.policy_name=" + policy_name])
         assert exit_code == 0
         resp = self.es.transport.perform_request('GET', '/_ilm/policy/' + policy_name)
         assert "delete" not in resp[policy_name]["policy"]["phases"]

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -28,7 +28,6 @@ class Test(BaseTest):
         Test shipping monitoring data directly to the monitoring cluster.
         Make sure expected documents are indexed in monitoring cluster.
         """
-
         self.render_config_template(
             "mockbeat",
             monitoring={
@@ -45,7 +44,7 @@ class Test(BaseTest):
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile(r"\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
-            "Connection to .*elasticsearch\(" + self.get_elasticsearch_monitoring_url() + "\).* established")))
+            r"Connection to .*elasticsearch\({}\).* established".format(self.get_elasticsearch_monitoring_url()))))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
 

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -43,9 +43,9 @@ class Test(BaseTest):
 
         proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
+        self.wait_until(lambda: self.log_contains(re.compile(r"\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
-            "Connection to .*elasticsearch\("+self.get_elasticsearch_monitoring_url()+"\).* established")))
+            "Connection to .*elasticsearch\(" + self.get_elasticsearch_monitoring_url() + "\).* established")))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
 
@@ -105,7 +105,7 @@ class Test(BaseTest):
     def search_monitoring_doc(self, monitoring_type):
         results = self.es_monitoring.search(
             index='.monitoring-beats-*',
-            q='type:'+monitoring_type,
+            q='type:' + monitoring_type,
             size=1
         )
         return results['hits']['hits']
@@ -123,7 +123,7 @@ class Test(BaseTest):
     def assert_monitoring_doc_contains_fields(self, monitoring_type, field_names):
         results = self.es_monitoring.search(
             index='.monitoring-beats-*',
-            q='type:'+monitoring_type,
+            q='type:' + monitoring_type,
             size=1
         )
         hits = results['hits']['hits']

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -295,7 +295,7 @@ class Test(metricbeat.BaseTest):
         # Enable xpack trial
         try:
             self.es.transport.perform_request('POST', self.license_url + "/start_trial?acknowledge=true")
-        except:
+        except BaseException:
             e = sys.exc_info()[0]
             print("Trial already enabled. Error: {}".format(e))
 
@@ -307,7 +307,7 @@ class Test(metricbeat.BaseTest):
 
         try:
             self.es.transport.perform_request('POST', self.license_url + "/start_basic?acknowledge=true")
-        except:
+        except BaseException:
             e = sys.exc_info()[0]
             print("Basic license already enabled. Error: {}".format(e))
 

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -533,7 +533,7 @@ class Test(metricbeat.BaseTest):
             assert isinstance(udp["all"]["count"], int)
 
     def check_username(self, observed, expected=None):
-        if expected == None:
+        if expected is None:
             expected = getpass.getuser()
 
         if os.name == 'nt':

--- a/metricbeat/module/uwsgi/test_uwsgi.py
+++ b/metricbeat/module/uwsgi/test_uwsgi.py
@@ -73,4 +73,4 @@ class Test(metricbeat.BaseTest):
         self.common_checks(output)
 
     def get_host(self, proto):
-        return proto + "://" + self.compose_host(service="uwsgi_"+proto)
+        return proto + "://" + self.compose_host(service="uwsgi_" + proto)

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import sys
@@ -11,7 +12,6 @@ COMMON_FIELDS = ["@timestamp", "agent", "metricset.name", "metricset.host",
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
-import logging
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
@@ -50,7 +50,7 @@ class BaseTest(TestCase):
 
         # Dedot further levels recursively
         for key in fields:
-            if type(fields[key]) is dict:
+            if isinstance(fields[key], dict):
                 fields[key] = self.de_dot(fields[key])
 
         return fields
@@ -61,7 +61,7 @@ class BaseTest(TestCase):
         """
         log = self.get_log()
 
-        pattern = self.build_log_regex("\[cfgwarn\]")
+        pattern = self.build_log_regex(r"\[cfgwarn\]")
         log = pattern.sub("", log)
 
         # Jenkins runs as a Windows service and when Jenkins executes these

--- a/metricbeat/tests/system/test_cmd.py
+++ b/metricbeat/tests/system/test_cmd.py
@@ -156,7 +156,7 @@ class TestCommands(metricbeat.BaseTest):
                 self.log_contains("ERROR error fetching status"),
                 self.log_contains("ERROR timeout waiting for an event"),
             ))
-        except:
+        except BaseException:
             # Print log to help debugging this if error message changes
             print(self.get_log())
             raise

--- a/packetbeat/tests/system/test_0012_http_basicauth.py
+++ b/packetbeat/tests/system/test_0012_http_basicauth.py
@@ -39,5 +39,5 @@ class Test(BaseTest):
 
         assert len(objs) >= 1
         assert all([o["type"] == "http" for o in objs])
-        assert all([re.search("[Aa]uthorization:\*+", o["request"])
+        assert all([re.search(r"[Aa]uthorization:\*+", o["request"])
                     is not None for o in objs])

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,5 +9,7 @@ markers =
 # Ignore setup and teardown for the timeout
 timeout_func_only = True
 
+# Fail on deprecation warnings
 filterwarnings =
+    error::DeprecationWarning
     error::yaml.YAMLLoadWarning

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -144,7 +144,7 @@ class WriteReadTest(BaseTest):
             assert "message" not in evt
         else:
             self.assertEqual(evt["message"], msg)
-            self.assertDictContainsSubset({"winlog.event_data.param1": msg}, evt)
+            self.assertEqual(msg, evt.get("winlog.event_data.param1"))
 
         if sid is None:
             self.assertEqual(evt["winlog.user.identifier"], self.get_sid_string())
@@ -158,7 +158,7 @@ class WriteReadTest(BaseTest):
             assert "winlog.user.type" not in evt
 
         if extra is not None:
-            self.assertDictContainsSubset(extra, evt)
+            assert extra.items() <= evt.items()
 
 
 def host_name(fqdn):

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -130,14 +130,15 @@ class WriteReadTest(BaseTest):
 
         assert host_name(evt["winlog.computer_name"]).lower() == host_name(platform.node()).lower()
         assert "winlog.record_id" in evt
-        self.assertDictContainsSubset({
+        expected = {
             "winlog.event_id": eventID,
             "event.code": eventID,
             "log.level": level.lower(),
             "winlog.channel": self.providerName,
             "winlog.provider_name": self.applicationName,
             "winlog.api": self.api,
-        }, evt)
+        }
+        assert expected.items() <= evt.items()
 
         if msg is None:
             assert "message" not in evt

--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -638,7 +638,7 @@ class DNSTestCase:
                 "user.id": str(os.getuid()),
             }, {
                 "agent.type": "auditbeat",
-                "client.bytes":  client_bytes,
+                "client.bytes": client_bytes,
                 "client.ip": self.client_addr[0],
                 "client.packets": client_packets,
                 "client.port": self.client_addr[1],
@@ -664,7 +664,7 @@ class DNSTestCase:
                 "server.packets": server_packets,
                 "server.port": self.server_addr[1],
                 "service.type": "system",
-                "source.bytes":  client_bytes,
+                "source.bytes": client_bytes,
                 "source.ip": self.client_addr[0],
                 "source.packets": client_packets,
                 "source.port": self.client_addr[1],

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -113,6 +113,6 @@ class Test(BaseTest, common_tests.TestExportsMixin):
         log = self.get_log()
         # Trim the extra output from the Go test wrapper (like PASS/FAIL and
         # coverage information).
-        log = log[:log.rindex('}')+1]
+        log = log[:log.rindex('}') + 1]
         function_template = json.loads(log)
         return function_template

--- a/x-pack/libbeat/tests/system/test_management.py
+++ b/x-pack/libbeat/tests/system/test_management.py
@@ -271,7 +271,8 @@ class TestManagement(BaseTest):
         assert r.status_code == 200
 
     def get_elasticsearch_url(self):
-        return 'http://' + self.es_user + ":" + self.es_pass + '@' + os.getenv('ES_HOST', 'localhost') + ':' + os.getenv('ES_PORT', '5601')
+        return 'http://' + self.es_user + ":" + self.es_pass + '@' + \
+            os.getenv('ES_HOST', 'localhost') + ':' + os.getenv('ES_PORT', '5601')
 
     def get_kibana_url(self):
         return 'http://' + os.getenv('KIBANA_HOST', 'kibana') + ':' + os.getenv('KIBANA_PORT', '5601')
@@ -283,7 +284,7 @@ class TestManagement(BaseTest):
         try:
             self.es.indices.refresh(index=index)
             return self.es.search(index=index, body={"query": {"match_all": {}}})['hits']['total']['value'] >= count
-        except:
+        except BaseException:
             return False
 
     def wait_documents(self, index, count):


### PR DESCRIPTION
## What does this PR do?

Solve python deprecation warnings, and make python tests to fail if deprecated code is added.

Summary of changes:
* Add `error::DeprecationWarning` to pytest's `filterwarnings` (so tests fail if use deprecated code).
* Add `pytest.ini` to the list of files that trigger all CI builds.
* Refactor tests to don't require deprecated `assertDictContainsSubset`.
* Update autopep8 to latest version, and run it once with `-a` (aggresive).
* Solve some other deprecation warnings not solved automatically by `autopep8 -a`.

## Why is it important?

To avoid introducing deprecated Python code on testing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Closes #20384 
- Fixes #19915