### PR TITLE
Elasticsearch output logging change to structured logging

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -405,13 +405,13 @@ func bulkCollectPublishFails(
 				stats.tooMany++
 			} else {
 				// hard failure, don't collect
-				log.Warn("Cannot index event",zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg))
+				log.With(zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg)).Warn("Cannot index event")
 				stats.nonIndexable++
 				continue
 			}
 		}
 
-		log.Debug("Bulk item insert failed",zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg))
+		log.With(zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg)).Debug("Bulk item insert failed")
 		stats.fails++
 		failed = append(failed, data[i])
 	}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.uber.org/zap"
 	"net/http"
 	"strings"
 	"time"
@@ -404,13 +405,13 @@ func bulkCollectPublishFails(
 				stats.tooMany++
 			} else {
 				// hard failure, don't collect
-				log.Warnf("Cannot index event %#v (status=%v): %s", data[i], status, msg)
+				log.Warn("Cannot index event",zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg))
 				stats.nonIndexable++
 				continue
 			}
 		}
 
-		log.Debugf("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
+		log.Debug("Bulk item insert failed",zap.Int("status",status),zap.Any("event",data[i]),zap.ByteString("error",msg))
 		stats.fails++
 		failed = append(failed, data[i])
 	}


### PR DESCRIPTION
In order to easily stats on fail events output in elasticsearch it will be easier with structured logging.

- Enhancement

## What does this PR do?

For elasticsearch output log errors in structured logging instead of plain text in order to stats events that failed to be indexed.

## Why is it important?

For an easy investigation on which events are not indexed in elasticsearch, we put the event as a json key.


