### PR TITLE
Cherry-pick #21071 to 7.9: Handling missing counters in application_pool metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,7 +102,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
-- Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
 - Handle missing counters in the application_pool metricset. {pull}21071[21071]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,6 +102,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
+- Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
+- Handle missing counters in the application_pool metricset. {pull}21071[21071]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/iis/application_pool/application_pool.go
+++ b/x-pack/metricbeat/module/iis/application_pool/application_pool.go
@@ -84,7 +84,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 			break
 		}
 	}
-
 	return nil
 }
 

--- a/x-pack/metricbeat/module/iis/application_pool/reader.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader.go
@@ -101,10 +101,10 @@ func (r *Reader) initAppPools() error {
 			if err == pdh.PDH_CSTATUS_NO_COUNTER || err == pdh.PDH_CSTATUS_NO_COUNTERNAME || err == pdh.PDH_CSTATUS_NO_INSTANCE || err == pdh.PDH_CSTATUS_NO_OBJECT {
 				r.log.Infow("Ignoring non existent counter", "error", err,
 					logp.Namespace("application pool"), "query", value)
-				continue
 			} else {
-				return errors.Wrapf(err, `failed to expand counter (query="%v")`, value)
+				r.log.Error(err, `failed to expand counter path (query= "%v")`, value)
 			}
+			continue
 		}
 		newQueries = append(newQueries, childQueries...)
 		// check if the pdhexpandcounterpath/pdhexpandwildcardpath functions have expanded the counter successfully.


### PR DESCRIPTION
Cherry-pick of PR #21071 to 7.9 branch. Original message:

## What does this PR do?

Mhe missing performance counters in the `application_pool` metricset would trigger an error and stop it.

## Why is it important?

There should only be an error message if this is the case but should not stop the metricset.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

