### PR TITLE
[packaging] use docker.elastic.co/ubi8/ubi-minimal

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -509,7 +509,7 @@ shared:
   - &docker_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi8'
-      from: 'registry.access.redhat.com/ubi8/ubi-minimal'
+      from: 'docker.elastic.co/ubi8/ubi-minimal'
 
   - &elastic_docker_spec
     extra_vars:


### PR DESCRIPTION
## What does this PR do?

Use the docker.elastic.co registry for sourcing the UBI.

## Why is it important?

Simplifies building our UBI-based images by ensuring continued auth-free access to the base image.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

`mage package`

## Related issues

None.