### PR TITLE
docs: Update docs to 7.9.3

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.9.2
+:stack-version: 7.9.3
 :doc-branch: 7.9
 :go-version: 1.14.7
 :release-state: released


### PR DESCRIPTION
Updates references to the new release 7.9.3.

Merge after the release 7.9.2.