### PR TITLE
Cherry-pick to 7.9: Fix broken links to external websites (#21061)

### DIFF
--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -10,8 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Zeek (Bro) Module
 
-This is a module for Zeek, which used to be called Bro. It parses logs that are in the
-https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
+This is a module for https://zeek.org/[Zeek], which used to be called Bro. It
+parses logs that are in the Zeek JSON format.
 
 include::../include/gs-link.asciidoc[]
 
@@ -21,8 +21,8 @@ include::../include/gs-link.asciidoc[]
 This module has been developed against Zeek 2.6.1, but is expected to work
 with other versions of Zeek.
 
-Zeek requires a Unix-like platform, and it currently supports Linux, FreeBSD, and Mac OS X.
-Find out how to use Zeek here: https://www.zeek.org/
+Zeek requires a Unix-like platform, and it currently supports Linux, FreeBSD,
+and Mac OS X.
 
 [float]
 === Example dashboard

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -9,8 +9,8 @@
 The open source community has been hard at work developing new Beats. You can check
 out some of them here.
 
-Have a question about a community Beat? You can post questions and discuss issues in the
-https://discuss.elastic.co/c/beats/community-beats[Community Beats] category of the Beats discussion forum.
+Have a question about developing a community Beat? You can post questions and discuss issues in the
+https://discuss.elastic.co/tags/c/elastic-stack/beats/28/beats-development[Beats discussion forum].
 
 Have you created a Beat that's not listed? Add the name and description of your Beat to the source document for
 https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc[Community Beats] and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[Beats GitHub repository] to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce] your new Beat in the Elastic
@@ -46,7 +46,7 @@ https://github.com/gamegos/etcdbeat[etcdbeat]:: Reads stats from the Etcd v2 API
 https://gitlab.com/hatricker/etherbeat[etherbeat]:: Reads blocks from Ethereum compatible blockchain and indexes them into Elasticsearch.
 https://github.com/christiangalsterer/execbeat[execbeat]:: Periodically executes shell commands and sends the standard output and standard error to
 Logstash or Elasticsearch.
-https://github.com/jarpy/factbeat[factbeat]:: Collects facts from https://puppetlabs.com/facter[Facter].
+https://github.com/jarpy/factbeat[factbeat]:: Collects facts from https://github.com/puppetlabs/facter[Facter].
 https://github.com/ctindel/fastcombeat[fastcombeat]:: Periodically gather internet download speed from  https://fast.com[fast.com].
 https://github.com/cloudronics/fileoccurancebeat[fileoccurencebeat]:: Checks for file existence recurssively under a given directory, handy while handling queues/pipeline buffers.
 https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes http://www.sflow.org/index.php[sflow] samples.

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -98,8 +98,8 @@ telnet <hostname or IP> 5044
 +
 TIP: For testing purposes only, you can set `verification_mode: none` to disable hostname checking.
 
-* Use OpenSSL to test connectivity to the {ls} server and diagnose problems. See the https://www.openssl.org/docs/manmaster/apps/s_client.html[OpenSSL documentation] for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for {ls}].
+* Use OpenSSL to test connectivity to the {ls} server and diagnose problems. See the https://www.openssl.org/docs/manmaster/man1/openssl-s_client.html[OpenSSL documentation] for more info.
+* Make sure that you have enabled SSL (set `ssl => true`) when configuring the {logstash-ref}/plugins-inputs-beats.html[Beats input plugin for {ls}].
 
 ==== Common SSL-Related Errors and Resolutions
 

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -31,7 +31,7 @@ Currently Packetbeat has several options for traffic capturing:
 
 The `af_packet` option, also known as "memory-mapped sniffing," makes use of a
 Linux-specific
-http://lxr.free-electrons.com/source/Documentation/networking/packet_mmap.txt[feature].
+https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt[feature].
 This could be the optimal sniffing mode for both the dedicated server and
 when Packetbeat is deployed on an existing application server.
 

--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -5,8 +5,8 @@
 
 == Zeek (Bro) Module
 
-This is a module for Zeek, which used to be called Bro. It parses logs that are in the
-https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
+This is a module for https://zeek.org/[Zeek], which used to be called Bro. It
+parses logs that are in the Zeek JSON format.
 
 include::../include/gs-link.asciidoc[]
 
@@ -16,8 +16,8 @@ include::../include/gs-link.asciidoc[]
 This module has been developed against Zeek 2.6.1, but is expected to work
 with other versions of Zeek.
 
-Zeek requires a Unix-like platform, and it currently supports Linux, FreeBSD, and Mac OS X.
-Find out how to use Zeek here: https://www.zeek.org/
+Zeek requires a Unix-like platform, and it currently supports Linux, FreeBSD,
+and Mac OS X.
 
 [float]
 === Example dashboard


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Fix broken links to external websites (#21061)