### PR TITLE
[Experiment]: metricbeat with v2 inputs

### DIFF
--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -38,10 +38,9 @@ import (
 // Name of this beat
 var Name = "metricbeat"
 
-// RootCmd to handle beats cli
-var RootCmd *cmd.BeatsRootCmd
-
-func init() {
+// RootCmd creates the to handle beats cli
+func RootCmd(opts ...beater.Option) *cmd.BeatsRootCmd {
+	var RootCmd *cmd.BeatsRootCmd
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
 	settings := instance.Settings{
@@ -49,7 +48,8 @@ func init() {
 		Name:          Name,
 		HasDashboards: true,
 	}
-	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), settings)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(opts...), settings)
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", BuildModulesManager))
 	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
+	return RootCmd
 }

--- a/metricbeat/main.go
+++ b/metricbeat/main.go
@@ -27,11 +27,31 @@ package main
 import (
 	"os"
 
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
+	"github.com/elastic/beats/v7/metricbeat/module/systemtest"
 )
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
+	rootCmd := cmd.RootCmd(beater.WithV2Inputs(v2Inputs))
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func v2Inputs(info beat.Info, log *logp.Logger) []v2.Plugin {
+	flatten := func(lists ...[]v2.Plugin) []v2.Plugin {
+		var inputs []v2.Plugin
+		for _, l := range lists {
+			inputs = append(inputs, l...)
+		}
+		return inputs
+	}
+
+	return flatten(
+		systemtest.Inputs(),
+	)
 }

