### PR TITLE
Cherry-pick #20827 to 7.x: [Build] Make mage-linux-amd64 statically compiled.

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -94,3 +94,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Update Go version to 1.14.4. {pull}19753[19753]
 - Update Go version to 1.14.7. {pull}20508[20508]
 - Add packaging for docker image based on UBI minimal 8. {pull}20576[20576]
+- Make the mage binary used by the build process in the docker container to be statically compiled. {pull}20827[20827]

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -173,7 +173,7 @@ func CrossBuildXPack(options ...CrossBuildOption) error {
 // values for Docker. It has the benefit of speeding up the build because the
 // mage -compile is done only once rather than in each Docker container.
 func buildMage() error {
-	return sh.Run("mage", "-f", "-goos=linux", "-goarch=amd64",
+	return sh.RunWith(map[string]string{"CGO_ENABLED": "0"}, "mage", "-f", "-goos=linux", "-goarch=amd64",
 		"-compile", CreateDir(filepath.Join("build", "mage-linux-amd64")))
 }
 


### PR DESCRIPTION
Cherry-pick of PR #20827 to 7.x branch. Original message: 

When I've upgraded my arch system, they have upgraded the libc library,
that libary is much newer than the library used in the crossbuild
docker images. This made building beats impossible because the
mage-linux-amd64 is compiled dynamically and used in all our docker
build.

This PR make the mage binary to be statically compiled so it doesn't
rely on any installed libraries.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run mage package in any beats.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
