### PR TITLE
Cherry-pick #21037 to 7.x: Increase kibana client timeout to 5 minutes 

### DIFF
--- a/x-pack/elastic-agent/pkg/kibana/config.go
+++ b/x-pack/elastic-agent/pkg/kibana/config.go
@@ -53,7 +53,7 @@ func DefaultClientConfig() *Config {
 		SpaceID:  "",
 		Username: "",
 		Password: "",
-		Timeout:  90 * time.Second,
+		Timeout:  5 * time.Minute,
 		TLS:      nil,
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #21037 to 7.x branch. Original message:

## What does this PR do?

Increased timeout as per https://github.com/elastic/beats/issues/21025

## Why is it important?

Fixes: https://github.com/elastic/beats/issues/21025

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
