### PR TITLE
Cherry-pick #20627 to 7.x: Ensure kind cluster has RFC1123 compliant name

### DIFF
--- a/dev-tools/mage/kubernetes/kind.go
+++ b/dev-tools/mage/kubernetes/kind.go
@@ -65,7 +65,7 @@ func (m *KindIntegrationTestStep) Setup(env map[string]string) error {
 		return nil
 	}
 
-	clusterName := kubernetesPodName()
+	clusterName := kubernetesClusterName()
 	stdOut := ioutil.Discard
 	stdErr := ioutil.Discard
 	if mg.Verbose() {


### PR DESCRIPTION
Cherry-pick of PR #20627 to 7.x branch. Original message: 

## What does this PR do?

This patch:
 * Modifies the cluster name generation function to produce `-` where it previously produced `_`
 * Adds run-time validation that the generated name is compliant
 * Renames the function from `kubernetesPodName` to `kubernetesClusterName`, reflecting its purpose

## Why is it important?


When creating a kind cluster, we must use a cluster name that is a valid Kubernetes resource name, and by extension, a valid DNS name. If not, kind cluster provisioning can fail when kind tries to create resources with invalid names.

For example, if trying to create a cluster called "a_b" (underscores are not permitted), control-plane provisioning will fail with:

```
host 'a_b-control-plane' must be [...] a valid RFC-1123 DNS subdomain
```

With this patch, the `kubernetes` Metricbeat module integration tests are able to run to completion on my system. Without it, `kind` fails in this manner:

```
$ kind create cluster --name metricbeat-8_0_0-a34234bc-master
Creating cluster "metricbeat-8_0_0-a34234bc-master" ...
 ✓ Ensuring node image (kindest/node:v1.18.2) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✗ Starting control-plane 🕹️ 
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged metricbeat-8_0_0-a34234bc-master-control-plane kubeadm init --ignore-preflight-errors=all --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1
Command Output: I0817 07:52:20.014341     163 initconfiguration.go:200] loading configuration from "/kind/kubeadm.conf"
[config] WARNING: Ignored YAML document with GroupVersionKind kubeadm.k8s.io/v1beta2, Kind=JoinConfiguration
I0817 07:52:20.018540     163 interface.go:400] Looking for default routes with IPv4 addresses
I0817 07:52:20.018553     163 interface.go:405] Default route transits interface "eth0"
I0817 07:52:20.018623     163 interface.go:208] Interface eth0 is up
I0817 07:52:20.018673     163 interface.go:256] Interface "eth0" has 3 addresses :[172.20.0.2/16 fc00:f853:ccd:e793::2/64 fe80::42:acff:fe14:2/64].
I0817 07:52:20.018689     163 interface.go:223] Checking addr  172.20.0.2/16.
I0817 07:52:20.018696     163 interface.go:230] IP found 172.20.0.2
I0817 07:52:20.018702     163 interface.go:262] Found valid IPv4 address 172.20.0.2 for interface "eth0".
I0817 07:52:20.018706     163 interface.go:411] Found active IP 172.20.0.2 
hostport metricbeat-8_0_0-a34234bc-master-control-plane:6443: host 'metricbeat-8_0_0-a34234bc-master-control-plane' must be a valid IP address or a valid RFC-1123 DNS subdomain
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

Run the integ tests for the `kubernetes` Metricbeat module with Mage in verbose mode. `kind` will be seen to run correctly. Without the patch `kind` will fail to provision the control-plane.

```
MODULE=kubernetes mage -v integtest
```

With Mage not in verbose mode, the `kubernetes` integ test is not run, and no output is seen (because it dies at setup time).