### PR TITLE
Cherry-pick to 7.9: [docs] typo (#21130)

### DIFF
--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -86,7 +86,8 @@ image::./images/kibana-logstash-slowlog.png[]
 
 [float]
 === Known issues
-When using the `log` fileset to parse plaintext logs, if a multiline plaintext log contains an embedded JSON objct such that
+
+When using the `log` fileset to parse plaintext logs, if a multiline plaintext log contains an embedded JSON object such that
 the JSON object starts on a new line, the fileset may not parse the multiline plaintext log event correctly.
 
 :has-dashboards!:

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -81,7 +81,8 @@ image::./images/kibana-logstash-slowlog.png[]
 
 [float]
 === Known issues
-When using the `log` fileset to parse plaintext logs, if a multiline plaintext log contains an embedded JSON objct such that
+
+When using the `log` fileset to parse plaintext logs, if a multiline plaintext log contains an embedded JSON object such that
 the JSON object starts on a new line, the fileset may not parse the multiline plaintext log event correctly.
 
 :has-dashboards!:


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [docs] typo (#21130)