### PR TITLE
Add language about ingest management upgrade restriction in 7.8

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-command-line.asciidoc
@@ -4,6 +4,8 @@
 
 experimental[]
 
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 The `elastic-agent run` command provides flags that alter the behavior of an
 agent:
 

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration-example.asciidoc
@@ -4,6 +4,8 @@
 
 experimental[]
 
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 The following example shows a full list of configuration options:
 
 [source,yaml]

--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -4,6 +4,8 @@
 
 experimental[]
 
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 By default {agent} runs in standalone mode to ingest system data and send it to
 a local {es} instance running on port 9200. It uses the demo credentials of the
 `elastic` user. It's also configured to monitor all {beats} managed by the Agent

--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -5,6 +5,12 @@
 
 experimental[]
 
+// tag::experimental-warning[]
+**This experimental release allows you to try out new capabilities. There is no
+migration path for future releases. You must test in a dedicated cluster. Delete
+the cluster when you are done. You will not be able to upgrade the cluster.**
+// end::experimental-warning[]
+
 // tag::agent-install-intro[]
 {agent} is a single, unified agent that you can deploy to hosts or containers to
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the

--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -4,6 +4,8 @@
 
 experimental[]
 
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 Download and install the Agent on each system you want to monitor.
 
 //TODO: Replace with tabbed panel when the code is stable. 

--- a/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/run-elastic-agent.asciidoc
@@ -4,6 +4,8 @@
 
 experimental[]
 
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 {agent} runs in two modes: standalone or fleet. The two modes differ in how you
 configure and manage the Agent.
 

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -2,6 +2,10 @@
 [role="xpack"]
 = Stop {agent}
 
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
 To stop {agent} and its related executables, stop the {agent} process. Use the
 commands that work for your system. 
 


### PR DESCRIPTION
As a follow-up to https://github.com/elastic/observability-docs/pull/133, adds the same statement to the docs that are sourced from the beats repo.

The statement seems less relevant to the agent docs, but I think works better for consistency if we want to have the statement appear on every page in the ingest management docs.