### PR TITLE
[packaging] Normalise GCP bucket folder structure

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -247,6 +247,9 @@ def publishPackages(baseDir){
 * There is a specific folder structure in https://staging.elastic.co/ and https://artifacts.elastic.co/downloads/
 * therefore the storage bucket in GCP should follow the same folder structure.
 * This is required by https://github.com/elastic/beats-tester
+* e.g.
+* baseDir=name -> return name
+* baseDir=name1/name2/name3-> return name2
 */
 def getBeatsName(baseDir) {
   return basedir.replace('x-pack/', '')

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -249,12 +249,7 @@ def publishPackages(baseDir){
 * This is required by https://github.com/elastic/beats-tester
 */
 def getBeatsName(baseDir) {
-  def PATH_SEPARATOR_QUOTED = '\\/'
-  def beatsFolderName = baseDir.replaceAll(PATH_SEPARATOR_QUOTED, '')
-  if (baseDir.split(PATH_SEPARATOR_QUOTED).length > 1) {
-    beatsFolderName = baseDir.split(PATH_SEPARATOR_QUOTED)[1]
-  }
-  return beatsFolderName
+  return basedir.replace('x-pack/', '')
 }
 
 def withBeatsEnv(Closure body) {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -249,9 +249,10 @@ def publishPackages(baseDir){
 * This is required by https://github.com/elastic/beats-tester
 */
 def getBeatsName(baseDir) {
-  def beatsFolderName = baseDir
-  if (baseDir.split('/')) {
-    beatsFolderName = baseDir.split('')[1]
+  def PATH_SEPARATOR_QUOTED = '\\/'
+  def beatsFolderName = baseDir.replaceAll(PATH_SEPARATOR_QUOTED, '')
+  if (baseDir.split(PATH_SEPARATOR_QUOTED).length > 1) {
+    beatsFolderName = baseDir.split(PATH_SEPARATOR_QUOTED)[1]
   }
   return beatsFolderName
 }


### PR DESCRIPTION
## What does this PR do?

It seems there was change a few weeks ago that broke the beats-tester pipeline, see [build](https://beats-ci.elastic.co/job/Beats/job/beats-tester-mbp/job/master/19/parameters/)

This change will normalise the folder structure in the GCP bucket similar to the folder structure in:
- https://artifacts.elastic.co/downloads
- https://staging.elastic.co/

See 
![image](https://user-images.githubusercontent.com/2871786/91880834-846a2180-ec78-11ea-966e-6fa78ec2d278.png)


## Why is it important?

Fix the beats-tester pipeline 

## How to test this PR locally

`/packaging` as a comment. Then see the google storage artifacts

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/91965441-63511180-ed08-11ea-8862-80313f69c591.png)


## Tests

See [build](https://beats-ci.elastic.co/job/Beats/job/beats-tester-mbp/job/master/39/) that consumes the artifacts that were generated in this particular PR