### PR TITLE
Cherry-pick to 7.9: [packaging] Normalise GCP bucket folder structure (#20903)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -229,17 +229,29 @@ def withMacOSEnv(Closure body){
 
 def publishPackages(baseDir){
   def bucketUri = "gs://${JOB_GCS_BUCKET}/snapshots"
-  if (env.CHANGE_ID?.trim()) {
+  if (isPR()) {
     bucketUri = "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}"
   }
-
-  googleStorageUpload(bucket: "${bucketUri}",
+  def beatsFolderName = getBeatsName(baseDir)
+  googleStorageUpload(bucket: "${bucketUri}/${beatsFolderName}",
     credentialsId: "${JOB_GCS_CREDENTIALS}",
     pathPrefix: "${baseDir}/build/distributions/",
     pattern: "${baseDir}/build/distributions/**/*",
     sharedPublicly: true,
     showInline: true
   )
+}
+
+/**
+* There is a specific folder structure in https://staging.elastic.co/ and https://artifacts.elastic.co/downloads/
+* therefore the storage bucket in GCP should follow the same folder structure.
+* This is required by https://github.com/elastic/beats-tester
+* e.g.
+* baseDir=name -> return name
+* baseDir=name1/name2/name3-> return name2
+*/
+def getBeatsName(baseDir) {
+  return basedir.replace('x-pack/', '')
 }
 
 def withBeatsEnv(Closure body) {


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [packaging] Normalise GCP bucket folder structure (#20903)