### PR TITLE
Only request wildcard expansion for hidden indices if supported

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -338,6 +338,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix resource tags in aws cloudwatch metricset {issue}20326[20326]  {pull}20385[20385]
 - Fix ec2 disk and network metrics to use Sum statistic method. {pull}20680[20680]
 - Fill cloud.account.name with accountID if account alias doesn't exist. {pull}20736[20736]
+- The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -61,21 +61,21 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 }
 
 var (
-// CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
-CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
+	// CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
+	CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 
-// EnrichStatsAPIAvailableVersion is the version of Elasticsearch since when the Enrich stats API is available.
-EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
+	// EnrichStatsAPIAvailableVersion is the version of Elasticsearch since when the Enrich stats API is available.
+	EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
 
-// BulkStatsAvailableVersion is the version since when bulk indexing stats are available
-BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
+	// BulkStatsAvailableVersion is the version since when bulk indexing stats are available
+	BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
 
-//ExpandWildcardsHiddenAvailableVersion is the version since when the "expand_wildcards" query parameter to
-// the Indices Stats API can accept "hidden" as a value.
- ExpandWildcardsHiddenAvailableVersion = common.MustNewVersion("7.9.0")
+	//ExpandWildcardsHiddenAvailableVersion is the version since when the "expand_wildcards" query parameter to
+	// the Indices Stats API can accept "hidden" as a value.
+	ExpandWildcardsHiddenAvailableVersion = common.MustNewVersion("7.9.0")
 
-// Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
-clusterIDCache = map[string]string{}
+	// Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
+	clusterIDCache = map[string]string{}
 )
 
 // ModuleName is the name of this module.

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -60,17 +60,23 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	return elastic.NewModule(&base, xpackEnabledMetricSets, logp.NewLogger(ModuleName))
 }
 
