### PR TITLE
Request prometheus endpoints to be gzipped by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -658,6 +658,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add host inventory metrics to azure compute_vm metricset. {pull}20641[20641]
 - Add host inventory metrics to googlecloud compute metricset. {pull}20391[20391]
+- Request prometheus endpoints to be gzipped by default {pull}20766[20766]
 
 *Packetbeat*
 

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -64,7 +64,7 @@ func NewPrometheusClient(base mb.BaseMetricSet) (Prometheus, error) {
 	}
 
 	http.SetHeaderDefault("Accept", acceptHeader)
-	http.SetHeader("Accept-Encoding", "gzip")
+	http.SetHeaderDefault("Accept-Encoding", "gzip")
 	return &prometheus{http, base.Logger()}, nil
 }
 
@@ -79,10 +79,12 @@ func (p *prometheus) GetFamilies() ([]*dto.MetricFamily, error) {
 	defer resp.Body.Close()
 
 	if resp.Header.Get("Content-Encoding") == "gzip" {
-		reader, err = gzip.NewReader(resp.Body)
+		greader, err := gzip.NewReader(resp.Body)
 		if err != nil {
 			return nil, err
 		}
+		defer greader.Close()
+		reader = greader
 	} else {
 		reader = resp.Body
 	}

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -18,6 +18,7 @@
 package prometheus
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -63,19 +64,31 @@ func NewPrometheusClient(base mb.BaseMetricSet) (Prometheus, error) {
 	}
 
 	http.SetHeaderDefault("Accept", acceptHeader)
+	http.SetHeader("Accept-Encoding", "gzip")
 	return &prometheus{http, base.Logger()}, nil
 }
 
 // GetFamilies requests metric families from prometheus endpoint and returns them
 func (p *prometheus) GetFamilies() ([]*dto.MetricFamily, error) {
+	var reader io.Reader
+
 	resp, err := p.FetchResponse()
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		reader, err = gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		reader = resp.Body
+	}
+
 	if resp.StatusCode > 399 {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := ioutil.ReadAll(reader)
 		if err == nil {
 			p.logger.Debug("error received from prometheus endpoint: ", string(bodyBytes))
 		}
@@ -87,7 +100,7 @@ func (p *prometheus) GetFamilies() ([]*dto.MetricFamily, error) {
 		return nil, fmt.Errorf("Invalid format for response of response")
 	}
 
-	decoder := expfmt.NewDecoder(resp.Body, format)
+	decoder := expfmt.NewDecoder(reader, format)
 	if decoder == nil {
 		return nil, fmt.Errorf("Unable to create decoder to decode response")
 	}


### PR DESCRIPTION

- Enhancement

## What does this PR do?

This PR ensures that we add gzip content type to all prometheus endpoint poll requests. 
## Why is it important?

This improves performance network performance as most of the payload of exposition format compresses really well. 

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