--- a/metricbeat/mb/adapter/mba/input.go
+++ b/metricbeat/mb/adapter/mba/input.go
@@ -1,0 +1,146 @@
+package mba
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/elastic/go-concert/ctxtool"
+	"github.com/elastic/go-concert/timed"
+	"github.com/elastic/go-concert/unison"
+	"github.com/urso/sderr"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+)
+
+type metricsetInput struct {
+	inputName     string
+	moduleName    string
+	metricsetName string
+	namespace     string
+	tasks         []mb.MetricSet
+	modifiers     []mb.EventModifier
+}
+
+func (m *metricsetInput) Name() string { return m.inputName }
+
+func (m *metricsetInput) Test(_ v2.TestContext) error {
+	// metricsets do not support active testing
+	return nil
+}
+
+func (m *metricsetInput) Run(ctx v2.Context, pipeline beat.PipelineConnector) error {
+	var grp unison.MultiErrGroup
+	for _, task := range m.tasks {
+		task := task
+		grp.Go(func() error {
+			inpCtx := ctx
+			inpCtx.ID = task.ID()
+			inpCtx.Logger = ctx.Logger.With("task", task.ID())
+
+			return m.runTask(inpCtx, task, pipeline)
+		})
+	}
+
+	if errs := grp.Wait(); len(errs) > 0 {
+		return sderr.WrapAll(errs, "input %{id} failed", ctx.ID)
+	}
+	return nil
+}
+
+func (m *metricsetInput) runTask(ctx v2.Context, ms mb.MetricSet, pipeline beat.Pipeline) error {
+	client, err := pipeline.Connect()
+	if err != nil {
+		return err
+	}
+
+	// setup internal metrics collection
+	metricsPath := ms.ID()
+	stats := getMetricSetStats(m.inputName)
+	defer releaseStats(stats)
+	registry := monitoring.GetNamespace("dataset").GetRegistry()
+	defer registry.Remove(metricsPath)
+	registry.Add(metricsPath, ms.Metrics(), monitoring.Full)
+	monitoring.NewString(ms.Metrics(), "starttime").Set(common.Time(time.Now()).String())
+
+	// event event finalization and publishing
+	reporter := &eventReporter{
+		cancel: ctx.Cancelation,
+		client: client,
+		stats:  stats,
+		eventTransformer: eventTransformer{
+			inputName: m.inputName,
+			namespace: m.namespace,
+			metricset: ms,
+			modifiers: m.modifiers,
+		},
+	}
+
+	// run the metricset fetch and publish loop
+	switch ms := ms.(type) {
+	case mb.PushMetricSet:
+		ms.Run(reporter.V1())
+	case mb.PushMetricSetV2:
+		ms.Run(reporter.V2())
+	case mb.PushMetricSetV2WithContext:
+		ms.Run(ctxtool.FromCanceller(ctx.Cancelation), reporter.V2())
+	case mb.EventFetcher, mb.EventsFetcher,
+		mb.ReportingMetricSet, mb.ReportingMetricSetV2,
+		mb.ReportingMetricSetV2Error, mb.ReportingMetricSetV2WithContext:
+		{
+			reporter.eventTransformer.periodic = true
+			stopCtx := ctxtool.FromCanceller(ctx.Cancelation)
+			reporter.StartFetchTimer()
+			m.fetchAndReport(stopCtx, ms, reporter)
+			timed.Periodic(stopCtx, ms.Module().Config().Period, func() error {
+				reporter.StartFetchTimer()
+				m.fetchAndReport(stopCtx, ms, reporter)
+				return nil
+			})
+		}
+	default:
+		// Earlier startup stages prevent this from happening.
+		logp.Err("MetricSet '%s' does not implement an event producing interface", m.inputName)
+	}
+	return nil
+}
+
+func (m *metricsetInput) fetchAndReport(ctx context.Context, ms mb.MetricSet, reporter reporter) {
+	switch fetcher := ms.(type) {
+	case mb.EventFetcher:
+		event, err := fetcher.Fetch()
+		reporter.V1().ErrorWith(err, event)
+	case mb.EventsFetcher:
+		events, err := fetcher.Fetch()
+		if len(events) == 0 {
+			reporter.V1().ErrorWith(err, nil)
+		} else {
+			for _, event := range events {
+				reporter.V1().ErrorWith(err, event)
+			}
+		}
+	case mb.ReportingMetricSet:
+		fetcher.Fetch(reporter.V1())
+	case mb.ReportingMetricSetV2:
+		fetcher.Fetch(reporter.V2())
+	case mb.ReportingMetricSetV2Error:
+		err := fetcher.Fetch(reporter.V2())
+		if err != nil {
+			reporter.V2().Error(err)
+			logp.Info("Error fetching data for metricset %s: %s", m.inputName, err)
+		}
+	case mb.ReportingMetricSetV2WithContext:
+		err := fetcher.Fetch(ctx, reporter.V2())
+		if err != nil {
+			reporter.V2().Error(err)
+			logp.Info("Error fetching data for metricset %s: %s", m.inputName, err)
+		}
+	default:
+		panic(fmt.Sprintf("unexpected fetcher type for %v", ms))
+	}
+}

