### PR TITLE
Cherry-pick to 7.x: Add FLEET_ENROLL_INSECURE env var to expose --insecure CLI option (#20713)

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -6,6 +6,7 @@ set -eo pipefail
 # FLEET_CONFIG_ID - config related to new token [defaul]
 # FLEET_ENROLLMENT_TOKEN - existing enrollment token to be used for enroll
 # FLEET_ENROLL - if set to 1 enroll will be performed
+# FLEET_ENROLL_INSECURE - if set to 1, agent will enroll with fleet using --insecure flag
 # FLEET_SETUP - if  set to 1 fleet setup will be performed
 # FLEET_TOKEN_NAME - token name for a token to be created
 # KIBANA_HOST - actual kibana host [http://localhost:5601]
@@ -53,7 +54,11 @@ function enroll(){
     apikey=$(echo $enrollResp | jq -r '.item.api_key')
     echo $apikey
 
-    ./{{ .BeatName }} enroll ${KIBANA_HOST:-http://localhost:5601} $apikey -f
+    if [[ -n "${FLEET_ENROLL_INSECURE}" ]] && [[ ${FLEET_ENROLL_INSECURE} == 1 ]]; then
+      insecure_flag="--insecure"
+    fi
+
+    ./{{ .BeatName }} enroll ${insecure_flag} ${KIBANA_HOST:-http://localhost:5601} $apikey -f
 }
 
 if [[ -n "${FLEET_SETUP}" ]] && [[ ${FLEET_SETUP} == 1 ]]; then setup; fi

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -104,3 +104,4 @@
 - Add restart CLI cmd {pull}20359[20359]
 - Add new `synthetics/*` inputs to run Heartbeat {pull}20387[20387]
 - Prepare packaging for endpoint and asc files {pull}20186[20186]
+- Users of the Docker image can now pass `FLEET_ENROLL_INSECURE=1` to include the `--insecure` flag with the `elastic-agent enroll` command {issue}20312[20312] {pull}20713[20713]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add FLEET_ENROLL_INSECURE env var to expose --insecure CLI option (#20713)