### PR TITLE
Cherry-pick #20171 to 7.x: Add host inventory metrics to ec2 metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -720,6 +720,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Added cache and connection_errors metrics to status metricset of MySQL module {issue}16955[16955] {pull}19844[19844]
 - Update MySQL dashboard with connection errors and cache metrics {pull}19913[19913] {issue}16955[16955]
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
+- Add host inventory metrics into aws ec2 metricset. {pull}20171[20171]
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 
 *Packetbeat*

--- a/metricbeat/_meta/fields.common.yml
+++ b/metricbeat/_meta/fields.common.yml
@@ -41,3 +41,28 @@
     - name: systemd.unit
       type: keyword
       description: the unit name of the systemd service
+
+    - name: host
+      type: group
+      fields:
+        - name: cpu.pct
+          type: scaled_float
+          description: Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+        - name: network.in.bytes
+          type: scaled_float
+          description: The number of bytes received on all network interfaces by the host in a given period of time.
+        - name: network.out.bytes
+          type: scaled_float
+          description: The number of bytes sent out on all network interfaces by the host in a given period of time.
+        - name: network.in.packets
+          type: scaled_float
+          description: The number of packets received on all network interfaces by the host in a given period of time.
+        - name: network.out.packets
+          type: scaled_float
+          description: The number of packets sent out on all network interfaces by the host in a given period of time.
+        - name: disk.read.bytes
+          type: scaled_float
+          description: The total number of bytes read successfully in a given period of time.
+        - name: disk.write.bytes
+          type: scaled_float
+          description: The total number of bytes write successfully in a given period of time.

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -6393,6 +6393,70 @@ type: keyword
 
 --
 
+
+*`host.cpu.pct`*::
++
+--
+Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+
+type: scaled_float
+
+--
+
+*`host.network.in.bytes`*::
++
+--
+The number of bytes received on all network interfaces by the host in a given period of time.
+
+type: scaled_float
+
+--
+
+*`host.network.out.bytes`*::
++
+--
+The number of bytes sent out on all network interfaces by the host in a given period of time.
+
+type: scaled_float
+
+--
+
+*`host.network.in.packets`*::
++
+--
+The number of packets received on all network interfaces by the host in a given period of time.
+
+type: scaled_float
+
+--
+
+*`host.network.out.packets`*::
++
+--
+The number of packets sent out on all network interfaces by the host in a given period of time.
+
+type: scaled_float
+
+--
+
+*`host.disk.read.bytes`*::
++
+--
+The total number of bytes read successfully in a given period of time.
+
+type: scaled_float
+
+--
+
+*`host.disk.write.bytes`*::
++
+--
+The total number of bytes write successfully in a given period of time.
+
+type: scaled_float
+
+--
+
 [[exported-fields-consul]]
 == Consul fields
 

