### PR TITLE
docs: Update docs to 7.9.2

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -109,7 +109,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:7.9.1
+        image: docker.elastic.co/beats/auditbeat:7.9.2
         args: [
           "-c", "/etc/auditbeat.yml",
           "-e",

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -64,7 +64,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:7.9.1
+        image: docker.elastic.co/beats/filebeat:7.9.2
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -74,7 +74,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: heartbeat
-        image: docker.elastic.co/beats/heartbeat:7.9.1
+        image: docker.elastic.co/beats/heartbeat:7.9.2
         args: [
           "-c", "/etc/heartbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -114,7 +114,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.9.1
+        image: docker.elastic.co/beats/metricbeat:7.9.2
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -270,7 +270,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.9.1
+        image: docker.elastic.co/beats/metricbeat:7.9.2
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.9.0
+:stack-version: 7.9.2
 :doc-branch: 7.9
 :go-version: 1.14.7
 :release-state: released


### PR DESCRIPTION
Updates references to the new release 7.9.2.

Merge after the release 7.9.1.

Ingest-dev ticket: https://github.com/elastic/ingest-dev/issues/771