### PR TITLE
Cherry-pick #20976 to 7.x: [Filebeat][santa] Map x509 fields in santa module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -639,6 +639,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Improve Zeek SSL module with `x509` ECS mappings {pull}20927[20927]
 - Improve Zeek Kerberos module with `x509` ECS mappings {pull}20958[20958]
 - Improve Fortinet firewall module with `x509` ECS mappings {pull}20983[20983]
+- Improve Santa module with `x509` ECS mappings {pull}20976[20976]
 
 *Heartbeat*
 

--- a/filebeat/module/santa/log/config/file.yml
+++ b/filebeat/module/santa/log/config/file.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/filebeat/module/santa/log/ingest/pipeline.yml
+++ b/filebeat/module/santa/log/ingest/pipeline.yml
@@ -89,6 +89,10 @@ processors:
     field: related.hash
     value: "{{process.hash.sha256}}"
     if: "ctx?.process?.hash != null"
+- set:
+    field: file.x509.issuer.common_name
+    value: "{{santa.certificate.common_name}}"
+    ignore_empty_value: true
 on_failure:
 - set:
     field: error.message

--- a/filebeat/module/santa/log/test/santa.log-expected.json
+++ b/filebeat/module/santa/log/test/santa.log-expected.json
@@ -12,6 +12,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -58,6 +59,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -105,6 +107,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -151,6 +154,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -198,6 +202,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -244,6 +249,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "0",
         "group.name": "wheel",
@@ -336,6 +342,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Software Signing",
         "fileset.name": "log",
         "group.id": "20",
         "group.name": "staff",
@@ -381,6 +388,7 @@
         "event.type": [
             "start"
         ],
+        "file.x509.issuer.common_name": "Developer ID Application: Google, Inc. (EQHXZ8M8AV)",
         "fileset.name": "log",
         "group.id": "20",
         "group.name": "staff",


### PR DESCRIPTION
Cherry-pick of PR #20976 to 7.x branch. Original message: 

## What does this PR do?

Maps x509 fields in santa module.

## Why is it important?

To keep modules up to date with ecs 1.6.

## Checklist


~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates elastic/beats#19472

