### PR TITLE
Filebeat: Fix random error on harvester close

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -260,6 +260,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update documentation in the azure module filebeat. {pull}20815[20815]
 - Provide backwards compatibility for the `set` processor when Elasticsearch is less than 7.9.0. {pull}20908[20908]
 - Remove wrongly mapped `tls.client.server_name` from `fortinet/firewall` fileset. {pull}20983[20983]
+- Fix an error updating file size being logged when EOF is reached. {pull}21048[21048]
 
 *Heartbeat*
 

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -83,6 +83,7 @@ type Harvester struct {
 
 	// shutdown handling
 	done     chan struct{}
+	doneWg   *sync.WaitGroup
 	stopOnce sync.Once
 	stopWg   *sync.WaitGroup
 	stopLock sync.Mutex
@@ -138,6 +139,7 @@ func NewHarvester(
 		publishState:  publishState,
 		done:          make(chan struct{}),
 		stopWg:        &sync.WaitGroup{},
+		doneWg:        &sync.WaitGroup{},
 		id:            id,
 		outletFactory: outletFactory,
 	}
@@ -299,7 +301,11 @@ func (h *Harvester) Run() error {
 
 	logp.Info("Harvester started for file: %s", h.state.Source)
 
-	go h.monitorFileSize()
+	h.doneWg.Add(1)
+	go func() {
+		h.monitorFileSize()
+		h.doneWg.Done()
+	}()
 
 	for {
 		select {
@@ -378,7 +384,8 @@ func (h *Harvester) monitorFileSize() {
 func (h *Harvester) stop() {
 	h.stopOnce.Do(func() {
 		close(h.done)
-
+		// Wait for goroutines monitoring h.done to terminate before closing source.
+		h.doneWg.Wait()
 		filesMetrics.Remove(h.id.String())
 	})
 }


### PR DESCRIPTION
This fixes a race condition when a harvester is closed at the same time that its source file size is being calculated.

## Why is it important?

Random `Error updating file size` errors have been reported. Other than that it looks like the bug has no other effect.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Make sure the new synchronization is safe

## How to test this PR locally

It's easy to trigger this error by removing the Ticker in `monitorFileSize` and busy loop calling `h.updateCurrentSize()`, with a configuration that uses `close_eof` and many files.

## Logs

> Error updating file size: GetFileInformationByHandleEx [...path...]: The handle is invalid.; File: [...path...]