### PR TITLE
Cherry-pick #20832 to 7.x: Setup python paths in test runner configuration

### DIFF
--- a/auditbeat/conftest.py
+++ b/auditbeat/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../metricbeat/tests/system'))

--- a/auditbeat/tests/system/auditbeat.py
+++ b/auditbeat/tests/system/auditbeat.py
@@ -3,8 +3,6 @@ import shutil
 import sys
 import tempfile
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../metricbeat/tests/system'))
-
 if os.name == "nt":
     import win32file
 

--- a/filebeat/conftest.py
+++ b/filebeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -3,9 +3,6 @@ import os
 import stat
 import sys
 
-curdir = os.path.dirname(__file__)
-sys.path.append(os.path.join(curdir, '../../../libbeat/tests/system'))
-
 from beat.beat import TestCase, TimeoutError, REGEXP_TYPE
 
 default_registry_path = 'registry/filebeat'

--- a/generator/_templates/beat/{beat}/tests/system/{beat}.py
+++ b/generator/_templates/beat/{beat}/tests/system/{beat}.py
@@ -1,6 +1,5 @@
 import os
 import sys
-sys.path.append('../../vendor/github.com/elastic/beats/libbeat/tests/system')
 from beat.beat import TestCase
 
 

--- a/heartbeat/conftest.py
+++ b/heartbeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -2,10 +2,6 @@ import os
 import sys
 import http.server
 import threading
-
-sys.path.append(os.path.join(os.path.dirname(
-    __file__), '../../../libbeat/tests/system'))
-
 from beat.beat import TestCase
 from time import sleep
 

--- a/journalbeat/conftest.py
+++ b/journalbeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))

--- a/journalbeat/tests/system/journalbeat.py
+++ b/journalbeat/tests/system/journalbeat.py
@@ -1,6 +1,5 @@
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
 from beat.beat import TestCase
 
 

--- a/metricbeat/conftest.py
+++ b/metricbeat/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))

--- a/metricbeat/module/aerospike/test_aerospike.py
+++ b/metricbeat/module/aerospike/test_aerospike.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/apache/test_apache.py
+++ b/metricbeat/module/apache/test_apache.py
@@ -1,15 +1,13 @@
+import metricbeat
 import os
-import unittest
-import urllib.request
-import urllib.error
-import urllib.parse
 import pytest
-import time
 import semver
 import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
+import time
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
 
 APACHE_FIELDS = metricbeat.COMMON_FIELDS + ["apache"]
 

--- a/metricbeat/module/ceph/test_ceph.py
+++ b/metricbeat/module/ceph/test_ceph.py
@@ -1,12 +1,10 @@
+import metricbeat
 import os
 import requests
 import sys
 import time
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 @metricbeat.parameterized_with_supported_versions

--- a/metricbeat/module/consul/test_consul.py
+++ b/metricbeat/module/consul/test_consul.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 CONSUL_FIELDS = metricbeat.COMMON_FIELDS + ["consul"]

--- a/metricbeat/module/couchbase/test_couchbase.py
+++ b/metricbeat/module/couchbase/test_couchbase.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import sys
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 @unittest.skip("See https://github.com/elastic/beats/issues/14660")

--- a/metricbeat/module/couchdb/test_couchdb.py
+++ b/metricbeat/module/couchdb/test_couchdb.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/docker/test_docker.py
+++ b/metricbeat/module/docker/test_docker.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/dropwizard/test_dropwizard.py
+++ b/metricbeat/module/dropwizard/test_dropwizard.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 @metricbeat.parameterized_with_supported_versions

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -1,18 +1,15 @@
-import re
-import sys
+import json
+import metricbeat
 import os
+import re
+import semver
+import sys
 import unittest
-import urllib.request
 import urllib.error
 import urllib.parse
-import json
-import semver
+import urllib.request
 from elasticsearch import Elasticsearch, TransportError, client
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/envoyproxy/test_envoyproxy.py
+++ b/metricbeat/module/envoyproxy/test_envoyproxy.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 @metricbeat.parameterized_with_supported_versions

--- a/metricbeat/module/etcd/test_etcd.py
+++ b/metricbeat/module/etcd/test_etcd.py
@@ -1,12 +1,9 @@
+import metricbeat
 import os
 import sys
-import unittest
 import time
+import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-
-import metricbeat
 
 
 @metricbeat.parameterized_with_supported_versions

--- a/metricbeat/module/golang/test_golang.py
+++ b/metricbeat/module/golang/test_golang.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 GOLANG_FIELDS = metricbeat.COMMON_FIELDS + ["golang"]

--- a/metricbeat/module/haproxy/test_haproxy.py
+++ b/metricbeat/module/haproxy/test_haproxy.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 HAPROXY_FIELDS = metricbeat.COMMON_FIELDS + ["haproxy"]

--- a/metricbeat/module/http/test_http.py
+++ b/metricbeat/module/http/test_http.py
@@ -1,11 +1,9 @@
+import metricbeat
 import os
 import requests
 import sys
 import time
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 HTTP_FIELDS = metricbeat.COMMON_FIELDS + ["http"]

