### PR TITLE
[docs] typo in the command line

### DIFF
--- a/filebeat/docs/inputs/input-log.asciidoc
+++ b/filebeat/docs/inputs/input-log.asciidoc
@@ -90,7 +90,7 @@ more volatile.
 
 ["source","sh",subs="attributes"]
 ----
-$ lsblk -o MOUNTPOINT,UUD | grep /logs | awk '{print $2}' >> /logs/.filebeat-marker
+$ lsblk -o MOUNTPOINT,UUID | grep /logs | awk '{print $2}' >> /logs/.filebeat-marker
 ----
 
 To set the generated file as a marker for `file_identity` you should configure


### PR DESCRIPTION
`UUD` command line parameter should read `UUID`

```
$ lsblk -o MOUNTPOINT,UUD
lsblk: unknown column: UUD

$ lsblk -o MOUNTPOINT,UUID
MOUNTPOINT                   UUID
/snap/core/9665              
[... and more ...]
```