### PR TITLE
Cherry-pick to 7.x: Update users.asciidoc (#20802)

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -81,7 +81,7 @@ endif::has_ml_jobs[]
 Omit any privileges that aren't relevant in your environment.
 +
 NOTE: These instructions assume that you are using the default name for
-{beatname_uc} indices. If you are using a custom name, modify the privileges to
+{beatname_uc} indices. If +{beat_default_index_prefix}-*+ is not listed, or you are using a custom name, enter it manually and modify the privileges to
 match your index naming pattern.
 
 . Assign the *setup role*, along with the following built-in roles, to users who


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update users.asciidoc (#20802)