### PR TITLE
Cherry-pick #20415 to 7.x: Add host inventory metrics to system module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -792,6 +792,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add state_daemonset metricset for Kubernetes Metricbeat module {pull}20649[20649]
 - Add host inventory metrics to googlecloud compute metricset. {pull}20391[20391]
 - Add host inventory metrics to azure compute_vm metricset. {pull}20641[20641]
+- Add host inventory metrics to system module. {pull}20415[20415]
 - Add billing data collection from Cost Explorer into aws billing metricset. {pull}20527[20527] {issue}20103[20103]
 - Migrate `compute_vm` metricset to a light one, map `cloud.instance.id` field. {pull}20889[20889]
 - Request prometheus endpoints to be gzipped by default {pull}20766[20766]

--- a/metricbeat/module/system/cpu/_meta/data.json
+++ b/metricbeat/module/system/cpu/_meta/data.json
@@ -1,36 +1,38 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "system.cpu",
         "duration": 115000,
         "module": "system"
     },
+    "host": {
+        "cpu": {
+            "pct": 0.0816
+        }
+    },
     "metricset": {
-        "name": "cpu"
+        "name": "cpu",
+        "period": 10000
     },
     "service": {
         "type": "system"
     },
     "system": {
         "cpu": {
-            "cores": 4,
+            "cores": 12,
             "idle": {
                 "norm": {
-                    "pct": 0.7198
+                    "pct": 0.9184
                 },
-                "pct": 2.8792,
-                "ticks": 81308898
+                "pct": 11.0208,
+                "ticks": 1964402
             },
             "iowait": {
                 "norm": {
                     "pct": 0
                 },
                 "pct": 0,
-                "ticks": 499109
+                "ticks": 5083
             },
             "irq": {
                 "norm": {
@@ -44,14 +46,14 @@
                     "pct": 0
                 },
                 "pct": 0,
-                "ticks": 172471
+                "ticks": 9752
             },
             "softirq": {
                 "norm": {
-                    "pct": 0
+                    "pct": 0.0058
                 },
-                "pct": 0,
-                "ticks": 578041
+                "pct": 0.0699,
+                "ticks": 10386
             },
             "steal": {
                 "norm": {
@@ -62,23 +64,23 @@
             },
             "system": {
                 "norm": {
-                    "pct": 0.0591
+                    "pct": 0.005
                 },
-                "pct": 0.2365,
-                "ticks": 25140781
+                "pct": 0.06,
+                "ticks": 22274
             },
             "total": {
                 "norm": {
-                    "pct": 0.2802
+                    "pct": 0.0816
                 },
-                "pct": 1.1208
+                "pct": 0.9792
             },
             "user": {
                 "norm": {
-                    "pct": 0.2211
+                    "pct": 0.0708
                 },
-                "pct": 0.8843,
-                "ticks": 75216920
+                "pct": 0.8493,
+                "ticks": 123767
             }
         }
     }

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -70,7 +70,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	event := common.MapStr{"cores": cpu.NumCores}
-
+	hostFields := common.MapStr{}
 	for _, metric := range m.config.Metrics {
 		switch strings.ToLower(metric) {
 		case percentages:
@@ -95,6 +95,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 			event.Put("softirq.norm.pct", normalizedPct.SoftIRQ)
 			event.Put("steal.norm.pct", normalizedPct.Steal)
 			event.Put("total.norm.pct", normalizedPct.Total)
+			hostFields.Put("host.cpu.pct", normalizedPct.Total)
 		case ticks:
 			ticks := sample.Ticks()
 			event.Put("user.ticks", ticks.User)
@@ -109,6 +110,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	r.Event(mb.Event{
+		RootFields:      hostFields,
 		MetricSetFields: event,
 	})
 

--- a/metricbeat/module/system/diskio/_meta/data.json
+++ b/metricbeat/module/system/diskio/_meta/data.json
@@ -1,16 +1,13 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "system.diskio",
         "duration": 115000,
         "module": "system"
     },
     "metricset": {
-        "name": "diskio"
+        "name": "diskio",
+        "period": 10000
     },
     "service": {
         "type": "system"
@@ -18,7 +15,7 @@
     "system": {
         "diskio": {
             "io": {
-                "time": 656
+                "time": 364
             },
             "iostat": {
                 "await": 0,
@@ -51,16 +48,16 @@
                     }
                 }
             },
-            "name": "nvme0n1p1",
+            "name": "loop1",
             "read": {
-                "bytes": 8028160,
-                "count": 3290,
-                "time": 130016
+                "bytes": 5267456,
+                "count": 4124,
+                "time": 557
             },
             "write": {
-                "bytes": 5120,
-                "count": 3,
-                "time": 12
+                "bytes": 0,
+                "count": 0,
+                "time": 0
             }
         }
     }

--- a/metricbeat/module/system/network/_meta/data.json
+++ b/metricbeat/module/system/network/_meta/data.json
@@ -1,16 +1,13 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "system.network",
         "duration": 115000,
         "module": "system"
     },
     "metricset": {
-        "name": "network"
+        "name": "network",
+        "period": 10000
     },
     "service": {
         "type": "system"
@@ -18,17 +15,17 @@
     "system": {
         "network": {
             "in": {
-                "bytes": 37904869172,
-                "dropped": 32,
-                "errors": 0,
-                "packets": 32143403
-            },
-            "name": "wlp4s0",
-            "out": {
-                "bytes": 6299331926,
+                "bytes": 0,
                 "dropped": 0,
                 "errors": 0,
-                "packets": 13362703
+                "packets": 0
+            },
+            "name": "br-18285ad7f418",
+            "out": {
+                "bytes": 0,
+                "dropped": 0,
+                "errors": 0,
+                "packets": 0
             }
         }
     }


### PR DESCRIPTION
Cherry-pick of PR #20415 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
This PR is to add proposed host common fields into `system` module:
- host.id
- host.name
- host.cpu.pct
- host.network.in.bytes
- host.network.in.packets
- host.network.out.bytes
- host.network.out.packets
- host.disk.read.bytes
- host.disk.write.bytes

For network and disk metrics, instead of reporting one event per interface, `host.network.*` and `host.disk.*` aggregates values from all interfaces.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Change `system` module config `system.yml` with:
```
- module: system
  period: 10s
  metricsets:
    - cpu
    - load
    - network
  cpu.metrics: [normalized_percentages]
```

Then start Metricbeat with `./metricbeat -e` and you should see host common fields listed above in events.

## Event Example
CPU metric:
```
{
    "event": {
      "duration": 88523,
      "dataset": "system.cpu",
      "module": "system"
    },
    "metricset": {
      "name": "cpu",
      "period": 10000
    },
    "service": {
      "type": "system"
    },
    "system": {
      "cpu": {
        "user": {
          "pct": 0.7653,
          "norm": {
            "pct": 0.0638
          }
        },
        "steal": {
          "pct": 0,
          "norm": {
            "pct": 0
          }
        },
        "cores": 12,
        "system": {
          "pct": 0.2961,
          "norm": {
            "pct": 0.0247
          }
        },
        "iowait": {
          "pct": 0,
          "norm": {
            "pct": 0
          }
        },
        "nice": {
          "pct": 0,
          "norm": {
            "pct": 0
          }
        },
        "total": {
          "norm": {
            "pct": 0.0884
          },
          "pct": 1.0614
        },
        "idle": {
          "pct": 10.9386,
          "norm": {
            "pct": 0.9116
          }
        },
        "irq": {
          "norm": {
            "pct": 0
          },
          "pct": 0
        },
        "softirq": {
          "pct": 0,
          "norm": {
            "pct": 0
          }
        }
      }
    },
    "host": {
      "cpu": {
        "pct": 0.0884
      },
      "name": "KaiyanMacBookPro",
      "hostname": "KaiyanMacBookPro",
      "architecture": "x86_64"
    }
  }
}
```

Network metrics:
```
{
  "_source": {
    "metricset": {
      "name": "network",
      "period": 60000
    },
    "service": {
      "type": "system"
    },
    "host.network.out.bytes": 26123693254,
    "host.network.out.packets": 134348248,
    "event": {
      "dataset": "system.network",
      "module": "system",
      "duration": 6234971
    },
    "host.network.in.bytes": 74833783286,
    "host.network.in.packets": 139823676,
    "host": {
      "name": "KaiyanMacBookPro",
      "hostname": "KaiyanMacBookPro",
      "architecture": "x86_64",
      "id": "9C7FAB7B-29D1-5926-8E84-158A9CA3E25D"
    }
}
```

Disk metrics:
```
{
  "_source": {
    "host.disk.read.bytes": 535049839616,
    "host.disk.write.bytes": 782890594304,
    "event": {
      "dataset": "system.diskio",
      "module": "system",
      "duration": 606341
    },
    "metricset": {
      "name": "diskio",
      "period": 10000
    },
    "service": {
      "type": "system"
    },
    "host": {
      "name": "KaiyanMacBookPro",
      "architecture": "x86_64",
      "hostname": "KaiyanMacBookPro"
    }
  }
}
```

## Related issues

- Relates to https://github.com/elastic/beats/issues/19757