### PR TITLE
Cherry-pick #21052 to 7.x: Add ingress controller dashboards

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -475,6 +475,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add capability of enriching process metadata with contianer id also for non-privileged containers in `add_process_metadata` processor. {pull}19767[19767]
 - Add replace_fields config option in add_host_metadata for replacing host fields. {pull}20490[20490] {issue}20464[20464]
 - Add container ECS fields in kubernetes metadata. {pull}20984[20984]
+- Add ingress controller dashboards. {pull}21052[21052]
 
 *Auditbeat*
 

--- a/filebeat/module/nginx/_meta/kibana/7/dashboard/Filebeat-nginx-ingress-logs.json
+++ b/filebeat/module/nginx/_meta/kibana/7/dashboard/Filebeat-nginx-ingress-logs.json
@@ -1,0 +1,359 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Dashboard for the Filebeat Nginx Ingress Controller",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 4,
+              "i": "36b94fba-26a2-4a63-9260-1e5bdf3a9dd8",
+              "w": 48,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "36b94fba-26a2-4a63-9260-1e5bdf3a9dd8",
+            "panelRefName": "panel_0",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "a7e7600a-703f-48a0-9a3a-3670294ee98b",
+              "w": 48,
+              "x": 0,
+              "y": 4
+            },
+            "panelIndex": "a7e7600a-703f-48a0-9a3a-3670294ee98b",
+            "panelRefName": "panel_1",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "1a56c416-e1e4-4e0e-bd2b-ac5e3553d118",
+              "w": 48,
+              "x": 0,
+              "y": 16
+            },
+            "panelIndex": "1a56c416-e1e4-4e0e-bd2b-ac5e3553d118",
+            "panelRefName": "panel_2",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 28,
+              "i": "7e5729fd-aa67-4ee2-aaa3-8a67e529d4b1",
+              "w": 48,
+              "x": 0,
+              "y": 28
+            },
+            "panelIndex": "7e5729fd-aa67-4ee2-aaa3-8a67e529d4b1",
+            "panelRefName": "panel_3",
+            "version": "7.8.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Nginx] Ingress Controller access and error logs",
+        "version": 1
+      },
+      "id": "0b3dba40-f341-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "c37e2770-f341-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "78738850-f342-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "a832bcf0-f342-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_2",
+          "type": "search"
+        },
+        {
+          "id": "d20d4ea0-f342-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_3",
+          "type": "search"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2020-09-10T08:52:04.498Z",
+      "version": "WzIzNzIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Dashboards Ingress Controller [Filebeat Nginx] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "fontSize": 12,
+            "markdown": "[Nginx Ingress Controller logs overview](#/dashboard/dfbc0840-f340-11ea-a3fd-1b45ec532bb3) | [Nginx Ingress Controller access and error logs](#/dashboard/0b3dba40-f341-11ea-a3fd-1b45ec532bb3)",
+            "openLinksInNewTab": false
+          },
+          "title": "Dashboards Ingress Controller [Filebeat Nginx] ECS",
+          "type": "markdown"
+        }
+      },
+      "id": "c37e2770-f341-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:43:56.647Z",
+      "version": "WzIyOTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller access logs over time [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "annotations": [
+              {
+                "color": "#F00",
+                "icon": "fa-tag",
+                "id": "970b1420-a1f3-11e7-a062-a1c3587f4874",
+                "ignore_global_filters": 1,
+                "ignore_panel_filters": 1,
+                "index_pattern": "filebeat-*",
+                "time_field": "@timestamp"
+              }
+            ],
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "3189aa80-a1f3-11e7-a062-a1c3587f4874"
+              }
+            ],
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module:nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Access logs",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "id": "1db649a0-a1f3-11e7-a062-a1c3587f4874"
+                  }
+                ],
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "url.original",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ingress Controller access logs over time [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "78738850-f342-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:49:00.245Z",
+      "version": "WzIzNTcsMV0="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "log.level",
+          "message"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlight": {
+              "fields": {
+                "*": {}
+              },
+              "fragment_size": 2147483647,
+              "post_tags": [
+                "@/kibana-highlighted-field@"
+              ],
+              "pre_tags": [
+                "@kibana-highlighted-field@"
+              ],
+              "require_field_match": false
+            },
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "event.module:nginx AND message:*"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          [
+            "@timestamp",
+            "desc"
+          ]
+        ],
+        "title": "Nginx Ingress Controller error logs [Filebeat Nginx]",
+        "version": 1
+      },
+      "id": "a832bcf0-f342-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "search": "7.4.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2020-09-10T08:50:20.351Z",
+      "version": "WzIzNjQsMV0="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "url.original",
+          "http.request.method",
+          "http.response.status_code",
+          "http.response.body.bytes"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlight": {
+              "fields": {
+                "*": {}
+              },
+              "fragment_size": 2147483647,
+              "post_tags": [
+                "@/kibana-highlighted-field@"
+              ],
+              "pre_tags": [
+                "@kibana-highlighted-field@"
+              ],
+              "require_field_match": false
+            },
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "event.module:nginx AND url.original:*"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          [
+            "@timestamp",
+            "desc"
+          ]
+        ],
+        "title": "Nginx Ingress Controller access logs [Filebeat Nginx]",
+        "version": 1
+      },
+      "id": "d20d4ea0-f342-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "search": "7.4.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2020-09-10T08:51:30.569Z",
+      "version": "WzIzNzEsMV0="
+    }
+  ],
+  "version": "7.8.0"
+}

