### PR TITLE
Cherry-pick to 7.x: [docs] Add steps for making agent persistent on macos (#20700)

### DIFF
--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -18,3 +18,83 @@ include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/install-widget.a
 // Add Javascript and CSS for tabbed panels
 include::tab-widgets/code.asciidoc[]
 
+[[elastic-agent-install-service-macos]]
+== Manually install {agent} as a service on macOS
+
+If you want {agent} to be persistent after restarts, you need to
+install and run it as a service. Improved support for running {agent} as a
+service on macOS will be available in a future release.
+
+. Create a file called `co.elastic.agent.plist` in `/Library/LaunchDaemons/`
+and copy the following settings into the new file:
++
+[source,text]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.elastic.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Elastic/Agent/elastic-agent</string>
+        <string>run</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/Library/Elastic/Agent</string>
+    <key>UserName</key>
+    <string>root</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>15</integer>
+    <key>EnableTransactions</key>
+    <false/>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
+</dict>
+</plist>
+----
+
+. Change the ownership of the `.plist` file to `root`:
++
+[source,shell]
+----
+sudo chown root:wheel /Library/LaunchDaemons/co.elastic.agent.plist
+----
+
+. Create the path `/Library/Elastic/Agent/`.
+
+. Copy the files that you extracted from
++elastic-agent-{version}-darwin-x86_64.tar.gz+ into
+`/Library/Elastic/Agent/`. 
+
+. Start the agent as a service:
++
+[source,shell]
+----
+sudo launchctl load -w /Library/LaunchDaemons/co.elastic.agent.plist
+----
++
+This command starts the agent, so do not attempt to use the `run` command.
+
+*To stop and remove the service:*
+
+. Stop the service and remove the property list file: 
++
+[source,shell]
+----
+sudo launchctl unload -w /Library/Launchdaemons/co.elastic.agent.plist
+rm /Library/Launchdaemons/co.elastic.agent.plist
+----
+
+. <<unenroll-elastic-agent,Unenroll the agent from {fleet}>>.
++
+Unenrolling the agent should stop {agent} and any other programs started by
+the agent, such as Elastic {endpoint-sec} and data shippers.
+
+. If necessary, manually kill the `elastic-agent` process and any other
+processes started by the agent. 

--- a/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
@@ -47,8 +47,14 @@ NOTE: {agent} will restart automatically if the system is rebooted.
 ./elastic-agent run
 ----
 
-NOTE: You must restart {agent} manually if the agent terminates or the system is
-rebooted.
+[NOTE]
+====
+This command starts {agent} in the foreground. You must restart {agent}
+manually if the agent terminates or the system is rebooted.
+
+To start the agent automatically when the system is rebooted, 
+{ingest-guide}/elastic-agent-installation.html#elastic-agent-install-service-macos[Install the agent as a service].
+====
 
 // end::mac[]
 
@@ -58,8 +64,14 @@ rebooted.
 ./elastic-agent run
 ----
 
-NOTE: You must restart {agent} manually if the agent terminates or the system is
-rebooted.
+[NOTE]
+====
+This command starts {agent} in the foreground. You must restart {agent} manually
+if the agent terminates or the system is rebooted.
+
+To start the agent automatically when the system is rebooted, 
+use the DEB or RPM package instead of the tarball.
+====
 
 // end::linux[]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Add steps for making agent persistent on macos (#20700)