### PR TITLE
[Winlogbeat] Add acceptable event log keys to winlog

### DIFF
--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -28,7 +28,7 @@ import (
 )
 
 var commonConfigKeys = []string{"type", "api", "name", "fields", "fields_under_root",
-	"tags", "processors", "index"}
+	"tags", "processors", "index", "id", "meta", "revision"}
 
 // ConfigCommon is the common configuration data used to instantiate a new
 // EventLog. Each implementation is free to support additional configuration


### PR DESCRIPTION
## What does this PR do?

Adds 'id', 'meta' and 'revision' as acceptable config keys for winlog
input.


## Why is it important?

when running filebeat under elasti-agent 'id', 'meta' and 'revision'
are sent as config keys to the winlog input type.  This change allows
those config keys to pass validation.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

