### PR TITLE
[Filebeat] Add backwards compatibility for append allow_duplicates

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -264,6 +264,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove wrongly mapped `tls.client.server_name` from `fortinet/firewall` fileset. {pull}20983[20983]
 - Fix an error updating file size being logged when EOF is reached. {pull}21048[21048]
 - Fix error when processing AWS Cloudtrail Digest logs. {pull}21086[21086] {issue}20943[20943]
+- Provide backwards compatibility for the `append` processor when Elasticsearch is less than 7.10.0. {pull}21159[21159]
 
 *Heartbeat*
 

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -132,6 +132,10 @@ func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string
 		return fmt.Errorf("failed to modify set processor in pipeline: %v", err)
 	}
 
+	if err := modifyAppendProcessor(esClient.GetVersion(), pipelineID, content); err != nil {
+		return fmt.Errorf("failed to modify append processor in pipeline: %v", err)
+	}
+
 	body, err := esClient.LoadJSON(path, content)
 	if err != nil {
 		return interpretError(err, body)
@@ -286,6 +290,76 @@ func modifySetProcessor(esVersion common.Version, pipelineID string, content map
 			newIf = "ctx?." + newIf + " != null"
 
 			logp.Debug("modules", "In pipeline %q adding if %s to replace 'ignore_empty_value' in set processor", pipelineID, newIf)
+			options["if"] = newIf
+		}
+	}
+	return nil
+}
+
+// modifyAppendProcessor replaces allow_duplicates option with an if statement
+// so ES less than 7.10 will still work
+func modifyAppendProcessor(esVersion common.Version, pipelineID string, content map[string]interface{}) error {
+	flagVersion := common.MustNewVersion("7.10.0")
+	if !esVersion.LessThan(flagVersion) {
+		return nil
+	}
+
+	p, ok := content["processors"]
+	if !ok {
+		return nil
+	}
+	processors, ok := p.([]interface{})
+	if !ok {
+		return fmt.Errorf("'processors' in pipeline '%s' expected to be a list, found %T", pipelineID, p)
+	}
+
+	for _, p := range processors {
+		processor, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if options, ok := processor["append"].(map[string]interface{}); ok {
+			allow, ok := options["allow_duplicates"].(bool)
+			if !ok {
+				// don't have allow_duplicates, nothing to do
+				continue
+			}
+
+			logp.Debug("modules", "In pipeline %q removing unsupported 'allow_duplicates' in append processor", pipelineID)
+			delete(options, "allow_duplicates")
+			if allow {
+				// it was set to true, nothing else to do after removing the option
+				continue
+			}
+
+			currIf, _ := options["if"].(string)
+			if strings.Contains(strings.ToLower(currIf), "contains") {
+				// if it has a contains statement, we assume it is checking for duplicates already
+				continue
+			}
+			field, ok := options["field"].(string)
+			if !ok {
+				continue
+			}
+			val, ok := options["value"].(string)
+			if !ok {
+				continue
+			}
+
+			field = strings.ReplaceAll(field, ".", "?.")
+
+			val = strings.TrimLeft(val, "{ ")
+			val = strings.TrimRight(val, "} ")
+			val = strings.ReplaceAll(val, ".", "?.")
+
+			if currIf == "" {
+				// if there is not a previous if we add a value sanity check
+				currIf = fmt.Sprintf("ctx?.%s != null", val)
+			}
+
+			newIf := fmt.Sprintf("%s && ((ctx?.%s instanceof List && !ctx?.%s.contains(ctx?.%s)) || ctx?.%s != ctx?.%s)", currIf, field, field, val, field, val)
+
+			logp.Debug("modules", "In pipeline %q adding if %s to replace 'allow_duplicates: false' in append processor", pipelineID, newIf)
 			options["if"] = newIf
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

When loading a pipeline this change checks the elasticsearch version
and if the version is less than 7.10.0 it will replace the
"allow_duplicates: false" option with an equivalent if statement on the append
processor.


## Why is it important?

This allows filebeat > 7.10.0 to be used with older versions of
elasticsearch.  Without it the pipelines fail to load because the
option isn't supported.


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

