### PR TITLE
Cherry-pick #20490 to 7.x: Add replace_fields config option in add_host_metadata for replacing host fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -447,6 +447,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Set index.max_docvalue_fields_search in index template to increase value to 200 fields. {issue}20215[20215]
 - Add leader election for Kubernetes autodiscover. {pull}20281[20281]
 - Add capability of enriching process metadata with contianer id also for non-privileged containers in `add_process_metadata` processor. {pull}19767[19767]
+- Add replace_fields config option in add_host_metadata for replacing host fields. {pull}20490[20490] {issue}20464[20464]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
+var (
+	hostName = "testHost"
+	hostID   = "9C7FAB7B"
+)
+
 func TestConfigDefault(t *testing.T) {
 	event := &beat.Event{
 		Fields:    common.MapStr{},
@@ -195,4 +200,214 @@ func TestConfigGeoDisabled(t *testing.T) {
 	eventGeoField, err := newEvent.GetValue("host.geo")
 	assert.Error(t, err)
 	assert.Equal(t, nil, eventGeoField)
+}
+
+func TestEventWithReplaceFieldsFalse(t *testing.T) {
+	cfg := map[string]interface{}{}
+	cfg["replace_fields"] = false
+	testConfig, err := common.NewConfigFrom(cfg)
+	assert.NoError(t, err)
+
+	p, err := New(testConfig)
+	switch runtime.GOOS {
+	case "windows", "darwin", "linux":
+		assert.NoError(t, err)
+	default:
+		assert.IsType(t, types.ErrNotImplemented, err)
+		return
+	}
+
+	cases := []struct {
+		title                   string
+		event                   beat.Event
+		hostLengthLargerThanOne bool
+		hostLengthEqualsToOne   bool
+		expectedHostFieldLength int
+	}{
+		{
+			"replace_fields=false with only host.name",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+					},
+				},
+			},
+			true,
+			false,
+			-1,
+		},
+		{
+			"replace_fields=false with only host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"id": hostID,
+					},
+				},
+			},
+			false,
+			true,
+			1,
+		},
+		{
+			"replace_fields=false with host.name and host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+						"id":   hostID,
+					},
+				},
+			},
+			true,
+			false,
+			2,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			newEvent, err := p.Run(&c.event)
+			assert.NoError(t, err)
+
+			v, err := newEvent.GetValue("host")
+			assert.NoError(t, err)
+			assert.Equal(t, c.hostLengthLargerThanOne, len(v.(common.MapStr)) > 1)
+			assert.Equal(t, c.hostLengthEqualsToOne, len(v.(common.MapStr)) == 1)
+			if c.expectedHostFieldLength != -1 {
+				assert.Equal(t, c.expectedHostFieldLength, len(v.(common.MapStr)))
+			}
+		})
+	}
+}
+
+func TestEventWithReplaceFieldsTrue(t *testing.T) {
+	cfg := map[string]interface{}{}
+	cfg["replace_fields"] = true
+	testConfig, err := common.NewConfigFrom(cfg)
+	assert.NoError(t, err)
+
+	p, err := New(testConfig)
+	switch runtime.GOOS {
+	case "windows", "darwin", "linux":
+		assert.NoError(t, err)
+	default:
+		assert.IsType(t, types.ErrNotImplemented, err)
+		return
+	}
+
+	cases := []struct {
+		title                   string
+		event                   beat.Event
+		hostLengthLargerThanOne bool
+		hostLengthEqualsToOne   bool
+	}{
+		{
+			"replace_fields=true with host.name",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+					},
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"replace_fields=true with host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"id": hostID,
+					},
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"replace_fields=true with host.name and host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+						"id":   hostID,
+					},
+				},
+			},
+			true,
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			newEvent, err := p.Run(&c.event)
+			assert.NoError(t, err)
+
+			v, err := newEvent.GetValue("host")
+			assert.NoError(t, err)
+			assert.Equal(t, c.hostLengthLargerThanOne, len(v.(common.MapStr)) > 1)
+			assert.Equal(t, c.hostLengthEqualsToOne, len(v.(common.MapStr)) == 1)
+		})
+	}
+}
+
+func TestSkipAddingHostMetadata(t *testing.T) {
+	cases := []struct {
+		title        string
+		event        beat.Event
+		expectedSkip bool
+	}{
+		{
+			"event only with host.name",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+					},
+				},
+			},
+			false,
+		},
+		{
+			"event only with host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"id": hostID,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"event with host.name and host.id",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": common.MapStr{
+						"name": hostName,
+						"id":   hostID,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"event without host field",
+			beat.Event{
+				Fields: common.MapStr{},
+			},
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			skip := skipAddingHostMetadata(&c.event)
+			assert.Equal(t, c.expectedSkip, skip)
+		})
+	}
 }

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -29,11 +29,13 @@ type Config struct {
 	CacheTTL       time.Duration   `config:"cache.ttl"`
 	Geo            *util.GeoConfig `config:"geo"`
 	Name           string          `config:"name"`
+	ReplaceFields  bool            `config:"replace_fields"` // replace existing host fields with add_host_metadata
 }
 
 func defaultConfig() Config {
 	return Config{
 		NetInfoEnabled: true,
 		CacheTTL:       5 * time.Minute,
+		ReplaceFields:  true,
 	}
 }

--- a/libbeat/processors/add_host_metadata/docs/add_host_metadata.asciidoc
+++ b/libbeat/processors/add_host_metadata/docs/add_host_metadata.asciidoc
@@ -42,6 +42,8 @@ It has the following settings:
 
 `geo.region_iso_code`:: (Optional) ISO region code.
 
+`replace_fields`:: (Optional) Default true. If set to false, original host
+fields from the event will not be replaced by host fields from `add_host_metadata`.
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
 The fields added to the event look like the following:
@@ -75,3 +77,9 @@ The fields added to the event look like the following:
    }
 }
 -------------------------------------------------------------------------------
+
+Note: `add_host_metadata` processor will overwrite host fields if `host.*`
+fields already exist in the event from Beats by default with `replace_fields`
+equals to `true`.
+Please use `add_observer_metadata` if the beat is being used to monitor external
+systems.


### PR DESCRIPTION
Cherry-pick of PR #20490 to 7.x branch. Original message: 

## What does this PR do?

This PR adds `replace_fields` config option in `add_host_metadata` for replacing host fields. By default, `replace_fields` equals to `true` to make sure this PR is not a breaking change. 

## Why is it important?

We are adding common host fields into several modules in Metricbeat, such as `host.id` and `host.name`. But `add_host_metadata` processor would overwrite `host.id` field without this PR. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This PR should work for any module/metricset. I'm using aws module as an example here:
1. Make sure https://github.com/elastic/beats/pull/20171 is in the code and then enable `aws` module by 
`./metricbeat modules enable aws`
2. Change `aws` config `modules.d/aws.yml` to:
```
- module: aws
  period: 5m
  credential_profile_name: elastic-beats
  metricsets:
    - ec2
```
3. Make sure in `metricbeat.yml`, `add_host_metadata` processor is enabled and `replace_fields` is set to `false`:
```
processors:
  - add_host_metadata:
      - replace_fields: false
```
4. Start Metricbeat with `./metricbeat -e`
5. Check metrics sent to ES from Kibana discover. Metrics should have `host.*` fields only from `ec2` metricset but not any fields from `add_host_metadata` such as `host.hostname`, `host.architecture`, `host.os.*` etc.

## Related issues

https://github.com/elastic/beats/issues/20464