### PR TITLE
Cherry-pick #20815 to 7.9: Update filebeat azure module documentation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed typo in log message. {pull}17897[17897]
 - Fix long registry migration times. {pull}20717[20717] {issue}20705[20705]
 - Fix event types and categories in auditd module to comply with ECS {pull}20652[20652]
+- Update documentation in the azure module filebeat. {pull}20815[20815]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -58,7 +58,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
    signinlogs:
      enabled: false
      var:
-       eventhub: ["insights-logs-signinlogs"]
+       eventhub: "insights-logs-signinlogs"
        consumer_group: "$Default"
        connection_string: ""
        storage_account: ""
@@ -69,9 +69,9 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 
 
 `eventhub` ::
-  _[]string_
-Is a fully managed, real-time data ingestion service.
-Default value `insights-operational-logs`
+  _string_
+Is the fully managed, real-time data ingestion service.
+Default value `insights-operational-logs`.
 
 `consumer_group` ::
 _string_

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -53,7 +53,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
    signinlogs:
      enabled: false
      var:
-       eventhub: ["insights-logs-signinlogs"]
+       eventhub: "insights-logs-signinlogs"
        consumer_group: "$Default"
        connection_string: ""
        storage_account: ""
@@ -64,9 +64,9 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 
 
 `eventhub` ::
-  _[]string_
-Is a fully managed, real-time data ingestion service.
-Default value `insights-operational-logs`
+  _string_
+Is the fully managed, real-time data ingestion service.
+Default value `insights-operational-logs`.
 
 `consumer_group` ::
 _string_


### PR DESCRIPTION
Cherry-pick of PR #20815 to 7.9 branch. Original message:

## What does this PR do?

Previously the azure module was using the kafka input to retrieve the azure logs. The `eventhub` property could support multiple eventhub names. Switching to the azure-eventhub input, this functionality is not supported (hopefully this will be the case in the future).
This detail was missed in the docs.

## Why is it important?

Fix docs.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/20808
