### PR TITLE
Cherry-pick #20804 to 7.x: [Elastic Agent] Add initial composable providers

### DIFF
--- a/x-pack/elastic-agent/pkg/composable/config.go
+++ b/x-pack/elastic-agent/pkg/composable/config.go
@@ -1,0 +1,12 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable
+
+import "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+
+// Config is config for multiple providers.
+type Config struct {
+	Providers map[string]*config.Config `config:"providers"`
+}

--- a/x-pack/elastic-agent/pkg/composable/context.go
+++ b/x-pack/elastic-agent/pkg/composable/context.go
@@ -1,0 +1,64 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+// ContextProviderComm is the interface that a context provider uses to communicate back to Elastic Agent.
+type ContextProviderComm interface {
+	context.Context
+
+	// Set sets the current mapping for this context.
+	Set(map[string]interface{}) error
+}
+
+// ContextProvider is the interface that a context provider must implement.
+type ContextProvider interface {
+	// Run runs the context provider.
+	Run(ContextProviderComm) error
+}
+
+// ContextProviderBuilder creates a new context provider based on the given config and returns it.
+type ContextProviderBuilder func(config *config.Config) (ContextProvider, error)
+
+// AddContextProvider adds a new ContextProviderBuilder
+func (r *providerRegistry) AddContextProvider(name string, builder ContextProviderBuilder) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if name == "" {
+		return fmt.Errorf("provider name is required")
+	}
+	if strings.ToLower(name) != name {
+		return fmt.Errorf("provider name must be lowercase")
+	}
+	_, contextExists := r.contextProviders[name]
+	_, dynamicExists := r.dynamicProviders[name]
+	if contextExists || dynamicExists {
+		return fmt.Errorf("provider '%s' is already registered", name)
+	}
+	if builder == nil {
+		return fmt.Errorf("provider '%s' cannot be registered with a nil factory", name)
+	}
+
+	r.contextProviders[name] = builder
+	r.logger.Debugf("Registered provider: %s", name)
+	return nil
+}
+
+// GetContextProvider returns the context provider with the giving name, nil if it doesn't exist
+func (r *providerRegistry) GetContextProvider(name string) (ContextProviderBuilder, bool) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	b, ok := r.contextProviders[name]
+	return b, ok
+}

