### PR TITLE
Cherry-pick #20989 to 7.x: Disable Kafka metricsets based on Jolokia

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -385,6 +385,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fill cloud.account.name with accountID if account alias doesn't exist. {pull}20736[20736]
 - Fix ec2 disk and network metrics to use Sum statistic method. {pull}20680[20680]
 - The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
+- Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/kafka/broker.asciidoc
+++ b/metricbeat/docs/modules/kafka/broker.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/kafka/broker/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/docs/modules/kafka/consumer.asciidoc
+++ b/metricbeat/docs/modules/kafka/consumer.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/kafka/consumer/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/docs/modules/kafka/producer.asciidoc
+++ b/metricbeat/docs/modules/kafka/producer.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/kafka/producer/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 

--- a/metricbeat/module/kafka/broker/manifest.yml
+++ b/metricbeat/module/kafka/broker/manifest.yml
@@ -1,4 +1,4 @@
-default: true
+default: false
 input:
   module: jolokia
   metricset: jmx

--- a/metricbeat/module/kafka/consumer/manifest.yml
+++ b/metricbeat/module/kafka/consumer/manifest.yml
@@ -1,4 +1,4 @@
-default: true
+default: false
 input:
   module: jolokia
   metricset: jmx

--- a/metricbeat/module/kafka/producer/manifest.yml
+++ b/metricbeat/module/kafka/producer/manifest.yml
@@ -1,4 +1,4 @@
-default: true
+default: false
 input:
   module: jolokia
   metricset: jmx


### PR DESCRIPTION
Cherry-pick of PR #20989 to 7.x branch. Original message: 

## What does this PR do?

Kafka metricsets based on Jolokia require a different configuration to
the native metricsets. Disable the Jolokia ones by default, if someone
wants to use them, they need to explicitly enable and configure them.
Reference configuration contains information about this.

At the moment there is no way we can provide default metricsets in the
same module that need different hosts configurations.

In any case `consumer` and `producer` metricsets are intended to monitor
Java consumers and producers, while the rest of metricsets are intended
to monitor Kafka brokers. So there is little chance that all of them are going
to be enabled in the same configuration.

## Why is it important?

To avoid errors with default configuration.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Errors seen in this discuss topic: https://discuss.elastic.co/t/kafka-monitoring-in-kubernetes/247527/3

## Use cases

Using the kafka module, without specifying defaults, should provide a working configuration.

## Logs

Errors like these ones appear when using default configuration:
```
Error fetching data for metricset kafka.broker: error making http request: Post "http://pipeline-kafka:9092/jolokia/%3FignoreErrors=true&canonicalNaming=false": read tcp 10.5.7.136:34466->172.20.79.178:9092: read: connection reset by peer
Error fetching data for metricset kafka.producer: error making http request: Post "http://pipeline-kafka:9092/jolokia/%3FignoreErrors=true&canonicalNaming=false": read tcp 10.5.7.136:34470->172.20.79.178:9092: read: connection reset by peer
```
Metricbeat tries to request jolokia metrics from the Kafka endpoint.