### PR TITLE
Cherry-pick #20606 to 7.x: Fix yaml warnings in python scripts and tests

### DIFF
--- a/auditbeat/scripts/docs_collector.py
+++ b/auditbeat/scripts/docs_collector.py
@@ -56,7 +56,7 @@ This file is generated! See scripts/docs_collector.py
 
         # Load title from fields.yml
         with open(beat_path + "/fields.yml") as f:
-            fields = yaml.load(f.read())
+            fields = yaml.load(f.read(), Loader=yaml.FullLoader)
             title = fields[0]["title"]
 
         modules_list[module] = title

--- a/filebeat/scripts/docs_collector.py
+++ b/filebeat/scripts/docs_collector.py
@@ -45,7 +45,7 @@ This file is generated! See scripts/docs_collector.py
 
         # Load title from fields.yml
         with open(beat_path + "/fields.yml", encoding='utf_8') as f:
-            fields = yaml.load(f.read())
+            fields = yaml.load(f.read(), Loader=yaml.FullLoader)
             title = fields[0]["title"]
 
         modules_list[module] = title

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -106,7 +106,7 @@ grouped in the following categories:
 
 """.format(**dict))
 
-    docs = yaml.load(input)
+    docs = yaml.load(input, Loader=yaml.FullLoader)
 
     # fields file is empty
     if docs is None:

--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -76,5 +76,5 @@ class TestExportsMixin:
         Test that the config can be exported with `export config`
         """
         output = self.run_export_cmd("config")
-        yml = yaml.load(output)
+        yml = yaml.load(output, Loader=yaml.FullLoader)
         assert isinstance(yml, dict)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,6 @@ markers =
 
 # Ignore setup and teardown for the timeout
 timeout_func_only = True
+
+filterwarnings =
+    error::yaml.YAMLLoadWarning

--- a/script/config_collector.py
+++ b/script/config_collector.py
@@ -45,7 +45,7 @@ def collect(beat_name, beat_path, full=False):
 
         # Load title from fields.yml
         with open(beat_path + "/fields.yml") as f:
-            fields = yaml.load(f.read())
+            fields = yaml.load(f.read(), Loader=yaml.FullLoader)
             title = fields[0]["title"]
 
             # Check if short config was disabled in fields.yml

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -111,7 +111,7 @@ class WriteReadTest(BaseTest):
 
     def read_registry(self, requireBookmark=False):
         f = open(os.path.join(self.working_dir, "data", ".winlogbeat.yml"), "r")
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.FullLoader)
         self.assertIn("update_time", data)
         self.assertIn("event_logs", data)
 


### PR DESCRIPTION
Cherry-pick of PR #20606 to 7.x branch. Original message: 

## What does this PR do?

Fix yaml warnings in python scripts and tests as proposed in https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

## Why is it important?

To avoid using deprecated code that may stop working in the future.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related to #20384 
- Part of #20603  