### PR TITLE
[Filebeat] sync with recent changes in zeek package

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -578,6 +578,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve Suricata Eve module with `x509` ECS mappings {pull}20973[20973]
 - Added new module for Zoom webhooks {pull}20414[20414]
 - Add type and sub_type to panw panos fileset {pull}20912[20912]
+- Always attempt community_id processor on zeek module {pull}21155[21155]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/connection/config/connection.yml
+++ b/x-pack/filebeat/module/zeek/connection/config/connection.yml
@@ -90,7 +90,6 @@ processors:
         kind: event
         category:
           - network
-{{ if .community_id }}
   - if:
       equals.network.transport: icmp
     then:
@@ -100,7 +99,6 @@ processors:
           icmp_code: zeek.connection.icmp.code
     else:
       community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/connection/manifest.yml
+++ b/x-pack/filebeat/module/zeek/connection/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/conn.log
   - name: tags
     default: [zeek.connection]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/connection.yml

--- a/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
@@ -54,9 +54,7 @@ processors:
           - connection
           - protocol
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/dce_rpc/manifest.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/dce_rpc.log
   - name: tags
     default: [zeek.dce_rpc]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/dce_rpc.yml

--- a/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
@@ -116,9 +116,7 @@ processors:
           - connection
           - protocol
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/dhcp/manifest.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/dhcp.log
   - name: tags
     default: [zeek.dhcp]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/dhcp.yml

--- a/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
@@ -64,9 +64,7 @@ processors:
           - connection
           - protocol
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/ingest/pipeline.yml
@@ -23,14 +23,6 @@ processors:
 - lowercase:
     field: event.action
     ignore_missing: true
-- append:
-    field: related.ip
-    value: '{{source.ip}}'
-    if: ctx?.source?.ip != null
-- append:
-    field: related.ip
-    value: '{{destination.ip}}'
-    if: ctx?.destination?.ip != null
 - geoip:
     field: destination.ip
     target_field: destination.geo
@@ -69,6 +61,14 @@ processors:
     field: destination.as.organization_name
     target_field: destination.as.organization.name
     ignore_missing: true
+- append:
+    field: related.ip
+    value: '{{source.ip}}'
+    if: ctx?.source?.ip != null
+- append:
+    field: related.ip
+    value: '{{destination.ip}}'
+    if: ctx?.destination?.ip != null
 on_failure:
 - set:
     field: error.message

--- a/x-pack/filebeat/module/zeek/dnp3/manifest.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/dnp3.log
   - name: tags
     default: [zeek.dnp3]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/dnp3.yml

--- a/x-pack/filebeat/module/zeek/dns/config/dns.yml
+++ b/x-pack/filebeat/module/zeek/dns/config/dns.yml
@@ -193,9 +193,7 @@ processors:
           - connection
           - info
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - drop_fields:
       ignore_missing: true
       fields:

--- a/x-pack/filebeat/module/zeek/dns/manifest.yml
+++ b/x-pack/filebeat/module/zeek/dns/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/dns.log
   - name: tags
     default: [zeek.dns]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/dns.yml

--- a/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
+++ b/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
@@ -53,9 +53,7 @@ processors:
         type:
           - connection
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/dpd/manifest.yml
+++ b/x-pack/filebeat/module/zeek/dpd/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/dpd.log
   - name: tags
     default: [zeek.dpd]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/dpd.yml

--- a/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
+++ b/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
@@ -82,9 +82,7 @@ processors:
           - connection
           - info
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/ftp/manifest.yml
+++ b/x-pack/filebeat/module/zeek/ftp/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/ftp.log
   - name: tags
     default: [zeek.ftp]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/ftp.yml

--- a/x-pack/filebeat/module/zeek/http/config/http.yml
+++ b/x-pack/filebeat/module/zeek/http/config/http.yml
@@ -89,9 +89,7 @@ processors:
           - connection
           - info
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/http/manifest.yml
+++ b/x-pack/filebeat/module/zeek/http/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/http.log
   - name: tags
     default: [zeek.http]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/http.yml

--- a/x-pack/filebeat/module/zeek/intel/config/intel.yml
+++ b/x-pack/filebeat/module/zeek/intel/config/intel.yml
@@ -63,9 +63,7 @@ processors:
         kind: alert
         type:
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/intel/manifest.yml
+++ b/x-pack/filebeat/module/zeek/intel/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/intel.log
   - name: tags
     default: [zeek.intel]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/intel.yml

--- a/x-pack/filebeat/module/zeek/irc/config/irc.yml
+++ b/x-pack/filebeat/module/zeek/irc/config/irc.yml
@@ -68,9 +68,7 @@ processors:
           - connection
           - protocol
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/irc/manifest.yml
+++ b/x-pack/filebeat/module/zeek/irc/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/irc.log
   - name: tags
     default: [zeek.irc]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/irc.yml

--- a/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
@@ -100,9 +100,7 @@ processors:
       tokenizer: "%{user.name}/%{user.domain}"
       field: zeek.kerberos.client
       target_prefix: ""
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/kerberos/manifest.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/kerberos.log
   - name: tags
     default: [zeek.kerberos]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/kerberos.yml

