### PR TITLE
[Auditbeat] Change event.kind=error to event.kind=event to comply with ECS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - File integrity dataset (macOS): Replace unnecessary `file.origin.raw` (type keyword) with `file.origin.text` (type `text`). {issue}12423[12423] {pull}15630[15630]
+- Change event.kind=error to event.kind=event to comply with ECS. {issue}18870[18870] {pull}20685[20685]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -39,7 +39,6 @@ const (
 
 	eventTypeState = "state"
 	eventTypeEvent = "event"
-	eventTypeError = "error"
 )
 
 type eventAction uint8
@@ -247,7 +246,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 			report.Event(event)
 		} else {
 			ms.log.Warn(p.Error)
-			report.Event(ms.processEvent(p, eventTypeError, eventActionProcessError))
+			report.Event(ms.processEvent(p, eventTypeEvent, eventActionProcessError))
 		}
 	}
 
@@ -287,7 +286,7 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 			report.Event(ms.processEvent(p, eventTypeEvent, eventActionProcessStarted))
 		} else {
 			ms.log.Warn(p.Error)
-			report.Event(ms.processEvent(p, eventTypeError, eventActionProcessError))
+			report.Event(ms.processEvent(p, eventTypeEvent, eventActionProcessError))
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

Changes `event.kind=error` occurrences to `event.kind=event` 

## Why is it important?

`event.kind=error` value is not one of the allowed values for the field.
https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-kind.html

## Checklist

- [x] My code follows the style guidelines of this project
~- [] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #18870

