### PR TITLE
Cherry-pick #21048 to 7.9: Filebeat: Fix random error on harvester close

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed `cloudfoundry.access` to have the correct `cloudfoundry.app.id` contents. {pull}17847[17847]
 - Fixing `ingress_controller.` fields to be of type keyword instead of text. {issue}17834[17834]
 - Fixed typo in log message. {pull}17897[17897]
+- Fix an error updating file size being logged when EOF is reached. {pull}21048[21048]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #21048 to 7.9 branch. Original message: 

This fixes a race condition when a harvester is closed at the same time that its source file size is being calculated.

## Why is it important?

Random `Error updating file size` errors have been reported. Other than that it looks like the bug has no other effect.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Make sure the new synchronization is safe

## How to test this PR locally

It's easy to trigger this error by removing the Ticker in `monitorFileSize` and busy loop calling `h.updateCurrentSize()`, with a configuration that uses `close_eof` and many files.

## Logs

> Error updating file size: GetFileInformationByHandleEx [...path...]: The handle is invalid.; File: [...path...]