### PR TITLE
[Packetbeat] Added support for MySQL Capability Flag

### DIFF
--- a/packetbeat/tests/system/test_0001_mysql_spaces.py
+++ b/packetbeat/tests/system/test_0001_mysql_spaces.py
@@ -12,22 +12,25 @@ class Test(BaseTest):
 
         objs = self.read_output()
         assert all([o["type"] == "mysql" for o in objs])
-        assert len(objs) == 7
+        assert len(objs) == 8
         assert all([o["server.port"] == 3306 for o in objs])
 
-        assert objs[0]["method"] == "SET"
+        assert objs[0]["method"] == "LOGIN"
         assert objs[0]["status"] == "OK"
 
-        assert objs[2]["method"] == "DROP"
-        assert objs[2]["status"] == "OK"
+        assert objs[1]["method"] == "SET"
+        assert objs[1]["status"] == "OK"
 
-        assert objs[3]["method"] == "CREATE"
+        assert objs[3]["method"] == "DROP"
         assert objs[3]["status"] == "OK"
 
-        assert objs[5]["method"] == "SELECT"
-        assert objs[5]["path"] == "test.test"
-        assert objs[5]["status"] == "OK"
-        assert objs[5]["destination.bytes"] == 118
+        assert objs[4]["method"] == "CREATE"
+        assert objs[4]["status"] == "OK"
+
+        assert objs[6]["method"] == "SELECT"
+        assert objs[6]["path"] == "test.test"
+        assert objs[6]["status"] == "OK"
+        assert objs[6]["destination.bytes"] == 118
 
         assert all(["source.bytes" in list(o.keys()) for o in objs])
         assert all(["destination.bytes" in list(o.keys()) for o in objs])

--- a/packetbeat/tests/system/test_0005_mysql_integration.py
+++ b/packetbeat/tests/system/test_0005_mysql_integration.py
@@ -15,7 +15,7 @@ class Test(BaseTest):
 
         objs = self.read_output()
         assert all([o["type"] == "mysql" for o in objs])
-        assert len(objs) == 157
+        assert len(objs) == 158
         assert all([o["server.port"] == 13001 for o in objs])
 
         assert len([o for o in objs

--- a/packetbeat/tests/system/test_0067_mysql_connection_phase.py
+++ b/packetbeat/tests/system/test_0067_mysql_connection_phase.py
@@ -15,9 +15,24 @@ class Test(BaseTest):
         """
         self.render_config_template(
             mysql_ports=[3306],
+            mysql_send_request=False,
+            mysql_send_response=True,
         )
         self.run_packetbeat(pcap="mysql_connection.pcap")
 
         objs = self.read_output()
-        assert len(objs) == 1
-        assert objs[0]['query'] == 'SELECT DATABASE()'
+        assert len(objs) == 5
+        assert objs[0]['query'] == 'Login'
+        assert objs[0]['method'] == 'LOGIN'
+
+        assert objs[1]['query'] == 'select @@version_comment limit 1'
+        assert objs[1]['method'] == 'SELECT'
+        assert 'response' in objs[1]
+
+        assert objs[3]['query'] == 'SELECT DATABASE()'
+        assert objs[3]['method'] == 'SELECT'
+        assert 'response' in objs[3]
+
+        assert objs[4]['query'] == 'SHOW TABLES'
+        assert objs[4]['method'] == 'SHOW'
+        assert 'response' in objs[4]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug
- Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
1. Parse MySQL connection phase and saved the information(MySQL [Capability Flags](https://dev.mysql.com/doc/internals/en/capability-flags.html) ) of every MySQL connection with `common.Cache`.
<!--2. Added a mysql fields:mysql.user, used to display the mysql user performing the command.-->
2. Added the data response parsing ability when the CLIENT_DEPRECATE_EOF [Capability Flag](https://dev.mysql.com/doc/internals/en/capability-flags.html) is set, and fixed the packet loss problem in such cases. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
&emsp;&emsp;If the CLIENT_DEPRECATE_EOF [Capability Flag](https://dev.mysql.com/doc/internals/en/capability-flags.html) is set, [resultset response](https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-ProtocolText::Resultset)  will not contain EOF packet, packetbeat release 7.5(we believe other releases have the bug too)  will fail to parse a ResultSet without EOF packet. This happens in mysql-connector-java-5.1.47  in our scenario.
&emsp;&emsp;When this happens, packetbeat may combine a request with an other response(not the expected one,  because of the failure of the Resultset without EOF packet) to build a transaction, in this  case, a wrong transaction will be published. Also, packetbeat may fail to match the request with  a response, so packetbeat can not build a transaction, and the request will be lost.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
&emsp;&emsp;Execute `TestMySQLParse_clientDeprecateEOFDataResponse` in mysql_test.go or run `test_0071_mysql_deprecate_eof.py` with pytest.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123

- Relates #123

- Requires #123

- Superseds elastic/beats#123
-->
- Relates elastic/beats#18471
- Relates elastic/beats#8173
