### PR TITLE
Auto-include node_stats metricset when xpack.enabled: true is set

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -54,6 +54,7 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		"index_recovery",
 		"index_summary",
 		"ml_job",
+		"node_stats",
 		"shard",
 	}
 	return elastic.NewModule(&base, xpackEnabledMetricSets, logp.NewLogger(ModuleName))

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -178,7 +178,7 @@ func TestXPackEnabled(t *testing.T) {
 
 			types := metricSetToTypesMap[metricSet.Name()]
 			fmt.Println("***** debugging: types:", types)
-			fmt.Println("***** debugging: len(events):", len(events))
+			fmt.Println("***** debugging: events:", events)
 			require.Len(t, events, len(types))
 
 			for i, event := range events {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -177,10 +177,17 @@ func TestXPackEnabled(t *testing.T) {
 			}
 
 			types := metricSetToTypesMap[metricSet.Name()]
-			fmt.Println("***** debugging: types:", types)
-			fmt.Printf("***** debugging: events: %#+v\n", events)
-			require.Len(t, events, len(types))
+			numTypes := len(types)
 
+			// If no types are returned for this metricset, then it's because this metricset
+			// is no longer indexing events into .monitoring-* indices. But instead it is indexing
+			// events into the default Metricbeat indices.
+			if numTypes == 0 {
+				require.Empty(t, event.Index)
+				return
+			}
+
+			require.Len(t, events, numTypes)
 			for i, event := range events {
 				require.Equal(t, types[i], event.RootFields["type"])
 				require.Regexp(t, `^.monitoring-es-\d-mb`, event.Index)

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -177,6 +177,8 @@ func TestXPackEnabled(t *testing.T) {
 			}
 
 			types := metricSetToTypesMap[metricSet.Name()]
+			fmt.Println("***** debugging: types:", types)
+			fmt.Println("***** debugging: len(events):", len(events))
 			require.Len(t, events, len(types))
 
 			for i, event := range events {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -133,6 +133,7 @@ func TestXPackEnabled(t *testing.T) {
 		"index_recovery": []string{"index_recovery"},
 		"index_summary":  []string{"indices_stats"},
 		"ml_job":         []string{"job_stats"},
+		"node_stats":     []string{}, // no longer indexed into .monitoring-es-*
 	}
 
 	config := getXPackConfig(host)

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -178,7 +178,7 @@ func TestXPackEnabled(t *testing.T) {
 
 			types := metricSetToTypesMap[metricSet.Name()]
 			fmt.Println("***** debugging: types:", types)
-			fmt.Println("***** debugging: events:", events)
+			fmt.Printf("***** debugging: events: %#+v\n", events)
 			require.Len(t, events, len(types))
 
 			for i, event := range events {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -133,7 +133,6 @@ func TestXPackEnabled(t *testing.T) {
 		"index_recovery": []string{"index_recovery"},
 		"index_summary":  []string{"indices_stats"},
 		"ml_job":         []string{"job_stats"},
-		"node_stats":     []string{"node_stats"},
 	}
 
 	config := getXPackConfig(host)

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -183,7 +183,9 @@ func TestXPackEnabled(t *testing.T) {
 			// is no longer indexing events into .monitoring-* indices. But instead it is indexing
 			// events into the default Metricbeat indices.
 			if numTypes == 0 {
-				require.Empty(t, event.Index)
+				for _, event := range events {
+					require.Empty(t, event.Index)
+				}
 				return
 			}
 

--- a/metricbeat/module/elasticsearch/elasticsearch_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_test.go
@@ -45,7 +45,7 @@ func TestXPackEnabledMetricsets(t *testing.T) {
 	}
 
 	metricSets := mbtest.NewReportingMetricSetV2Errors(t, config)
-	require.Len(t, metricSets, 8)
+	require.Len(t, metricSets, 9)
 	for _, ms := range metricSets {
 		name := ms.Name()
 		switch name {

--- a/metricbeat/module/elasticsearch/elasticsearch_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_test.go
@@ -50,7 +50,7 @@ func TestXPackEnabledMetricsets(t *testing.T) {
 		name := ms.Name()
 		switch name {
 		case "ccr", "enrich", "cluster_stats", "index", "index_recovery",
-			"index_summary", "ml_job", "shard":
+			"index_summary", "ml_job", "node_stats", "shard":
 		default:
 			t.Errorf("unexpected metricset name = %v", name)
 		}

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -145,6 +145,9 @@ class Test(metricbeat.BaseTest):
 
         docs = self.read_output_json()
         for doc in docs:
+            if "type" not in doc:
+                continue
+
             t = doc["type"]
             if t != "cluster_stats":
                 continue

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -127,6 +127,7 @@ class Test(metricbeat.BaseTest):
                 "index_recovery",
                 "index_summary",
                 "ml_job",
+                "node_stats",
                 "shard"
             ],
             "hosts": self.get_hosts(),


### PR DESCRIPTION
Follow up to #19747.  A line of code was accidentally removed in #19747. This PR puts it back.

This line of code ensures that when `metricbeat modules enable elasticsearch-xpack` is run or, alternatively, when the `elasticsearch` module is enabled and configured with `xpack.enabled: true`, the `node_stats` metricset is automatically enabled for the module.