--- a/x-pack/elastic-agent/pkg/composable/controller.go
+++ b/x-pack/elastic-agent/pkg/composable/controller.go
@@ -1,0 +1,300 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+// Vars is a context of variables that also contain a list of processors that go with the mapping.
+type Vars struct {
+	Mapping map[string]interface{}
+
+	ProcessorsKey string
+	Processors    []map[string]interface{}
+}
+
+// VarsCallback is callback called when the current vars state changes.
+type VarsCallback func([]Vars)
+
+// Controller manages the state of the providers current context.
+type Controller struct {
+	contextProviders map[string]*contextProviderState
+	dynamicProviders map[string]*dynamicProviderState
+}
+
+// New creates a new controller.
+func New(c *config.Config) (*Controller, error) {
+	var providersCfg Config
+	err := c.Unpack(&providersCfg)
+	if err != nil {
+		return nil, errors.New(err, "failed to unpack providers config", errors.TypeConfig)
+	}
+
+	// build all the context providers
+	contextProviders := map[string]*contextProviderState{}
+	for name, builder := range Providers.contextProviders {
+		pCfg, ok := providersCfg.Providers[name]
+		if ok && !pCfg.Enabled() {
+			// explicitly disabled; skipping
+			continue
+		}
+		provider, err := builder(pCfg)
+		if err != nil {
+			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
+		}
+		contextProviders[name] = &contextProviderState{
+			provider: provider,
+		}
+	}
+
+	// build all the dynamic providers
+	dynamicProviders := map[string]*dynamicProviderState{}
+	for name, builder := range Providers.dynamicProviders {
+		pCfg, ok := providersCfg.Providers[name]
+		if ok && !pCfg.Enabled() {
+			// explicitly disabled; skipping
+			continue
+		}
+		provider, err := builder(pCfg)
+		if err != nil {
+			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
+		}
+		dynamicProviders[name] = &dynamicProviderState{
+			provider: provider,
+			mappings: map[string]Vars{},
+		}
+	}
+
+	return &Controller{
+		contextProviders: contextProviders,
+		dynamicProviders: dynamicProviders,
+	}, nil
+}
+
+// Run runs the controller.
+func (c *Controller) Run(ctx context.Context, cb VarsCallback) error {
+	// large number not to block performing Run on the provided providers
+	notify := make(chan bool, 5000)
+	localCtx, cancel := context.WithCancel(ctx)
+
+	// run all the enabled context providers
+	for name, state := range c.contextProviders {
+		state.Context = localCtx
+		state.signal = notify
+		err := state.provider.Run(state)
+		if err != nil {
+			cancel()
+			return errors.New(err, fmt.Sprintf("failed to run provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
+		}
+	}
+
+	// run all the enabled dynamic providers
+	for name, state := range c.dynamicProviders {
+		state.Context = localCtx
+		state.signal = notify
+		err := state.provider.Run(state)
+		if err != nil {
+			cancel()
+			return errors.New(err, fmt.Sprintf("failed to run provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
+		}
+	}
+
+	go func() {
+		for {
+			// performs debounce of notifies; accumulates them into 100 millisecond chunks
+			changed := false
+			for {
+				exitloop := false
+				select {
+				case <-ctx.Done():
+					cancel()
+					return
+				case <-notify:
+					changed = true
+				case <-time.After(100 * time.Millisecond):
+					exitloop = true
+					break
+				}
+				if exitloop {
+					break
+				}
+			}
+			if !changed {
+				continue
+			}
+
+			// build the vars list of mappings
+			vars := make([]Vars, 1)
+			mapping := map[string]interface{}{}
+			for name, state := range c.contextProviders {
+				mapping[name] = state.Current()
+			}
+			vars[0] = Vars{
+				Mapping: mapping,
+			}
+
+			// add to the vars list for each dynamic providers mappings
+			for name, state := range c.dynamicProviders {
+				for _, mappings := range state.Mappings() {
+					local, _ := cloneMap(mapping) // will not fail; already been successfully cloned once
+					local[name] = mappings.Mapping
+					vars = append(vars, Vars{
+						Mapping:       local,
+						ProcessorsKey: name,
+						Processors:    mappings.Processors,
+					})
+				}
+			}
+
+			// execute the callback
+			cb(vars)
+		}
+	}()
+
+	return nil
+}
+
+type contextProviderState struct {
+	context.Context
+
+	provider ContextProvider
+	lock     sync.RWMutex
+	mapping  map[string]interface{}
+	signal   chan bool
+}
+
+// Set sets the current mapping.
+func (c *contextProviderState) Set(mapping map[string]interface{}) error {
+	var err error
+	mapping, err = cloneMap(mapping)
+	if err != nil {
+		return err
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if reflect.DeepEqual(c.mapping, mapping) {
+		// same mapping; no need to update and signal
+		return nil
+	}
+	c.mapping = mapping
+	c.signal <- true
+	return nil
+}
+
+// Current returns the current mapping.
+func (c *contextProviderState) Current() map[string]interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.mapping
+}
+
+type dynamicProviderState struct {
+	context.Context
+
+	provider DynamicProvider
+	lock     sync.RWMutex
+	mappings map[string]Vars
+	signal   chan bool
+}
+
+// AddOrUpdate adds or updates the current mapping for the dynamic provider.
+func (c *dynamicProviderState) AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error {
+	var err error
+	mapping, err = cloneMap(mapping)
+	if err != nil {
+		return err
+	}
+	processors, err = cloneMapArray(processors)
+	if err != nil {
+		return err
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	curr, ok := c.mappings[id]
+	if ok && reflect.DeepEqual(curr.Mapping, mapping) && reflect.DeepEqual(curr.Processors, processors) {
+		// same mapping; no need to update and signal
+		return nil
+	}
+	c.mappings[id] = Vars{
+		Mapping:    mapping,
+		Processors: processors,
+	}
+	c.signal <- true
+	return nil
+}
+
+// Remove removes the current mapping for the dynamic provider.
+func (c *dynamicProviderState) Remove(id string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, exists := c.mappings[id]
+	if exists {
+		// existed; remove and signal
+		delete(c.mappings, id)
+		c.signal <- true
+	}
+}
+
+// Mappings returns the current mappings.
+func (c *dynamicProviderState) Mappings() []Vars {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	mappings := make([]Vars, 0)
+	ids := make([]string, 0)
+	for name := range c.mappings {
+		ids = append(ids, name)
+	}
+	sort.Strings(ids)
+	for _, name := range ids {
+		mappings = append(mappings, c.mappings[name])
+	}
+	return mappings
+}
+
+func cloneMap(source map[string]interface{}) (map[string]interface{}, error) {
+	if source == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone: %s", err)
+	}
+	var dest map[string]interface{}
+	err = json.Unmarshal(bytes, &dest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone: %s", err)
+	}
+	return dest, nil
+}
+
+func cloneMapArray(source []map[string]interface{}) ([]map[string]interface{}, error) {
+	if source == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone: %s", err)
+	}
+	var dest []map[string]interface{}
+	err = json.Unmarshal(bytes, &dest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone: %s", err)
+	}
+	return dest, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/controller_test.go
+++ b/x-pack/elastic-agent/pkg/composable/controller_test.go
@@ -1,0 +1,85 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+
+	_ "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/providers/env"
+	_ "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/providers/host"
+	_ "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/providers/local"
+	_ "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/providers/localdynamic"
+)
+
+func TestController(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"providers": map[string]interface{}{
+			"env": map[string]interface{}{
+				"enabled": "false",
+			},
+			"local": map[string]interface{}{
+				"vars": map[string]interface{}{
+					"key1": "value1",
+				},
+			},
+			"local_dynamic": map[string]interface{}{
+				"vars": []map[string]interface{}{
+					{
+						"key1": "value1",
+					},
+					{
+						"key1": "value2",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	c, err := composable.New(cfg)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wg.Add(1)
+	var setVars []composable.Vars
+	err = c.Run(ctx, func(vars []composable.Vars) {
+		setVars = vars
+		wg.Done()
+	})
+	require.NoError(t, err)
+	wg.Wait()
+
+	assert.Len(t, setVars, 3)
+
+	_, hostExists := setVars[0].Mapping["host"]
+	assert.True(t, hostExists)
+	_, envExists := setVars[0].Mapping["env"]
+	assert.False(t, envExists)
+	localMap := setVars[0].Mapping["local"].(map[string]interface{})
+	assert.Equal(t, "value1", localMap["key1"])
+	assert.Equal(t, "", setVars[0].ProcessorsKey)
+	assert.Nil(t, setVars[0].Processors)
+
+	localMap = setVars[1].Mapping["local_dynamic"].(map[string]interface{})
+	assert.Equal(t, "value1", localMap["key1"])
+	assert.Equal(t, "local_dynamic", setVars[1].ProcessorsKey)
+	assert.Nil(t, setVars[1].Processors)
+
+	localMap = setVars[2].Mapping["local_dynamic"].(map[string]interface{})
+	assert.Equal(t, "value2", localMap["key1"])
+	assert.Equal(t, "local_dynamic", setVars[2].ProcessorsKey)
+	assert.Nil(t, setVars[2].Processors)
+}

--- a/x-pack/elastic-agent/pkg/composable/dynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/dynamic.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+// DynamicProviderComm is the interface that an dynamic provider uses to communicate back to Elastic Agent.
+type DynamicProviderComm interface {
+	context.Context
+
+	// AddOrUpdate updates a mapping with given ID with latest mapping and processors.
+	AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error
+	// Remove removes a mapping by given ID.
+	Remove(id string)
+}
+
+// DynamicProvider is the interface that a dynamic provider must implement.
+type DynamicProvider interface {
+	// Run runs the inventory provider.
+	Run(DynamicProviderComm) error
+}
+
+// DynamicProviderBuilder creates a new dynamic provider based on the given config and returns it.
+type DynamicProviderBuilder func(config *config.Config) (DynamicProvider, error)
+
+// AddDynamicProvider adds a new DynamicProviderBuilder
+func (r *providerRegistry) AddDynamicProvider(name string, builder DynamicProviderBuilder) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if name == "" {
+		return fmt.Errorf("provider name is required")
+	}
+	if strings.ToLower(name) != name {
+		return fmt.Errorf("provider name must be lowercase")
+	}
+	_, contextExists := r.contextProviders[name]
+	_, dynamicExists := r.dynamicProviders[name]
+	if contextExists || dynamicExists {
+		return fmt.Errorf("provider '%s' is already registered", name)
+	}
+	if builder == nil {
+		return fmt.Errorf("provider '%s' cannot be registered with a nil factory", name)
+	}
+
+	r.dynamicProviders[name] = builder
+	r.logger.Debugf("Registered provider: %s", name)
+	return nil
+}
+
+// GetDynamicProvider returns the dynamic provider with the giving name, nil if it doesn't exist
+func (r *providerRegistry) GetDynamicProvider(name string) (DynamicProviderBuilder, bool) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	b, ok := r.dynamicProviders[name]
+	return b, ok
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package agent
+
+import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
+
+func init() {
+	composable.Providers.AddContextProvider("agent", ContextProviderBuilder)
+}
+
+type contextProvider struct{}
+
+// Run runs the Agent context provider.
+func (*contextProvider) Run(comm composable.ContextProviderComm) error {
+	a, err := info.NewAgentInfo()
+	if err != nil {
+		return err
+	}
+	err = comm.Set(map[string]interface{}{
+		"id": a.AgentID(),
+		"version": map[string]interface{}{
+			"version":    release.Version(),
+			"commit":     release.Commit(),
+			"build_time": release.BuildTime().Format("2006-01-02 15:04:05 -0700 MST"),
+			"snapshot":   release.Snapshot(),
+		},
+	})
+	if err != nil {
+		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)
+	}
+	return nil
+}
+
+// ContextProviderBuilder builds the context provider.
+func ContextProviderBuilder(_ *config.Config) (composable.ContextProvider, error) {
+	return &contextProvider{}, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/agent/agent_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/agent/agent_test.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+)
+
+func TestContextProvider(t *testing.T) {
+	builder, _ := composable.Providers.GetContextProvider("agent")
+	provider, err := builder(nil)
+	require.NoError(t, err)
+
+	comm := ctesting.NewContextComm(context.Background())
+	err = provider.Run(comm)
+	require.NoError(t, err)
+
+	current := comm.Current()
+	_, hasID := current["id"]
+	assert.True(t, hasID, "missing id")
+	_, hasVersion := current["version"]
+	assert.True(t, hasVersion, "missing version")
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/env/env.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/env/env.go
@@ -1,0 +1,43 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package env
+
+import (
+	"os"
+	"strings"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+func init() {
+	composable.Providers.AddContextProvider("env", ContextProviderBuilder)
+}
+
+type contextProvider struct{}
+
+// Run runs the environment context provider.
+func (*contextProvider) Run(comm composable.ContextProviderComm) error {
+	err := comm.Set(getEnvMapping())
+	if err != nil {
+		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)
+	}
+	return nil
+}
+
+// ContextProviderBuilder builds the context provider.
+func ContextProviderBuilder(_ *config.Config) (composable.ContextProvider, error) {
+	return &contextProvider{}, nil
+}
+
+func getEnvMapping() map[string]interface{} {
+	mapping := map[string]interface{}{}
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		mapping[pair[0]] = pair[1]
+	}
+	return mapping
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/env/env_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/env/env_test.go
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package env
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+)
+
+func TestContextProvider(t *testing.T) {
+	builder, _ := composable.Providers.GetContextProvider("env")
+	provider, err := builder(nil)
+	require.NoError(t, err)
+
+	comm := ctesting.NewContextComm(context.Background())
+	err = provider.Run(comm)
+	require.NoError(t, err)
+
+	assert.Equal(t, getEnvMapping(), comm.Current())
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host.go
@@ -1,0 +1,121 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package host
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"time"
+
+	"github.com/elastic/go-sysinfo"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+// DefaultCheckInterval is the default timeout used to check if any host information has changed.
+const DefaultCheckInterval = 5 * time.Minute
+
+func init() {
+	composable.Providers.AddContextProvider("host", ContextProviderBuilder)
+}
+
+type infoFetcher func() (map[string]interface{}, error)
+
+type contextProvider struct {
+	logger *logger.Logger
+
+	CheckInterval time.Duration `config:"check_interval"`
+
+	// used by testing
+	fetcher infoFetcher
+}
+
+// Run runs the environment context provider.
+func (c *contextProvider) Run(comm composable.ContextProviderComm) error {
+	current, err := c.fetcher()
+	if err != nil {
+		return err
+	}
+	err = comm.Set(current)
+	if err != nil {
+		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)
+	}
+
+	// Update context when any host information changes.
+	go func() {
+		for {
+			select {
+			case <-comm.Done():
+				return
+			case <-time.After(c.CheckInterval):
+				break
+			}
+
+			updated, err := c.fetcher()
+			if err != nil {
+				c.logger.Warnf("Failed fetching latest host information: %s", err)
+				continue
+			}
+			if reflect.DeepEqual(current, updated) {
+				// nothing to do
+				continue
+			}
+			current = updated
+			err = comm.Set(updated)
+			if err != nil {
+				c.logger.Errorf("Failed updating mapping to latest host information: %s", err)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// ContextProviderBuilder builds the context provider.
+func ContextProviderBuilder(c *config.Config) (composable.ContextProvider, error) {
+	logger, err := logger.New("composable.providers.host")
+	if err != nil {
+		return nil, err
+	}
+	p := &contextProvider{
+		logger:  logger,
+		fetcher: getHostInfo,
+	}
+	if c != nil {
+		err := c.Unpack(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack config: %s", err)
+		}
+	}
+	if p.CheckInterval <= 0 {
+		p.CheckInterval = DefaultCheckInterval
+	}
+	return p, nil
+}
+
+func getHostInfo() (map[string]interface{}, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	sysInfo, err := sysinfo.Host()
+	if err != nil {
+		return nil, err
+	}
+	info := sysInfo.Info()
+	return map[string]interface{}{
+		"id":           info.UniqueID,
+		"name":         hostname,
+		"platform":     runtime.GOOS,
+		"architecture": info.Architecture,
+		"ip":           info.IPs,
+		"mac":          info.MACs,
+	}, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package host
+
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+)
+
+func TestContextProvider(t *testing.T) {
+	// first call will have idx of 0
+	starting, err := getHostInfo()
+	starting["idx"] = 0
+	require.NoError(t, err)
+
+	c, err := config.NewConfigFrom(map[string]interface{}{
+		"check_interval": 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	builder, _ := composable.Providers.GetContextProvider("host")
+	provider, err := builder(c)
+	require.NoError(t, err)
+
+	hostProvider := provider.(*contextProvider)
+	hostProvider.fetcher = returnHostMapping()
+	require.Equal(t, 100*time.Millisecond, hostProvider.CheckInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	comm := ctesting.NewContextComm(ctx)
+	err = provider.Run(comm)
+	require.NoError(t, err)
+	starting, err = ctesting.CloneMap(starting)
+	require.NoError(t, err)
+	require.Equal(t, starting, comm.Current())
+
+	// wait for it to be called again
+	var wg sync.WaitGroup
+	wg.Add(1)
+	comm.CallOnSet(func() {
+		wg.Done()
+	})
+	wg.Wait()
+	comm.CallOnSet(nil)
+	cancel()
+
+	// next should have been set idx to 1
+	next, err := getHostInfo()
+	require.NoError(t, err)
+	next["idx"] = 1
+	next, err = ctesting.CloneMap(next)
+	require.NoError(t, err)
+	assert.Equal(t, next, comm.Current())
+}
+
+func returnHostMapping() infoFetcher {
+	i := -1
+	return func() (map[string]interface{}, error) {
+		host, err := getHostInfo()
+		if err != nil {
+			return nil, err
+		}
+		i++
+		host["idx"] = i
+		return host, nil
+	}
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/local/local.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/local/local.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package local
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+func init() {
+	composable.Providers.AddContextProvider("local", ContextProviderBuilder)
+}
+
+type contextProvider struct {
+	Mapping map[string]interface{} `config:"vars"`
+}
+
+// Run runs the environment context provider.
+func (c *contextProvider) Run(comm composable.ContextProviderComm) error {
+	err := comm.Set(c.Mapping)
+	if err != nil {
+		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)
+	}
+	return nil
+}
+
+// ContextProviderBuilder builds the context provider.
+func ContextProviderBuilder(c *config.Config) (composable.ContextProvider, error) {
+	p := &contextProvider{}
+	if c != nil {
+		err := c.Unpack(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack vars: %s", err)
+		}
+	}
+	if p.Mapping == nil {
+		p.Mapping = map[string]interface{}{}
+	}
+	return p, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/local/local_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/local/local_test.go
@@ -1,0 +1,37 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+func TestContextProvider(t *testing.T) {
+	mapping := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"vars": mapping,
+	})
+	require.NoError(t, err)
+	builder, _ := composable.Providers.GetContextProvider("local")
+	provider, err := builder(cfg)
+	require.NoError(t, err)
+
+	comm := ctesting.NewContextComm(context.Background())
+	err = provider.Run(comm)
+	require.NoError(t, err)
+
+	assert.Equal(t, mapping, comm.Current())
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package localdynamic
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+func init() {
+	composable.Providers.AddDynamicProvider("local_dynamic", DynamicProviderBuilder)
+}
+
+type dynamicProvider struct {
+	Mappings []map[string]interface{} `config:"vars"`
+}
+
+// Run runs the environment context provider.
+func (c *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
+	for i, mapping := range c.Mappings {
+		if err := comm.AddOrUpdate(strconv.Itoa(i), mapping, nil); err != nil {
+			return errors.New(err, fmt.Sprintf("failed to add mapping for index %d", i), errors.TypeUnexpected)
+		}
+	}
+	return nil
+}
+
+// DynamicProviderBuilder builds the dynamic provider.
+func DynamicProviderBuilder(c *config.Config) (composable.DynamicProvider, error) {
+	p := &dynamicProvider{}
+	if c != nil {
+		err := c.Unpack(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack vars: %s", err)
+		}
+	}
+	if p.Mappings == nil {
+		p.Mappings = []map[string]interface{}{}
+	}
+	return p, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
@@ -1,0 +1,48 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package localdynamic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+)
+
+func TestContextProvider(t *testing.T) {
+	mapping1 := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	mapping2 := map[string]interface{}{
+		"key1": "value12",
+		"key2": "value22",
+	}
+	mapping := []map[string]interface{}{mapping1, mapping2}
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"vars": mapping,
+	})
+	require.NoError(t, err)
+	builder, _ := composable.Providers.GetDynamicProvider("local_dynamic")
+	provider, err := builder(cfg)
+	require.NoError(t, err)
+
+	comm := ctesting.NewDynamicComm(context.Background())
+	err = provider.Run(comm)
+	require.NoError(t, err)
+
+	curr1, ok1 := comm.Current("0")
+	assert.True(t, ok1)
+	assert.Equal(t, mapping1, curr1.Mapping)
+
+	curr2, ok2 := comm.Current("1")
+	assert.True(t, ok2)
+	assert.Equal(t, mapping2, curr2.Mapping)
+}

--- a/x-pack/elastic-agent/pkg/composable/registry.go
+++ b/x-pack/elastic-agent/pkg/composable/registry.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package composable
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+// providerRegistry is a registry of providers
+type providerRegistry struct {
+	contextProviders map[string]ContextProviderBuilder
+	dynamicProviders map[string]DynamicProviderBuilder
+
+	logger *logp.Logger
+	lock   sync.RWMutex
+}
+
+// Providers holds all known providers, they must be added to it to enable them for use
+var Providers = &providerRegistry{
+	contextProviders: make(map[string]ContextProviderBuilder, 0),
+	dynamicProviders: make(map[string]DynamicProviderBuilder, 0),
+	logger:           logp.NewLogger("dynamic"),
+}

--- a/x-pack/elastic-agent/pkg/composable/testing/clone.go
+++ b/x-pack/elastic-agent/pkg/composable/testing/clone.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testing
+
+import "encoding/json"
+
+// CloneMap clones the source and returns a deep copy of the source.
+func CloneMap(source map[string]interface{}) (map[string]interface{}, error) {
+	if source == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return nil, err
+	}
+	var dest map[string]interface{}
+	err = json.Unmarshal(bytes, &dest)
+	if err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
+
+// CloneMapArray clones the source and returns a deep copy of the source.
+func CloneMapArray(source []map[string]interface{}) ([]map[string]interface{}, error) {
+	if source == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return nil, err
+	}
+	var dest []map[string]interface{}
+	err = json.Unmarshal(bytes, &dest)
+	if err != nil {
+		return nil, err
+	}
+	return dest, nil
+}

--- a/x-pack/elastic-agent/pkg/composable/testing/context.go
+++ b/x-pack/elastic-agent/pkg/composable/testing/context.go
@@ -1,0 +1,68 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testing
+
+import (
+	"context"
+	"sync"
+)
+
+// ContextComm is used in tests for ContextProviderComm.
+type ContextComm struct {
+	context.Context
+
+	lock     sync.Mutex
+	previous map[string]interface{}
+	current  map[string]interface{}
+	onSet    func()
+}
+
+// NewContextComm creates a new ContextComm.
+func NewContextComm(ctx context.Context) *ContextComm {
+	return &ContextComm{
+		Context: ctx,
+	}
+}
+
+// Set sets the current mapping for the context.
+func (t *ContextComm) Set(mapping map[string]interface{}) error {
+	var err error
+	mapping, err = CloneMap(mapping)
+	if err != nil {
+		return err
+	}
+
+	t.lock.Lock()
+	t.previous = t.current
+	t.current = mapping
+	onSet := t.onSet
+	t.lock.Unlock()
+
+	if onSet != nil {
+		onSet()
+	}
+	return nil
+}
+
+// Previous returns the previous set mapping.
+func (t *ContextComm) Previous() map[string]interface{} {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.previous
+}
+
+// Current returns the current set mapping.
+func (t *ContextComm) Current() map[string]interface{} {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.current
+}
+
+// CallOnSet sets the OnSet callback.
+func (t *ContextComm) CallOnSet(f func()) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.onSet = f
+}

--- a/x-pack/elastic-agent/pkg/composable/testing/dynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/testing/dynamic.go
@@ -1,0 +1,119 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testing
+
+import (
+	"context"
+	"sync"
+)
+
+// DynamicState is the state of the dynamic mapping.
+type DynamicState struct {
+	Mapping    map[string]interface{}
+	Processors []map[string]interface{}
+}
+
+// DynamicComm is used in tests for DynamicProviderComm.
+type DynamicComm struct {
+	context.Context
+
+	lock     sync.Mutex
+	previous map[string]DynamicState
+	current  map[string]DynamicState
+}
+
+// NewDynamicComm creates a new DynamicComm.
+func NewDynamicComm(ctx context.Context) *DynamicComm {
+	return &DynamicComm{
+		Context:  ctx,
+		previous: make(map[string]DynamicState),
+		current:  make(map[string]DynamicState),
+	}
+}
+
+// AddOrUpdate adds or updates a current mapping.
+func (t *DynamicComm) AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error {
+	var err error
+	mapping, err = CloneMap(mapping)
+	if err != nil {
+		return err
+	}
+	processors, err = CloneMapArray(processors)
+	if err != nil {
+		return err
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	prev, ok := t.current[id]
+	if ok {
+		t.previous[id] = prev
+	}
+	t.current[id] = DynamicState{
+		Mapping:    mapping,
+		Processors: processors,
+	}
+	return nil
+}
+
+// Remove removes the a mapping.
+func (t *DynamicComm) Remove(id string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	prev, ok := t.current[id]
+	if ok {
+		t.previous[id] = prev
+	}
+	delete(t.current, id)
+}
+
+// Previous returns the previous set mapping for ID.
+func (t *DynamicComm) Previous(id string) (DynamicState, bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	prev, ok := t.previous[id]
+	return prev, ok
+}
+
+// PreviousIDs returns the previous set mapping ID.
+func (t *DynamicComm) PreviousIDs() []string {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	var keys []string
+	for key := range t.previous {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// Current returns the current set mapping for ID.
+func (t *DynamicComm) Current(id string) (DynamicState, bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	curr, ok := t.current[id]
+	return curr, ok
+}
+
+// CurrentIDs returns the current set mapping ID.
+func (t *DynamicComm) CurrentIDs() []string {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	var keys []string
+	for key := range t.current {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// Deleted returns ture if mapping ID was deleted.
+func (t *DynamicComm) Deleted(id string) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	_, prevOk := t.previous[id]
+	_, currOk := t.current[id]
+	return prevOk && !currOk
+}

--- a/x-pack/elastic-agent/pkg/config/config.go
+++ b/x-pack/elastic-agent/pkg/config/config.go
@@ -102,6 +102,22 @@ func (c *Config) ToMapStr() (map[string]interface{}, error) {
 	return m, nil
 }
 
+// Enabled return the configured enabled value or true by default.
+func (c *Config) Enabled() bool {
+	testEnabled := struct {
+		Enabled bool `config:"enabled"`
+	}{true}
+
+	if c == nil {
+		return false
+	}
+	if err := c.Unpack(&testEnabled); err != nil {
+		// if unpacking fails, expect 'enabled' being set to default value
+		return true
+	}
+	return testEnabled.Enabled
+}
+
 // LoadFile take a path and load the file and return a new configuration.
 func LoadFile(path string) (*Config, error) {
 	c, err := yaml.NewConfigWithFile(path, DefaultOptions...)


### PR DESCRIPTION
Cherry-pick of PR #20804 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the initial context providers `agent`, `env`, `host`, and `local`. Adds the initial dynamic provider `local_dynamic`.

Adds `composable.Controller` that manages the state of the providers and calls the `VarsCallback` when the current state has been re-computed.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To support the overall goal of #20781 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #20781 

