### PR TITLE
[Heartbeat]Adds negative body match

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -70,6 +70,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix PANW field spelling "veredict" to "verdict" on event.action {pull}18808[18808]
 
 *Heartbeat*
+- Adds negative body match. {pull}20728[20728]
 
 
 *Journalbeat*

--- a/heartbeat/docs/monitors/monitor-http.asciidoc
+++ b/heartbeat/docs/monitors/monitor-http.asciidoc
@@ -188,6 +188,87 @@ response body for the strings `saved` or `Saved` and expects 200 or 201 status c
       - saved
 -------------------------------------------------------------------------------
 
+Under `check.response.body`, specify these options:
+*`positive`*:: This option has the same behavior as given a list of regular expressions under `check.response.body`.
+*`negative`*:: A list of regular expressions to match the the body output negatively.
+Return match failed if single expression matches.
+HTTP response bodies of up to 100MiB are supported.
+
+Example configuration:
+This monitor examines the response body for the strings 'foo' or 'Foo'
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    body:
+      positive:
+        - foo
+        - Foo
+-------------------------------------------------------------------------------
+
+Example configuration:
+This monitor examines match successfully if there is no 'bar' or 'Bar' at all,
+examines match failed if there is 'bar' or 'Bar' in the response body
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    status: [200, 201]
+    body:
+      negative:
+        - bar
+        - Bar
+-------------------------------------------------------------------------------
+
+Example configuration:
+This monitor examines match successfully only when 'foo' or 'Foo' in body AND no 'bar' or 'Bar' in body
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    status: [200, 201]
+    body:
+      positive:
+        - foo
+        - Foo
+      negative:
+        - bar
+        - Bar
+-------------------------------------------------------------------------------
+
 *`json`*:: A list of <<conditions,condition>> expressions executed against the body when parsed as JSON. Body sizes
 must be less than or equal to 100 MiB.
 

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -143,6 +143,11 @@ func checkHeaders(headers map[string]string) respValidator {
 }
 
 func parseBody(b interface{}) (positiveMatch, negativeMatch []match.Matcher, err error) {
+	// run through this code block if there is only string
+	if pat, ok := b.(string); ok {
+		return append(positiveMatch, match.MustCompile(pat)), negativeMatch, nil
+	}
+
 	// run through this code block if there is no positive or negative keyword in response body
 	// in this case, there's only plain body
 	if p, ok := b.([]interface{}); ok {

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -137,10 +137,10 @@ func checkHeaders(headers map[string]string) respValidator {
 func parseBody(b interface{}) ([]match.Matcher, []match.Matcher) {
 	var (
 		pm, nm []match.Matcher
+		positive = "positive"
+		negative = "negative"
 	)
-	positive := "positive"
-	negative := "negative"
-	// run through this block if there is no positive or negative keyword under body namespace
+	// run through this code block if there is no positive or negative keyword in response body
 	// in this case, there's only plain body
 	p, ok := b.([]interface{})
 	if ok {
@@ -152,15 +152,15 @@ func parseBody(b interface{}) ([]match.Matcher, []match.Matcher) {
 		}
 	}
 
-	// run through this part if there is positive/negative keyword
+	// run through this part if there exists positive/negative keyword in response body
 	// in this case, there will be 3 possibilities: positive + negative / positive / negative
-	k, ok := b.(map[string]interface{})
+	m, ok := b.(map[string]interface{})
 	if ok {
-		for checkType, kk := range k {
-			kkk, ok := kk.([]interface{})
+		for checkType, v := range m {
+			params, ok := v.([]interface{})
 			if ok {
-				for _, kkkk := range kkk {
-					pat, ok := kkkk.(string)
+				for _, param := range params {
+					pat, ok := param.(string)
 					if ok {
 						if checkType == positive {
 							pm = append(pm, match.MustCompile(pat))

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -74,7 +74,7 @@ var (
 	errBodyNegativeMismatch  = errors.New("only negative pattern mismatch")
 	errBodyNoValidCheckType  = errors.New("no valid check type under check.body, only 'positive' or 'negative' is expected")
 	errBodyNoValidCheckParam = errors.New("no valid check parameters under check.body")
-	errBodyIllegalBody = errors.New("unsupported content under check.body")
+	errBodyIllegalBody       = errors.New("unsupported content under check.body")
 )
 
 func makeValidateResponse(config *responseParameters) (multiValidator, error) {
@@ -98,7 +98,7 @@ func makeValidateResponse(config *responseParameters) (multiValidator, error) {
 				return err
 			})
 		}
-		bodyValidators = append(bodyValidators,  checkBody(pm, nm))
+		bodyValidators = append(bodyValidators, checkBody(pm, nm))
 	}
 
 	if len(config.RecvJSON) > 0 {

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -88,7 +88,7 @@ func makeValidateResponse(config *responseParameters) (multiValidator, error) {
 	}
 
 	if len(config.RecvBody) > 0 {
-		bodyValidators = append(bodyValidators, checkBody(config.RecvBody))
+		bodyValidators = append(bodyValidators, checkBody(config.RecvBody, config.PositiveCheckOnHTTPBody))
 	}
 
 	if len(config.RecvJSON) > 0 {
@@ -132,14 +132,22 @@ func checkHeaders(headers map[string]string) respValidator {
 	}
 }
 
-func checkBody(matcher []match.Matcher) bodyValidator {
+func checkBody(matcher []match.Matcher, positiveCheck bool) bodyValidator {
 	return func(r *http.Response, body string) error {
 		for _, m := range matcher {
 			if m.MatchString(body) {
-				return nil
+				if positiveCheck {
+					return nil
+				} else {
+					return errBodyMismatch
+				}
 			}
 		}
-		return errBodyMismatch
+		if positiveCheck {
+			return errBodyMismatch
+		} else {
+			return nil
+		}
 	}
 }
 

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -152,6 +152,13 @@ func TestCheckBody(t *testing.T) {
 			[]string{"healthy"},
 			false,
 		},
+		{
+			"Positive and negative check are both empty",
+			"'status': 'green', 'cluster': 'healthy'",
+			nil,
+			nil,
+			false,
+		},
 	}
 
 	for _, test := range matchTests {

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -38,8 +38,8 @@ func TestCheckBody(t *testing.T) {
 		description   string
 		body          string
 		patterns      []string
-		result        bool
 		positiveCheck bool
+		result        bool
 	}{
 		{
 			"Single regex that matches",
@@ -128,15 +128,15 @@ func TestCheckBody(t *testing.T) {
 			"Positive check on HTTP body when body check is not matched and positiveCheck is true",
 			"'status': 'red'",
 			[]string{"green"},
-			false,
 			true,
+			false,
 		},
 		{
 			"Negative check on HTTP body when body check is not matched and positiveCheck is false",
 			"'status': 'red'",
 			[]string{"green"},
-			true,
 			false,
+			true,
 		},
 	}
 

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors"
-	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/conditions"
 )
@@ -77,10 +76,8 @@ type responseParameters struct {
 	// expected HTTP response configuration
 	Status      []uint16             `config:"status"`
 	RecvHeaders map[string]string    `config:"headers"`
-	RecvBody    []match.Matcher      `config:"body"`
+	RecvBody    interface{}          `config:"body"`
 	RecvJSON    []*jsonResponseCheck `config:"json"`
-	// add this option to control the match on http body is positive check or negative check
-	PositiveCheckOnHTTPBody bool `config:"positive_check_on_http_body"`
 }
 
 type jsonResponseCheck struct {
@@ -109,10 +106,9 @@ var defaultConfig = Config{
 			SendBody:    "",
 		},
 		Response: responseParameters{
-			RecvHeaders:             nil,
-			RecvBody:                []match.Matcher{},
-			RecvJSON:                nil,
-			PositiveCheckOnHTTPBody: true,
+			RecvHeaders: nil,
+			RecvBody:    nil,
+			RecvJSON:    nil,
 		},
 	},
 }

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -75,10 +75,12 @@ type requestParameters struct {
 
 type responseParameters struct {
 	// expected HTTP response configuration
-	Status      []uint16             `config:"status"`
-	RecvHeaders map[string]string    `config:"headers"`
-	RecvBody    []match.Matcher      `config:"body"`
-	RecvJSON    []*jsonResponseCheck `config:"json"`
+	Status                  []uint16             `config:"status"`
+	RecvHeaders             map[string]string    `config:"headers"`
+	RecvBody                []match.Matcher      `config:"body"`
+	RecvJSON                []*jsonResponseCheck `config:"json"`
+	// add this option to control the match on http body is positive check or negative check
+	PositiveCheckOnHTTPBody bool                 `config:"positive_check_on_http_body"`
 }
 
 type jsonResponseCheck struct {
@@ -107,9 +109,10 @@ var defaultConfig = Config{
 			SendBody:    "",
 		},
 		Response: responseParameters{
-			RecvHeaders: nil,
-			RecvBody:    []match.Matcher{},
-			RecvJSON:    nil,
+			RecvHeaders:             nil,
+			RecvBody:                []match.Matcher{},
+			RecvJSON:                nil,
+			PositiveCheckOnHTTPBody: true,
 		},
 	},
 }

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -75,12 +75,12 @@ type requestParameters struct {
 
 type responseParameters struct {
 	// expected HTTP response configuration
-	Status                  []uint16             `config:"status"`
-	RecvHeaders             map[string]string    `config:"headers"`
-	RecvBody                []match.Matcher      `config:"body"`
-	RecvJSON                []*jsonResponseCheck `config:"json"`
+	Status      []uint16             `config:"status"`
+	RecvHeaders map[string]string    `config:"headers"`
+	RecvBody    []match.Matcher      `config:"body"`
+	RecvJSON    []*jsonResponseCheck `config:"json"`
 	// add this option to control the match on http body is positive check or negative check
-	PositiveCheckOnHTTPBody bool                 `config:"positive_check_on_http_body"`
+	PositiveCheckOnHTTPBody bool `config:"positive_check_on_http_body"`
 }
 
 type jsonResponseCheck struct {

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func Test_handleRespBody(t *testing.T) {
-	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")}, true)
-	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")}, true)
+	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")}, nil)
+	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")}, nil)
 
 	matchingComboValidator := multiValidator{bodyValidators: []bodyValidator{matchingBodyValidator}}
 	failingComboValidator := multiValidator{bodyValidators: []bodyValidator{failingBodyValidator}}

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func Test_handleRespBody(t *testing.T) {
-	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")})
-	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")})
+	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")}, true)
+	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")}, true)
 
 	matchingComboValidator := multiValidator{bodyValidators: []bodyValidator{matchingBodyValidator}}
 	failingComboValidator := multiValidator{bodyValidators: []bodyValidator{failingBodyValidator}}


### PR DESCRIPTION
## What does this PR do?

**Adds new option "positive_check_on_http_body" under "check.response" to control if the check on http response body is positive or negative.**


## Why is it important?

**Heartbeat can match HTTP response bodies using an arbitrary regexp with check.response.body, however this only matches positively, customers might want to perform a negative match.**

## Checklist

- [x] My code follows the style guidelines of this project
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made a corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Opens #20728 

## Use cases
Add positive and negative options under check.response.body. 

Case1): If the customer specifies both of them, then the response body should match these 2 conditions at the same time,
1.  for the positive option, the positive regex pattern should match the response body;
2. for the negative option, the negative regex pattern should not match the response body;

For example:
```yaml
# Both negative and positive option gave
check.response.body:
positive:
- foo
- faa
negative:
- bar
- boo
```

In this case, check.response.body should match the following condition:
```bash
check.response.body ~ /(foo|faa)/ && check.response.body !~ /(bar|boo)/
```

Case2): If the customer specifies any of the positive/negative options, then the response body should match the specified type of check:
1.  for the positive option, the positive regex pattern should match the response body;
2. for the negative option, the negative regex pattern should not match the response body;

Case3): If the custom doesn't give any positive or negative option, we just take it as a positive check, this used to tolerate the previous version of Heartbeat.