### PR TITLE
Cherry-pick #20811 to 7.9: Add missing country_name geo field in add host metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `setup.dashboards.index` setting not working. {pull}17749[17749]
 - Fix Elasticsearch license endpoint URL referenced in error message. {issue}17880[17880] {pull}18030[18030]
 - Change `decode_json_fields` processor, to merge parsed json objects with existing objects in the event instead of fully replacing them. {pull}17958[17958]
+- Add missing country_name geo field in `add_host_metadata` and `add_observer_metadata` processors. {issue}20796[20796] {pull}20811[20811]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -153,6 +153,7 @@ func TestConfigGeoEnabled(t *testing.T) {
 		"geo.name":             "yerevan-am",
 		"geo.location":         "40.177200, 44.503490",
 		"geo.continent_name":   "Asia",
+		"geo.country_name":     "Armenia",
 		"geo.country_iso_code": "AM",
 		"geo.region_name":      "Erevan",
 		"geo.region_iso_code":  "AM-ER",

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
@@ -120,6 +120,7 @@ func TestConfigGeoEnabled(t *testing.T) {
 		"geo.name":             "yerevan-am",
 		"geo.location":         "40.177200, 44.503490",
 		"geo.continent_name":   "Asia",
+		"geo.country_name":     "Armenia",
 		"geo.country_iso_code": "AM",
 		"geo.region_name":      "Erevan",
 		"geo.region_iso_code":  "AM-ER",

--- a/libbeat/processors/util/geo.go
+++ b/libbeat/processors/util/geo.go
@@ -29,6 +29,7 @@ type GeoConfig struct {
 	Name           string `config:"name"`
 	Location       string `config:"location"`
 	ContinentName  string `config:"continent_name"`
+	CountryName    string `config:"country_name"`
 	CountryISOCode string `config:"country_iso_code"`
 	RegionName     string `config:"region_name"`
 	RegionISOCode  string `config:"region_iso_code"`
@@ -59,6 +60,7 @@ func GeoConfigToMap(config GeoConfig) (common.MapStr, error) {
 		"name":             config.Name,
 		"location":         config.Location,
 		"continent_name":   config.ContinentName,
+		"country_name":     config.CountryName,
 		"country_iso_code": config.CountryISOCode,
 		"region_name":      config.RegionName,
 		"region_iso_code":  config.RegionISOCode,


### PR DESCRIPTION
Cherry-pick of PR #20811 to 7.9 branch. Original message: 

## What does this PR do?

Add missing `country_name` geo field in `add_host_metadata` and `add_observer_metadata` processors.

## Why is it important?

Documentation includes this field, and it is also part of ECS.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #20796