### PR TITLE
Cherry-pick #20736 to 7.9: Fill cloud.account.name with accountID if account alias doesn't exist

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Groups same timestamp metric values to one event in the app_insights metricset. {pull}20403[20403]
 - Updates vm_compute metricset with more info on guest metrics. {pull}20448[20448]
 - Fix resource tags in aws cloudwatch metricset {issue}20326[20326]  {pull}20385[20385]
+- Fix ec2 disk and network metrics to use Sum statistic method. {pull}20680[20680]
+- Fill cloud.account.name with accountID if account alias doesn't exist. {pull}20736[20736]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,7 +106,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Groups same timestamp metric values to one event in the app_insights metricset. {pull}20403[20403]
 - Updates vm_compute metricset with more info on guest metrics. {pull}20448[20448]
 - Fix resource tags in aws cloudwatch metricset {issue}20326[20326]  {pull}20385[20385]
-- Fix ec2 disk and network metrics to use Sum statistic method. {pull}20680[20680]
 - Fill cloud.account.name with accountID if account alias doesn't exist. {pull}20736[20736]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -103,19 +103,24 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	default:
 		awsConfig.Region = "us-east-1"
 	}
+
 	svcIam := iam.New(awscommon.EnrichAWSConfigWithEndpoint(
 		config.AWSConfig.Endpoint, "iam", "", awsConfig))
 	req := svcIam.ListAccountAliasesRequest(&iam.ListAccountAliasesInput{})
 	output, err := req.Send(context.TODO())
 	if err != nil {
 		base.Logger().Warn("failed to list account aliases, please check permission setting: ", err)
+		metricSet.AccountName = metricSet.AccountID
 	} else {
+		// When there is no account alias, account ID will be used as cloud.account.name
+		if len(output.AccountAliases) == 0 {
+			metricSet.AccountName = metricSet.AccountID
+		}
+
 		// There can be more than one aliases for each account, for now we are only
 		// collecting the first one.
-		if output.AccountAliases != nil {
-			metricSet.AccountName = output.AccountAliases[0]
-			base.Logger().Debug("AWS Credentials belong to account name: ", metricSet.AccountName)
-		}
+		metricSet.AccountName = output.AccountAliases[0]
+		base.Logger().Debug("AWS Credentials belong to account name: ", metricSet.AccountName)
 	}
 
 	// Get IAM account id


### PR DESCRIPTION
Cherry-pick of PR #20736 to 7.9 branch. Original message: 

This PR is to make sure `cloud.account.name` is not empty even when account alias/name does not exist. This is required because dashboards for `aws` module requires `cloud.account.name` as a filter. 