### PR TITLE
[CI] autodetect when to run packaging

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -41,7 +41,7 @@ pipeline {
           triggeredBy cause: "IssueCommentCause"
           // Trigger the build if a PR changed this file.
           allOf {
-            changeRequest
+            changeRequest()
             changeset '.ci/packaging.groovy'
           }
           expression {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -39,6 +39,11 @@ pipeline {
         beforeAgent true
         anyOf {
           triggeredBy cause: "IssueCommentCause"
+          // Trigger the build if a PR changed this file.
+          allOf {
+            changeRequest
+            changeset '.ci/packaging.groovy'
+          }
           expression {
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){


### PR DESCRIPTION
## What does this PR do?

In case the pipeline gets changed then force the run of the pipeline itself.

## Why is it important?

Test the pipeline itself to avoid regressions such as https://github.com/elastic/beats/pull/20930