### PR TITLE
Cherry-pick #20683 to 7.x: testing: fix Kibana healthcheck

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -27,7 +27,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:7.10.0-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600
       interval: 1s
 

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -28,6 +28,6 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600
       interval: 1s

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: kibana
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", "curl -u myelastic:changeme -f http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 1200
       interval: 5s
       start_period: 60s


### PR DESCRIPTION
Cherry-pick of PR #20683 to 7.x branch. Original message: 

## What does this PR do?

Update the Kibana Docker healthchecks to stop using Python, and instead of parsing the result just grep for the string "Looking good".

## Why is it important?

With https://github.com/elastic/kibana/pull/74656, Kibana images will no longer have Python installed.
APM Server system tests are failing due to these health checks failing, and I presume Beats tests are failing too.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

```
cd x-pack/libbeat
mage build test
```

## Related issues

None.