### PR TITLE
Cherry-pick to 7.9: [docs] Add breaking changes for 7.9 (#20595)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.9.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.9.asciidoc
@@ -1,0 +1,23 @@
+[[breaking-changes-7.9]]
+
+=== Breaking changes in 7.9
+++++
+<titleabbrev>7.9</titleabbrev>
+++++
+
+{see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+[float]
+==== Some {filebeat} Okta module settings no longer accept JSON strings
+
+Prior to version 7.9, the OKTA module accepted JSON strings for some
+configuration settings (`http_headers`, `http_request_body`, `pagination`,
+`rate_limit`, and `ssl`). This was inconsistent with other {beats} settings, so
+it has been removed.
+
+The affected settings now expect regular YAML objects for values.
+// end::notable-breaking-changes[]

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.9>>
+
 * <<breaking-changes-7.8>>
 
 * <<breaking-changes-7.7>>
@@ -28,6 +30,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.9.asciidoc[]
 
 include::breaking-7.8.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [docs] Add breaking changes for 7.9 (#20595)