### PR TITLE
Cherry-pick #20447 to 7.x: Fix path and reference to metadata in hints docs

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -112,7 +112,7 @@ filebeat.autodiscover:
       hints.default_config:
         type: container
         paths:
-          - /var/log/container/*-${container.id}.log  # CRI path
+          - /var/log/containers/*-${data.container.id}.log  # CRI path
 -----
 
 You can also disable default settings entirely, so only Pods annotated like `co.elastic.logs/enabled: true`
@@ -215,7 +215,7 @@ filebeat.autodiscover:
       hints.default_config:
         type: container
         paths:
-          - /var/log/container/*-${container.id}.log  # CRI path
+          - /var/log/containers/*-${data.container.id}.log  # CRI path
 -----
 
 You can also disable default settings entirely, so only containers labeled with `co.elastic.logs/enabled: true`


### PR DESCRIPTION
Cherry-pick of PR #20447 to 7.x branch. Original message: 

