### PR TITLE
Cherry-pick to 7.x: Update input-log.asciidoc (#20965)

### DIFF
--- a/filebeat/docs/inputs/input-log.asciidoc
+++ b/filebeat/docs/inputs/input-log.asciidoc
@@ -73,7 +73,7 @@ of the file. To solve this problem you can configure `file_identity` option. Pos
 values besides the default `inode_deviceid` are `path` and `inode_marker`.
 
 Selecting `path` instructs {beatname_uc} to identify files based on their
-paths. This is a quick way to aviod rereading files if inode and device ids
+paths. This is a quick way to avoid rereading files if inode and device ids
 might change. However, keep in mind if the files are rotated (renamed), they
 will be reread and resubmitted.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update input-log.asciidoc (#20965)