### PR TITLE
Cherry-pick #20855 to 7.x: [Filebeat][Gsuite] Add note about admin in gsuite docs

### DIFF
--- a/filebeat/docs/modules/gsuite.asciidoc
+++ b/filebeat/docs/modules/gsuite.asciidoc
@@ -32,12 +32,15 @@ It is compatible with a subset of applications under the https://developers.goog
 | Groups https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[api docs] https://support.google.com/a/answer/6270454?hl=en&ref_topic=9027054[help]                    | Track changes to groups, group memberships and group messages.                                                                                                                |
 |===========================================================================================================================================================================================================================
 
+[float]
 === Configure the module
 
-In order for filebeat to ingest data from the Google Reports API you must https://support.google.com/gsuitemigrate/answer/9222993?hl=en[set up a ServiceAccount] that https://support.google.com/gsuitemigrate/answer/9222865?hl=en[has access to the Admin SDK API].
+In order for Filebeat to ingest data from the Google Reports API you must:
 
-
-Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+- Have an *administrator account*.
+- https://support.google.com/gsuitemigrate/answer/9222993?hl=en[Set up a ServiceAccount] using the administrator account.
+- https://support.google.com/gsuitemigrate/answer/9222865?hl=en[Set up access to the Admin SDK API] for the ServiceAccount.
+- https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Enable Domain-Wide Delegation] for your ServiceAccount.
 
 This module will make use of the following *oauth2 scope*:
 

--- a/x-pack/filebeat/module/gsuite/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/gsuite/_meta/docs.asciidoc
@@ -27,12 +27,15 @@ It is compatible with a subset of applications under the https://developers.goog
 | Groups https://developers.google.com/admin-sdk/reports/v1/appendix/activity/groups[api docs] https://support.google.com/a/answer/6270454?hl=en&ref_topic=9027054[help]                    | Track changes to groups, group memberships and group messages.                                                                                                                |
 |===========================================================================================================================================================================================================================
 
+[float]
 === Configure the module
 
-In order for filebeat to ingest data from the Google Reports API you must https://support.google.com/gsuitemigrate/answer/9222993?hl=en[set up a ServiceAccount] that https://support.google.com/gsuitemigrate/answer/9222865?hl=en[has access to the Admin SDK API].
+In order for Filebeat to ingest data from the Google Reports API you must:
 
-
-Additionally https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Domain-Wide Delegation] is required for your application to work properly.
+- Have an *administrator account*.
+- https://support.google.com/gsuitemigrate/answer/9222993?hl=en[Set up a ServiceAccount] using the administrator account.
+- https://support.google.com/gsuitemigrate/answer/9222865?hl=en[Set up access to the Admin SDK API] for the ServiceAccount.
+- https://developers.google.com/admin-sdk/reports/v1/guides/delegation[Enable Domain-Wide Delegation] for your ServiceAccount.
 
 This module will make use of the following *oauth2 scope*:
 


### PR DESCRIPTION
Cherry-pick of PR #20855 to 7.x branch. Original message: 

## What does this PR do?

Adds a note about the user used for the GSuite module being required to be an administrator.

## Why is it important?

This information was in Google docs that are linked in our module but was not easy to notice. Adding a clear note about it in our own docs will make for a much easier setup.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
