### PR TITLE
Cherry-pick #20993 to 7.9: Add support for GMT timezone offset in decode_cef

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - Fix parsing of Elasticsearch node name by `elasticsearch/slowlog` fileset. {pull}14547[14547]
+- Add support for GMT timezone offsets in `decode_cef`. {pull}20993[20993]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/processors/decode_cef/cef/types.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types.go
@@ -105,6 +105,7 @@ var timeLayouts = []string{
 	"Jan _2 15:04:05.000 MST",
 	"Jan _2 15:04:05.000 Z0700",
 	"Jan _2 15:04:05.000 Z07:00",
+	"Jan _2 15:04:05.000 GMT-07:00",
 
 	// MMM dd HH:mm:sss.SSS
 	"Jan _2 15:04:05.000",
@@ -113,6 +114,7 @@ var timeLayouts = []string{
 	"Jan _2 15:04:05 MST",
 	"Jan _2 15:04:05 Z0700",
 	"Jan _2 15:04:05 Z07:00",
+	"Jan _2 15:04:05 GMT-07:00",
 
 	// MMM dd HH:mm:ss
 	"Jan _2 15:04:05",
@@ -121,6 +123,7 @@ var timeLayouts = []string{
 	"Jan _2 2006 15:04:05.000 MST",
 	"Jan _2 2006 15:04:05.000 Z0700",
 	"Jan _2 2006 15:04:05.000 Z07:00",
+	"Jan _2 2006 15:04:05.000 GMT-07:00",
 
 	// MMM dd yyyy HH:mm:ss.SSS
 	"Jan _2 2006 15:04:05.000",
@@ -129,6 +132,7 @@ var timeLayouts = []string{
 	"Jan _2 2006 15:04:05 MST",
 	"Jan _2 2006 15:04:05 Z0700",
 	"Jan _2 2006 15:04:05 Z07:00",
+	"Jan _2 2006 15:04:05 GMT-07:00",
 
 	// MMM dd yyyy HH:mm:ss
 	"Jan _2 2006 15:04:05",

--- a/x-pack/filebeat/processors/decode_cef/cef/types_test.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types_test.go
@@ -21,6 +21,7 @@ func TestToTimestamp(t *testing.T) {
 		"Jun 23 17:37:24.000 +05",
 		"Jun 23 17:37:24.000 +0500",
 		"Jun 23 17:37:24.000 +05:00",
+		"Jun 23 17:37:24.000 GMT+05:00",
 
 		// MMM dd HH:mm:sss.SSS
 		"Jun 23 17:37:24.000",
@@ -31,6 +32,7 @@ func TestToTimestamp(t *testing.T) {
 		"Jun 23 17:37:24 +05",
 		"Jun 23 17:37:24 +0500",
 		"Jun 23 17:37:24 +05:00",
+		"Jun 23 17:37:24 GMT+05:00",
 
 		// MMM dd HH:mm:ss
 		"Jun 23 17:37:24",
@@ -41,6 +43,7 @@ func TestToTimestamp(t *testing.T) {
 		"Jun 23 2020 17:37:24.000 +05",
 		"Jun 23 2020 17:37:24.000 +0500",
 		"Jun 23 2020 17:37:24.000 +05:00",
+		"Jun 23 2020 17:37:24.000 GMT+05:00",
 
 		// MMM dd yyyy HH:mm:ss.SSS
 		"Jun 23 2020 17:37:24.000",
@@ -51,6 +54,7 @@ func TestToTimestamp(t *testing.T) {
 		"Jun 23 2020 17:37:24 +05",
 		"Jun 23 2020 17:37:24 +0500",
 		"Jun 23 2020 17:37:24 +05:00",
+		"Jun 23 2020 17:37:24 GMT+05:00",
 
 		// MMM dd yyyy HH:mm:ss
 		"Jun 23 2020 17:37:24",


### PR DESCRIPTION
Cherry-pick of PR #20993 to 7.9 branch. Original message: 

## What does this PR do?

The Java SimpleDataFormat's `zzz` allows for `GMT-07:00` in timestamps
but this wasn't handled in the processor.

- https://community.microfocus.com/dcvta86296/attachments/dcvta86296/connector-documentation/1197/2/CommonEventFormatV25.pdf
- https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html#timezone

## Why is it important?

The processor should be able to parse all formats in the specification.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Related issues



- Relates elastic/beats#19346

