### PR TITLE
Cherry-pick #20968 to 7.x: Skip flaky test for prometheus remote write

### DIFF
--- a/metricbeat/module/prometheus/test_prometheus.py
+++ b/metricbeat/module/prometheus/test_prometheus.py
@@ -65,6 +65,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
 
+@unittest.skip("Flaky test: https://github.com/elastic/beats/issues/20967")
 class TestRemoteWrite(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['prometheus-host-network']


### PR DESCRIPTION
Cherry-pick of PR #20968 to 7.x branch. Original message: 

See https://github.com/elastic/beats/issues/20967