### PR TITLE
Adding HMAC support to http_endpoint input

### DIFF
--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -26,6 +26,9 @@ type config struct {
 	ContentType   string                  `config:"content_type"`
 	SecretHeader  string                  `config:"secret.header"`
 	SecretValue   string                  `config:"secret.value"`
+	HmacHeader    string                  `config:"hmac.header"`
+	HmacPrefix    string                  `config:"hmac.prefix"`
+	HmacToken     string                  `config:"hmac.token"`
 }
 
 func defaultConfig() config {
@@ -42,6 +45,9 @@ func defaultConfig() config {
 		ContentType:   "application/json",
 		SecretHeader:  "",
 		SecretValue:   "",
+		HmacHeader:    "",
+		HmacPrefix:    "",
+		HmacToken:     "",
 	}
 }
 

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -36,17 +36,16 @@ var errUnsupportedType = errors.New("Only JSON objects are accepted")
 func (h *httpHandler) apiResponse(w http.ResponseWriter, r *http.Request) {
 	obj, status, err := httpReadJsonObject(r.Body)
 	if err != nil {
-		w.Header().Add("Content-Type", "application/json")
 		sendErrorResponse(w, status, err)
 		return
 	}
 
 	h.publishEvent(obj)
-	w.Header().Add("Content-Type", "application/json")
 	h.sendResponse(w, h.responseCode, h.responseBody)
 }
 
 func (h *httpHandler) sendResponse(w http.ResponseWriter, status int, message string) {
+	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
 	io.WriteString(w, message)
 }

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -63,7 +63,7 @@ func (h *httpHandler) publishEvent(obj common.MapStr) {
 
 func withValidator(v validator, handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if status, err := v.ValidateHeader(r); status != 0 && err != nil {
+		if status, err := v.Validate(r); status != 0 && err != nil {
 			sendErrorResponse(w, status, err)
 		} else {
 			handler(w, r)

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -61,13 +61,15 @@ func (h *httpHandler) publishEvent(obj common.MapStr) {
 	h.publisher.Publish(event)
 }
 
-func withValidator(v validator, handler http.HandlerFunc) http.HandlerFunc {
+func withValidators(handler http.HandlerFunc, vs ...validator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if status, err := v.Validate(r); status != 0 && err != nil {
-			sendErrorResponse(w, status, err)
-		} else {
-			handler(w, r)
+		for _, v := range vs {
+			if status, err := v.Validate(r); status != 0 && err != nil {
+				sendErrorResponse(w, status, err)
+				return
+			}
 		}
+		handler(w, r)
 	}
 }
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -90,6 +90,9 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 		contentType:  e.config.ContentType,
 		secretHeader: e.config.SecretHeader,
 		secretValue:  e.config.SecretValue,
+		hmacHeader:   e.config.HmacHeader,
+		hmacPrefix:   e.config.HmacPrefix,
+		hmacToken:    e.config.HmacToken,
 	}
 
 	handler := &httpHandler{

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -15,6 +15,7 @@ import (
 )
 
 type validator interface {
+	Validate(*http.Request) (int, error)
 	// ValidateHeader checks the HTTP headers for compliance. The body must not
 	// be touched.
 	ValidateHeader(*http.Request) (int, error)
@@ -37,6 +38,18 @@ type apiValidator struct {
 var errIncorrectUserOrPass = errors.New("Incorrect username or password")
 var errIncorrectHeaderSecret = errors.New("Incorrect header or header secret")
 var errIncorrectHmac = errors.New("The HMAC signature of the request body does not match with the configured secret")
+
+func (v *apiValidator) Validate(r *http.Request) (int, error) {
+	i, err := v.ValidateHeader(r)
+	if err != nil {
+		return i, err
+	}
+	h, err := v.ValidateHmac(r)
+	if err != nil {
+		return h, err
+	}
+	return 0, nil
+}
 
 func (v *apiValidator) ValidateHeader(r *http.Request) (int, error) {
 	if v.basicAuth {

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -40,12 +40,10 @@ var errIncorrectHeaderSecret = errors.New("Incorrect header or header secret")
 var errIncorrectHmac = errors.New("The HMAC signature of the request body does not match with the configured secret")
 
 func (v *apiValidator) Validate(r *http.Request) (int, error) {
-	i, err := v.ValidateHeader(r)
-	if err != nil {
+	if i, err := v.ValidateHeader(r); err != nil {
 		return i, err
 	}
-	h, err := v.ValidateHmac(r)
-	if err != nil {
+	if h, err := v.ValidateHmac(r); err != nil {
 		return h, err
 	}
 	return 0, nil

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -80,7 +80,7 @@ func (v *apiValidator) ValidateHmac(r *http.Request) (int, error) {
 	}
 
 	if v.hmacToken != "" && v.hmacHeader != "" {
-		if len(r.Header.Get(v.hmacHeader)) != 0 {
+		if len(r.Header.Get(v.hmacHeader)) == 0 {
 			return http.StatusInternalServerError, fmt.Errorf("The HMAC signature in the configured request header is empty")
 		}
 		s := hmac.New(sha1.New, []byte(v.hmacToken))


### PR DESCRIPTION
## What does this PR do?

To support certain Webhooks that uses HMAC signatures (like Github) this change introduces the possibility to set a HMAC token, a HMAC header and optionally a HMAC Prefix (if the header includes a prefix before the token).

## Why is it important?

Allows the http_endpoint input to support more security features

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #19534 
