### PR TITLE
[docs] fix minor typos in docs

### DIFF
--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -33,13 +33,13 @@ filebeat.registry.path: registry
 -------------------------------------------------------------------------------------
 
 NOTE: The registry is only updated when new events are flushed and not on a predefined period.
-That means in case there are some states where the TTL expired, these are only removed when new event are processed.
+That means in case there are some states where the TTL expired, these are only removed when new events are processed.
 
-NOTE: The registry stores it's data in the subdirectory filebeat/data.json. It
+NOTE: The registry stores its data in the subdirectory filebeat/data.json. It
 also contains a meta data file named filebeat/meta.json. The meta file contains
 the file format version number.
 
-NOTE: The content stored in filebeat/data.json is compatible to the old registry file data format.
+NOTE: The content stored in filebeat/data.json is compatible with the old registry file data format.
 
 [float]
 ==== `registry.file_permissions`


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix a few minor typos in the "Configure Filebeat » Configure general settings" documentation.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~