### PR TITLE
Cherry-pick #20580 to 7.x: libbeat/kibana: add ClientConfig.Headers

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1205,6 +1205,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1931,6 +1931,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1358,6 +1358,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1147,6 +1147,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/libbeat/_meta/config/setup.kibana.reference.yml.tmpl
+++ b/libbeat/_meta/config/setup.kibana.reference.yml.tmpl
@@ -21,6 +21,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/libbeat/docs/shared-kibana-config.asciidoc
+++ b/libbeat/docs/shared-kibana-config.asciidoc
@@ -98,6 +98,18 @@ The {kibana-ref}/xpack-spaces.html[Kibana space] ID to use. If specified,
 use the default space.
 
 [float]
+===== `setup.kibana.headers`
+
+Custom HTTP headers to add to each request sent to Kibana.
+Example:
+
+[source,yaml]
+------------------------------------------------------------------------------
+setup.kibana.headers:
+  X-My-Header: Header contents
+------------------------------------------------------------------------------
+
+[float]
 ==== `setup.kibana.ssl.enabled`
 
 Enables {beatname_uc} to use SSL settings when connecting to Kibana via HTTPS.

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -41,6 +41,7 @@ type Connection struct {
 	URL      string
 	Username string
 	Password string
+	Headers  http.Header
 
 	HTTP    *http.Client
 	Version common.Version
@@ -130,11 +131,17 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 		return nil, err
 	}
 
+	headers := make(http.Header)
+	for k, v := range config.Headers {
+		headers.Set(k, v)
+	}
+
 	client := &Client{
 		Connection: Connection{
 			URL:      kibanaURL,
 			Username: username,
 			Password: password,
+			Headers:  headers,
 			HTTP: &http.Client{
 				Transport: &http.Transport{
 					Dial:            dialer.Dial,
@@ -200,17 +207,21 @@ func (conn *Connection) SendWithContext(ctx context.Context, method, extraPath s
 		req.SetBasicAuth(conn.Username, conn.Password)
 	}
 
+	addHeaders(req.Header, conn.Headers)
+	addHeaders(req.Header, headers)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("kbn-xsrf", "1")
 
-	for header, values := range headers {
-		for _, value := range values {
-			req.Header.Add(header, value)
+	return conn.RoundTrip(req)
+}
+
+func addHeaders(out, in http.Header) {
+	for k, vs := range in {
+		for _, v := range vs {
+			out.Add(k, v)
 		}
 	}
-
-	return conn.RoundTrip(req)
 }
 
 // Implements RoundTrip interface

--- a/libbeat/kibana/client_config.go
+++ b/libbeat/kibana/client_config.go
@@ -25,14 +25,18 @@ import (
 
 // ClientConfig to connect to Kibana
 type ClientConfig struct {
-	Protocol      string            `config:"protocol" yaml:"protocol,omitempty"`
-	Host          string            `config:"host" yaml:"host,omitempty"`
-	Path          string            `config:"path" yaml:"path,omitempty"`
-	SpaceID       string            `config:"space.id" yaml:"space.id,omitempty"`
-	Username      string            `config:"username" yaml:"username,omitempty"`
-	Password      string            `config:"password" yaml:"password,omitempty"`
-	TLS           *tlscommon.Config `config:"ssl" yaml:"ssl"`
-	Timeout       time.Duration     `config:"timeout" yaml:"timeout"`
+	Protocol string            `config:"protocol" yaml:"protocol,omitempty"`
+	Host     string            `config:"host" yaml:"host,omitempty"`
+	Path     string            `config:"path" yaml:"path,omitempty"`
+	SpaceID  string            `config:"space.id" yaml:"space.id,omitempty"`
+	Username string            `config:"username" yaml:"username,omitempty"`
+	Password string            `config:"password" yaml:"password,omitempty"`
+	TLS      *tlscommon.Config `config:"ssl" yaml:"ssl"`
+	Timeout  time.Duration     `config:"timeout" yaml:"timeout"`
+
+	// Headers holds headers to include in every request sent to Kibana.
+	Headers map[string]string `config:"headers" yaml:"headers,omitempty"`
+
 	IgnoreVersion bool
 }
 

--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -18,12 +18,16 @@
 package kibana
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 func TestErrorJson(t *testing.T) {
@@ -73,4 +77,45 @@ func TestSuccess(t *testing.T) {
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
 	assert.Equal(t, http.StatusOK, code)
 	assert.NoError(t, err)
+}
+
+func TestNewKibanaClient(t *testing.T) {
+	var requests []*http.Request
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r)
+		if r.URL.Path == "/api/status" {
+			w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
+		}
+	}))
+	defer kibanaTs.Close()
+
+	client, err := NewKibanaClient(common.MustNewConfigFrom(fmt.Sprintf(`
+protocol: http
+host: %s
+headers:
+  key: value
+  content-type: text/plain
+  accept: text/plain
+  kbn-xsrf: 0
+`, kibanaTs.Listener.Addr().String())))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+
+	// NewKibanaClient issues a request to /api/status to fetch the version.
+	require.Len(t, requests, 2)
+	assert.Equal(t, "/api/status", requests[0].URL.Path)
+	assert.Equal(t, []string{"value"}, requests[0].Header.Values("key"))
+	assert.Equal(t, "1.2.3-beta-SNAPSHOT", client.Version.String())
+
+	// Headers specified in cient.Request are added to those defined in config.
+	//
+	// Content-Type, Accept, and kbn-xsrf cannot be overridden.
+	assert.Equal(t, "/foo", requests[1].URL.Path)
+	assert.Equal(t, []string{"value", "another_value"}, requests[1].Header.Values("key"))
+	assert.Equal(t, []string{"application/json"}, requests[1].Header.Values("Content-Type"))
+	assert.Equal(t, []string{"application/json"}, requests[1].Header.Values("Accept"))
+	assert.Equal(t, []string{"1"}, requests[1].Header.Values("kbn-xsrf"))
+
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1970,6 +1970,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1631,6 +1631,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1127,6 +1127,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1261,6 +1261,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3177,6 +3177,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1131,6 +1131,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1358,6 +1358,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2434,6 +2434,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1170,6 +1170,10 @@ setup.kibana:
   # Optional Kibana space ID.
   #space.id: ""
 
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 


### PR DESCRIPTION
Cherry-pick of PR #20580 to 7.x branch. Original message: 

## What does this PR do?

Add configurable headers to include in every request sent to Kibana.

## Why is it important?

This is needed in some security applications, for authenticating the Beat. Specifically, this is needed to fix https://github.com/elastic/apm-server/issues/4065

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

1. Run `nc -l 1234`
2. Configure filebeat with `setup.kibana.host: localhost:1234`, and a custom header in `setup.kibana.headers`
3. Run `filebeat setup`

Observe the custom header is logged by netcat:

<pre>
GET /api/status HTTP/1.1
Host: localhost:1234
User-Agent: Go-http-client/1.1
Accept: application/json
Content-Type: application/json
<b>Foo: bar</b>
Kbn-Xsrf: 1
Accept-Encoding: gzip
</pre>

## Related issues

https://github.com/elastic/apm-server/issues/4065

## Use cases

Introduces a means of specifying custom HTTP headers to add to all requests sent to Kibana. As above, needed in some security use cases.