### PR TITLE
Check host fields type before converting to common.MapStr

### DIFF
--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -161,12 +161,29 @@ func skipAddingHostMetadata(event *beat.Event) bool {
 		return false
 	}
 
-	hostFieldsMap := hostFields.(common.MapStr)
-	// or if "name" is the only field, don't skip
-	hasName, _ := hostFieldsMap.HasKey("name")
-	if hasName && len(hostFieldsMap) == 1 {
+	switch m := hostFields.(type) {
+	case common.MapStr:
+		// if "name" is the only field, don't skip
+		hasName, _ := m.HasKey("name")
+		if hasName && len(m) == 1 {
+			return false
+		}
+		return true
+	case map[string]interface{}:
+		hostMapStr := common.MapStr(m)
+		// if "name" is the only field, don't skip
+		hasName, _ := hostMapStr.HasKey("name")
+		if hasName && len(m) == 1 {
+			return false
+		}
+		return true
+	case map[string]string:
+		// if "name" is the only field, don't skip
+		if m["name"] != "" && len(m) == 1 {
+			return false
+		}
+		return true
+	default:
 		return false
 	}
-
-	return true
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -356,6 +356,16 @@ func TestEventWithReplaceFieldsTrue(t *testing.T) {
 }
 
 func TestSkipAddingHostMetadata(t *testing.T) {
+	hostIDMap := map[string]string{}
+	hostIDMap["id"] = hostID
+
+	hostNameMap := map[string]string{}
+	hostNameMap["name"] = hostName
+
+	hostIDNameMap := map[string]string{}
+	hostIDNameMap["id"] = hostID
+	hostIDNameMap["name"] = hostName
+
 	cases := []struct {
 		title        string
 		event        beat.Event
@@ -399,6 +409,42 @@ func TestSkipAddingHostMetadata(t *testing.T) {
 			"event without host field",
 			beat.Event{
 				Fields: common.MapStr{},
+			},
+			false,
+		},
+		{
+			"event with field type map[string]string hostID",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": hostIDMap,
+				},
+			},
+			true,
+		},
+		{
+			"event with field type map[string]string host name",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": hostNameMap,
+				},
+			},
+			false,
+		},
+		{
+			"event with field type map[string]string host ID and name",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": hostIDNameMap,
+				},
+			},
+			true,
+		},
+		{
+			"event with field type string",
+			beat.Event{
+				Fields: common.MapStr{
+					"host": "string",
+				},
 			},
 			false,
 		},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to address [comment](https://github.com/elastic/beats/pull/20490/files/336a4b9b37b42727a439ec8191436f2d7cd59a2c#r476363621 ) for checking `hostFields` type before converting to `common.MapStr`. Directly converting to `common.MapStr` will panic if the host field is not a `common.MapStr`. 

## Why is it important?

Filebeat can handle arbitrary data so it's not guaranteed host field is `common.MapStr` type and this will cause a panic.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
