### PR TITLE
Cherry-pick to 7.x: docs: add beat specific install widget (#21050)

### DIFF
--- a/libbeat/docs/tab-widgets/install-widget-filebeat.asciidoc
+++ b/libbeat/docs/tab-widgets/install-widget-filebeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Filebeat
+:beatname_lc: filebeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-f">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-filebeat"
+            id="deb-install-filebeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-filebeat"
+            id="rpm-install-filebeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-filebeat"
+            id="mac-install-filebeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-install-filebeat"
+            id="brew-install-filebeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-filebeat"
+            id="linux-install-filebeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-filebeat"
+            id="win-install-filebeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-filebeat"
+       aria-labelledby="deb-install-filebeat">
+++++
+
+include::install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-filebeat"
+       aria-labelledby="rpm-install-filebeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-filebeat"
+       aria-labelledby="mac-install-filebeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-install-filebeat"
+       aria-labelledby="brew-install-filebeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-filebeat"
+       aria-labelledby="linux-install-filebeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-filebeat"
+       aria-labelledby="win-install-filebeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/install-widget-heartbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/install-widget-heartbeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Heartbeat
+:beatname_lc: heartbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-h">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-heartbeat"
+            id="deb-install-heartbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-heartbeat"
+            id="rpm-install-heartbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-heartbeat"
+            id="mac-install-heartbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-install-heartbeat"
+            id="brew-install-heartbeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-heartbeat"
+            id="linux-install-heartbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-heartbeat"
+            id="win-install-heartbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-heartbeat"
+       aria-labelledby="deb-install-heartbeat">
+++++
+
+include::install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-heartbeat"
+       aria-labelledby="rpm-install-heartbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-heartbeat"
+       aria-labelledby="mac-install-heartbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-install-heartbeat"
+       aria-labelledby="brew-install-heartbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-heartbeat"
+       aria-labelledby="linux-install-heartbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-heartbeat"
+       aria-labelledby="win-install-heartbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/install-widget-metricbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/install-widget-metricbeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Metricbeat
+:beatname_lc: metricbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-m">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-metricbeat"
+            id="deb-install-metricbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-metricbeat"
+            id="rpm-install-metricbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-metricbeat"
+            id="mac-install-metricbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-install-metricbeat"
+            id="brew-install-metricbeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-metricbeat"
+            id="linux-install-metricbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-metricbeat"
+            id="win-install-metricbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-metricbeat"
+       aria-labelledby="deb-install-metricbeat">
+++++
+
+include::install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-metricbeat"
+       aria-labelledby="rpm-install-metricbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-metricbeat"
+       aria-labelledby="mac-install-metricbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-install-metricbeat"
+       aria-labelledby="brew-install-metricbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-metricbeat"
+       aria-labelledby="linux-install-metricbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-metricbeat"
+       aria-labelledby="win-install-metricbeat"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add beat specific install widget (#21050)