### PR TITLE
Cherry-pick #20776 to 7.x: [Elastic Agent] Fix tests to use localhost

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -58,7 +58,7 @@ func getTestOperator(t *testing.T, downloadPath string, installPath string, p *a
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := server.New(l, ":0", &ApplicationStatusHandler{})
+	srv, err := server.New(l, "localhost:0", &ApplicationStatusHandler{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -122,7 +122,7 @@ func getMonitorableTestOperator(t *testing.T, installPath string, m monitoring.M
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := server.New(l, ":0", &ApplicationStatusHandler{})
+	srv, err := server.New(l, "localhost:0", &ApplicationStatusHandler{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/core/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/server/server.go
@@ -894,11 +894,12 @@ func (s *Server) getCertificate(chi *tls.ClientHelloInfo) (*tls.Certificate, err
 
 // getListenAddr returns the listening address of the server.
 func (s *Server) getListenAddr() string {
-	if s.listenAddr != ":0" {
-		return s.listenAddr
+	addr := strings.SplitN(s.listenAddr, ":", 2)
+	if len(addr) == 2 && addr[1] == "0" {
+		port := s.listener.Addr().(*net.TCPAddr).Port
+		return fmt.Sprintf("%s:%d", addr[0], port)
 	}
-	port := s.listener.Addr().(*net.TCPAddr).Port
-	return fmt.Sprintf(":%d", port)
+	return s.listenAddr
 }
 
 type pendingAction struct {

--- a/x-pack/elastic-agent/pkg/core/server/server_test.go
+++ b/x-pack/elastic-agent/pkg/core/server/server_test.go
@@ -634,7 +634,7 @@ func newErrorLogger(t *testing.T) *logger.Logger {
 
 func createAndStartServer(t *testing.T, handler Handler, extraConfigs ...func(*Server)) *Server {
 	t.Helper()
-	srv, err := New(newErrorLogger(t), ":0", handler)
+	srv, err := New(newErrorLogger(t), "localhost:0", handler)
 	require.NoError(t, err)
 	for _, extra := range extraConfigs {
 		extra(srv)


### PR DESCRIPTION
Cherry-pick of PR #20776 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the tests to listen only on localhost.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Prevents showing allow/deny modals on Mac OS X, and generally a good idea anyway.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20743 
