### PR TITLE
Bump kibana version to 7.9.0 in x-pack/metricbeat

### DIFF
--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.7.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.9.0}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
This PR is to bump kibana version to 7.9.0 in x-pack/metricbeat, which is missed in previous PR https://github.com/elastic/beats/pull/20801