### PR TITLE
Cherry-pick to master: fix minor typos in docs (#21074)

### DIFF
--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -33,13 +33,13 @@ filebeat.registry.path: registry
 -------------------------------------------------------------------------------------
 
 NOTE: The registry is only updated when new events are flushed and not on a predefined period.
-That means in case there are some states where the TTL expired, these are only removed when new event are processed.
+That means in case there are some states where the TTL expired, these are only removed when new events are processed.
 
-NOTE: The registry stores it's data in the subdirectory filebeat/data.json. It
+NOTE: The registry stores its data in the subdirectory filebeat/data.json. It
 also contains a meta data file named filebeat/meta.json. The meta file contains
 the file format version number.
 
-NOTE: The content stored in filebeat/data.json is compatible to the old registry file data format.
+NOTE: The content stored in filebeat/data.json is compatible with the old registry file data format.
 
 [float]
 ==== `registry.file_permissions`


### PR DESCRIPTION
Backports the following commits to master:

* fix minor typos in docs (#21074)