### PR TITLE
Cherry-pick #20766 to 7.x: Request prometheus endpoints to be gzipped by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -733,6 +733,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add `scope` setting for elasticsearch module, allowing it to monitor an Elasticsearch cluster behind a load-balancing proxy. {issue}18539[18539] {pull}18547[18547]
 - Add host inventory metrics to googlecloud compute metricset. {pull}20391[20391]
 - Add host inventory metrics to azure compute_vm metricset. {pull}20641[20641]
+- Request prometheus endpoints to be gzipped by default {pull}20766[20766]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #20766 to 7.x branch. Original message: 


- Enhancement

## What does this PR do?

This PR ensures that we add gzip content type to all prometheus endpoint poll requests. 
## Why is it important?

This improves performance network performance as most of the payload of exposition format compresses really well. 

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
