### PR TITLE
[JJBB][CI] Run beats-tester on master and release branches

### DIFF
--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -69,7 +69,9 @@ pipeline {
           options { skipDefaultCheckout() }
           when { triggeredBy cause: "IssueCommentCause" }
           steps {
-            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT",
+                              apm: "https://storage.googleapis.com/apm-ci-artifacts/jobs/pull-requests/pr-${env.CHANGE_ID}",
+                              beats: "https://storage.googleapis.com/beats-ci-artifacts/pull-requests/pr-${env.CHANGE_ID}")
           }
         }
         stage('Build release branch') {

--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -21,7 +21,7 @@ pipeline {
   triggers {
     issueCommentTrigger('(?i)^\\/beats-tester$')
     // disable upstream trigger on a PR basis
-    upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+    upstream("Beats/packaging/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
   }
   stages {
     stage('Filter build') {

--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -10,7 +10,7 @@ pipeline {
     BEATS_TESTER_JOB = 'Beats/beats-tester-mbp/master'
   }
   options {
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 1, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')

--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -1,0 +1,102 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    BASE_DIR = 'src/github.com/elastic/beats'
+    PIPELINE_LOG_LEVEL = "INFO"
+    BEATS_TESTER_JOB = 'Beats/beats-tester-mbp/master'
+  }
+  options {
+    timeout(time: 3, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    disableConcurrentBuilds()
+  }
+  triggers {
+    issueCommentTrigger('(?i)^\\/beats-tester$')
+    // disable upstream trigger on a PR basis
+    upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+  }
+  stages {
+    stage('Filter build') {
+      agent { label 'ubuntu && immutable' }
+      when {
+        beforeAgent true
+        anyOf {
+          triggeredBy cause: "IssueCommentCause"
+          expression {
+            def ret = isUserTrigger() || isUpstreamTrigger()
+            if(!ret){
+              currentBuild.result = 'NOT_BUILT'
+              currentBuild.description = "The build has been skipped"
+              currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
+              echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, GitHub comment, and upstream job")
+            }
+            return ret
+          }
+        }
+      }
+      stages {
+        stage('Checkout') {
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}")
+            setEnvVar('VERSION', sh(script: "grep ':stack-version:' ${BASE_DIR}/libbeat/docs/version.asciidoc | cut -d' ' -f2", returnStdout: true).trim())
+          }
+        }
+        stage('Build master') {
+          options { skipDefaultCheckout() }
+          when { branch 'master' }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+        stage('Build *.x branch') {
+          options { skipDefaultCheckout() }
+          when { branch '*.x' }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+        stage('Build PullRequest') {
+          options { skipDefaultCheckout() }
+          when { triggeredBy cause: "IssueCommentCause" }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+        stage('Build release branch') {
+          options { skipDefaultCheckout() }
+          when {
+            not {
+              branch comparator: 'REGEXP', pattern: '(master|.*x)'
+            }
+           }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+      }
+    }
+  }
+}
+
+def runBeatsTesterJob(Map args = [:]) {
+  if (args.apm && args.beats) {
+    build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false,
+          parameters: [
+            string(name: 'APM_URL_BASE', value: args.apm),
+            string(name: 'BEATS_URL_BASE', value: args.beats),
+            string(name: 'VERSION', value: args.version)
+          ])
+  } else {
+    build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false, parameters: [ string(name: 'VERSION', value: args.version) ])
+  }
+}

--- a/.ci/jobs/beats-tester.yml
+++ b/.ci/jobs/beats-tester.yml
@@ -1,0 +1,56 @@
+---
+- job:
+    name: Beats/beats-tester
+    display-name: Beats Tester
+    description: Run the beats-tester
+    view: Beats
+    disabled: false
+    project-type: multibranch
+    script-path: .ci/beats-tester.groovy
+    scm:
+      - github:
+          branch-discovery: 'no-pr'
+          discover-pr-forks-strategy: 'merge-current'
+          discover-pr-forks-trust: 'permission'
+          discover-pr-origin: 'merge-current'
+          discover-tags: true
+          head-filter-regex: '(master|7\.([x9]|1\d+)|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          disable-pr-notifications: true
+          notification-context: 'beats-tester'
+          repo: 'beats'
+          repo-owner: 'elastic'
+          credentials-id: github-app-beats-ci
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+          - skip-initial-build: true
+          - tags:
+              ignore-tags-older-than: -1
+              ignore-tags-newer-than: 30
+          - named-branches:
+              - exact-name:
+                  name: 'master'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '7\.([x9]|1\d+)'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '8\.\d+'
+                  case-sensitive: true
+          - change-request:
+              ignore-target-only-changes: true
+          clean:
+              after: true
+              before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ It is possible to trigger some jobs by putting a comment on a GitHub PR.
   * `/run apm-beats-update`
 * [apm-beats-packaging][]
   * `/package` or `/packaging` will kick of a build to generate the packages for beats.
+* [apm-beats-tester][]
+  * `/beats-tester` will kick of a build to validate the generated packages.
 
 [beats]: https://beats-ci.elastic.co/job/Beats/job/beats/
 [apm-beats-update]: https://beats-ci.elastic.co/job/Beats/job/apm-beats-update/
 [apm-beats-packaging]: https://beats-ci.elastic.co/job/Beats/job/packaging/
+[apm-beats-tester]: https://beats-ci.elastic.co/job/Beats/job/beats-tester/


### PR DESCRIPTION
## What does this PR do?

Create MBP for running beats-tester when the packaging has been successfully executed for the master and release branches.

__NOTE:__ It does not support `BCs` but `SNAPSHOTS`

It also supports PullRequests, how?

- Create packaging (with comment `/packaging`) then the beats-tester will be executed

## Why is it important?

This will help to validate the installers for every commit that has been successfully validated in the CI.

## Related issues

Closes https://github.com/elastic/beats-tester/issues/176

