### PR TITLE
Cherry-pick #21209 to 7.x: Add compatibility note about ingress-controller-v0.34.1

### DIFF
--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -28,7 +28,7 @@ The Nginx module was tested with logs from version 1.10.
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
 
-`ingress_controller` fileset was tested with version 0.28.0 of `nginx-ingress-controller`.
+`ingress_controller` fileset was tested with version v0.28.0 and v0.34.1 of `nginx-ingress-controller`.
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -23,7 +23,7 @@ The Nginx module was tested with logs from version 1.10.
 On Windows, the module was tested with Nginx installed from the Chocolatey
 repository.
 
-`ingress_controller` fileset was tested with version 0.28.0 of `nginx-ingress-controller`.
+`ingress_controller` fileset was tested with version v0.28.0 and v0.34.1 of `nginx-ingress-controller`.
 
 include::../include/configuring-intro.asciidoc[]
 


### PR DESCRIPTION
Cherry-pick of PR #21209 to 7.x branch. Original message: 

## What does this PR do?
Adds compatibility note for version `v0.34.1` of ingress-controller.


## Why is it important?
To keep our docs and module updated with latest versions.



## Related issues

- Closes https://github.com/elastic/beats/issues/21198


