### PR TITLE
Remove billing from the list of AWS light metricsets

### DIFF
--- a/x-pack/metricbeat/module/aws/module.yml
+++ b/x-pack/metricbeat/module/aws/module.yml
@@ -3,7 +3,6 @@ metricsets:
   - elb
   - ebs
   - usage
-  - billing
   - sns
   - lambda
   - dynamodb


### PR DESCRIPTION
On tests, loading any metricset from the AWS module is trying
to load the billing metricset as light metricset, what fails. This
shouldn't happen after #15011, but it is probably happening
because on tests, not all metricsets are registered.

`billing` metricset was refactored to a native implementation
recently, in #20527.

By now I am removing billing from the list so tests can be executed.

Integration tests fail with errors like this one:
```
go test -tags=integration,aws ./x-pack/metricbeat/module/aws/sns/
--- FAIL: TestData (0.00s)
    modules.go:111: failed to create new MetricSet 1 error: failed to obtain registration for non-registered metricset 'aws/sns': loading module 'aws': loading metric sets for light module 'aws': loading light metricset 'billing': loading metricset manifest from '../../../module/aws/billing/manifest.yml': open ../../../module/aws/billing/manifest.yml: no such file or directory
FAIL
FAIL	github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/sns	0.013s
FAIL
```

Thanks @v1v for reporting!