--- a/metricbeat/mb/adapter/mba/manager.go
+++ b/metricbeat/mb/adapter/mba/manager.go
@@ -1,0 +1,119 @@
+package mba
+
+import (
+	"fmt"
+
+	"github.com/elastic/go-concert/unison"
+	"github.com/gofrs/uuid"
+	"github.com/urso/sderr"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+)
+
+// ModuleManager interfaces that can provide a metricset with a custom
+// mb.Module at initialization time. Normally one want to use ModuleAdapter, in order to wrap
+// an existing Module, or create a ModuleManager with dedicated Module implementation.
+type ModuleManager interface {
+	ModuleName() string
+	Create(base mb.BaseModule) (mb.Module, error)
+	EventModifiers() []mb.EventModifier
+}
+
+// MetricsetManager provides the v2.InputManager that will provide a Metricset as an v2.Input.
+type MetricsetManager struct {
+	MetricsetName string
+	InputName     string
+	ModuleManager ModuleManager
+
+	Factory mb.MetricSetFactory
+
+	HostParser mb.HostParser
+	Namespace  string
+}
+
+// WithHostParser creates a new MetricsetManager using the new host parser.
+func (m MetricsetManager) WithHostParser(p mb.HostParser) MetricsetManager {
+	m.HostParser = p
+	return m
+}
+
+// WithNamespace creates a new MetricsetManager using the new namespace.
+func (m MetricsetManager) WithNamespace(n string) MetricsetManager {
+	m.Namespace = n
+	return m
+}
+
+func (m *MetricsetManager) Init(grp unison.Group, mode v2.Mode) error { return nil }
+
+// Create builds a new Input instance from the given configuation, or returns
+// an error if the configuation is invalid.
+// The input must establish any connection for data collection yet. The Beat
+// will use the Test/Run methods of the input.
+func (m *MetricsetManager) Create(cfg *common.Config) (v2.Input, error) {
+	var errs []error
+
+	cfg.SetString("module", -1, m.ModuleManager.ModuleName())
+	cfg.SetString("metricset", 0, m.MetricsetName)
+
+	baseModule, err := mb.NewBaseModuleFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	module, err := m.ModuleManager.Create(baseModule)
+	if err != nil {
+		return nil, err
+	}
+
+	hosts := []string{""}
+	if l := module.Config().Hosts; len(l) > 0 {
+		hosts = l
+	}
+
+	var metricsets []mb.MetricSet
+	for _, host := range hosts {
+		id, err := uuid.NewV4()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate ID for metricset: %w", err)
+		}
+
+		ms, err := m.createMetricSet(module, id.String(), host)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		metricsets = append(metricsets, ms)
+	}
+
+	// XXX: do we want to error the configure step, or log the error and continue with the subset of ok metricsets?
+	return &metricsetInput{
+		inputName:     m.InputName,
+		moduleName:    m.ModuleManager.ModuleName(),
+		metricsetName: m.MetricsetName,
+		namespace:     m.Namespace,
+		tasks:         metricsets,
+		modifiers:     m.ModuleManager.EventModifiers(),
+	}, sderr.WrapAll(errs, "Failed to fully initialize the input")
+}
+
+func (m *MetricsetManager) createMetricSet(module mb.Module, id, host string) (mb.MetricSet, error) {
+	hd, host, err := m.parseHost(module, host)
+	if err != nil {
+		return nil, err
+	}
+
+	bm := mb.NewBaseMetricSet(module, id, m.MetricsetName, host, hd)
+	return m.Factory(bm)
+}
+
+func (m *MetricsetManager) parseHost(module mb.Module, host string) (mb.HostData, string, error) {
+	if m.HostParser == nil {
+		return mb.HostData{URI: host}, host, nil
+	}
+
+	hd, err := m.HostParser(module, host)
+	return hd, hd.Host, err
+}

--- a/metricbeat/mb/adapter/mba/mba.go
+++ b/metricbeat/mb/adapter/mba/mba.go
@@ -1,0 +1,63 @@
+// Package mba provides adapters for using metricbeat modules and metricsets as v2 inputs.
+//
+// The metricsets provided by these wrappers are mostly independent of the
+// Metricbeat core framework. No globals or shared state in the metricbeat core
+// will be read or written. Each MeticsetManager will be fully independent.
+//
+// The MetricsetManager is used to wrap a Metricbeat module and its Metricsets.
+//
+// In Metricbeat a module implementation is optional. The module
+// implementations purpose is to provide additional functionality (parsing,
+// query, cache data, coordination/sharing) for its metricsets. A module
+// instance will be shared between all metricsets.
+// Independent if a Module is implemnted or not, an mb.Module instance will be
+// passed to the metricset.
+//
+// The adapters provided in this package provide similar functionality to metricbeat. The sharing
+// of Modules with metricsets requires authors to create a common ModuleAdapter, that will be shared between
+// add metricset input adapters.
+//
+// Note: The ModuleAdapter should also be used for metricsets that do not require a shared module.
+//
+//
+// Example system module:
+//
+// ```
+//
+// func systemMetricsPlugins() []v2.Plugin {
+//	// Create shared module adapter. The Factory is optional. The adapter
+//	// provides helpers to create inputs from metricsets.
+//	systemModule := &mba.ModuleAdapter{Name: "system", Factory: system.NewModule}
+//
+//
+//	// Create list of inputs from metricset implementations:
+//	return []v2.Plugin{
+//			systemModule.MetricsetInput("system.cpu", "cpu", cpu.New),
+//			...
+//	}
+// }
+//
+// ```
+//
+// Metricbeat allows developers to pass additional options when registering with the mb.Registry.
+// The optionas can provide simple meta-data, some form of config validation, or additional hooks to modify some of
+// the default behavior (e.g. HostParser). The MetricsetManager returned by
+// (*ModuleAdapter).MetricsetInput can be modified directly, or using one of its WithX methods.
+package mba
+
+//go:generate godocdown -plain=false -output Readme.md
+
+import (
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/feature"
+)
+
+// Plugin create a v2.Plugin for a MetricsetManager.
+func Plugin(stability feature.Stability, deprecated bool, mm MetricsetManager) v2.Plugin {
+	return v2.Plugin{
+		Name:       mm.InputName,
+		Stability:  stability,
+		Deprecated: deprecated,
+		Manager:    &mm,
+	}
+}

