### PR TITLE
[Elastic Agent] Fix tests for Heartbeat config

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-heartbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-heartbeat.yml
@@ -6,7 +6,7 @@ inputs:
   host: "http://localhost:80/service/status"
   timeout: 16s
   wait: 1s
-  dataset.namespace: default
+  data_stream.namespace: default
 output:
   elasticsearch:
     hosts:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/synthetics_config-heartbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/synthetics_config-heartbeat.yml
@@ -6,7 +6,7 @@ inputs:
   host: "http://localhost:80/service/status"
   timeout: 16s
   wait: 1s
-  dataset.namespace: default
+  data_stream.namespace: default
 - type: synthetics/tcp
   id: unique-tcp-id
   name: my-tcp
@@ -14,7 +14,7 @@ inputs:
   host: "localhost:777"
   timeout: 16s
   wait: 1s
-  dataset.namespace: default
+  data_stream.namespace: default
 - type: synthetics/icmp
   id: unique-icmp-id
   name: my-icmp
@@ -25,7 +25,7 @@ inputs:
   mode: any
   timeout: 16s
   wait: 1s
-  dataset.namespace: default
+  data_stream.namespace: default
 output:
   elasticsearch:
     hosts: [127.0.0.1:9200, 127.0.0.1:9300]


### PR DESCRIPTION
## What does this PR do?

Fixes a broken test in Elastic Agent. The tests expected `dataset` rather than `data_stream`.
