### PR TITLE
Add event.ingested to all rsa2elk modules

### DIFF
--- a/x-pack/filebeat/module/barracuda/waf/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/barracuda/waf/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Barracuda Web Application Firewall
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/bluecoat/director/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/bluecoat/director/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Blue Coat Director
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/cisco/nexus/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cisco/nexus/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Cisco Nexus
 
 processors:
+  # ECS event.ingested
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/cylance/protect/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cylance/protect/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for CylanceProtect
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/f5/bigipapm/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/f5/bigipapm/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Big-IP Access Policy Manager
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/fortinet/clientendpoint/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/clientendpoint/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Fortinet FortiClient Endpoint Security
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/imperva/securesphere/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/imperva/securesphere/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Imperva SecureSphere
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/infoblox/nios/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/infoblox/nios/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Infoblox NIOS
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/juniper/junos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/juniper/junos/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Juniper JUNOS
 
 processors:
+  # ECS event.ingested
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/microsoft/dhcp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/microsoft/dhcp/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Microsoft DHCP
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/netscout/sightline/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/netscout/sightline/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Arbor Peakflow SP
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/radware/defensepro/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/radware/defensepro/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Radware DefensePro
 
 processors:
+  # ECS event.ingested
+  - set:
+        field: event.ingested
+        value: '{{_ingest.timestamp}}'
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/sonicwall/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/sonicwall/firewall/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Sonicwall-FW
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/squid/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/squid/log/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Squid
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/tomcat/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/tomcat/log/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Apache Tomcat
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original

--- a/x-pack/filebeat/module/zscaler/zia/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zscaler/zia/ingest/pipeline.yml
@@ -2,10 +2,10 @@
 description: Pipeline for Zscaler NSS
 
 processors:
+  # ECS event.ingested
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
-
   # User agent
   - user_agent:
         field: user_agent.original


### PR DESCRIPTION
Updated the autogenerated ingest pipelines to add the event.ingested field.

Most pipelines already had the processor due to #20386, just a few of them were missing. I think because this pipelines don't have tests.