--- a/metricbeat/mb/adapter/mba/module.go
+++ b/metricbeat/mb/adapter/mba/module.go
@@ -1,0 +1,27 @@
+package mba
+
+import "github.com/elastic/beats/v7/metricbeat/mb"
+
+type ModuleAdapter struct {
+	Name      string
+	Factory   mb.ModuleFactory
+	Modifiers []mb.EventModifier
+}
+
+func (ma *ModuleAdapter) ModuleName() string                 { return ma.Name }
+func (ma *ModuleAdapter) EventModifiers() []mb.EventModifier { return ma.Modifiers }
+func (ma *ModuleAdapter) Create(base mb.BaseModule) (mb.Module, error) {
+	if ma.Factory != nil {
+		return ma.Factory(base)
+	}
+	return mb.DefaultModuleFactory(base)
+}
+
+func (ma *ModuleAdapter) MetricsetInput(inputName string, metricsetName string, factory mb.MetricSetFactory) MetricsetManager {
+	return MetricsetManager{
+		InputName:     inputName,
+		MetricsetName: metricsetName,
+		ModuleManager: ma,
+		Factory:       factory,
+	}
+}

--- a/metricbeat/mb/adapter/mba/process.go
+++ b/metricbeat/mb/adapter/mba/process.go
@@ -1,0 +1,1 @@
+package mba