--- a/metricbeat/module/jolokia/test_jolokia.py
+++ b/metricbeat/module/jolokia/test_jolokia.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import sys
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/kafka/test_kafka.py
+++ b/metricbeat/module/kafka/test_kafka.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import sys
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 @metricbeat.parameterized_with_supported_versions

--- a/metricbeat/module/kibana/test_kibana.py
+++ b/metricbeat/module/kibana/test_kibana.py
@@ -1,4 +1,5 @@
 import json
+import metricbeat
 import os
 import semver
 import sys
@@ -6,9 +7,6 @@ import unittest
 import urllib.error
 import urllib.parse
 import urllib.request
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/logstash/test_logstash.py
+++ b/metricbeat/module/logstash/test_logstash.py
@@ -1,4 +1,5 @@
 import json
+import metricbeat
 import os
 import semver
 import sys
@@ -7,9 +8,6 @@ import unittest
 import urllib.error
 import urllib.parse
 import urllib.request
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/memcached/test_memcached.py
+++ b/metricbeat/module/memcached/test_memcached.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/mongodb/test_mongodb.py
+++ b/metricbeat/module/mongodb/test_mongodb.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 MONGODB_FIELDS = metricbeat.COMMON_FIELDS + ["mongodb"]

--- a/metricbeat/module/munin/test_munin.py
+++ b/metricbeat/module/munin/test_munin.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/mysql/test_mysql.py
+++ b/metricbeat/module/mysql/test_mysql.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 MYSQL_FIELDS = metricbeat.COMMON_FIELDS + ["mysql"]
 

--- a/metricbeat/module/nats/test_nats.py
+++ b/metricbeat/module/nats/test_nats.py
@@ -1,10 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
-
 
 NATS_FIELDS = metricbeat.COMMON_FIELDS + ["nats"]
 

--- a/metricbeat/module/php_fpm/test_phpfpm.py
+++ b/metricbeat/module/php_fpm/test_phpfpm.py
@@ -1,10 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
-
 
 PHPFPM_FIELDS = metricbeat.COMMON_FIELDS + ["php_fpm"]
 

--- a/metricbeat/module/postgresql/test_postgresql.py
+++ b/metricbeat/module/postgresql/test_postgresql.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/prometheus/test_prometheus.py
+++ b/metricbeat/module/prometheus/test_prometheus.py
@@ -1,10 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 PROMETHEUS_FIELDS = metricbeat.COMMON_FIELDS + ["prometheus"]

--- a/metricbeat/module/redis/test_redis.py
+++ b/metricbeat/module/redis/test_redis.py
@@ -1,11 +1,9 @@
+import metricbeat
 import os
 import pytest
 import redis
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 REDIS_FIELDS = metricbeat.COMMON_FIELDS + ["redis"]

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -1,12 +1,10 @@
+import getpass
+import metricbeat
+import os
 import re
 import six
 import sys
 import unittest
-import getpass
-import os
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 SYSTEM_CPU_FIELDS = ["cores", "idle.pct", "iowait.pct", "irq.pct", "nice.pct",

--- a/metricbeat/module/traefik/test_traefik.py
+++ b/metricbeat/module/traefik/test_traefik.py
@@ -1,12 +1,9 @@
+import metricbeat
 import os
 import sys
-import unittest
 import time
+import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-
-import metricbeat
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/uwsgi/test_uwsgi.py
+++ b/metricbeat/module/uwsgi/test_uwsgi.py
@@ -1,12 +1,10 @@
 import logging
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 logger = logging.getLogger(__name__)

--- a/metricbeat/module/vsphere/test_vsphere.py
+++ b/metricbeat/module/vsphere/test_vsphere.py
@@ -1,9 +1,7 @@
+import metricbeat
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 VSPHERE_FIELDS = metricbeat.COMMON_FIELDS + ["vsphere"]

--- a/metricbeat/module/zookeeper/test_zookeeper.py
+++ b/metricbeat/module/zookeeper/test_zookeeper.py
@@ -1,10 +1,8 @@
+import metricbeat
 import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
-import metricbeat
 
 
 ZK_FIELDS = metricbeat.COMMON_FIELDS + ["zookeeper"]

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -2,9 +2,6 @@ import os
 import re
 import sys
 import yaml
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
-
 from beat.beat import TestCase
 from beat.tags import tag
 from parameterized import parameterized_class

--- a/packetbeat/conftest.py
+++ b/packetbeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -2,9 +2,6 @@ import os
 import sys
 import subprocess
 import json
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
-
 from beat.beat import TestCase
 from beat.beat import Proc
 

--- a/packetbeat/tests/system/test_base.py
+++ b/packetbeat/tests/system/test_base.py
@@ -1,10 +1,7 @@
 import os
 import sys
-from packetbeat import BaseTest
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
-
 from beat import common_tests
+from packetbeat import BaseTest
 
 
 class Test(BaseTest, common_tests.TestExportsMixin):

--- a/winlogbeat/conftest.py
+++ b/winlogbeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system'))

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -11,8 +11,6 @@ if sys.platform.startswith("win"):
     import win32security
     import win32evtlogutil
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
-
 from beat.beat import TestCase
 
 PROVIDER = "WinlogbeatTestPython"

--- a/x-pack/auditbeat/conftest.py
+++ b/x-pack/auditbeat/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../metricbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -1,9 +1,6 @@
 import jinja2
 import os
 import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../metricbeat/tests/system')))
-
 from metricbeat import BaseTest as MetricbeatTest
 
 

--- a/x-pack/filebeat/conftest.py
+++ b/x-pack/filebeat/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../filebeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))

