### PR TITLE
[docs] Mention UI in the config settings documentation

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -4,19 +4,25 @@
 
 beta[]
 
+// TODO: This topic assumes users know what standalone and fleet are. When we
+// add the settings reference, we should clean this up: describe the available
+// options, then show how to configure them manually for standalone. We should
+// assume Fleet is the common use case, even if it's not the default, and make
+// sure this reference is useful for both use cases.
+
 By default {agent} runs in standalone mode to ingest system data and send it to
 a local {es} instance running on port 9200. It uses the demo credentials of the
-`elastic` user. It's also configured to monitor all {beats} managed by {agent}
-and send the {beats} logs and metrics to the same {es} instance.
+`elastic` user. It's also configured to monitor all programs managed by {agent}
+and send the logs and metrics to the same {es} instance.
 
-To alter this behavior, configure the output and other configuration settings:
+To alter this behavior, configure the output and other configuration settings.
+When running the agent standalone, specify configuration settings in the
+`elastic-agent.yml` file. When using {fleet}, do not modify settings in
+the `elastic-agent.yml` file. Instead, use {ingest-manager} in {kib} to change
+settings.
 
-* <<elastic-agent-output-configuration>>
-* <<elastic-agent-monitoring-configuration>>
-* <<elastic-agent-input-configuration>>
-
-TIP: To get started quickly, use {fleet} in {ingest-manager} to generate a
-standalone configuration. For more information, see <<agent-standalone-mode>>.
+TIP: To get started quickly, you can use {fleet} to generate a standalone
+configuration. For more information, see <<agent-standalone-mode>>.
 
 [discrete]
 [[elastic-agent-output-configuration]]


### PR DESCRIPTION
Fixes one of the issues described in https://github.com/elastic/observability-docs/issues/90. 

These docs still need work, but hopefully this will help Fleet users know that they don't need to change the local config file.