### PR TITLE
Cherry-pick #20929 to 7.x: Clarify use for shared_credential_file

### DIFF
--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -38,7 +38,8 @@ given, the default profile will be used.
 `shared_credential_file` is optional to specify the directory of your shared
 credentials file. If it's empty, the default directory will be used.
 In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.
-For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please see
+For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. When running as a service, 
+the home path depends on the user that manages the service, so the `shared_credential_file` parameter can be used to avoid ambiguity. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
 


### PR DESCRIPTION
Cherry-pick of PR #20929 to 7.x branch. Original message: 

When starting Beats as a service, the Beat's PID will be owned by the user that manages the service. This would be root in most cases.

Users tend to run tests as non-root, running beats directly (./metricbeat) on the command line. Without the shared_credential_file path the beat checks for credentials under the user's home directory.

As a service, the home directory of the user managing the service (typically root) tends to be different than that of the user  in testing and development, which can be difficult to figure out.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Clarifies AWS module's credential lookup behavior and when to use shared_credential_file to avoid ambiguity.

## Why is it important?
Helps users avoid credential lookup issues, especially deviations between environments where Beats run as standalone process vs service.
