### PR TITLE
Cherry-pick to 7.x: [CI] fix regression with variable name (#20930)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -252,7 +252,7 @@ def publishPackages(baseDir){
 * baseDir=name1/name2/name3-> return name2
 */
 def getBeatsName(baseDir) {
-  return basedir.replace('x-pack/', '')
+  return baseDir.replace('x-pack/', '')
 }
 
 def withBeatsEnv(Closure body) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] fix regression with variable name (#20930)