### PR TITLE
Cherry-pick #20689 to 7.x: Rename cloud.provider to `azure` instead of `az` in add_cloud_metadata processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -183,7 +183,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add service resource in k8s cluster role. {pull}20546[20546]
 - [Metricbeat][Kubernetes] Change cluster_ip field from ip to keyword. {pull}20571[20571]
 - Rename cloud.provider `az` value to `azure` inside the add_cloud_metadata processor. {pull}20689[20689]
-- Add missing country_name geo field in `add_host_metadata` and `add_observer_metadata` processors. {issue}20796[20796] {pull}20811[20811]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,6 +182,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix issue in autodiscover that kept inputs stopped after config updates. {pull}20305[20305]
 - Add service resource in k8s cluster role. {pull}20546[20546]
 - [Metricbeat][Kubernetes] Change cluster_ip field from ip to keyword. {pull}20571[20571]
+- Rename cloud.provider `az` value to `azure` inside the add_cloud_metadata processor. {pull}20689[20689]
+- Add missing country_name geo field in `add_host_metadata` and `add_observer_metadata` processors. {issue}20796[20796] {pull}20811[20811]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -143,7 +143,7 @@ _Azure Virtual Machine_
 -------------------------------------------------------------------------------
 {
   "cloud": {
-    "provider": "az",
+    "provider": "azure",
     "instance.id": "04ab04c3-63de-4709-a9f9-9ab8c0411d5e",
     "instance.name": "test-az-vm",
     "machine.type": "Standard_D3_v2",

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
@@ -46,7 +46,7 @@ var azureVMMetadataFetcher = provider{
 			return out
 		}
 
-		fetcher, err := newMetadataFetcher(config, "az", azHeaders, metadataHost, azSchema, azMetadataURI)
+		fetcher, err := newMetadataFetcher(config, "azure", azHeaders, metadataHost, azSchema, azMetadataURI)
 		return fetcher, err
 	},
 }

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -79,7 +79,7 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 
 	expected := common.MapStr{
 		"cloud": common.MapStr{
-			"provider": "az",
+			"provider": "azure",
 			"instance": common.MapStr{
 				"id":   "04ab04c3-63de-4709-a9f9-9ab8c0411d5e",
 				"name": "test-az-vm",


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#20689 to 7.x branch. Original message:

## What does this PR do?

Rename cloud.provider to `azure` instead of `az` in add_cloud_metadata

## Why is it important?

The cloud.provider's value is `az` but it is matched to `azure` in the `azure` module. 
Not sure why it is shorten `azure` to `az`. Looking around I do not see the `az` terminology being a popular one or even used anywhere (maybe in the az client). Unlike `aws` or `gcp`, `azure` is does not to abbreviate to `az`, using azure instead seems to me to be the most reasonable solution.
Also, the elastic documentation shows that `azure` should be used instead.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/19758

