### PR TITLE
Cherry-pick #21047 to 7.x: [Elastic Agent] Fix loggers in composable module.

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
@@ -178,7 +178,7 @@ func getProgramsFromConfig(log *logger.Logger, cfg *config.Config) (map[string][
 	router := &inmemRouter{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	composableCtrl, err := composable.New(cfg)
+	composableCtrl, err := composable.New(log, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -103,7 +103,7 @@ func newLocal(
 	}
 	localApplication.router = router
 
-	composableCtrl, err := composable.New(rawConfig)
+	composableCtrl, err := composable.New(log, rawConfig)
 	if err != nil {
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -152,7 +152,7 @@ func newManaged(
 	}
 	managedApplication.router = router
 
-	composableCtrl, err := composable.New(rawConfig)
+	composableCtrl, err := composable.New(log, rawConfig)
 	if err != nil {
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode_test.go
@@ -32,7 +32,7 @@ func TestManagedModeRouting(t *testing.T) {
 
 	log, _ := logger.New("")
 	router, _ := newRouter(log, streamFn)
-	composableCtrl, _ := composable.New(nil)
+	composableCtrl, _ := composable.New(log, nil)
 	emit, err := emitter(ctx, log, composableCtrl, router, &configModifiers{Decorators: []decoratorFunc{injectMonitoring}})
 	require.NoError(t, err)
 

--- a/x-pack/elastic-agent/pkg/composable/context.go
+++ b/x-pack/elastic-agent/pkg/composable/context.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 // ContextProviderComm is the interface that a context provider uses to communicate back to Elastic Agent.
@@ -27,7 +28,7 @@ type ContextProvider interface {
 }
 
 // ContextProviderBuilder creates a new context provider based on the given config and returns it.
-type ContextProviderBuilder func(config *config.Config) (ContextProvider, error)
+type ContextProviderBuilder func(log *logger.Logger, config *config.Config) (ContextProvider, error)
 
 // AddContextProvider adds a new ContextProviderBuilder
 func (r *providerRegistry) AddContextProvider(name string, builder ContextProviderBuilder) error {

--- a/x-pack/elastic-agent/pkg/composable/controller.go
+++ b/x-pack/elastic-agent/pkg/composable/controller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"reflect"
 	"sort"
@@ -38,11 +39,8 @@ type controller struct {
 }
 
 // New creates a new controller.
-func New(c *config.Config) (Controller, error) {
-	l, err := logger.New("composable")
-	if err != nil {
-		return nil, err
-	}
+func New(log *logger.Logger, c *config.Config) (Controller, error) {
+	l := log.Named("composable")
 	l.Info("EXPERIMENTAL - Inputs with variables are currently experimental and should not be used in production")
 
 	var providersCfg Config
@@ -61,7 +59,7 @@ func New(c *config.Config) (Controller, error) {
 			// explicitly disabled; skipping
 			continue
 		}
-		provider, err := builder(pCfg)
+		provider, err := builder(l, pCfg)
 		if err != nil {
 			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
 		}
@@ -78,7 +76,7 @@ func New(c *config.Config) (Controller, error) {
 			// explicitly disabled; skipping
 			continue
 		}
-		provider, err := builder(pCfg)
+		provider, err := builder(l.Named(strings.Join([]string{"providers", name}, ".")), pCfg)
 		if err != nil {
 			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
 		}

--- a/x-pack/elastic-agent/pkg/composable/controller_test.go
+++ b/x-pack/elastic-agent/pkg/composable/controller_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/transpiler"
 
 	"github.com/stretchr/testify/assert"
@@ -73,7 +75,9 @@ func TestController(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	c, err := composable.New(cfg)
+	log, err := logger.New("")
+	require.NoError(t, err)
+	c, err := composable.New(log, cfg)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup

--- a/x-pack/elastic-agent/pkg/composable/dynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/dynamic.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 // DynamicProviderComm is the interface that an dynamic provider uses to communicate back to Elastic Agent.
@@ -29,7 +30,7 @@ type DynamicProvider interface {
 }
 
 // DynamicProviderBuilder creates a new dynamic provider based on the given config and returns it.
-type DynamicProviderBuilder func(config *config.Config) (DynamicProvider, error)
+type DynamicProviderBuilder func(log *logger.Logger, config *config.Config) (DynamicProvider, error)
 
 // AddDynamicProvider adds a new DynamicProviderBuilder
 func (r *providerRegistry) AddDynamicProvider(name string, builder DynamicProviderBuilder) error {

--- a/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
@@ -40,6 +41,6 @@ func (*contextProvider) Run(comm composable.ContextProviderComm) error {
 }
 
 // ContextProviderBuilder builds the context provider.
-func ContextProviderBuilder(_ *config.Config) (composable.ContextProvider, error) {
+func ContextProviderBuilder(_ *logger.Logger, _ *config.Config) (composable.ContextProvider, error) {
 	return &contextProvider{}, nil
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/agent/agent_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/agent/agent_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestContextProvider(t *testing.T) {
 	builder, _ := composable.Providers.GetContextProvider("agent")
-	provider, err := builder(nil)
+	provider, err := builder(nil, nil)
 	require.NoError(t, err)
 
 	comm := ctesting.NewContextComm(context.Background())

--- a/x-pack/elastic-agent/pkg/composable/providers/env/env.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/env/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 func init() {
@@ -29,7 +30,7 @@ func (*contextProvider) Run(comm composable.ContextProviderComm) error {
 }
 
 // ContextProviderBuilder builds the context provider.
-func ContextProviderBuilder(_ *config.Config) (composable.ContextProvider, error) {
+func ContextProviderBuilder(_ *logger.Logger, _ *config.Config) (composable.ContextProvider, error) {
 	return &contextProvider{}, nil
 }
 

--- a/x-pack/elastic-agent/pkg/composable/providers/env/env_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/env/env_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestContextProvider(t *testing.T) {
 	builder, _ := composable.Providers.GetContextProvider("env")
-	provider, err := builder(nil)
+	provider, err := builder(nil, nil)
 	require.NoError(t, err)
 
 	comm := ctesting.NewContextComm(context.Background())

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host.go
@@ -79,13 +79,9 @@ func (c *contextProvider) Run(comm composable.ContextProviderComm) error {
 }
 
 // ContextProviderBuilder builds the context provider.
-func ContextProviderBuilder(c *config.Config) (composable.ContextProvider, error) {
-	logger, err := logger.New("composable.providers.host")
-	if err != nil {
-		return nil, err
-	}
+func ContextProviderBuilder(log *logger.Logger, c *config.Config) (composable.ContextProvider, error) {
 	p := &contextProvider{
-		logger:  logger,
+		logger:  log,
 		fetcher: getHostInfo,
 	}
 	if c != nil {

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
@@ -7,8 +7,6 @@ package host
 import (
 	"context"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
-
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +16,8 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	ctesting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable/testing"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 func TestContextProvider(t *testing.T) {
@@ -31,7 +31,9 @@ func TestContextProvider(t *testing.T) {
 	})
 	require.NoError(t, err)
 	builder, _ := composable.Providers.GetContextProvider("host")
-	provider, err := builder(c)
+	log, err := logger.New("host_test")
+	require.NoError(t, err)
+	provider, err := builder(log, c)
 	require.NoError(t, err)
 
 	hostProvider := provider.(*contextProvider)

--- a/x-pack/elastic-agent/pkg/composable/providers/local/local.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/local/local.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 func init() {
@@ -30,7 +31,7 @@ func (c *contextProvider) Run(comm composable.ContextProviderComm) error {
 }
 
 // ContextProviderBuilder builds the context provider.
-func ContextProviderBuilder(c *config.Config) (composable.ContextProvider, error) {
+func ContextProviderBuilder(_ *logger.Logger, c *config.Config) (composable.ContextProvider, error) {
 	p := &contextProvider{}
 	if c != nil {
 		err := c.Unpack(p)

--- a/x-pack/elastic-agent/pkg/composable/providers/local/local_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/local/local_test.go
@@ -26,7 +26,7 @@ func TestContextProvider(t *testing.T) {
 	})
 	require.NoError(t, err)
 	builder, _ := composable.Providers.GetContextProvider("local")
-	provider, err := builder(cfg)
+	provider, err := builder(nil, cfg)
 	require.NoError(t, err)
 
 	comm := ctesting.NewContextComm(context.Background())

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 func init() {
@@ -37,7 +38,7 @@ func (c *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
 }
 
 // DynamicProviderBuilder builds the dynamic provider.
-func DynamicProviderBuilder(c *config.Config) (composable.DynamicProvider, error) {
+func DynamicProviderBuilder(_ *logger.Logger, c *config.Config) (composable.DynamicProvider, error) {
 	p := &dynamicProvider{}
 	if c != nil {
 		err := c.Unpack(p)

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
@@ -60,7 +60,7 @@ func TestContextProvider(t *testing.T) {
 	})
 	require.NoError(t, err)
 	builder, _ := composable.Providers.GetDynamicProvider("local_dynamic")
-	provider, err := builder(cfg)
+	provider, err := builder(nil, cfg)
 	require.NoError(t, err)
 
 	comm := ctesting.NewDynamicComm(context.Background())

--- a/x-pack/elastic-agent/pkg/composable/providers/path/path.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/path/path.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 func init() {
@@ -32,6 +33,6 @@ func (*contextProvider) Run(comm composable.ContextProviderComm) error {
 }
 
 // ContextProviderBuilder builds the context provider.
-func ContextProviderBuilder(_ *config.Config) (composable.ContextProvider, error) {
+func ContextProviderBuilder(_ *logger.Logger, _ *config.Config) (composable.ContextProvider, error) {
 	return &contextProvider{}, nil
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/path/path_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/path/path_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestContextProvider(t *testing.T) {
 	builder, _ := composable.Providers.GetContextProvider("path")
-	provider, err := builder(nil)
+	provider, err := builder(nil, nil)
 	require.NoError(t, err)
 
 	comm := ctesting.NewContextComm(context.Background())


### PR DESCRIPTION
Cherry-pick of PR #21047 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where `logger.New` was being used in the new `composable` module. This was creating a new logger instead of using application created logger. Providers are updated to take a logger, that is already named correctly.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So logging works correctly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20992 
