### PR TITLE
Cherry-pick to 7.9: [JJBB][CI] Run beats-tester on master and release branches (#21169)

### DIFF
--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -1,0 +1,106 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    BASE_DIR = 'src/github.com/elastic/beats'
+    PIPELINE_LOG_LEVEL = "INFO"
+    BEATS_TESTER_JOB = 'Beats/beats-tester-mbp/master'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    disableConcurrentBuilds()
+  }
+  triggers {
+    issueCommentTrigger('(?i)^\\/beats-tester$')
+    upstream("Beats/packaging/${env.JOB_BASE_NAME}")
+  }
+  stages {
+    stage('Filter build') {
+      agent { label 'ubuntu && immutable' }
+      when {
+        beforeAgent true
+        anyOf {
+          triggeredBy cause: "IssueCommentCause"
+          expression {
+            def ret = isUserTrigger() || isUpstreamTrigger()
+            if(!ret){
+              currentBuild.result = 'NOT_BUILT'
+              currentBuild.description = "The build has been skipped"
+              currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
+              echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, GitHub comment, and upstream job")
+            }
+            return ret
+          }
+        }
+      }
+      stages {
+        stage('Checkout') {
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}")
+            setEnvVar('VERSION', sh(script: "grep ':stack-version:' ${BASE_DIR}/libbeat/docs/version.asciidoc | cut -d' ' -f2", returnStdout: true).trim())
+          }
+        }
+        stage('Build master') {
+          options { skipDefaultCheckout() }
+          when { branch 'master' }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+        stage('Build *.x branch') {
+          options { skipDefaultCheckout() }
+          when { branch '*.x' }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+        stage('Build PullRequest') {
+          options { skipDefaultCheckout() }
+          when { changeRequest() }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT",
+                              apm: "https://storage.googleapis.com/apm-ci-artifacts/jobs/pull-requests/pr-${env.CHANGE_ID}",
+                              beats: "https://storage.googleapis.com/beats-ci-artifacts/pull-requests/pr-${env.CHANGE_ID}")
+          }
+        }
+        stage('Build release branch') {
+          options { skipDefaultCheckout() }
+          when {
+            not {
+              allOf {
+                branch comparator: 'REGEXP', pattern: '(master|.*x)'
+                changeRequest()
+              }
+            }
+           }
+          steps {
+            runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
+          }
+        }
+      }
+    }
+  }
+}
+
+def runBeatsTesterJob(Map args = [:]) {
+  if (args.apm && args.beats) {
+    build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false,
+          parameters: [
+            string(name: 'APM_URL_BASE', value: args.apm),
+            string(name: 'BEATS_URL_BASE', value: args.beats),
+            string(name: 'VERSION', value: args.version)
+          ])
+  } else {
+    build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false, parameters: [ string(name: 'VERSION', value: args.version) ])
+  }
+}

--- a/.ci/jobs/beats-tester.yml
+++ b/.ci/jobs/beats-tester.yml
@@ -1,0 +1,56 @@
+---
+- job:
+    name: Beats/beats-tester
+    display-name: Beats Tester
+    description: Run the beats-tester
+    view: Beats
+    disabled: false
+    project-type: multibranch
+    script-path: .ci/beats-tester.groovy
+    scm:
+      - github:
+          branch-discovery: 'no-pr'
+          discover-pr-forks-strategy: 'merge-current'
+          discover-pr-forks-trust: 'permission'
+          discover-pr-origin: 'merge-current'
+          discover-tags: true
+          head-filter-regex: '(master|7\.([x9]|1\d+)|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          disable-pr-notifications: true
+          notification-context: 'beats-tester'
+          repo: 'beats'
+          repo-owner: 'elastic'
+          credentials-id: github-app-beats-ci
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+          - skip-initial-build: true
+          - tags:
+              ignore-tags-older-than: -1
+              ignore-tags-newer-than: 30
+          - named-branches:
+              - exact-name:
+                  name: 'master'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '7\.([x9]|1\d+)'
+                  case-sensitive: true
+              - regex-name:
+                  regex: '8\.\d+'
+                  case-sensitive: true
+          - change-request:
+              ignore-target-only-changes: true
+          clean:
+              after: true
+              before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true

--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ It is possible to trigger some jobs by putting a comment on a GitHub PR.
   * `/test macos` will kick off a default build with also the `macos` stages.
 * [apm-beats-update][]
   * `/run apm-beats-update`
+* [apm-beats-packaging][]
+  * `/package` or `/packaging` will kick of a build to generate the packages for beats.
+* [apm-beats-tester][]
+  * `/beats-tester` will kick of a build to validate the generated packages.
 
 
 [beats]: https://beats-ci.elastic.co/job/Beats/job/beats-beats-mbp/
 [apm-beats-update]: https://beats-ci.elastic.co/job/Beats/job/apm-beats-update/
+[apm-beats-packaging]: https://beats-ci.elastic.co/job/Beats/job/packaging/
+[apm-beats-tester]: https://beats-ci.elastic.co/job/Beats/job/beats-tester/


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [JJBB][CI] Run beats-tester on master and release branches (#21169)