### PR TITLE
[Filebeat][Sophos] Docs YAML example for serial number mapping fixes

### DIFF
--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -47,8 +47,10 @@ Below you will see an example configuration file, that sets the default hostname
     var.syslog_port: 9005
     var.default_host_name: firewall.localgroup.local
     var.known_devices:
-       "1234567890123457": "a.host.local"
-       "1234234590678557": "b.host.local"
+      - serial_number: "1234567890123457"
+        hostname: "a.host.local"
+      - serial_number: "1234234590678557"
+        hostname: "b.host.local"
 ----
 
 include::../include/var-paths.asciidoc[]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1297,8 +1297,10 @@ filebeat.modules:
 
     # known firewalls
     #var.known_devices:
-    #   "device1_serialnumber": "a.host.local"
-    #   "device2_serialnumber": "b.host.local"
+      #- serial_number: "1234567890123457"
+      #  hostname: "a.host.local"
+      #- serial_number: "1234234590678557"
+      #  hostname: "b.host.local"
 
 
 #-------------------------------- Squid Module --------------------------------

--- a/x-pack/filebeat/module/sophos/_meta/config.yml
+++ b/x-pack/filebeat/module/sophos/_meta/config.yml
@@ -17,6 +17,8 @@
 
     # known firewalls
     #var.known_devices:
-    #   "device1_serialnumber": "a.host.local"
-    #   "device2_serialnumber": "b.host.local"
+      #- serial_number: "1234567890123457"
+      #  hostname: "a.host.local"
+      #- serial_number: "1234234590678557"
+      #  hostname: "b.host.local"
 

--- a/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
@@ -42,8 +42,10 @@ Below you will see an example configuration file, that sets the default hostname
     var.syslog_port: 9005
     var.default_host_name: firewall.localgroup.local
     var.known_devices:
-       "1234567890123457": "a.host.local"
-       "1234234590678557": "b.host.local"
+      - serial_number: "1234567890123457"
+        hostname: "a.host.local"
+      - serial_number: "1234234590678557"
+        hostname: "b.host.local"
 ----
 
 include::../include/var-paths.asciidoc[]

--- a/x-pack/filebeat/modules.d/sophos.yml.disabled
+++ b/x-pack/filebeat/modules.d/sophos.yml.disabled
@@ -20,6 +20,8 @@
 
     # known firewalls
     #var.known_devices:
-    #   "device1_serialnumber": "a.host.local"
-    #   "device2_serialnumber": "b.host.local"
+      #- serial_number: "1234567890123457"
+      #  hostname: "a.host.local"
+      #- serial_number: "1234234590678557"
+      #  hostname: "b.host.local"
 


### PR DESCRIPTION
## What does this PR do?

The example config and documentation on serial number mapping was in the wrong format, causing confusion

## Why is it important?

Give correct default values to users that utilizes the module

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
