### PR TITLE
Cherry-pick to 7.x: Added a link to phishbeat (#21062)

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -90,7 +90,8 @@ https://github.com/aristanetworks/openconfigbeat[openconfigbeat]:: Streams data 
 https://github.com/radoondas/owmbeat[owmbeat]:: Open Weather Map beat to pull weather data from all around the world and store and visualize them in Elastic Stack
 https://github.com/joehillen/packagebeat[packagebeat]:: Collects information about system packages from package
 managers.
-https://github.com/WuerthIT/perfstatbeat[perfstatbeat]:: Collect performance metrics on the AIX operating system.
+https://github.com/WuerthIT/perfstatbeat[perfstatbeat]:: Collects performance metrics on the AIX operating system.
+https://github.com/stric-co/phishbeat[phishbeat]:: Monitors Certificate Transparency logs for phishing and defamatory domains.
 https://github.com/kozlice/phpfpmbeat[phpfpmbeat]:: Reads status from PHP-FPM.
 https://github.com/joshuar/pingbeat[pingbeat]:: Sends ICMP pings to a list
 of targets and stores the round trip time (RTT) in Elasticsearch.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Added a link to phishbeat (#21062)