--- a/x-pack/filebeat/tests/system/test_filebeat_xpack.py
+++ b/x-pack/filebeat/tests/system/test_filebeat_xpack.py
@@ -1,11 +1,8 @@
 import jinja2
 import os
 import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../filebeat/tests/system')))
-
-from filebeat import BaseTest as FilebeatTest
 from beat import common_tests
+from filebeat import BaseTest as FilebeatTest
 
 
 class FilebeatXPackTest(FilebeatTest, common_tests.TestExportsMixin):

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -3,11 +3,8 @@ import requests
 import sys
 import os
 import json
-from requests.auth import HTTPBasicAuth
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../filebeat/tests/system'))
-
 from filebeat import BaseTest
+from requests.auth import HTTPBasicAuth
 
 
 class Test(BaseTest):

--- a/x-pack/filebeat/tests/system/test_xpack_modules.py
+++ b/x-pack/filebeat/tests/system/test_xpack_modules.py
@@ -1,8 +1,5 @@
 import os
 import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../filebeat/tests/system'))
-
 import test_modules
 
 

--- a/x-pack/functionbeat/conftest.py
+++ b/x-pack/functionbeat/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))

--- a/x-pack/functionbeat/tests/system/functionbeat.py
+++ b/x-pack/functionbeat/tests/system/functionbeat.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../libbeat/tests/system'))
 from beat.beat import TestCase
 
 

--- a/x-pack/libbeat/conftest.py
+++ b/x-pack/libbeat/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../libbeat/tests/system'))

--- a/x-pack/libbeat/tests/system/base.py
+++ b/x-pack/libbeat/tests/system/base.py
@@ -1,11 +1,5 @@
 import sys
 import os
-
-
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             '../../../../libbeat/tests/system'))
-
-
 from beat.beat import TestCase
 
 

--- a/x-pack/metricbeat/conftest.py
+++ b/x-pack/metricbeat/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../metricbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../libbeat/tests/system'))
+sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))

--- a/x-pack/metricbeat/module/activemq/test_activemq.py
+++ b/x-pack/metricbeat/module/activemq/test_activemq.py
@@ -4,8 +4,6 @@ import stomp
 import string
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/appsearch/test_appsearch.py
+++ b/x-pack/metricbeat/module/appsearch/test_appsearch.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/cockroachdb/test_cockroachdb.py
+++ b/x-pack/metricbeat/module/cockroachdb/test_cockroachdb.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/coredns/test_coredns.py
+++ b/x-pack/metricbeat/module/coredns/test_coredns.py
@@ -1,9 +1,6 @@
 import os
 import sys
 import unittest
-from xpack_metricbeat import XPackTest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
+++ b/x-pack/metricbeat/module/ibmmq/test_ibmmq.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -2,8 +2,6 @@ import os
 import pytest
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/openmetrics/test_openmetrics.py
+++ b/x-pack/metricbeat/module/openmetrics/test_openmetrics.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/redisenterprise/test_redisenterprise.py
+++ b/x-pack/metricbeat/module/redisenterprise/test_redisenterprise.py
@@ -1,10 +1,8 @@
 import os
-from parameterized import parameterized
 import redis
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
+from parameterized import parameterized
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/sql/test_sql.py
+++ b/x-pack/metricbeat/module/sql/test_sql.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 

--- a/x-pack/metricbeat/module/stan/test_stan.py
+++ b/x-pack/metricbeat/module/stan/test_stan.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 from parameterized import parameterized
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 STAN_FIELDS = metricbeat.COMMON_FIELDS + ["stan"]

--- a/x-pack/metricbeat/module/statsd/test_statsd.py
+++ b/x-pack/metricbeat/module/statsd/test_statsd.py
@@ -1,8 +1,6 @@
 import os
 import socket
 import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 from xpack_metricbeat import XPackTest, metricbeat
 
 STATSD_HOST = '127.0.0.1'

--- a/x-pack/metricbeat/tests/system/xpack_metricbeat.py
+++ b/x-pack/metricbeat/tests/system/xpack_metricbeat.py
@@ -1,9 +1,6 @@
+import metricbeat
 import os
 import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../metricbeat/tests/system'))
-
-import metricbeat
 
 
 class XPackTest(metricbeat.BaseTest):


### PR DESCRIPTION
Cherry-pick of PR #20832 to 7.x branch. Original message: 

Add `conftest.py` files to projects with python tests. This file is imported by the test runner. Use it to setup python paths so tests don't need to care about them depending on where they are located, and we control paths from central points.