### PR TITLE
Cherry-pick #20898 to 7.x: Avoid generating incomplete configurations in autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,6 +27,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Introduce APM libbeat instrumentation, active when running the beat with ELASTIC_APM_ACTIVE=true. {pull}17938[17938]
 - Make error message about locked data path actionable. {pull}18667[18667]
 - Ensure dynamic template names are unique for the same field. {pull}18849[18849]
+- Remove the deprecated `xpack.monitoring.*` settings. Going forward only `monitoring.*` settings may be used. {issue}9424[9424] {pull}18608[18608]
+- Added `certificate` TLS verification mode to ignore server name mismatch. {issue}12283[12283] {pull}20293[20293]
+- Autodiscover doesn't generate any configuration when a variable is missing. Previously it generated an incomplete configuration. {pull}20898[20898]
 
 *Auditbeat*
 
@@ -184,6 +187,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - [Metricbeat][Kubernetes] Change cluster_ip field from ip to keyword. {pull}20571[20571]
 - Rename cloud.provider `az` value to `azure` inside the add_cloud_metadata processor. {pull}20689[20689]
 - Add missing country_name geo field in `add_host_metadata` and `add_observer_metadata` processors. {issue}20796[20796] {pull}20811[20811]
+- Explicitly detect missing variables in autodiscover configuration, log them at the debug level. {issue}20568[20568] {pull}20898[20898]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,8 +27,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Introduce APM libbeat instrumentation, active when running the beat with ELASTIC_APM_ACTIVE=true. {pull}17938[17938]
 - Make error message about locked data path actionable. {pull}18667[18667]
 - Ensure dynamic template names are unique for the same field. {pull}18849[18849]
-- Remove the deprecated `xpack.monitoring.*` settings. Going forward only `monitoring.*` settings may be used. {issue}9424[9424] {pull}18608[18608]
-- Added `certificate` TLS verification mode to ignore server name mismatch. {issue}12283[12283] {pull}20293[20293]
 - Autodiscover doesn't generate any configuration when a variable is missing. Previously it generated an incomplete configuration. {pull}20898[20898]
 
 *Auditbeat*

--- a/libbeat/autodiscover/template/config_test.go
+++ b/libbeat/autodiscover/template/config_test.go
@@ -28,9 +28,12 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/bus"
 	"github.com/elastic/beats/v7/libbeat/keystore"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestConfigsMapping(t *testing.T) {
+	logp.TestingSetup()
+
 	config, _ := common.NewConfigFrom(map[string]interface{}{
 		"correct": "config",
 	})
@@ -39,6 +42,13 @@ func TestConfigsMapping(t *testing.T) {
 		"correct": "config",
 		"hosts":   [1]string{"1.2.3.4:8080"},
 	})
+
+	const envValue = "valuefromenv"
+	configFromEnv, _ := common.NewConfigFrom(map[string]interface{}{
+		"correct": envValue,
+	})
+
+	os.Setenv("CONFIGS_MAPPING_TESTENV", envValue)
 
 	tests := []struct {
 		mapping  string
@@ -79,6 +89,16 @@ func TestConfigsMapping(t *testing.T) {
 			},
 			expected: []*common.Config{config},
 		},
+		// No condition, value from environment
+		{
+			mapping: `
+- config:
+    - correct: ${CONFIGS_MAPPING_TESTENV}`,
+			event: bus.Event{
+				"foo": 3,
+			},
+			expected: []*common.Config{configFromEnv},
+		},
 		// Match config and replace data.host and data.ports.<name> properly
 		{
 			mapping: `
@@ -110,6 +130,17 @@ func TestConfigsMapping(t *testing.T) {
 				"port": 8080,
 			},
 			expected: []*common.Config{configPorts},
+		},
+		// Missing variable, config is not generated
+		{
+			mapping: `
+- config:
+  - module: something
+    hosts: ["${not.exists.host}"]`,
+			event: bus.Event{
+				"host": "1.2.3.4",
+			},
+			expected: nil,
 		},
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #20898 to 7.x branch. Original message: 

## What does this PR do?

Handle errors when configuration unpacking fails. In principle this can
only happen when some variable is missing, because configuration has
been previously parsed as YAML. Errors on unpacking were previously
ignored.

When a variable is missing, this is clearly logged at the debug level.

This changes the behaviour, previously an incomplete configuration was
generated on this case.

## Why is it important?

To detect problems with incomplete configuration earlier and improve feedback in logs
when a variable is missing in event.

Since #18979 this error is more frequent, as a legit configuration for containers produces
errors with pod events that don't contain container fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Related to #18979.
- Fixes #20568.

## Logs

For example the following configuration includes an incorrect field `container.id`.
```
filebeat.autodiscover:
  providers:
    - type: docker
      hints.enabled: true
      hints.default_config:
        type: container
        paths:
          - /var/lib/docker/containers/${container.id}/*.log
```

Before this change, an incomplete configuration is generated, and errors like these ones are logged:
```
2020-09-01T16:52:50.094+0200	ERROR	[autodiscover]	autodiscover/autodiscover.go:209	Auto discover config check failed for config '{
  "docker-json": {
    "cri_flags": true,
    "format": "auto",
    "partial": true,
    "stream": "all"
  },
  "symlinks": true,
  "type": "container"
}', won't start runner: each input must have at least one path defined
```
After this change, the cause of the problem is more clear, and it is only logged at the debug level:
```
2020-09-02T11:57:08.225+0200	DEBUG	[autodiscover]	template/config.go:156	Configuration template cannot be resolved: field 'container.id' not available in event or environment accessing 'paths' (source:'/home/jaime/tmp/filebeat-autodiscover-docker-hints.yml')
```