### PR TITLE
Cherry-pick to 7.x: Adding cborbeat to community beats (#20884)

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -23,11 +23,11 @@ endif::[]
 NOTE: Elastic provides no warranty or support for community-sourced Beats.
 
 [horizontal]
-https://github.com/visasimbu/IIBBeat[IIBBeat]:: Periodically executes shell commands or batch commands to collect IBM Integration node, Integration server, app status, bar file deployment time and bar file location to Logstash or Elasticsearch.
 https://github.com/awormuth/amazonbeat[amazonbeat]:: Reads data from a specified Amazon product.
 https://github.com/radoondas/apachebeat[apachebeat]:: Reads status from Apache HTTPD server-status.
 https://github.com/verticle-io/apexbeat[apexbeat]:: Extracts configurable contextual data and metrics from Java applications via the  http://toolkits.verticle.io[APEX] toolkit.
-https://github.com/hsngerami/hsnburrowbeat[hsnburrowbeat]:: Monitors Kafka consumer lag for Burrow V1.0.0(API V3).
+https://github.com/MelonSmasher/browserbeat[browserbeat]:: Reads and ships browser history (Chrome, Firefox, & Safari) to an Elastic output.
+https://github.com/toravir/cborbeat[cborbeat]:: Reads from cbor encoded files (specifically log files). More: https://cbor.io[CBOR Encoding] https://github.com/toravir/csd[Decoder]
 https://github.com/hartfordfive/cloudflarebeat[cloudflarebeat]:: Indexes log entries from the Cloudflare Enterprise Log Share API.
 https://github.com/jarl-tornroos/cloudfrontbeat[cloudfrontbeat]:: Reads log events from Amazon Web Services https://aws.amazon.com/cloudfront/[CloudFront].
 https://github.com/aidan-/cloudtrailbeat[cloudtrailbeat]:: Reads events from Amazon Web Services' https://aws.amazon.com/cloudtrail/[CloudTrail].
@@ -59,8 +59,10 @@ https://github.com/ullaakut/hackerbeat[hackerbeat]:: Indexes the top stories of 
 https://github.com/YaSuenag/hsbeat[hsbeat]:: Reads all performance counters in Java HotSpot VM.
 https://github.com/christiangalsterer/httpbeat[httpbeat]:: Polls multiple HTTP(S) endpoints and sends the data to
 Logstash or Elasticsearch. Supports all HTTP methods and proxies.
+https://github.com/hsngerami/hsnburrowbeat[hsnburrowbeat]:: Monitors Kafka consumer lag for Burrow V1.0.0(API V3).
 https://github.com/jasperla/hwsensorsbeat[hwsensorsbeat]:: Reads sensors information from OpenBSD.
 https://github.com/icinga/icingabeat[icingabeat]:: Icingabeat ships events and states from Icinga 2 to Elasticsearch or Logstash.
+https://github.com/visasimbu/IIBBeat[IIBBeat]:: Periodically executes shell commands or batch commands to collect IBM Integration node, Integration server, app status, bar file deployment time and bar file location to Logstash or Elasticsearch.
 https://github.com/devopsmakers/iobeat[iobeat]:: Reads IO stats from /proc/diskstats on Linux.
 https://github.com/radoondas/jmxproxybeat[jmxproxybeat]:: Reads Tomcat JMX metrics exposed over 'JMX Proxy Servlet' to HTTP.
 https://github.com/mheese/journalbeat[journalbeat]:: Used for log shipping from systemd/journald based Linux systems.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding cborbeat to community beats (#20884)