### PR TITLE
[Winlogbeat][Sysmon] Remove top level hash property from sysmon events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -97,6 +97,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Powershell module. Support for event ID's: `400`, `403`, `600`, `800`, `4103`, `4014`, `4105`, `4106`. {issue}16262[16262] {pull}18526[18526]
 - Fix Powershell processing of downgraded engine events. {pull}18966[18966]
 - Fix unprefixed fields in `fields.yml` for Powershell module {issue}18984[18984]
+- Remove top level `hash` property from sysmon events {pull}20653[20653]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -424,9 +424,6 @@ var sysmon = (function () {
 
             evt.Put(path, value);
             evt.AppendTo("related.hash", value);
-
-            // TODO: remove in 8.0, see (https://github.com/elastic/beats/issues/18364).
-            evt.Put("hash." + key, value);
         });
     };
 

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
@@ -19,10 +19,6 @@
       "name": "test.test.exe",
       "path": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\1\\go-build583768550\\b001\\test.test.exe"
     },
-    "hash": {
-      "imphash": "d90d8c7812aec8da0fa173afa1293ab2",
-      "md5": "199e1cf5b2250bd515ecccf4ca686301"
-    },
     "host": {
       "name": "vagrant-2012-r2"
     },
@@ -104,9 +100,6 @@
       "name": "lastalive0.dat",
       "path": "C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local\\lastalive0.dat"
     },
-    "hash": {
-      "sha1": "115106f5b338c87ae6836d50dd890de3da296367"
-    },
     "host": {
       "name": "vagrant-2012-r2"
     },
@@ -180,9 +173,6 @@
       "directory": "C:\\Windows\\System32\\LogFiles\\Scm",
       "name": "8b34f644-f627-47e7-98e0-957ba1c5eb6d",
       "path": "C:\\Windows\\System32\\LogFiles\\Scm\\8b34f644-f627-47e7-98e0-957ba1c5eb6d"
-    },
-    "hash": {
-      "md5": "5a9bddf83be530b481f0fd24db28a6ff"
     },
     "host": {
       "name": "vagrant-2012-r2"

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -99,9 +99,6 @@
         "process_start"
       ]
     },
-    "hash": {
-      "sha1": "ac93c3b38e57a2715572933dbcb2a1c2892dbc5e"
-    },
     "host": {
       "name": "vagrant-2012-r2"
     },
@@ -187,9 +184,6 @@
         "start",
         "process_start"
       ]
-    },
-    "hash": {
-      "sha1": "6df8163a6320b80b60733f9d62e2f39b4b16b678"
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -379,9 +373,6 @@
         "start",
         "process_start"
       ]
-    },
-    "hash": {
-      "sha1": "5a4c0e82ff95c9fb762d46a696ef9f1b68001c21"
     },
     "host": {
       "name": "vagrant-2012-r2"


### PR DESCRIPTION
## What does this PR do?

Removes top level `hash` property from sysmon events

## Why is it important?

To be compliant with ECS, `hash` property should only be nested. 

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