+var (
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
-var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
+CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 
 // EnrichStatsAPIAvailableVersion is the version of Elasticsearch since when the Enrich stats API is available.
-var EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
+EnrichStatsAPIAvailableVersion = common.MustNewVersion("7.5.0")
 
 // BulkStatsAvailableVersion is the version since when bulk indexing stats are available
-var BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
+BulkStatsAvailableVersion = common.MustNewVersion("8.0.0")
+
+//ExpandWildcardsHiddenAvailableVersion is the version since when the "expand_wildcards" query parameter to
+// the Indices Stats API can accept "hidden" as a value.
+ ExpandWildcardsHiddenAvailableVersion = common.MustNewVersion("7.9.0")
 
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
-var clusterIDCache = map[string]string{}
+clusterIDCache = map[string]string{}
+)
 
 // ModuleName is the name of this module.
 const ModuleName = "elasticsearch"

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -72,7 +72,7 @@ var (
 
 	//ExpandWildcardsHiddenAvailableVersion is the version since when the "expand_wildcards" query parameter to
 	// the Indices Stats API can accept "hidden" as a value.
-	ExpandWildcardsHiddenAvailableVersion = common.MustNewVersion("7.9.0")
+	ExpandWildcardsHiddenAvailableVersion = common.MustNewVersion("7.7.0")
 
 	// Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 	clusterIDCache = map[string]string{}

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -19,7 +19,6 @@ package index
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -124,17 +123,13 @@ func getServicePath(esVersion common.Version) (string, error) {
 	}
 
 	if !esVersion.LessThan(elasticsearch.BulkStatsAvailableVersion) {
-		if !strings.HasSuffix(u.Path, bulkSuffix) {
-			u.Path += bulkSuffix
-		}
+		u.Path += bulkSuffix
 	}
 
 	if !esVersion.LessThan(elasticsearch.ExpandWildcardsHiddenAvailableVersion) {
 		ew := u.Query().Get(expandWildcardsParam)
-		if !strings.HasSuffix(ew, hiddenSuffix) {
-			ew += hiddenSuffix
-			u.Query().Set(expandWildcardsParam, ew)
-		}
+		ew += hiddenSuffix
+		u.Query().Set(expandWildcardsParam, ew)
 	}
 
 	return u.String(), nil

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -114,21 +114,19 @@ func (m *MetricSet) updateServicePath(esVersion common.Version) error {
 
 func getServicePath(esVersion common.Version) (string, error) {
 	currPath := statsPath
-	if esVersion.LessThan(elasticsearch.BulkStatsAvailableVersion) {
-		// Can't request bulk stats so don't change service URI
-		return currPath, nil
-	}
-
 	u, err := url.Parse(currPath)
 	if err != nil {
 		return "", err
 	}
 
-	if strings.HasSuffix(u.Path, ",bulk") {
-		// Bulk stats already being requested so don't change service URI
-		return currPath, nil
+	if !esVersion.LessThan(elasticsearch.BulkStatsAvailableVersion) {
+		if strings.HasSuffix(u.Path, ",bulk") {
+			// Bulk stats already being requested so don't change service URI
+			return currPath, nil
+		}
+
+		u.Path += ",bulk"
 	}
 
-	u.Path += ",bulk"
 	return u.String(), nil
 }

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -19,6 +19,7 @@ package index
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -37,9 +38,9 @@ func init() {
 }
 
 const (
-	statsMetrics         = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
-	expandWildcardsParam = "expand_wildcards"
-	statsPath            = "/_stats/" + statsMetrics + "?filter_path=indices&" + expandWildcardsParam + "=open"
+	statsMetrics    = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
+	expandWildcards = "expand_wildcards=open"
+	statsPath       = "/_stats/" + statsMetrics + "?filter_path=indices&" + expandWildcards
 
 	bulkSuffix   = ",bulk"
 	hiddenSuffix = ",hidden"
@@ -127,9 +128,7 @@ func getServicePath(esVersion common.Version) (string, error) {
 	}
 
 	if !esVersion.LessThan(elasticsearch.ExpandWildcardsHiddenAvailableVersion) {
-		ew := u.Query().Get(expandWildcardsParam)
-		ew += hiddenSuffix
-		u.Query().Set(expandWildcardsParam, ew)
+		u.RawQuery = strings.Replace(u.RawQuery, expandWildcards, expandWildcards+hiddenSuffix, 1)
 	}
 
 	return u.String(), nil

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -38,12 +38,12 @@ func init() {
 }
 
 const (
-	statsMetrics = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
+	statsMetrics         = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
 	expandWildcardsParam = "expand_wildcards"
-	statsPath    = "/_stats/" + statsMetrics + "?filter_path=indices&"+expandWildcardsParam+"=open"
+	statsPath            = "/_stats/" + statsMetrics + "?filter_path=indices&" + expandWildcardsParam + "=open"
 
-	bulkSuffix = ",bulk"
- hiddenSuffix = ",hidden"
+	bulkSuffix   = ",bulk"
+	hiddenSuffix = ",hidden"
 )
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -133,9 +133,8 @@ func getServicePath(esVersion common.Version) (string, error) {
 		ew := u.Query().Get(expandWildcardsParam)
 		if !strings.HasSuffix(ew, hiddenSuffix) {
 			ew += hiddenSuffix
+			u.Query().Set(expandWildcardsParam, ew)
 		}
-
-		u.Query().Set(expandWildcardsParam, ew)
 	}
 
 	return u.String(), nil

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -63,6 +63,9 @@ func TestGetServiceURIExpectedPath(t *testing.T) {
 }
 
 func TestGetServiceURIMultipleCalls(t *testing.T) {
+	path := strings.Replace(statsPath, expandWildcards, expandWildcards+hiddenSuffix, 1)
+	path = strings.Replace(path, statsMetrics, statsMetrics+bulkSuffix, 1)
+
 	err := quick.Check(func(r uint) bool {
 		numCalls := 2 + (r % 10) // between 2 and 11
 
@@ -75,7 +78,7 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 			}
 		}
 
-		return err == nil && uri == strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1)
+		return err == nil && uri == path
 	}, nil)
 	require.NoError(t, err)
 }

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -27,18 +27,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetServiceURI(t *testing.T) {
+func TestGetServiceURIExpectedPath(t *testing.T) {
+	path770 := strings.Replace(statsPath, expandWildcards, expandWildcards+hiddenSuffix, 1)
+	path800 := strings.Replace(path770, statsMetrics, statsMetrics+bulkSuffix, 1)
+
 	tests := map[string]struct {
 		esVersion    *common.Version
 		expectedPath string
 	}{
 		"bulk_stats_unavailable": {
-			esVersion:    common.MustNewVersion("7.9.0"),
+			esVersion:    common.MustNewVersion("7.6.0"),
 			expectedPath: statsPath,
 		},
 		"bulk_stats_available": {
 			esVersion:    common.MustNewVersion("8.0.0"),
-			expectedPath: strings.Replace(statsPath, statsMetrics, statsMetrics+",bulk", 1),
+			expectedPath: path800,
+		},
+		"expand_wildcards_hidden_unavailable": {
+			esVersion:    common.MustNewVersion("7.6.0"),
+			expectedPath: statsPath,
+		},
+		"expand_wildcards_hidden_available": {
+			esVersion:    common.MustNewVersion("7.7.0"),
+			expectedPath: path770,
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR teaches the `elasticsearch/index` metricset to check the version of the Elasticsearch cluster it's monitoring and, depending on that, ask the cluster to expand wildcards for hidden indices or not.

## Why is it important?

In #18703 we enhanced the `elasticsearch/index` metricset to ask the monitored Elasticsearch cluster to expand wildcards for hidden indices. This enhancement was released in Metricbeat 7.9.0.

Unfortunately this enhancement a backwards-incompatible change, as wildcard expansion for hidden indices is only supported starting Elasticsearch 7.9.0. So if a Metricbeat >= 7.90 tries to monitor an Elasticsearch cluster < 7.9.0, the `elasticsearch/index` metricset is not able to collect metrics and throws the following error:

```
Error fetching data for metricset elasticsearch.index: HTTP error 400 in : 400 Bad Request.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

