### PR TITLE
Cherry-pick to 7.9: Document how to set the ES host and Kibana URLs in Ingest Manager (#20874)

### DIFF
--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -22,9 +22,15 @@ To enroll an {agent} to {fleet}:
 
 . Stop {agent}, if it's already running.
 
-. In {ingest-manager}, select **{fleet}**, then click **Add agent** to
-get an enrollment token. See <<ingest-management-getting-started>> for
-detailed steps.
+. In {ingest-manager}, click **Settings** and change the defaults, if necessary.
+For self-managed installations, set the URLs for {es} and {kib}, including
+the http ports, then save your changes.
++
+[role="screenshot"]
+image::images/kibana-ingest-manager-settings.png[{ingest-manager} settings]
+
+. Select **{fleet}**, then click **Add agent** to get an enrollment token. See
+<<ingest-management-getting-started>> for detailed steps.
 
 . Change to the directory where {agent} is installed, and enroll the agent to
 {fleet}:


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Document how to set the ES host and Kibana URLs in Ingest Manager (#20874)