### PR TITLE
docs: Update cipher suites documentation

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -155,34 +155,39 @@ The default is `full`.
 ==== `cipher_suites`
 
 The list of cipher suites to use. The first entry has the highest priority.
-If this option is omitted, the Go crypto library's default
-suites are used (recommended). Note that TLS 1.3 cipher suites are not
+If this option is omitted, the Go crypto library's https://golang.org/pkg/crypto/tls/[default suites]
+are used (recommended). Note that TLS 1.3 cipher suites are not
 individually configurable in Go, so they are not included in this list.
 
+// tag::cipher_suites[]
 The following cipher suites are available:
 
-* ECDHE-ECDSA-AES-128-CBC-SHA
-* ECDHE-ECDSA-AES-128-CBC-SHA256 (TLS 1.2 only, disabled by default)
-* ECDHE-ECDSA-AES-128-GCM-SHA256 (TLS 1.2 only)
-* ECDHE-ECDSA-AES-256-CBC-SHA
-* ECDHE-ECDSA-AES-256-GCM-SHA384 (TLS 1.2 only)
-* ECDHE-ECDSA-CHACHA20-POLY1305 (TLS 1.2 only)
-* ECDHE-ECDSA-RC4-128-SHA (disabled by default - RC4 not recommended)
-* ECDHE-RSA-3DES-CBC3-SHA
-* ECDHE-RSA-AES-128-CBC-SHA
-* ECDHE-RSA-AES-128-CBC-SHA256 (TLS 1.2 only, disabled by default)
-* ECDHE-RSA-AES-128-GCM-SHA256 (TLS 1.2 only)
-* ECDHE-RSA-AES-256-CBC-SHA
-* ECDHE-RSA-AES-256-GCM-SHA384 (TLS 1.2 only)
-* ECDHE-RSA-CHACHA20-POLY1205 (TLS 1.2 only)
-* ECDHE-RSA-RC4-128-SHA (disabled by default- RC4 not recommended)
-* RSA-3DES-CBC3-SHA
-* RSA-AES-128-CBC-SHA
-* RSA-AES-128-CBC-SHA256 (TLS 1.2 only, disabled by default)
-* RSA-AES-128-GCM-SHA256 (TLS 1.2 only)
-* RSA-AES-256-CBC-SHA
-* RSA-AES-256-GCM-SHA384 (TLS 1.2 only)
-* RSA-RC4-128-SHA (disabled by default - RC4 not recommended)
+[options="header"]
+|===
+| Cypher | Notes
+| ECDHE-ECDSA-AES-128-CBC-SHA |
+| ECDHE-ECDSA-AES-128-CBC-SHA256 | TLS 1.2 only. Disabled by default.
+| ECDHE-ECDSA-AES-128-GCM-SHA256 | TLS 1.2 only.
+| ECDHE-ECDSA-AES-256-CBC-SHA |
+| ECDHE-ECDSA-AES-256-GCM-SHA384 | TLS 1.2 only.
+| ECDHE-ECDSA-CHACHA20-POLY1305 | TLS 1.2 only.
+| ECDHE-ECDSA-RC4-128-SHA | Disabled by default. RC4 not recommended.
+| ECDHE-RSA-3DES-CBC3-SHA |
+| ECDHE-RSA-AES-128-CBC-SHA |
+| ECDHE-RSA-AES-128-CBC-SHA256 | TLS 1.2 only. Disabled by default.
+| ECDHE-RSA-AES-128-GCM-SHA256 | TLS 1.2 only.
+| ECDHE-RSA-AES-256-CBC-SHA |
+| ECDHE-RSA-AES-256-GCM-SHA384 | TLS 1.2 only.
+| ECDHE-RSA-CHACHA20-POLY1205 | TLS 1.2 only.
+| ECDHE-RSA-RC4-128-SHA | Disabled by default. RC4 not recommended.
+| RSA-3DES-CBC3-SHA |
+| RSA-AES-128-CBC-SHA |
+| RSA-AES-128-CBC-SHA256 | TLS 1.2 only. Disabled by default.
+| RSA-AES-128-GCM-SHA256 | TLS 1.2 only.
+| RSA-AES-256-CBC-SHA |
+| RSA-AES-256-GCM-SHA384 | TLS 1.2 only.
+| RSA-RC4-128-SHA | Disabled by default. RC4 not recommended.
+|===
 
 Here is a list of acronyms used in defining the cipher suites:
 
@@ -212,6 +217,7 @@ Here is a list of acronyms used in defining the cipher suites:
 
 * SHA, SHA256, SHA384:
   Cipher suites using SHA-1, SHA-256 or SHA-384.
+// end::cipher_suites[]
 
 [float]
 ==== `curve_types`


### PR DESCRIPTION
## What does this PR do?

This PR:
* Updates the `cipher_suites` documentation to better display TLS version compatibility.
* Adds a tagged region around the content so that it can be reused in APM Server's input (agent ←→ server) documentation. Note that I attempted to list TLS versions for each cipher, but it made the content tougher to scan. I think it works best to only note the ciphers that are compatible with 1.2.
* Links to Go's crypto library default cipher suites. Is [this](https://golang.org/pkg/crypto/tls/) the correct place to link?

## Why is it important?

This content previously only existed in the APM Server's output (server ←→ es) documentation.

## Open questions

- [x] @andrewvc - Do the ciphers you added in https://github.com/elastic/beats/pull/17687 need to be added to the documentation? https://github.com/elastic/beats/blob/5f42d21067306a312a9c0bcd10a00198cd6b8c33/libbeat/common/transport/tlscommon/types.go#L69-L71
- [x] Determine if [this](https://golang.org/pkg/crypto/tls/) link is correct.

## Related issues

For https://github.com/elastic/apm-server/issues/4002.

## Screenshots

<img width="799" alt="Screen Shot 2020-08-19 at 3 31 58 PM" src="https://user-images.githubusercontent.com/5618806/90696456-262d4f80-e231-11ea-9ba4-dcaadd2096e1.png">
