### PR TITLE
[Ingest Manager] Align introspect-inspect naming in code

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -150,11 +150,11 @@ accepts additional flags:
 +
 --
 `--output <string>`::
-The name of the output to introspect.
+The name of the output to inspect.
 
 `--program <string>`::
-The type of program to introspect. For example, `filebeat`. This option must be
-combined with `--output`. 
+The type of program to inspect. For example, `filebeat`. This option must be
+combined with `--output`.
 --
 
 `--help`::

--- a/x-pack/elastic-agent/pkg/agent/application/inspect_config_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/inspect_config_cmd.go
@@ -17,25 +17,25 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 )
 
-// IntrospectConfigCmd is an introspect subcommand that shows configurations of the agent.
-type IntrospectConfigCmd struct {
+// InspectConfigCmd is an inspect subcommand that shows configurations of the agent.
+type InspectConfigCmd struct {
 	cfgPath string
 }
 
-// NewIntrospectConfigCmd creates a new introspect command.
-func NewIntrospectConfigCmd(configPath string,
-) (*IntrospectConfigCmd, error) {
-	return &IntrospectConfigCmd{
+// NewInspectConfigCmd creates a new inspect command.
+func NewInspectConfigCmd(configPath string,
+) (*InspectConfigCmd, error) {
+	return &InspectConfigCmd{
 		cfgPath: configPath,
 	}, nil
 }
 
-// Execute introspects agent configuration.
-func (c *IntrospectConfigCmd) Execute() error {
-	return c.introspectConfig()
+// Execute inspects agent configuration.
+func (c *InspectConfigCmd) Execute() error {
+	return c.inspectConfig()
 }
 
-func (c *IntrospectConfigCmd) introspectConfig() error {
+func (c *InspectConfigCmd) inspectConfig() error {
 	rawConfig, err := loadConfig(c.cfgPath)
 	if err != nil {
 		return err

--- a/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
@@ -16,16 +16,16 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/noop"
 )
 
-// IntrospectOutputCmd is an introspect subcommand that shows configurations of the agent.
-type IntrospectOutputCmd struct {
+// InspectOutputCmd is an inspect subcommand that shows configurations of the agent.
+type InspectOutputCmd struct {
 	cfgPath string
 	output  string
 	program string
 }
 
-// NewIntrospectOutputCmd creates a new introspect command.
-func NewIntrospectOutputCmd(configPath, output, program string) (*IntrospectOutputCmd, error) {
-	return &IntrospectOutputCmd{
+// NewInspectOutputCmd creates a new inspect command.
+func NewInspectOutputCmd(configPath, output, program string) (*InspectOutputCmd, error) {
+	return &InspectOutputCmd{
 		cfgPath: configPath,
 		output:  output,
 		program: program,
@@ -33,15 +33,15 @@ func NewIntrospectOutputCmd(configPath, output, program string) (*IntrospectOutp
 }
 
 // Execute tries to enroll the agent into Fleet.
-func (c *IntrospectOutputCmd) Execute() error {
+func (c *InspectOutputCmd) Execute() error {
 	if c.output == "" {
-		return c.introspectOutputs()
+		return c.inspectOutputs()
 	}
 
-	return c.introspectOutput()
+	return c.inspectOutput()
 }
 
-func (c *IntrospectOutputCmd) introspectOutputs() error {
+func (c *InspectOutputCmd) inspectOutputs() error {
 	rawConfig, err := loadConfig(c.cfgPath)
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func listOutputsFromMap(log *logger.Logger, cfg map[string]interface{}) error {
 	return listOutputsFromConfig(log, c)
 }
 
-func (c *IntrospectOutputCmd) introspectOutput() error {
+func (c *InspectOutputCmd) inspectOutput() error {
 	rawConfig, err := loadConfig(c.cfgPath)
 	if err != nil {
 		return err
@@ -149,7 +149,7 @@ func printOutputFromConfig(log *logger.Logger, output, programName string, cfg *
 		}
 
 		if !programFound {
-			return fmt.Errorf("program '%s' is not recognized within output '%s', try running `elastic-agent introspect output` to find available outputs",
+			return fmt.Errorf("program '%s' is not recognized within output '%s', try running `elastic-agent inspect output` to find available outputs",
 				programName,
 				output)
 		}
@@ -157,7 +157,7 @@ func printOutputFromConfig(log *logger.Logger, output, programName string, cfg *
 		return nil
 	}
 
-	return fmt.Errorf("output '%s' is not recognized, try running `elastic-agent introspect output` to find available outputs", output)
+	return fmt.Errorf("output '%s' is not recognized, try running `elastic-agent inspect output` to find available outputs", output)
 
 }
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -64,7 +64,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(basecmd.NewDefaultCommandsWithArgs(args, streams)...)
 	cmd.AddCommand(run)
 	cmd.AddCommand(newEnrollCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newIntrospectCommandWithArgs(flags, args, streams))
+	cmd.AddCommand(newInspectCommandWithArgs(flags, args, streams))
 
 	// windows special hidden sub-command (only added on windows)
 	reexec := newReExecWindowsCommand(flags, args, streams)

--- a/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
@@ -14,14 +14,14 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newIntrospectCommandWithArgs(flags *globalFlags, s []string, streams *cli.IOStreams) *cobra.Command {
+func newInspectCommandWithArgs(flags *globalFlags, s []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "Shows configuration of the agent",
 		Long:  "Shows current configuration of the agent",
 		Args:  cobra.ExactArgs(0),
 		Run: func(c *cobra.Command, args []string) {
-			command, err := application.NewIntrospectConfigCmd(flags.Config())
+			command, err := application.NewInspectConfigCmd(flags.Config())
 			if err != nil {
 				fmt.Fprintf(streams.Err, "%v\n", err)
 				os.Exit(1)
@@ -34,12 +34,12 @@ func newIntrospectCommandWithArgs(flags *globalFlags, s []string, streams *cli.I
 		},
 	}
 
-	cmd.AddCommand(newIntrospectOutputCommandWithArgs(flags, s, streams))
+	cmd.AddCommand(newInspectOutputCommandWithArgs(flags, s, streams))
 
 	return cmd
 }
 
-func newIntrospectOutputCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newInspectOutputCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "output",
 		Short: "Displays configuration generated for output",
@@ -49,7 +49,7 @@ func newIntrospectOutputCommandWithArgs(flags *globalFlags, _ []string, streams 
 			outName, _ := c.Flags().GetString("output")
 			program, _ := c.Flags().GetString("program")
 
-			command, err := application.NewIntrospectOutputCmd(flags.Config(), outName, program)
+			command, err := application.NewInspectOutputCmd(flags.Config(), outName, program)
 			if err != nil {
 				fmt.Fprintf(streams.Err, "%v\n", err)
 				os.Exit(1)
@@ -62,8 +62,8 @@ func newIntrospectOutputCommandWithArgs(flags *globalFlags, _ []string, streams 
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "", "name of the output to be introspected")
-	cmd.Flags().StringP("program", "p", "", "type of program to introspect, needs to be combined with output. e.g filebeat")
+	cmd.Flags().StringP("output", "o", "", "name of the output to be inspected")
+	cmd.Flags().StringP("program", "p", "", "type of program to inspect, needs to be combined with output. e.g filebeat")
 
 	return cmd
 }


### PR DESCRIPTION
## What does this PR do?

As we changed `introspect` command to `inspect` there was a misalignment between names in code and in CLI.
This PR aligns that.

## Why is it important?

Improves readability

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