--- a/x-pack/metricbeat/module/aws/ec2/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/data.json
@@ -4,11 +4,11 @@
         "ec2": {
             "cpu": {
                 "credit_balance": 144,
-                "credit_usage": 0.061395,
+                "credit_usage": 0.058005,
                 "surplus_credit_balance": 0,
                 "surplus_credits_charged": 0,
                 "total": {
-                    "pct": 1.1651199407241788
+                    "pct": 1.1631008613503082
                 }
             },
             "diskio": {
@@ -51,16 +51,16 @@
             },
             "network": {
                 "in": {
-                    "bytes": 7375.4,
-                    "bytes_per_sec": 24.584666666666667,
-                    "packets": 49,
-                    "packets_per_sec": 0.16333333333333333
+                    "bytes": 786.6,
+                    "bytes_per_sec": 2.622,
+                    "packets": 5.8,
+                    "packets_per_sec": 0.019333333333333334
                 },
                 "out": {
-                    "bytes": 11567,
-                    "bytes_per_sec": 38.556666666666665,
-                    "packets": 44.8,
-                    "packets_per_sec": 0.14933333333333332
+                    "bytes": 627,
+                    "bytes_per_sec": 2.09,
+                    "packets": 5.8,
+                    "packets_per_sec": 0.019333333333333334
                 }
             },
             "status": {
@@ -94,6 +94,31 @@
         "dataset": "aws.ec2",
         "duration": 115000,
         "module": "aws"
+    },
+    "host": {
+        "cpu": {
+            "pct": 0.011631008613503082
+        },
+        "disk": {
+            "read": {
+                "bytes": 0
+            },
+            "write": {
+                "bytes": 0
+            }
+        },
+        "id": "i-0516ddaca5c1d231f",
+        "name": "mysql-test",
+        "network": {
+            "in": {
+                "bytes": 786.6,
+                "packets": 5.8
+            },
+            "out": {
+                "bytes": 627,
+                "packets": 5.8
+            }
+        }
     },
     "metricset": {
         "name": "ec2",


### PR DESCRIPTION
Cherry-pick of PR #20171 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to add proposed host common fields into `ec2` metricset:
- host.id
- host.name
- host.cpu.pct
- host.network.in.bytes
- host.network.in.packets
- host.network.out.bytes
- host.network.out.packets
- host.disk.read.bytes
- host.disk.write.bytes

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

1. Start Metricbeat AWS module: `./metricbeat modules enable aws`
2. Edit `modules.d/aws.yml` to only include `ec2` metricset:
```
- module: aws
  period: 5m
  credential_profile_name: elastic-beats
  metricsets:
    - ec2
```
3. Change add_host_metadata processor config in metricbeat.yml file:
```
processors:
  - add_host_metadata:
      replace_fields: false
```
4. Start metricbeat
5. You should see metrics from `ec2` metricset and includes fields listed above.
(`host.name` only equals to EC2 instance name when EC2 instance name is available.)

## Event Example
```
{
    "@timestamp": "2017-10-12T08:05:34.853Z",
    "aws": {
        "ec2": {
            "cpu": {
                "credit_balance": 144,
                "credit_usage": 0.05477,
                "surplus_credit_balance": 0,
                "surplus_credits_charged": 0,
                "total": {
                    "pct": 1.166484417714406
                }
            },
            "diskio": {
                "read": {
                    "bytes": 0,
                    "bytes_per_sec": 0,
                    "count": 0,
                    "count_per_sec": 0
                },
                "write": {
                    "bytes": 0,
                    "bytes_per_sec": 0,
                    "count": 0,
                    "count_per_sec": 0
                }
            },
            "instance": {
                "core": {
                    "count": 1
                },
                "image": {
                    "id": "ami-04bc3da8f14823e88"
                },
                "monitoring": {
                    "state": "disabled"
                },
                "private": {
                    "dns_name": "ip-172-31-9-119.us-west-1.compute.internal",
                    "ip": "172.31.9.119"
                },
                "public": {
                    "dns_name": "ec2-13-52-163-56.us-west-1.compute.amazonaws.com",
                    "ip": "13.52.163.56"
                },
                "state": {
                    "code": 16,
                    "name": "running"
                },
                "threads_per_core": 1
            },
            "network": {
                "in": {
                    "bytes": 6644.4,
                    "bytes_per_sec": 22.148,
                    "packets": 44.6,
                    "packets_per_sec": 0.14866666666666667
                },
                "out": {
                    "bytes": 6016.6,
                    "bytes_per_sec": 20.055333333333333,
                    "packets": 35.4,
                    "packets_per_sec": 0.118
                }
            },
            "status": {
                "check_failed": 0,
                "check_failed_instance": 0,
                "check_failed_system": 0
            }
        },
        "tags": {
            "Name": "mysql-test",
            "created-by": "ks"
        }
    },
    "cloud": {
        "account": {
            "id": "428152502467",
            "name": "elastic-beats"
        },
        "availability_zone": "us-west-1b",
        "instance": {
            "id": "i-0516ddaca5c1d231f",
            "name": "mysql-test"
        },
        "machine": {
            "type": "t2.micro"
        },
        "provider": "aws",
        "region": "us-west-1"
    },
    "event": {
        "dataset": "aws.ec2",
        "duration": 115000,
        "module": "aws"
    },
    "host": {
        "cpu": {
            "pct": 1.166484417714406
        },
        "disk": {
            "read": {
                "bytes": 0
            }
        },
        "diskio": {
            "write": {
                "bytes": 0
            }
        },
        "id": "i-0516ddaca5c1d231f",
        "name": "mysql-test",
        "network": {
            "in": {
                "bytes": 6644.4,
                "packets": 44.6
            },
            "out": {
                "bytes": 6016.6,
                "packets": 35.4
            }
        }
    },
    "metricset": {
        "name": "ec2",
        "period": 10000
    },
    "service": {
        "type": "aws"
    }
}
```
