### PR TITLE
Adds a default for failure_cache.min_ttl

### DIFF
--- a/libbeat/processors/dns/config.go
+++ b/libbeat/processors/dns/config.go
@@ -29,7 +29,7 @@ import (
 
 // Config defines the configuration options for the DNS processor.
 type Config struct {
-	CacheConfig
+	CacheConfig  `config:",inline"`
 	Nameservers  []string      `config:"nameservers"`              // Required on Windows. /etc/resolv.conf is used if none are given.
 	Timeout      time.Duration `conifg:"timeout"`                  // Per request timeout (with 2 nameservers the total timeout would be 2x).
 	Type         string        `config:"type" validate:"required"` // Reverse is the only supported type currently.
@@ -89,7 +89,7 @@ type CacheSettings struct {
 	TTL time.Duration `config:"ttl"`
 
 	// Minimum TTL value for successful DNS responses.
-	MinTTL time.Duration `config:"min_ttl" validate:"min=1"`
+	MinTTL time.Duration `config:"min_ttl" validate:"min=1ns"`
 
 	// Initial capacity. How much space is allocated at initialization.
 	InitialCapacity int `config:"capacity.initial" validate:"min=0"`

--- a/libbeat/processors/dns/config.go
+++ b/libbeat/processors/dns/config.go
@@ -166,6 +166,7 @@ var defaultConfig = Config{
 			MaxCapacity:     10000,
 		},
 		FailureCache: CacheSettings{
+			MinTTL:          time.Minute,
 			TTL:             time.Minute,
 			InitialCapacity: 1000,
 			MaxCapacity:     10000,


### PR DESCRIPTION
## What does this PR do?

It adds a default value for the `failure_cache.min_ttl` setting added in #18986. The default value is the same as that for the `success_cache.min_ttl` setting.

## Why is it important?

As reported in https://discuss.elastic.co/t/fail-to-unpack-the-dns-configuration-requires-duration-1-accessing-processors-0-dns-min-ttl/248453/1, before the change in this PR, when a user configures the DNS processor minimally like so:

```
processors:
- dns:
    type: reverse
```

The following error is thrown:

```
Exiting: error initializing processors: fail to unpack the dns configuration: requires duration < 1 accessing 'processors.0.dns.min_ttl'
```

Resolves #21103.