### PR TITLE
Cherry-pick #21101 to 7.9: Fix index out of range error when getting AWS account name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,9 +102,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
-- Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
 - Fix panic index out of range error when getting AWS account name. {pull}21101[21101] {issue}21095[21095]
-- Handle missing counters in the application_pool metricset. {pull}21071[21071]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,6 +102,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix overflow on Prometheus rates when new buckets are added on the go. {pull}17753[17753]
 - Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - The `elasticsearch/index` metricset only requests wildcard expansion for hidden indices if the monitored Elasticsearch cluster supports it. {pull}20938[20938]
+- Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
+- Fix panic index out of range error when getting AWS account name. {pull}21101[21101] {issue}21095[21095]
+- Handle missing counters in the application_pool metricset. {pull}21071[21071]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -104,25 +105,6 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		awsConfig.Region = "us-east-1"
 	}
 
-	svcIam := iam.New(awscommon.EnrichAWSConfigWithEndpoint(
-		config.AWSConfig.Endpoint, "iam", "", awsConfig))
-	req := svcIam.ListAccountAliasesRequest(&iam.ListAccountAliasesInput{})
-	output, err := req.Send(context.TODO())
-	if err != nil {
-		base.Logger().Warn("failed to list account aliases, please check permission setting: ", err)
-		metricSet.AccountName = metricSet.AccountID
-	} else {
-		// When there is no account alias, account ID will be used as cloud.account.name
-		if len(output.AccountAliases) == 0 {
-			metricSet.AccountName = metricSet.AccountID
-		}
-
-		// There can be more than one aliases for each account, for now we are only
-		// collecting the first one.
-		metricSet.AccountName = output.AccountAliases[0]
-		base.Logger().Debug("AWS Credentials belong to account name: ", metricSet.AccountName)
-	}
-
 	// Get IAM account id
 	svcSts := sts.New(awscommon.EnrichAWSConfigWithEndpoint(
 		config.AWSConfig.Endpoint, "sts", "", awsConfig))
@@ -134,6 +116,11 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		metricSet.AccountID = *outputIdentity.Account
 		base.Logger().Debug("AWS Credentials belong to account ID: ", metricSet.AccountID)
 	}
+
+	// Get account name/alias
+	svcIam := iam.New(awscommon.EnrichAWSConfigWithEndpoint(
+		config.AWSConfig.Endpoint, "iam", "", awsConfig))
+	metricSet.AccountName = getAccountName(svcIam, base, metricSet)
 
 	// Construct MetricSet with a full regions list
 	if config.Regions == nil {
@@ -167,6 +154,30 @@ func getRegions(svc ec2iface.ClientAPI) (completeRegionsList []string, err error
 		completeRegionsList = append(completeRegionsList, *region.RegionName)
 	}
 	return
+}
+
+func getAccountName(svc iamiface.ClientAPI, base mb.BaseMetricSet, metricSet MetricSet) string {
+	req := svc.ListAccountAliasesRequest(&iam.ListAccountAliasesInput{})
+	output, err := req.Send(context.TODO())
+
+	accountName := metricSet.AccountID
+	if err != nil {
+		base.Logger().Warn("failed to list account aliases, please check permission setting: ", err)
+		return accountName
+	}
+
+	// When there is no account alias, account ID will be used as cloud.account.name
+	if len(output.AccountAliases) == 0 {
+		accountName = metricSet.AccountID
+		base.Logger().Debug("AWS Credentials belong to account ID: ", metricSet.AccountID)
+		return accountName
+	}
+
+	// There can be more than one aliases for each account, for now we are only
+	// collecting the first one.
+	accountName = output.AccountAliases[0]
+	base.Logger().Debug("AWS Credentials belong to account name: ", metricSet.AccountName)
+	return accountName
 }
 
 // StringInSlice checks if a string is already exists in list and its location


### PR DESCRIPTION
Cherry-pick of PR #21101 to 7.9 branch. Original message: 

## What does this PR do?

This PR is to fix panic in aws metricbeat module for by skipping running `output.AccountAliases[0]` after checking if the length of `output.AccountAliases`is zero.

```
"panic": "runtime error: index out of range [0] with length 0"
```

## Why is it important?

This error will happen when the user is trying to collect metrics with an account that does not have an account alias.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #21095