### PR TITLE
Do not need Google credentials before using it

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -356,6 +356,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Functionbeat*
 
 - Fix timeout option of GCP functions. {issue}16282[16282] {pull}16287[16287]
+- Do not need Google credentials if not required for the operation. {issue}17329[17329] {pull}21072[21072]
 
 ==== Added
 


### PR DESCRIPTION
## What does this PR do?

This PR moves retrieving a GCP token to a later stage of running Functionbeat. From now on tokens are only needed when the operations require it.

## Why is it important?

Previously user was required to set a proper credentials file under `GOOGLE_APPLICATION_CREDENTIALS` environment variable regardless of the operation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Make sure that `GOOGLE_APPLICATION_CREDENTIALS` is not set. Run the following command and make sure it does not return an error:

```
./functionbeat package
```

## Related issues

Closes #17329
