### PR TITLE
Cherry-pick #20641 to 7.x: Add host inventory metrics to azure compute_vm metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -724,6 +724,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add cloud.instance.name into aws ec2 metricset. {pull}20077[20077]
 - Add host inventory metrics into aws ec2 metricset. {pull}20171[20171]
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
+- Add host inventory metrics to azure compute_vm metricset. {pull}20641[20641]
+- Add host inventory metrics to googlecloud compute metricset. {pull}20391[20391]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/azure/compute_vm/_meta/data.json
+++ b/x-pack/metricbeat/module/azure/compute_vm/_meta/data.json
@@ -1,131 +1,158 @@
 {
-    "@timestamp":"2020-08-05T10:36:00.000Z",
-    "cloud":{
-        "provider":"azure",
-        "region":"westeurope",
-        "instance":{
-            "id":"/subscriptions/fd675b6f-b5e5-426e-ac45-d1f876d0ffa6/resourceGroups/obs-infrastructure/providers/Microsoft.Compute/virtualMachines/obstestmemleak",
-            "name":"obstestmemleak"
-        },
-        "machine":{
-            "type":"Standard_B2ms"
-        }
-    },
-    "event":{
-        "dataset":"azure.compute_vm",
-        "module":"azure",
-        "duration":5364973100
-    },
-    "metricset":{
-        "name":"compute_vm",
-        "period":300000
-    },
-    "azure":{
-        "timegrain":"PT5M",
-        "resource":{
-            "type":"Microsoft.Compute/virtualMachines",
-            "group":"obs-infrastructure",
-            "tags":{
-                "vmtest":"value1, value 2",
-                "vmtest1":"value3"
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "azure": {
+        "compute_vm": {
+            "cpu_credits_consumed": {
+                "avg": 0.01
+            },
+            "cpu_credits_remaining": {
+                "avg": 288
+            },
+            "disk_read_bytes": {
+                "total": 4019543.24
+            },
+            "disk_read_operations_per_sec": {
+                "avg": 0.0605
+            },
+            "disk_write_bytes": {
+                "total": 16739967.27
+            },
+            "disk_write_operations_per_sec": {
+                "avg": 1.9525
+            },
+            "inbound_flows": {
+                "avg": 31
+            },
+            "inbound_flows_maximum_creation_rate": {
+                "avg": 0.8
+            },
+            "network_in": {
+                "total": 1501534
+            },
+            "network_in_total": {
+                "total": 1806936
+            },
+            "network_out": {
+                "total": 1647640
+            },
+            "network_out_total": {
+                "total": 3633130
+            },
+            "os_disk_queue_depth": {
+                "avg": 0
+            },
+            "os_disk_read_bytes_per_sec": {
+                "avg": 13398.475
+            },
+            "os_disk_read_operations_per_sec": {
+                "avg": 0.121
+            },
+            "os_disk_write_bytes_per_sec": {
+                "avg": 55799.886
+            },
+            "os_disk_write_operations_per_sec": {
+                "avg": 3.905
+            },
+            "os_per_disk_qd": {
+                "avg": 0
+            },
+            "os_per_disk_read_bytes_per_sec": {
+                "avg": 13398.475
+            },
+            "os_per_disk_read_operations_per_sec": {
+                "avg": 0.121
+            },
+            "os_per_disk_write_bytes_per_sec": {
+                "avg": 55799.886
+            },
+            "os_per_disk_write_operations_per_sec": {
+                "avg": 3.905
+            },
+            "outbound_flows": {
+                "avg": 31
+            },
+            "outbound_flows_maximum_creation_rate": {
+                "avg": 0.8
+            },
+            "per_disk_qd": {
+                "avg": 0
+            },
+            "per_disk_read_bytes_per_sec": {
+                "avg": 0
+            },
+            "per_disk_read_operations_per_sec": {
+                "avg": 0
+            },
+            "per_disk_write_bytes_per_sec": {
+                "avg": 0
+            },
+            "per_disk_write_operations_per_sec": {
+                "avg": 0
+            },
+            "percentage_cpu": {
+                "avg": 1.585
+            },
+            "premium_os_disk_cache_read_hit": {
+                "avg": 100
+            },
+            "premium_os_disk_cache_read_miss": {
+                "avg": 0
             }
         },
-        "subscription_id":"fd675b6f-b5e5-426e-ac45-d1f876d0ffa6",
-        "namespace":"Microsoft.Compute/virtualMachines",
-        "compute_vm":{
-            "outbound_flows":{
-                "avg":291.2
+        "namespace": "Microsoft.Compute/virtualMachines",
+        "resource": {
+            "group": "obs-test",
+            "type": "Microsoft.Compute/virtualMachines"
+        },
+        "subscription_id": "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
+        "timegrain": "PT5M"
+    },
+    "cloud": {
+        "instance": {
+            "id": "/subscriptions/7657426d-c4c3-44ac-88a2-3b2cd59e6dba/resourceGroups/obs-test/providers/Microsoft.Compute/virtualMachines/perfmon-test",
+            "name": "perfmon-test"
+        },
+        "machine": {
+            "type": "Standard_B1ms"
+        },
+        "provider": "azure",
+        "region": "westeurope"
+    },
+    "event": {
+        "dataset": "azure.compute_vm",
+        "duration": 115000,
+        "module": "azure"
+    },
+    "host": {
+        "cpu": {
+            "pct": 0.01585
+        },
+        "disk": {
+            "read": {
+                "bytes": 4019543.24
             },
-            "outbound_flows_maximum_creation_rate":{
-                "avg":6
+            "write": {
+                "bytes": 16739967.27
+            }
+        },
+        "id": "/subscriptions/7657426d-c4c3-44ac-88a2-3b2cd59e6dba/resourceGroups/obs-test/providers/Microsoft.Compute/virtualMachines/perfmon-test",
+        "name": "perfmon-test",
+        "network": {
+            "in": {
+                "bytes": 1806936,
+                "packets": 1501534
             },
-            "inbound_flows_maximum_creation_rate":{
-                "avg":6
-            },
-            "os_per_disk_read_bytes_per_sec":{
-                "avg":341.35875
-            },
-            "per_disk_read_bytes_per_sec":{
-                "avg":0
-            },
-            "os_disk_queue_depth":{
-                "avg":0
-            },
-            "os_per_disk_qd":{
-                "avg":0
-            },
-            "os_disk_read_bytes_per_sec":{
-                "avg":341.35875
-            },
-            "network_in":{
-                "total":3933481.0
-            },
-            "network_out":{
-                "total":7169752.0
-            },
-            "os_disk_write_operations_per_sec":{
-                "avg":4.994285714285715
-            },
-            "percentage_cpu":{
-                "avg":8.780625
-            },
-            "cpu_credits_remaining":{
-                "avg":864
-            },
-            "network_out_total":{
-                "total":9249694.0
-            },
-            "disk_read_operations_per_sec":{
-                "avg":0.022857142857142857
-            },
-            "disk_write_bytes":{
-                "total":1.759878456E7
-            },
-            "os_disk_write_bytes_per_sec":{
-                "avg":73050.70375
-            },
-            "cpu_credits_consumed":{
-                "avg":0.175
-            },
-            "per_disk_qd":{
-                "avg":0
-            },
-            "disk_write_operations_per_sec":{
-                "avg":2.5221428571428572
-            },
-            "os_per_disk_write_operations_per_sec":{
-                "avg":4.994285714285715
-            },
-            "per_disk_write_operations_per_sec":{
-                "avg":0.049999999999999996
-            },
-            "inbound_flows":{
-                "avg":291.2
-            },
-            "os_disk_read_operations_per_sec":{
-                "avg":0.045714285714285714
-            },
-            "disk_read_bytes":{
-                "total":81926.52
-            },
-            "network_in_total":{
-                "total":4920267.0
-            },
-            "per_disk_read_operations_per_sec":{
-                "avg":0
-            },
-            "per_disk_write_bytes_per_sec":{
-                "avg":277.56
-            },
-            "os_per_disk_write_bytes_per_sec":{
-                "avg":73050.70375
-            },
-            "os_per_disk_read_operations_per_sec":{
-                "avg":0.045714285714285714
+            "out": {
+                "bytes": 3633130,
+                "packets": 1647640
             }
         }
     },
-    "service":{
-        "type":"azure"
+    "metricset": {
+        "name": "compute_vm",
+        "period": 10000
+    },
+    "service": {
+        "type": "azure"
     }
 }


### PR DESCRIPTION
Cherry-pick of PR #20641 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to add proposed host common fields into `compute` metricset:
- host.id
- host.name
- host.cpu.pct
- host.network.in.bytes
- host.network.in.packets
- host.network.out.bytes
- host.network.out.packets
- host.disk.read.bytes
- host.disk.write.bytes

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This PR is a part of the inventory schema work. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Start Metricbeat `azure` module: `./metricbeat modules enable azure`
2. Edit `modules.d/azure.yml` to only include `compute_vm` metricset:
```
- module: azure
  metricsets:
    - compute_vm
  enabled: true
  period: 300s
  client_id: '123'
  client_secret: '123'
  tenant_id: '123'
  subscription_id: '123'
  refresh_list_interval: 600s
```
3. Change `add_host_metadata` processor config in metricbeat.yml file:
```
processors:
  - add_host_metadata:
      replace_fields: false
```
4. Start metricbeat
5. You should see metrics from `compute_vm` metricset and includes fields listed above.
