### PR TITLE
Cherry-pick #20576 to 7.x: Build docker images based on Red Hat UBI

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -92,3 +92,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Added SQL helper that can be used from any Metricbeat module {pull}18955[18955]
 - Update Go version to 1.14.4. {pull}19753[19753]
 - Update Go version to 1.14.7. {pull}20508[20508]
+- Add packaging for docker image based on UBI minimal 8. {pull}20576[20576]

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -151,19 +151,14 @@ func isDockerFile(path string) bool {
 }
 
 func (b *dockerBuilder) expandDockerfile(templatesDir string, data map[string]interface{}) error {
-	// has specific dockerfile
-	dockerfile := fmt.Sprintf("Dockerfile.%s.tmpl", b.imageName)
-	_, err := os.Stat(filepath.Join(templatesDir, dockerfile))
-	if err != nil {
-		// specific missing fallback to generic
-		dockerfile = "Dockerfile.tmpl"
+	dockerfile := "Dockerfile.tmpl"
+	if f, found := b.ExtraVars["dockerfile"]; found {
+		dockerfile = f
 	}
 
-	entrypoint := fmt.Sprintf("docker-entrypoint.%s.tmpl", b.imageName)
-	_, err = os.Stat(filepath.Join(templatesDir, entrypoint))
-	if err != nil {
-		// specific missing fallback to generic
-		entrypoint = "docker-entrypoint.tmpl"
+	entrypoint := "docker-entrypoint.tmpl"
+	if e, found := b.ExtraVars["docker_entrypoint"]; found {
+		entrypoint = e
 	}
 
 	type fileExpansion struct {
@@ -176,7 +171,7 @@ func (b *dockerBuilder) expandDockerfile(templatesDir string, data map[string]in
 			".tmpl",
 		)
 		path := filepath.Join(templatesDir, file.source)
-		err = b.ExpandFile(path, target, data)
+		err := b.ExpandFile(path, target, data)
 		if err != nil {
 			return errors.Wrapf(err, "expanding template '%s' to '%s'", path, target)
 		}

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -91,6 +91,7 @@ var (
 		"repo":              GetProjectRepoInfo,
 		"title":             strings.Title,
 		"tolower":           strings.ToLower,
+		"contains":          strings.Contains,
 	}
 )
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -28,6 +28,9 @@ shared:
       /usr/share/{{.BeatName}}/LICENSE.txt:
         source: '{{ repo.RootDir }}/LICENSE.txt'
         mode: 0644
+      /usr/share/{{.BeatName}}/NOTICE.txt:
+        source: '{{ repo.RootDir }}/NOTICE.txt'
+        mode: 0644
       /usr/share/{{.BeatName}}/README.md:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
         mode: 0644
@@ -117,6 +120,9 @@ shared:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
         source: '{{ repo.RootDir }}/LICENSE.txt'
         mode: 0644
+      /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/NOTICE.txt:
+        source: '{{ repo.RootDir }}/NOTICE.txt'
+        mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/README.md:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
         mode: 0644
@@ -185,6 +191,9 @@ shared:
       mode: 0755
     LICENSE.txt:
       source: '{{ repo.RootDir }}/LICENSE.txt'
+      mode: 0644
+    NOTICE.txt:
+      source: '{{ repo.RootDir }}/NOTICE.txt'
       mode: 0644
     README.md:
       template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
@@ -307,6 +316,9 @@ shared:
     <<: *agent_binary_spec
     extra_vars:
       from: 'centos:7'
+      buildFrom: 'centos:7'
+      dockerfile: 'Dockerfile.elastic-agent.tmpl'
+      docker_entrypoint: 'docker-entrypoint.elastic-agent.tmpl'
       user: 'root'
       linux_capabilities: ''
     files:
@@ -460,6 +472,7 @@ shared:
     <<: *binary_spec
     extra_vars:
       from: 'centos:7'
+      buildFrom: 'centos:7'
       user: '{{ .BeatName }}'
       linux_capabilities: ''
     files:
@@ -467,6 +480,11 @@ shared:
         source: '{{.BeatName}}.docker.yml'
         mode: 0600
         config: true
+
+  - &docker_ubi_spec
+    extra_vars:
+      image_name: '{{.BeatName}}-ubi8'
+      from: 'registry.access.redhat.com/ubi8/ubi-minimal'
 
   - &elastic_docker_spec
     extra_vars:
@@ -637,6 +655,14 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
 
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+
   # Elastic Beat with Elastic License and binary taken the current directory.
   elastic_beat_xpack_reduced:
     ###
@@ -721,6 +747,17 @@ specs:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
   # Elastic Beat with Elastic License and binary taken from the x-pack dir.
   elastic_beat_agent_binaries:
     ###
@@ -776,6 +813,17 @@ specs:
       types: [docker]
       spec:
         <<: *agent_docker_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *agent_docker_spec
+        <<: *docker_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -2,38 +2,14 @@
 {{- $beatBinary := printf "%s/%s" $beatHome .BeatName }}
 {{- $repoInfo := repo }}
 
-FROM {{ .from }}
-
-# Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
-RUN yum -y --setopt=tsflags=nodocs update && \
-    yum install epel-release -y && \
-    yum install jq -y && \
-    yum clean all
-
-LABEL \
-  org.label-schema.build-date="{{ date }}" \
-  org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="{{ .BeatVendor }}" \
-  org.label-schema.license="{{ .License }}" \
-  org.label-schema.name="{{ .BeatName }}" \
-  org.label-schema.version="{{ beat_version }}" \
-  org.label-schema.url="{{ .BeatURL }}" \
-  org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
-  org.label-schema.vcs-ref="{{ commit }}" \
-  license="{{ .License }}" \
-  description="{{ .BeatDescription }}"
-
-ENV ELASTIC_CONTAINER "true"
-ENV PATH={{ $beatHome }}:$PATH
+# Prepare home in a different stage to avoid creating additional layers on
+# the final image because of permission changes.
+FROM {{ .buildFrom }} AS home
 
 COPY beat {{ $beatHome }}
-COPY docker-entrypoint /usr/local/bin/docker-entrypoint
-RUN chmod 755 /usr/local/bin/docker-entrypoint
-
-RUN groupadd --gid 1000 {{ .BeatName }}
 
 RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/logs && \
-    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
+    chown -R root:root {{ $beatHome }} && \
     find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
     find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
     chmod 0750 {{ $beatBinary }} && \
@@ -45,8 +21,61 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/logs && \
 {{- end }}
     chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
 
+FROM {{ .from }}
+
+{{- if contains .from "ubi-minimal" }}
+RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
+RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && \
+    chmod +x /usr/local/bin/jq
+{{- else }}
+# Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
+RUN yum -y --setopt=tsflags=nodocs update && \
+    yum install epel-release -y && \
+    yum install jq -y && \
+    yum clean all
+{{- end }}
+
+LABEL \
+  org.label-schema.build-date="{{ date }}" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="{{ .BeatVendor }}" \
+  org.label-schema.license="{{ .License }}" \
+  org.label-schema.name="{{ .BeatName }}" \
+  org.label-schema.version="{{ beat_version }}" \
+  org.label-schema.url="{{ .BeatURL }}" \
+  org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
+  org.label-schema.vcs-ref="{{ commit }}" \
+  io.k8s.description="{{ .BeatDescription }}" \
+  io.k8s.display-name="{{ .BeatName | title }} image" \
+  org.opencontainers.image.created="{{ date }}" \
+  org.opencontainers.image.licenses="{{ .License }}" \
+  org.opencontainers.image.title="{{ .BeatName | title }}" \
+  org.opencontainers.image.vendor="{{ .BeatVendor }}" \
+  name="{{ .BeatName }}" \
+  maintainer="infra@elastic.co" \
+  vendor="{{ .BeatVendor }}" \
+  version="{{ beat_version }}" \
+  release="1" \
+  url="{{ .BeatURL }}" \
+  summary="{{ .BeatName }}" \
+  license="{{ .License }}" \
+  description="{{ .BeatDescription }}"
+
+ENV ELASTIC_CONTAINER "true"
+ENV PATH={{ $beatHome }}:$PATH
+
+COPY docker-entrypoint /usr/local/bin/docker-entrypoint
+RUN chmod 755 /usr/local/bin/docker-entrypoint
+
+COPY --from=home {{ $beatHome }} {{ $beatHome }}
+
+RUN mkdir /licenses
+COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
+COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
+
 {{- if ne .user "root" }}
-RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
+RUN groupadd --gid 1000 {{ .BeatName }}
+RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
 {{- end }}
 USER {{ .user }}
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -4,7 +4,7 @@
 
 # Prepare home in a different stage to avoid creating additional layers on
 # the final image because of permission changes.
-FROM {{ .from }} AS home
+FROM {{ .buildFrom }} AS home
 
 COPY beat {{ $beatHome }}
 
@@ -23,8 +23,13 @@ RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
 
 FROM {{ .from }}
 
-RUN yum -y --setopt=tsflags=nodocs update && \
-    yum clean all
+{{- if contains .from "ubi-minimal" }}
+RUN microdnf -y --setopt=tsflags=nodocs update && \
+    microdnf install shadow-utils && \
+    microdnf clean all
+{{- else }}
+RUN yum -y --setopt=tsflags=nodocs update && yum clean all
+{{- end }}
 
 LABEL \
   org.label-schema.build-date="{{ date }}" \
@@ -36,6 +41,19 @@ LABEL \
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
+  io.k8s.description="{{ .BeatDescription }}" \
+  io.k8s.display-name="{{ .BeatName | title }} image" \
+  org.opencontainers.image.created="{{ date }}" \
+  org.opencontainers.image.licenses="{{ .License }}" \
+  org.opencontainers.image.title="{{ .BeatName | title }}" \
+  org.opencontainers.image.vendor="{{ .BeatVendor }}" \
+  name="{{ .BeatName }}" \
+  maintainer="infra@elastic.co" \
+  vendor="{{ .BeatVendor }}" \
+  version="{{ beat_version }}" \
+  release="1" \
+  url="{{ .BeatURL }}" \
+  summary="{{ .BeatName }}" \
   license="{{ .License }}" \
   description="{{ .BeatDescription }}"
 
@@ -46,6 +64,10 @@ COPY docker-entrypoint /usr/local/bin/docker-entrypoint
 RUN chmod 755 /usr/local/bin/docker-entrypoint
 
 COPY --from=home {{ $beatHome }} {{ $beatHome }}
+
+RUN mkdir /licenses
+COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
+COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
 
 {{- if ne .user "root" }}
 RUN groupadd --gid 1000 {{ .BeatName }}

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -268,14 +268,30 @@ func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
-	packageAgent([]string{
-		"darwin-x86_64.tar.gz",
-		"linux-x86.tar.gz",
-		"linux-x86_64.tar.gz",
-		"windows-x86.zip",
-		"windows-x86_64.zip",
-		"linux-arm64.tar.gz",
-	}, devtools.UseElasticAgentPackaging)
+	platformPackages := []struct {
+		platform string
+		packages string
+	}{
+		{"darwin/amd64", "darwin-x86_64.tar.gz"},
+		{"linux/386", "linux-x86.tar.gz"},
+		{"linux/amd64", "linux-x86_64.tar.gz"},
+		{"linux/arm64", "linux-arm64.tar.gz"},
+		{"windows/386", "windows-x86.zip"},
+		{"windows/amd64", "windows-x86_64.zip"},
+	}
+
+	var requiredPackages []string
+	for _, p := range platformPackages {
+		if _, enabled := devtools.Platforms.Get(p.platform); enabled {
+			requiredPackages = append(requiredPackages, p.packages)
+		}
+	}
+
+	if len(requiredPackages) == 0 {
+		panic("elastic-agent package is expected to include other packages")
+	}
+
+	packageAgent(requiredPackages, devtools.UseElasticAgentPackaging)
 }
 
 func requiredPackagesPresent(basePath, beat, version string, requiredPackages []string) bool {
@@ -293,7 +309,7 @@ func requiredPackagesPresent(basePath, beat, version string, requiredPackages []
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages()
+	return devtools.TestPackages(devtools.WithRootUserContainer())
 }
 
 // RunGo runs go command and output the feedback to the stdout and the stderr.
@@ -514,18 +530,16 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				panic(err)
 			}
 
-			if requiredPackagesPresent(pwd, b, version, requiredPackages) {
-				continue
-			}
+			if !requiredPackagesPresent(pwd, b, version, requiredPackages) {
+				cmd := exec.Command("mage", "package")
+				cmd.Dir = pwd
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
 
-			cmd := exec.Command("mage", "package")
-			cmd.Dir = pwd
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
-
-			if err := cmd.Run(); err != nil {
-				panic(err)
+				if err := cmd.Run(); err != nil {
+					panic(err)
+				}
 			}
 
 			// copy to new drop
@@ -541,7 +555,7 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 
 	mg.Deps(Update)
 	mg.Deps(CrossBuild, CrossBuildGoDaemon)
-	mg.SerialDeps(devtools.Package)
+	mg.SerialDeps(devtools.Package, TestPackages)
 }
 
 func copyAll(from, to string) error {


### PR DESCRIPTION
Cherry-pick of PR #20576 to 7.x branch. Original message: 

## What does this PR do?

Add an additional docker build that builds images based on Red Hat UBI, following [Red Hat requirements for certified images](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/program-on-boarding/technical-prerequisites).

Additional checks have been added to packaging tests for labels and licenses.

Additional changes done to support it also in Elastic Agent images:
* Apply #20356 and #18873 to agent Dockerfile.
* Explicitly select a Dockerfile and entry point template, selecting it based on the image name is error prone, as our image names can have suffixes (`-oss`, `-ubi8`...).
* Add `NOTICE.txt` file to all agent packages.
* Actually run package tests after building packages, added flag to allow root user.
* Improved checks on required packages, so they are not always built, what significantly speeds up local builds.

**NOTE**: Some of the changes for Elastic Agent could be actually moved to separate PRs, but they are quite intertwined and I would like to test them together. I decided to do them on this PR to don't have to conditionally disable package tests, and to be able to test everything together. But happy to move them to other PRs if preferred.

## Why is it important?

To build images that can be certified for Red Hat OpenShift.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Move licenses to `/licenses`
  - [x] Add the proper licenses to x-pack and OSS images
- [x] Add labels
- [x] Add test to check that licenses are in place
- [x] Add test to check that required labels are present
- [x] Add build for Elastic Agent

Possibly to be done in a follow up PR
- [ ] Refactor how files are prepared and copied, so it is not needed to change permissions in Dockerfile
- [ ] Unify Dockerfiles for Agent and the rest of beats, as they are quite similar
- [ ] Add checks for the included packages in Agent image

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->