### PR TITLE
Fix remote_write flaky test

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -344,6 +344,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
 - Fix panic index out of range error when getting AWS account name. {pull}21101[21101] {issue}21095[21095]
 - Handle missing counters in the application_pool metricset. {pull}21071[21071]
+- Fix remote_write flaky test. {pull}21173[21173]
 
 *Packetbeat*
 

--- a/metricbeat/module/prometheus/_meta/prometheus.yml
+++ b/metricbeat/module/prometheus/_meta/prometheus.yml
@@ -17,7 +17,7 @@ rule_files:
   # - "second_rules.yml"
 
 remote_write:
-  - url: "http://REMOTE/write"
+  - url: "http://0.0.0.0:9201/write"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.

--- a/metricbeat/module/prometheus/_meta/run.sh
+++ b/metricbeat/module/prometheus/_meta/run.sh
@@ -1,25 +1,5 @@
 #!/bin/sh
 
-
-for i in 1 2 3 4 5;
-do
-  a=`nslookup host.docker.internal | grep "** server can't find " | wc -l`;
-  if [ $a -gt 0 ]; then
-    # this works only on Linux envs
-    HOST_DOMAIN="0.0.0.0"
-  else
-    # this works only on Mac envs
-    HOST_DOMAIN="host.docker.internal"
-    break
-  fi
-done
-
-
-
-REMOTE="$HOST_DOMAIN:9201"
-
-sed -i "s/REMOTE/$REMOTE/g" /etc/prometheus/prometheus.yml
-
 /bin/prometheus --config.file=/etc/prometheus/prometheus.yml \
  --storage.tsdb.path=/prometheus \
  --web.console.libraries=/usr/share/prometheus/console_libraries \

--- a/metricbeat/module/prometheus/test_prometheus.py
+++ b/metricbeat/module/prometheus/test_prometheus.py
@@ -65,7 +65,6 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
 
-@unittest.skip("Flaky test: https://github.com/elastic/beats/issues/20967")
 class TestRemoteWrite(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['prometheus-host-network']


### PR DESCRIPTION
## What does this PR do?
This PR fixes the flaky `remote_write` system test. The issue should be due to docker networking since the `http://host.docker.internal:9201/write` endpoint seems to not be working properly and we can stick with `http://0.0.0.0:9201/write` only...

I tested  locally (on macOS) with `MODULE=prometheus mage -v pythonIntegTest` and seems to work now. Let's see if CI is happy too.

## Why is it important?
To enable back the system test for the `remote_write` metricset.



## Related issues

- Closes https://github.com/elastic/beats/issues/20967