### PR TITLE
Decode strings inside arrays when using decode_json_fields and process_array

### DIFF
--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -18,6 +18,7 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -336,6 +337,33 @@ func TestArrayWithArraysEnabled(t *testing.T) {
 	expected := common.MapStr{
 		"msg": common.MapStr{
 			"arrayOfMap": []common.MapStr{common.MapStr{"a": "b"}},
+		},
+	}
+
+	assert.Equal(t, expected.String(), actual.String())
+}
+
+func TestArrayWithJsonObjectsStringified(t *testing.T) {
+	m := common.MapStr{
+		"inner": []string{`{"a": "b"}`},
+	}
+	byt, _ := json.Marshal(m)
+
+	input := common.MapStr{
+		"msg": string(byt),
+	}
+
+	testConfig, _ = common.NewConfigFrom(map[string]interface{}{
+		"fields":        fields,
+		"max_depth":     10,
+		"process_array": true,
+	})
+
+	actual := getActualValue(t, testConfig, input)
+
+	expected := common.MapStr{
+		"msg": common.MapStr{
+			"inner": []common.MapStr{{"a": "b"}},
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

WIP Checking CI...

This PR allows to decode stringified JSON in an incoming inner array:

```json
{ "outer": "value", "inner": ["{\"data1\": \"value1\"}", "{\"data2\": \"value2\"}"] }
```

## Why is it important?

Some users have reported that they did like that they can also decode stringified JSON arrays. Now we only manage to decode inner JSON arrays as soon as the content is a JSON object or the array is also stringified.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
