### PR TITLE
Cherry-pick to 7.9: docs: Update beats for APM (#20881)

### DIFF
--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -4,7 +4,7 @@
 {es} uses {ref}/indices-templates.html[index templates] to define:
 
 * Settings that control the behavior of your indices. The settings include the
-lifecycle policy used to manage indices as they grow and age. 
+lifecycle policy used to manage indices as they grow and age.
 * Mappings that determine how fields are analyzed. Each mapping sets the
 {ref}/mapping-types.html[{es} datatype] to use for a specific data field.
 
@@ -17,7 +17,7 @@ it's not overwritten unless you configure {beatname_uc} to do so.
 ifndef::no-output-logstash[]
 NOTE: A connection to {es} is required to load the index template. If
 the output is not {es} (or {ess}), you must
-<<load-template-manually,load the template manually>>. 
+<<load-template-manually,load the template manually>>.
 endif::[]
 
 This page shows how to change the default template loading behavior to:
@@ -83,9 +83,10 @@ The examples here assume that Logstash output is enabled.
 endif::[]
 You can omit the `-E` flags if {es} output is already enabled.
 
-
+ifndef::apm-server[]
 If you are connecting to a secured {es} cluster, make sure you've
 configured credentials as described in the <<{beatname_lc}-installation-configuration>>.
+endif::[]
 
 If the host running {beatname_uc} does not have direct connectivity to
 {es}, see <<load-template-manually-alternate>>.

--- a/libbeat/docs/shared/configuring-intro.asciidoc
+++ b/libbeat/docs/shared/configuring-intro.asciidoc
@@ -1,12 +1,14 @@
 
+ifndef::apm-server[]
 TIP: To get started quickly, read <<{beatname_lc}-installation-configuration>>.
+endif::[]
 
 To configure {beatname_uc}, edit the configuration file. The default
 configuration file is called  +{beatname_lc}.yml+. The location of the file
-varies by platform. To locate the file, see <<directory-layout>>. 
+varies by platform. To locate the file, see <<directory-layout>>.
 
-ifeval::["{beatname_lc}"!="apm-server"]
-There’s also a full example configuration file called +{beatname_lc}.reference.yml+ 
+ifndef::apm-server[]
+There’s also a full example configuration file called +{beatname_lc}.reference.yml+
 that shows all non-deprecated options.
 endif::[]
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: Update beats for APM (#20881)