--- a/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
+++ b/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
@@ -69,9 +69,7 @@ processors:
           target: event
           fields:
             outcome: success
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/modbus/manifest.yml
+++ b/x-pack/filebeat/module/zeek/modbus/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/modbus.log
   - name: tags
     default: [zeek.modbus]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/modbus.yml

--- a/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
+++ b/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
@@ -68,9 +68,7 @@ processors:
           target: event
           fields:
             outcome: failure
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/mysql/manifest.yml
+++ b/x-pack/filebeat/module/zeek/mysql/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/mysql.log
   - name: tags
     default: [zeek.mysql]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/mysql.yml

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -100,9 +100,7 @@ processors:
           - intrusion_detection
         type:
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/notice/manifest.yml
+++ b/x-pack/filebeat/module/zeek/notice/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/notice.log
   - name: tags
     default: [zeek.notice]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/notice.yml

--- a/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
@@ -82,9 +82,7 @@ processors:
           target: event
           fields:
             outcome: failure
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/ntlm/manifest.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/ntlm.log
   - name: tags
     default: [zeek.ntlm]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/ntlm.yml

--- a/x-pack/filebeat/module/zeek/radius/config/radius.yml
+++ b/x-pack/filebeat/module/zeek/radius/config/radius.yml
@@ -54,9 +54,7 @@ processors:
         type:
           - info
           - connection
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/radius/manifest.yml
+++ b/x-pack/filebeat/module/zeek/radius/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/radius.log
   - name: tags
     default: [zeek.radius]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/radius.yml

--- a/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
+++ b/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
@@ -84,9 +84,7 @@ processors:
         type:
           - protocol
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/rdp/manifest.yml
+++ b/x-pack/filebeat/module/zeek/rdp/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/rdp.log
   - name: tags
     default: [zeek.rdp]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/rdp.yml

--- a/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
+++ b/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
@@ -69,9 +69,7 @@ processors:
         type:
           - connection
           - info
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/rfb/manifest.yml
+++ b/x-pack/filebeat/module/zeek/rfb/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/rfb.log
   - name: tags
     default: [zeek.rfb]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/rfb.yml

--- a/x-pack/filebeat/module/zeek/sip/config/sip.yml
+++ b/x-pack/filebeat/module/zeek/sip/config/sip.yml
@@ -91,9 +91,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/sip/manifest.yml
+++ b/x-pack/filebeat/module/zeek/sip/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/sip.log
   - name: tags
     default: [zeek.sip]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/sip.yml

--- a/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
@@ -97,9 +97,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/smb_cmd/manifest.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/smb_cmd.log
   - name: tags
     default: [zeek.smb_cmd]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/smb_cmd.yml

--- a/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
@@ -57,9 +57,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/smb_files/manifest.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/smb_files.log
   - name: tags
     default: [zeek.smb_files]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/smb_files.yml

--- a/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
@@ -53,9 +53,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/smb_mapping/manifest.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/smb_mapping.log
   - name: tags
     default: [zeek.smb_mapping]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/smb_mapping.yml

--- a/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
+++ b/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
@@ -63,9 +63,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/smtp/manifest.yml
+++ b/x-pack/filebeat/module/zeek/smtp/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/smtp.log
   - name: tags
     default: [zeek.smtp]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/smtp.yml

--- a/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
+++ b/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
@@ -65,9 +65,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/snmp/manifest.yml
+++ b/x-pack/filebeat/module/zeek/snmp/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/snmp.log
   - name: tags
     default: [zeek.snmp]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/snmp.yml

--- a/x-pack/filebeat/module/zeek/socks/config/socks.yml
+++ b/x-pack/filebeat/module/zeek/socks/config/socks.yml
@@ -63,9 +63,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/socks/manifest.yml
+++ b/x-pack/filebeat/module/zeek/socks/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/socks.log
   - name: tags
     default: [zeek.socks]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/socks.yml

--- a/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
+++ b/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
@@ -72,9 +72,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/ssh/manifest.yml
+++ b/x-pack/filebeat/module/zeek/ssh/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/ssh.log
   - name: tags
     default: [zeek.ssh]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/ssh.yml

--- a/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
+++ b/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
@@ -75,9 +75,7 @@ processors:
         type:
           - connection
           - protocol
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/ssl/manifest.yml
+++ b/x-pack/filebeat/module/zeek/ssl/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/ssl.log
   - name: tags
     default: [zeek.ssl]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/ssl.yml

--- a/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
+++ b/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
@@ -53,9 +53,7 @@ processors:
       target: event
       fields:
         kind: event
-{{ if .community_id }}
   - community_id:
-{{ end }}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/zeek/syslog/manifest.yml
+++ b/x-pack/filebeat/module/zeek/syslog/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/syslog.log
   - name: tags
     default: [zeek.syslog]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/syslog.yml

--- a/x-pack/filebeat/module/zeek/x509/manifest.yml
+++ b/x-pack/filebeat/module/zeek/x509/manifest.yml
@@ -10,8 +10,6 @@ var:
       - /usr/local/var/logs/current/x509.log
   - name: tags
     default: [zeek.x509]
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/x509.yml


### PR DESCRIPTION
## What does this PR do?

Syncs changes made in zeek package with zeek module

- always attempt community_id processor
- dnp3 reorder pipeline to be same as package

## Why is it important?

Filebeat module and package should be the same.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

```
TESTING_FILEBEAT_MODULES=zeek mage -v pythonIntegTest
```