--- a/metricbeat/mb/adapter/mba/reporter.go
+++ b/metricbeat/mb/adapter/mba/reporter.go
@@ -1,0 +1,169 @@
+package mba
+
+import (
+	"time"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+)
+
+type reporter interface {
+	V1() mb.PushReporter
+	V2() mb.PushReporterV2
+}
+
+type eventReporter struct {
+	eventTransformer eventTransformer
+	client           beat.Client
+	cancel           v2.Canceler
+	stats            *stats
+}
+
+type eventTransformer struct {
+	inputName string
+	namespace string
+	metricset mb.MetricSet
+	modifiers []mb.EventModifier
+	start     time.Time //TODO
+	periodic  bool
+}
+
+func (r *eventReporter) StartFetchTimer()      { r.eventTransformer.start = time.Now() }
+func (r *eventReporter) V1() mb.PushReporter   { return (*reporterV1)(r) }
+func (r *eventReporter) V2() mb.PushReporterV2 { return (*reporterV2)(r) }
+
+type reporterV1 eventReporter
+
+func (r *reporterV1) access() *eventReporter         { return (*eventReporter)(r) }
+func (r *reporterV1) V2() *reporterV2                { return (*reporterV2)(r) }
+func (r *reporterV1) Done() <-chan struct{}          { return r.access().cancel.Done() }
+func (r *reporterV1) Event(event common.MapStr) bool { return r.ErrorWith(nil, event) }
+func (r *reporterV1) Error(err error) bool           { return r.ErrorWith(err, nil) }
+func (r *reporterV1) ErrorWith(err error, meta common.MapStr) bool {
+	if err == nil && meta == nil {
+		return true
+	}
+	return r.V2().Event(fromMapStr(r.access().eventTransformer.inputName, meta, err))
+}
+
+type reporterV2 eventReporter
+
+func (r *reporterV2) access() *eventReporter { return (*eventReporter)(r) }
+func (r *reporterV2) Error(err error) bool   { return r.Event(mb.Event{Error: err}) }
+func (r *reporterV2) Done() <-chan struct{}  { return r.access().cancel.Done() }
+func (r *reporterV2) Event(event mb.Event) bool {
+	er := r.access()
+
+	if event.Error == nil {
+		r.stats.success.Add(1)
+	} else {
+		r.stats.failures.Add(1)
+	}
+
+	beatEvent := er.eventTransformer.BuildBeatsEvent(&event)
+	if !sendEvent(r.cancel, r.client, beatEvent) {
+		return false
+	}
+	er.stats.events.Add(1)
+
+	return true
+}
+
+func sendEvent(cancel v2.Canceler, client beat.Client, event beat.Event) bool {
+	if cancel.Err() != nil {
+		return false
+	}
+
+	client.Publish(event)
+	return cancel.Err() == nil
+}
+
+func (et *eventTransformer) BuildBeatsEvent(e *mb.Event) beat.Event {
+	return et.finalizeEvent(e).BeatEvent(
+		et.metricset.Module().Name(),
+		et.metricset.Name(),
+		et.modifiers...,
+	)
+}
+
+// finalizeEvent adds missing fields that are not required by modules to be set
+// and fixes some mappings.
+func (et *eventTransformer) finalizeEvent(e *mb.Event) *mb.Event {
+	if e.Took == 0 && !et.start.IsZero() {
+		e.Took = time.Since(et.start)
+	}
+	if et.periodic {
+		e.Period = et.metricset.Module().Config().Period
+	}
+
+	if e.Timestamp.IsZero() {
+		if !et.start.IsZero() {
+			e.Timestamp = et.start
+		} else {
+			e.Timestamp = time.Now().UTC()
+		}
+	}
+
+	if e.Host == "" {
+		e.Host = et.metricset.Host()
+	}
+
+	if e.Namespace == "" {
+		e.Namespace = et.namespace
+	}
+
+	return e
+}
+
+// fromMapStr transforms a common.MapStr produced by MetricSet
+// (like any MetricSet that does not natively produce a mb.Event). It accounts
+// for the special key names and routes the data stored under those keys to the
+// correct location in the event.
+//
+// XXX: this function is a modified copy of mb.TransformMapStrToEvent
+func fromMapStr(module string, m common.MapStr, err error) mb.Event {
+	var (
+		event = mb.Event{RootFields: common.MapStr{}, Error: err}
+	)
+
+	for k, v := range m {
+		switch k {
+		case mb.TimestampKey:
+			switch ts := v.(type) {
+			case time.Time:
+				delete(m, mb.TimestampKey)
+				event.Timestamp = ts
+			case common.Time:
+				delete(m, mb.TimestampKey)
+				event.Timestamp = time.Time(ts)
+			}
+		case mb.ModuleDataKey:
+			delete(m, mb.ModuleDataKey)
+			event.ModuleFields, _ = tryToMapStr(v)
+		case mb.RTTKey:
+			delete(m, mb.RTTKey)
+			if took, ok := v.(time.Duration); ok {
+				event.Took = took
+			}
+		case mb.NamespaceKey:
+			delete(m, mb.NamespaceKey)
+			event.Namespace = module
+		}
+	}
+
+	event.MetricSetFields = m
+	return event
+}
+
+func tryToMapStr(v interface{}) (common.MapStr, bool) {
+	switch m := v.(type) {
+	case common.MapStr:
+		return m, true
+	case map[string]interface{}:
+		return common.MapStr(m), true
+	default:
+		return nil, false
+	}
+}

