### PR TITLE
Cherry-pick #21003 to 7.x: [Filebeat][zeek] Bump zeek kerberos/ssl/x509 ecs version

### DIFF
--- a/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
@@ -106,4 +106,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
+++ b/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
@@ -81,4 +81,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/x-pack/filebeat/module/zeek/x509/config/x509.yml
+++ b/x-pack/filebeat/module/zeek/x509/config/x509.yml
@@ -67,4 +67,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0


### PR DESCRIPTION
Cherry-pick of PR #21003 to 7.x branch. Original message: 

##  What does this PR do?

Bump ECS version in updated filesets

## Why is it important?

These filesets use 1.6.0 features but the version was not changed.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
