### PR TITLE
Cherry-pick #20926 to 7.x: Use go install to install tools from go modules

### DIFF
--- a/dev-tools/mage/install.go
+++ b/dev-tools/mage/install.go
@@ -37,7 +37,7 @@ func InstallVendored(importPath string) error {
 
 // InstallGoLicenser target installs go-licenser
 func InstallGoLicenser() error {
-	return gotool.Get(
-		gotool.Get.Package(GoLicenserImportPath),
+	return gotool.Install(
+		gotool.Install.Package(GoLicenserImportPath),
 	)
 }

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -25,7 +25,7 @@ ELASTIC_LICENSE_FILE?=../licenses/ELASTIC-LICENSE.txt
 SECCOMP_BINARY?=${BEAT_NAME}
 SECCOMP_BLACKLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-blacklist.txt
 SECCOMP_ALLOWLIST?=${ES_BEATS}/libbeat/common/seccomp/seccomp-profiler-allow.txt
-INSTALL_CMD?=get
+INSTALL_CMD?=install
 export INSTALL_FLAG
 export INSTALL_CMD
 MAGE_PRESENT := $(shell command -v mage 2> /dev/null)


### PR DESCRIPTION
Cherry-pick of PR #20926 to 7.x branch. Original message: 

The issue found in https://github.com/elastic/beats/pull/20856#issuecomment-683758612 seems to indicate that we are still not pinning some tool. Taking a look to that I have seen that we are still installing some tools with `go get`, this updates `go.mod` to the latest version, what can lead to uncontrolled results. `go install` installs the version specified in `go.mod`, without updating it. We are already installing other tools with `go install`.