--- a/filebeat/module/nginx/_meta/kibana/7/dashboard/Filebeat-nginx-ingress-overview.json
+++ b/filebeat/module/nginx/_meta/kibana/7/dashboard/Filebeat-nginx-ingress-overview.json
@@ -1,0 +1,1118 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Dashboard for the Filebeat Nginx Ingress Controller",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "3",
+              "w": 12,
+              "x": 36,
+              "y": 32
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_0",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": true
+              }
+            },
+            "gridData": {
+              "h": 12,
+              "i": "4",
+              "w": 11,
+              "x": 25,
+              "y": 32
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_1",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapBounds": {
+                "bottom_right": {
+                  "lat": -7.362466865535738,
+                  "lon": 245.39062500000003
+                },
+                "top_left": {
+                  "lat": 77.07878389624943,
+                  "lon": -245.74218750000003
+                }
+              },
+              "mapCenter": null,
+              "mapCollar": {
+                "bottom_right": {
+                  "lat": -49.583095,
+                  "lon": 180
+                },
+                "top_left": {
+                  "lat": 90,
+                  "lon": -180
+                },
+                "zoom": 2
+              },
+              "mapZoom": null
+            },
+            "gridData": {
+              "h": 16,
+              "i": "8",
+              "w": 48,
+              "x": 0,
+              "y": 4
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_2",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 4,
+              "i": "f760cd68-8472-4709-b516-ba74f0c00db8",
+              "w": 48,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "f760cd68-8472-4709-b516-ba74f0c00db8",
+            "panelRefName": "panel_3",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "9351d7ed-b2f4-419b-8c15-4696f69c2831",
+              "w": 48,
+              "x": 0,
+              "y": 20
+            },
+            "panelIndex": "9351d7ed-b2f4-419b-8c15-4696f69c2831",
+            "panelRefName": "panel_4",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "a62866e6-5c7f-4c52-a619-d01fb5005d7c",
+              "w": 12,
+              "x": 0,
+              "y": 32
+            },
+            "panelIndex": "a62866e6-5c7f-4c52-a619-d01fb5005d7c",
+            "panelRefName": "panel_5",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "453e4965-85d2-48a8-aea6-b37970d50ec5",
+              "w": 13,
+              "x": 12,
+              "y": 32
+            },
+            "panelIndex": "453e4965-85d2-48a8-aea6-b37970d50ec5",
+            "panelRefName": "panel_6",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "606dd662-23fe-4fec-a781-7a5831eb1dc4",
+              "w": 18,
+              "x": 0,
+              "y": 44
+            },
+            "panelIndex": "606dd662-23fe-4fec-a781-7a5831eb1dc4",
+            "panelRefName": "panel_7",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "23972f5a-8e18-457a-8288-adf6f15e792e",
+              "w": 15,
+              "x": 18,
+              "y": 44
+            },
+            "panelIndex": "23972f5a-8e18-457a-8288-adf6f15e792e",
+            "panelRefName": "panel_8",
+            "version": "7.8.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "4b4ec4d3-b8a2-4d94-9a6c-b469552940e8",
+              "w": 15,
+              "x": 33,
+              "y": 44
+            },
+            "panelIndex": "4b4ec4d3-b8a2-4d94-9a6c-b469552940e8",
+            "panelRefName": "panel_9",
+            "version": "7.8.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Nginx] Ingress Controller Overview",
+        "version": 1
+      },
+      "id": "dfbc0840-f340-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "Nginx-Access-Browsers-ecs",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "Nginx-Access-OSes-ecs",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "Nginx-Access-Map-ecs",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "c37e2770-f341-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "ba138ab0-f344-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "f137cb40-f345-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "ee250270-f344-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "1aa782a0-f345-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "a3bf1ce0-f347-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "afd506b0-f348-11ea-a3fd-1b45ec532bb3",
+          "name": "panel_9",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2020-09-10T09:37:31.793Z",
+      "version": "WzI0OTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Browsers breakdown [Filebeat Nginx] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "user_agent.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "user_agent.version",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "bottom",
+            "shareYAxis": true
+          },
+          "title": "Nginx Access Browsers ECS",
+          "type": "pie"
+        }
+      },
+      "id": "Nginx-Access-Browsers-ecs",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:33:36.686Z",
+      "version": "WzIxNjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Operating systems breakdown [Filebeat Nginx] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "user_agent.os.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "user_agent.os.version",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "bottom",
+            "shareYAxis": true
+          },
+          "title": "Nginx Access OSes ECS",
+          "type": "pie"
+        }
+      },
+      "id": "Nginx-Access-OSes-ecs",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:33:36.686Z",
+      "version": "WzIxNjgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": []
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Access Map [Filebeat Nginx] ECS",
+        "uiStateJSON": {
+          "mapCenter": [
+            12.039320557540572,
+            -0.17578125
+          ]
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location"
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addTooltip": true,
+            "heatBlur": 15,
+            "heatMaxZoom": 16,
+            "heatMinOpacity": 0.1,
+            "heatNormalizeData": true,
+            "heatRadius": 25,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              15,
+              5
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "attribution": "Maps provided by USGS",
+                "format": "image/png",
+                "layers": "0",
+                "styles": "",
+                "transparent": true,
+                "version": "1.3.0"
+              },
+              "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+            }
+          },
+          "title": "Nginx Access Map ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "Nginx-Access-Map-ecs",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [
+        {
+          "id": "Filebeat-Nginx-module-ecs",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:33:36.686Z",
+      "version": "WzIxNjksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Dashboards Ingress Controller [Filebeat Nginx] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "fontSize": 12,
+            "markdown": "[Nginx Ingress Controller logs overview](#/dashboard/dfbc0840-f340-11ea-a3fd-1b45ec532bb3) | [Nginx Ingress Controller access and error logs](#/dashboard/0b3dba40-f341-11ea-a3fd-1b45ec532bb3)",
+            "openLinksInNewTab": false
+          },
+          "title": "Dashboards Ingress Controller [Filebeat Nginx] ECS",
+          "type": "markdown"
+        }
+      },
+      "id": "c37e2770-f341-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T08:43:56.647Z",
+      "version": "WzIyOTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller response codes over time [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module:nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "bar",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[200 TO 299]"
+                    },
+                    "id": "5acdc750-a29d-11e7-a062-a1c3587f4874",
+                    "label": "200s"
+                  },
+                  {
+                    "color": "rgba(252,196,0,1)",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[300 TO 399]"
+                    },
+                    "id": "6efd2ae0-a29d-11e7-a062-a1c3587f4874",
+                    "label": "300s"
+                  },
+                  {
+                    "color": "rgba(211,49,21,1)",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[400 TO 499]"
+                    },
+                    "id": "76089a90-a29d-11e7-a062-a1c3587f4874",
+                    "label": "400s"
+                  },
+                  {
+                    "color": "rgba(171,20,158,1)",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[500 TO 599]"
+                    },
+                    "id": "7c7929d0-a29d-11e7-a062-a1c3587f4874",
+                    "label": "500s"
+                  }
+                ],
+                "split_mode": "filters",
+                "stacked": "stacked",
+                "terms_field": "http.response.status_code",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ingress Controller response codes over time [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "ba138ab0-f344-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:05:09.339Z",
+      "version": "WzIzOTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller top Upstreams [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "6252c320-a1f5-11e7-92ba-5d0b8663aece"
+              }
+            ],
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module:nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "nginx.ingress_controller.upstream.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "value_template": ""
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ingress Controller top Upstreams [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "f137cb40-f345-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:13:51.348Z",
+      "version": "WzI0MzAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller top pages [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "6252c320-a1f5-11e7-92ba-5d0b8663aece"
+              }
+            ],
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module:nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "url.original",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "value_template": ""
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ingress Controller top pages [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "ee250270-f344-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:06:36.695Z",
+      "version": "WzI0MDIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller Data Volume [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module: nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "http.response.body.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[200 TO 299]"
+                    },
+                    "id": "7c343c20-a29e-11e7-a062-a1c3587f4874",
+                    "label": "200s"
+                  }
+                ],
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": null
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ingress Controller Data Volume [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "1aa782a0-f345-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:07:51.369Z",
+      "version": "WzI0MTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller Upstream Time Consumed By Path [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module: nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "s,s,",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "nginx.ingress_controller.upstream.response.time",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[200 TO 299]"
+                    },
+                    "id": "7c343c20-a29e-11e7-a062-a1c3587f4874",
+                    "label": "200s"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "url.original",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ingress Controller Upstream Time Consumed By Path [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "a3bf1ce0-f347-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:26:00.366Z",
+      "version": "WzI0NjMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ingress Controller Request Volume By Path [Filebeat Nginx]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "heartbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module: nginx AND fileset.name:ingress_controller"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "isModelInvalid": false,
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "nginx.ingress_controller.upstream.response.length",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum",
+                    "values": [
+                      "0.5",
+                      "0.95",
+                      "0.99"
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "lucene",
+                      "query": "http.response.status_code:[200 TO 299]"
+                    },
+                    "id": "7c343c20-a29e-11e7-a062-a1c3587f4874",
+                    "label": "200s"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_exclude": "",
+                "terms_field": "url.original",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ingress Controller request Volume By Path [Filebeat Nginx]",
+          "type": "metrics"
+        }
+      },
+      "id": "afd506b0-f348-11ea-a3fd-1b45ec532bb3",
+      "migrationVersion": {
+        "visualization": "7.8.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2020-09-10T09:33:30.139Z",
+      "version": "WzI0OTMsMV0="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "url.original",
+          "http.request.method",
+          "http.response.status_code",
+          "http.request.referrer",
+          "http.response.body.bytes"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlight": {
+              "fields": {
+                "*": {}
+              },
+              "fragment_size": 2147483647,
+              "post_tags": [
+                "@/kibana-highlighted-field@"
+              ],
+              "pre_tags": [
+                "@kibana-highlighted-field@"
+              ],
+              "require_field_match": false
+            },
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "event.module:nginx"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          [
+            "@timestamp",
+            "desc"
+          ]
+        ],
+        "title": "Nginx logs [Filebeat Nginx] ECS",
+        "version": 1
+      },
+      "id": "Filebeat-Nginx-module-ecs",
+      "migrationVersion": {
+        "search": "7.4.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2020-09-10T08:33:36.686Z",
+      "version": "WzIxNzUsMV0="
+    }
+  ],
+  "version": "7.8.0"
+}