--- a/metricbeat/mb/adapter/mba/stats.go
+++ b/metricbeat/mb/adapter/mba/stats.go
@@ -1,0 +1,67 @@
+package mba
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+// stats bundles common metricset stats.
+type stats struct {
+	key      string          // full stats key
+	ref      uint32          // number of modules/metricsets reusing stats instance
+	success  *monitoring.Int // Total success events.
+	failures *monitoring.Int // Total error events.
+	events   *monitoring.Int // Total events published.
+}
+
+var (
+	fetchesLock = sync.Mutex{}
+	fetches     = map[string]*stats{}
+)
+
+// Expvar metric names.
+const (
+	successesKey = "success"
+	failuresKey  = "failures"
+	eventsKey    = "events"
+)
+
+func getMetricSetStats(key string) *stats {
+	fetchesLock.Lock()
+	defer fetchesLock.Unlock()
+
+	// XXX: need to adapt the name here, because metricbeat maintains the names
+	// globally, which can lead to panics in case we have duplicates.
+	key = "ng_" + key
+
+	if s := fetches[key]; s != nil {
+		s.ref++
+		return s
+	}
+
+	reg := monitoring.Default.NewRegistry(key)
+	s := &stats{
+		key:      key,
+		ref:      1,
+		success:  monitoring.NewInt(reg, successesKey),
+		failures: monitoring.NewInt(reg, failuresKey),
+		events:   monitoring.NewInt(reg, eventsKey),
+	}
+
+	fetches[key] = s
+	return s
+}
+
+func releaseStats(s *stats) {
+	fetchesLock.Lock()
+	defer fetchesLock.Unlock()
+
+	s.ref--
+	if s.ref > 0 {
+		return
+	}
+
+	delete(fetches, s.key)
+	monitoring.Default.Remove(s.key)
+}

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -52,7 +52,7 @@ func NewModule(config *common.Config, r *Register) (Module, []MetricSet, error) 
 		return nil, nil, ErrModuleDisabled
 	}
 
-	bm, err := newBaseModuleFromConfig(config)
+	bm, err := NewBaseModuleFromConfig(config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,9 +70,9 @@ func NewModule(config *common.Config, r *Register) (Module, []MetricSet, error) 
 	return module, metricsets, nil
 }
 
-// newBaseModuleFromConfig creates a new BaseModule from config. The returned
+// NewBaseModuleFromConfig creates a new BaseModule from config. The returned
 // BaseModule's name will always be lower case.
