### PR TITLE
Cherry-pick #20385 to 7.9: [MetricBeat] resource tags map should be compatible with short or whole resource id

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,6 +101,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add required option for `metrics` in app_insights. {pull}20406[20406]
 - Groups same timestamp metric values to one event in the app_insights metricset. {pull}20403[20403]
 - Updates vm_compute metricset with more info on guest metrics. {pull}20448[20448]
+- Fix resource tags in aws cloudwatch metricset {issue}20326[20326]  {pull}20385[20385]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -652,7 +652,7 @@ func insertTags(events map[string]mb.Event, identifier string, resourceTagMap ma
 		tags := resourceTagMap[v]
 		// some metric dimension values are arn format, eg: AWS/DDOS namespace metric
 		if len(tags) == 0 && strings.HasPrefix(v, "arn:") {
-			resourceID, err := aws.FindIdentifierFromARN(v)
+			resourceID, err := aws.FindShortIdentifierFromARN(v)
 			if err == nil {
 				tags = resourceTagMap[resourceID]
 			}


### PR DESCRIPTION
Cherry-pick of PR #20385 to 7.9 branch. Original message: 


- Bug

## What does this PR do?

fix resource tags in metircbeat aws cloudwatch module.  more detail has be explained in #20326


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

1.  metricbeat aws module config

```yaml
metricbeat.modules:
  - module: aws
    aws_partition: aws
    period: 300s
    access_key_id: 'your key'
    secret_access_key: 'your key'
    regions:
      - ap-northeast-2
    metricsets:
      - cloudwatch
    metrics:
      - namespace: AWS/ApplicationELB
        statistic: ['Minimum']
        name: ['HealthyHostCount']
        #tags.resource_type_filter: elasticloadbalancing   # for verion 7.x
        resource_type: elasticloadbalancing     # for version 8.0

```

2. set AWS ELB TargetGroup tags

3. run metricbeat,  `aws.tags` field in event should contain both LoadBalancer and TargetGroup tags


## Related issues

- Closes #20326

