### PR TITLE
Cherry-pick #20948 to 7.x: Print a message confirming shutdown 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -128,12 +128,16 @@ func run(flags *globalFlags, streams *cli.IOStreams) error {
 			}
 		}
 		if breakout {
+			if !reexecing {
+				logger.Info("Shutting down Elastic Agent and sending last events...")
+			}
 			break
 		}
 	}
 
 	err = app.Stop()
 	if !reexecing {
+		logger.Info("Shutting down completed.")
 		return err
 	}
 	rex.ShutdownComplete()

--- a/x-pack/elastic-agent/pkg/agent/control/server/listener.go
+++ b/x-pack/elastic-agent/pkg/agent/control/server/listener.go
@@ -23,7 +23,7 @@ func createListener(log *logger.Logger) (net.Listener, error) {
 	path := strings.TrimPrefix(control.Address(), "unix://")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		err = os.Remove(path)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			log.Errorf("%s", errors.New(err, fmt.Sprintf("Failed to cleanup %s", path), errors.TypeFilesystem, errors.M("path", path)))
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #20948 to 7.x branch. Original message:

## What does this PR do?

Currently, when you exit the Elastic Agent it takes several seconds to close the app. The user may be left wondering if its frozen or crashed. It'd be better to print a line to stdout and to the logfile confirming the shutdown is in progress and what needs to happen before the application exits.

## Why is it important?

Fixes: #20578

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
