### PR TITLE
Cherry-pick #20788 to 7.x: [Filebeat] Remove duplicate ListGroupsForUsers in aws/cloudtrail

### DIFF
--- a/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/ingest/pipeline.yml
@@ -468,12 +468,6 @@ processors:
           type:
             - user
             - info
-        ListGroupsForUser:
-          category:
-            - iam
-          type:
-            - user
-            - info
         ListGroupPolicies:
           category:
             - iam


### PR DESCRIPTION
Cherry-pick of PR #20788 to 7.x branch. Original message: 

## What does this PR do?
Removes duplicate ListGroupsForUsers in aws/cloudtrail ingest pipeline.

## Why is it important?

Not causing a problem in Filebeat but does when used as a package with
elastic agent.  Files should be kept in sync so diffing is easier and
experience is the same for users.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

```
TESTING_FILEBEAT_MODULES=aws TESTING_FILEBEAT_FILESETS=cloudtrail mage -v pythonIntegTest
```

