### PR TITLE
Cherry-pick #20998 to 7.x: [Filebeat][Azure Module] Fixing event.outcome from result_type issue

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -666,6 +666,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Avoid goroutine leaks in Filebeat readers. {issue}19193[19193] {pull}20455[20455]
 - Improve Zeek x509 module with `x509` ECS mappings {pull}20867[20867]
 - Improve Zeek SSL module with `x509` ECS mappings {pull}20927[20927]
+- Added new properties field support for event.outcome in azure module {pull}20998[20998]
 - Improve Zeek Kerberos module with `x509` ECS mappings {pull}20958[20958]
 - Improve Fortinet firewall module with `x509` ECS mappings {pull}20983[20983]
 - Improve Santa module with `x509` ECS mappings {pull}20976[20976]

--- a/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
@@ -74,7 +74,12 @@ processors:
     field: azure.activitylogs.result_type
     target_field: event.outcome
     type: string
-    if: "ctx?.azure?.activitylogs?.resultType != null && ctx.azure.activitylogs.resultType instanceof String && (ctx.azure.activitylogs.resultType.toLowerCase() == 'success' || ctx.azure.activitylogs.resultType.toLowerCase() == 'failure')"
+    if: "ctx?.azure?.activitylogs?.result_type != null && ctx.azure.activitylogs.result_type instanceof String && (ctx.azure.activitylogs.result_type.toLowerCase() == 'success' || ctx.azure.activitylogs.result_type.toLowerCase() == 'failure')"
+- convert:
+    field: azure.activitylogs.properties.result
+    target_field: event.outcome
+    type: string
+    if: "ctx?.event?.outcome == null && ctx?.azure?.activitylogs?.properties?.result != null && ctx?.azure?.activitylogs?.properties?.result instanceof String && ['success', 'failure', 'unknown'].contains(ctx.azure?.activitylogs?.properties?.result)"
 - rename:
     field: azure.activitylogs.operationName
     target_field: azure.activitylogs.operation_name

--- a/x-pack/filebeat/module/azure/activitylogs/test/supporttickets_write.log-expected.json
+++ b/x-pack/filebeat/module/azure/activitylogs/test/supporttickets_write.log-expected.json
@@ -45,6 +45,7 @@
         "event.duration": -1468967296,
         "event.kind": "event",
         "event.module": "azure",
+        "event.outcome": "success",
         "event.type": [
             "change"
         ],


### PR DESCRIPTION
Cherry-pick of PR #20998 to 7.x branch. Original message: 

## What does this PR do?

Adding a small fix to event.outcome from resulttype and adding a second property to event.outcome if result_type does not exist

## Why is it important?

Fixes small issues for event.outcome parsing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #20990
