### PR TITLE
Cherry-pick #20630 to 7.9: windows/perfmon fix for `There is more data to return than will fit in the supplied buffer`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add required option for `metrics` in app_insights. {pull}20406[20406]
 - Groups same timestamp metric values to one event in the app_insights metricset. {pull}20403[20403]
 - Updates vm_compute metricset with more info on guest metrics. {pull}20448[20448]
+- Add fallback for PdhExpandWildCardPathW failing in perfmon metricset. {issue}20139[20139] {pull}20630[20630]
 - Fix resource tags in aws cloudwatch metricset {issue}20326[20326]  {pull}20385[20385]
 
 *Packetbeat*

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -212,6 +212,12 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 		expdPaths, err = PdhExpandCounterPath(utfPath)
 	} else {
 		expdPaths, err = PdhExpandWildCardPath(utfPath)
+		// rarely the PdhExpandWildCardPathW will not retrieve the expanded buffer size initially so the next call will encounter the PDH_MORE_DATA error since the specified size on the input is still less than
+		// the required size. If this is the case we will fallback on the PdhExpandCounterPathW api since it looks to act in a more stable manner. The PdhExpandCounterPathW api does come with some limitations but will
+		// satisfy most cases and return valid paths.
+		if err == PDH_MORE_DATA {
+			expdPaths, err = PdhExpandCounterPath(utfPath)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -61,7 +61,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	// if the ignore_non_existent_counters flag is set and no valid counter paths are found the Read func will still execute, a check is done before
 	if len(m.reader.query.Counters) == 0 {
-		return errors.New("no counters to read")
+		m.log.Error("no counter paths were found")
 	}
 
 	// refresh performance counter list


### PR DESCRIPTION
Cherry-pick of PR #20630 to 7.9 branch. Original message:

## What does this PR do?

In some cases the `PdhExpandWildCardPathW` api call will not retrieve the expanded buffer size initially so the next call will encounter the `PDH_MORE_DATA` error since the specified size on the input is still less than the required size.
If this is the case a fallback on the `PdhExpandCounterPathW` api is executed since it looks to act in a more stable manner. The `PdhExpandCounterPathW` api does come with some limitations but will satisfy most cases and return valid paths.

## Why is it important?

Will fix `There is more data to return than will fit in the supplied buffer` errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/20139


