### PR TITLE
[Elastic Agent] Add fleet.host.id for sending to endpoint.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -19,3 +19,4 @@
 - Users of the Docker image can now pass `FLEET_ENROLL_INSECURE=1` to include the `--insecure` flag with the `elastic-agent enroll` command {issue}20312[20312] {pull}20713[20713]
 - Add support for dynamic inputs with providers and `{{variable|"default"}}` substitution. {pull}20839[20839]
 - Add support for EQL based condition on inputs {pull}20994[20994]
+- Send `fleet.host.id` to Endpoint Security {pull}21042[21042]

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/elastic/go-sysinfo"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filters"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
@@ -113,6 +115,13 @@ func newManaged(
 			errors.M(errors.MetaKeyURI, cfg.Fleet.Kibana.Host))
 	}
 
+	sysInfo, err := sysinfo.Host()
+	if err != nil {
+		return nil, errors.New(err,
+			"fail to get system information",
+			errors.TypeUnexpected)
+	}
+
 	managedApplication := &Managed{
 		log:       log,
 		agentInfo: agentInfo,
@@ -160,7 +169,7 @@ func newManaged(
 		router,
 		&configModifiers{
 			Decorators: []decoratorFunc{injectMonitoring},
-			Filters:    []filterFunc{filters.StreamChecker, injectFleet(config)},
+			Filters:    []filterFunc{filters.StreamChecker, injectFleet(config, sysInfo.Info())},
 		},
 		monitor,
 	)

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic-endpoint-security.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic-endpoint-security.yml
@@ -2,6 +2,8 @@ revision: 5
 fleet:
   agent:
     id: fleet-agent-id
+  host:
+    id: host-agent-id
   api:
     access_api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
     kibana:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic.yml
@@ -3,6 +3,8 @@ name: Endpoint Host
 fleet:
   agent:
     id: fleet-agent-id
+  host:
+    id: host-agent-id
   access_api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
   kibana:
     protocol: https


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds `host.id` to `fleet`, resulting in `fleet.host.id` being send to Elastic Endpoint Security.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This ensures that Elastic Endpoint Security uses the same `host.id` in events that all the beats and elastic-agent uses.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