-func newBaseModuleFromConfig(rawConfig *common.Config) (BaseModule, error) {
+func NewBaseModuleFromConfig(rawConfig *common.Config) (BaseModule, error) {
 	baseModule := BaseModule{
 		config:    DefaultModuleConfig(),
 		rawConfig: rawConfig,
@@ -174,32 +174,37 @@ func newBaseMetricSets(r *Register, m Module) ([]BaseMetricSet, error) {
 
 	var metricsets []BaseMetricSet
 	for _, name := range metricSetNames {
-		name = strings.ToLower(name)
 		for _, host := range hosts {
 			id, err := uuid.NewV4()
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to generate ID for metricset")
 			}
-			msID := id.String()
-			metrics := monitoring.NewRegistry()
-			monitoring.NewString(metrics, "module").Set(m.Name())
-			monitoring.NewString(metrics, "metricset").Set(name)
-			if host != "" {
-				monitoring.NewString(metrics, "host").Set(host)
-			}
-			monitoring.NewString(metrics, "id").Set(msID)
-
-			metricsets = append(metricsets, BaseMetricSet{
-				id:      msID,
-				name:    name,
-				module:  m,
-				host:    host,
-				metrics: metrics,
-				logger:  logp.NewLogger(m.Name() + "." + name),
-			})
+			metricsets = append(metricsets, NewBaseMetricSet(m, id.String(), name, host, HostData{URI: host}))
 		}
 	}
 	return metricsets, nil
+}
+
+func NewBaseMetricSet(module Module, id, name, host string, hostData HostData) BaseMetricSet {
+	name = strings.ToLower(name)
+
+	metrics := monitoring.NewRegistry()
+	monitoring.NewString(metrics, "module").Set(module.Name())
+	monitoring.NewString(metrics, "metricset").Set(name)
+	if host != "" {
+		monitoring.NewString(metrics, "host").Set(host)
+	}
+	monitoring.NewString(metrics, "id").Set(id)
+
+	return BaseMetricSet{
+		id:       id,
+		name:     name,
+		module:   module,
+		host:     host,
+		hostData: hostData,
+		metrics:  metrics,
+		logger:   logp.NewLogger(module.Name() + "." + name),
+	}
 }
 
 // mustHaveModule returns an error if the given MetricSet's Module() method

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -114,7 +114,7 @@ func (m *LightMetricSet) baseModule(from Module) (*BaseModule, error) {
 	}
 
 	// Create the base module
-	baseModule, err := newBaseModuleFromConfig(rawConfig)
+	baseModule, err := NewBaseModuleFromConfig(rawConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create base module")
 	}

--- a/metricbeat/mb/lightmetricset_test.go
+++ b/metricbeat/mb/lightmetricset_test.go
@@ -127,7 +127,7 @@ func baseModule(t *testing.T, r *Register, module, metricSet string) BaseMetricS
 	c.Query = QueryParams{"default": "foo"}
 	raw, err := common.NewConfigFrom(c)
 	require.NoError(t, err)
-	baseModule, err := newBaseModuleFromConfig(raw)
+	baseModule, err := NewBaseModuleFromConfig(raw)
 	require.NoError(t, err)
 
 	bm := BaseMetricSet{

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -337,7 +337,7 @@ func TestNewBaseModuleFromModuleConfigStruct(t *testing.T) {
 
 	c := newConfig(t, moduleConf)
 
-	baseModule, err := newBaseModuleFromConfig(c)
+	baseModule, err := NewBaseModuleFromConfig(c)
 	assert.NoError(t, err)
 
 	assert.Equal(t, moduleName, baseModule.Name())

--- a/metricbeat/module/systemtest/systemtest.go
+++ b/metricbeat/module/systemtest/systemtest.go
@@ -1,0 +1,95 @@
+package systemtest
+
+import (
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/feature"
+
+	"github.com/elastic/beats/v7/metricbeat/mb/adapter/mba"
+	"github.com/elastic/beats/v7/metricbeat/module/system"
+	"github.com/elastic/beats/v7/metricbeat/module/system/core"
+	"github.com/elastic/beats/v7/metricbeat/module/system/cpu"
+	"github.com/elastic/beats/v7/metricbeat/module/system/diskio"
+	"github.com/elastic/beats/v7/metricbeat/module/system/entropy"
+	"github.com/elastic/beats/v7/metricbeat/module/system/filesystem"
+	"github.com/elastic/beats/v7/metricbeat/module/system/fsstat"
+	"github.com/elastic/beats/v7/metricbeat/module/system/load"
+	"github.com/elastic/beats/v7/metricbeat/module/system/memory"
+	"github.com/elastic/beats/v7/metricbeat/module/system/network"
+	"github.com/elastic/beats/v7/metricbeat/module/system/network_summary"
+	"github.com/elastic/beats/v7/metricbeat/module/system/process"
+	"github.com/elastic/beats/v7/metricbeat/module/system/process_summary"
+	"github.com/elastic/beats/v7/metricbeat/module/system/raid"
+	"github.com/elastic/beats/v7/metricbeat/module/system/service"
+	"github.com/elastic/beats/v7/metricbeat/module/system/socket"
+	"github.com/elastic/beats/v7/metricbeat/module/system/socket_summary"
+	"github.com/elastic/beats/v7/metricbeat/module/system/uptime"
+	"github.com/elastic/beats/v7/metricbeat/module/system/users"
+)
+
+func Inputs() []v2.Plugin {
+	// The system module registers a global CLI flag. The flag will not be
+	// populated, so we have to workaround the initialization by replacing HostFS
+	// pointer.
+	// TODO: better allow HostFS to be configured using settings
+	// system.HostFS = &hostFS
+
+	systemModule := &mba.ModuleAdapter{Name: "system-ng", Factory: system.NewModule}
+	return []v2.Plugin{
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.cpu", "cpu", cpu.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.core", "core", core.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.diskio", "diskio", diskio.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.entropy", "entropy", entropy.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.filesystem", "filesystem", filesystem.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.fsstat", "fsstat", fsstat.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.load", "load", load.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.memory", "memory", memory.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.network", "network", network.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.network_summary", "network_summary", network_summary.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.process", "process", process.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.process_summary", "process_summary", process_summary.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.raid", "raid", raid.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.service", "service", service.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.socket", "socket", socket.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.
+				MetricsetInput("system.socket_summary", "socket_summary", socket_summary.New).
+				WithNamespace("system.socket.summary"),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.uptime", "uptime", uptime.New),
+		),
+		mba.Plugin(feature.Stable, false,
+			systemModule.MetricsetInput("system.users", "users", users.New),
+		),
+	}
+}

--- a/metricbeat/module/systemtest/systemtest.go
+++ b/metricbeat/module/systemtest/systemtest.go
@@ -33,7 +33,7 @@ func Inputs() []v2.Plugin {
 	// TODO: better allow HostFS to be configured using settings
 	// system.HostFS = &hostFS
 
-	systemModule := &mba.ModuleAdapter{Name: "system-ng", Factory: system.NewModule}
+	systemModule := &mba.ModuleAdapter{Name: "system", Factory: system.NewModule}
 	return []v2.Plugin{
 		mba.Plugin(feature.Stable, false,
 			systemModule.MetricsetInput("system.cpu", "cpu", cpu.New),


### PR DESCRIPTION
Experiment adding support for running/implementing data collectors based on the filebeat v2 inputs in metricbeat.

Limitations:
- Lightweight modules are backed into the mb module, but are not driven from RunnerFactory directly => Inputs/Modules based on the v2 input are not available to lightweight modules
- Metricbeat adds many fields in many places. The adapters for wrapping metricsets into the v2 API try to mimic the core metricbeat framework. Custom inputs not making use of the adapter might miss important fields.
- No statestore to store state between restarts as is available in filebeat (shouldn't be difficult to add).

The new runner factory (used for static configs, config reloading, and autodiscovery) first checks if the module exists in the static global metricbeat registry. If the module name is known to metricbeat, we follow the old code paths. If not, we check the list of v2 inputs, and fail if there is no known module at all.

In order to configure an input, one needs to configure a module. For example I turned each system metricset into an input in `systemtest.go`. The input names are `system.cpu`, `system.core`, `system.X`. The naming can be fully custom, but I did follow the original module+metricset naming, to make it more obvious where an input comes from.

Sample configuration:

```
metricbeat.modules:
- module: system.cpu
- module: system.process_summary
- module: system.fsstat

output.console:
  pretty: true
```

The `metricbeat/adapter/mba` package provides adapters for using modules or individual existing metricsets as v2 inputs. Inputs created this way are fully independent and self-contained. Metricbeat allows modules/metricsets to configure behavior globally (e.g. host parser) with the registry. When using the adapter all the functionality should be local to the input definition.

Note: The adapters are for reusing existing metricsets in the context of Fleet only (hidden/private inputs). In case we want to use the v2 input API for new inputs in metricbeat, we should not use metricsets/modules as is, but we are free to mix metricsets and existing modules with new inputs if there is need.

Note: The collector POC implements all inputs based on the v2 input API, and provides adapters for wrapping existing legacy inputs/modules/monitors into the v2 input API. The for this POC was copied directly from the collector. All inputs/modules based on this API will be reusable in the collector POC without (major) modifications.

Note: Inputs do not have metricsets. We just define a flat list of modules/inputs. Each metricset becomes and independent 'module' in the configuration file (although sharing functionality between multiple metricsets/modules still exists). This makes these definitions less user friendly in case inputs are configured right in the metricbeat configuration. Using Fleet/Agent, we have similar behavior as is implemented here> each stream in Fleet/Agent becomes one module with exactly one metricset.