### PR DESCRIPTION
Cherry-pick of PR #21052 to 7.x branch. Original message: 

## What does this PR do?
This PR adds 2 Dashboards based ingress nginx controller fileset (implemented with https://github.com/elastic/beats/pull/16197).

Most of the fields of `ingress_controller` are the same with `access` fileset of `nginx` module. In this most of the visualisations of these new dashboards are just copied from pre existing ones and modified accordingly while others are re-used. There are also some completely new ones. More spcifically:

1. Operating systems breakdown [Filebeat Nginx] ECS, Browsers breakdown [Filebeat Nginx] ECS, Access Map [Filebeat Nginx] ECS. -> reused
2. Top Upstreams [Filebeat Nginx Ingress Controller], Upstream Time Consumed By Path [Filebeat Nginx Ingress Controller], Request Volume By Path [Filebeat Nginx Ingress Controller] -> completely new inspired by some of https://github.com/kubernetes/ingress-nginx/tree/master/deploy/grafana/dashboards#2-request-handling-performance
3. all others are duplicates with modified `fileset.name`

## Why is it important?
To provide out of the box Dashboards for ingress controller service monitoring.


## How to test this PR locally
1. Setup ingress controller on minikube following https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/
2. Redirect pods' logs to a temporary file: `kubectl -n kube-system logs -f nginx-ingress-controller-6fc5bcc8c9-zm8zv >> /tmp/ingresspod`
3.
```
- module: nginx
  # Ingress-nginx controller logs. This is disabled by default. It could be used in Kubernetes environments to parse ingress-nginx logs
  ingress_controller:
    enabled: true

    # Set custom paths for the log files. If left empty,
    # Filebeat will choose the paths depending on your OS.
    var.paths: ["/tmp/ingresspod"]
```
4. Setup pipelines and dashboards in ES
5. Start Filebeat
6. Produce traffic:
```
1. visit `http://hello-world.info/v2` and `http://hello-world.info` from different browser engines
2. use curl and wget to access the pages with different http words ie: curl -d "param1=value1&param2=value2" -X GET hello-world.info 
```

## Related issues

- Relates https://github.com/elastic/beats/issues/20897


## Screenshots

![Screenshot 2020-09-10 at 13 54 28](https://user-images.githubusercontent.com/11754898/92720385-3090c400-f36d-11ea-9eca-b574410c3ed5.png)
![Screenshot 2020-09-10 at 13 52 59](https://user-images.githubusercontent.com/11754898/92720402-3686a500-f36d-11ea-97fa-47d1c9a0e524.png)

