### PR TITLE
[DOCS] Add beat specific start widgets

### DIFF
--- a/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Filebeat
+:beatname_lc: filebeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-f">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-filebeat"
+            id="deb-start-filebeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-filebeat"
+            id="rpm-start-filebeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-filebeat"
+            id="mac-start-filebeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-start-filebeat"
+            id="brew-start-filebeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-filebeat"
+            id="linux-start-filebeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-filebeat"
+            id="win-start-filebeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-filebeat"
+       aria-labelledby="deb-start-filebeat">
+++++
+
+include::start.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-filebeat"
+       aria-labelledby="rpm-start-filebeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-filebeat"
+       aria-labelledby="mac-start-filebeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-start-filebeat"
+       aria-labelledby="brew-start-filebeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-filebeat"
+       aria-labelledby="linux-start-filebeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-filebeat"
+       aria-labelledby="win-start-filebeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
@@ -1,5 +1,6 @@
 :beatname_uc: Filebeat
 :beatname_lc: filebeat
+:beatname_pkg: filebeat
 ++++
 <div class="tabs" data-tab-group="os">
   <div role="tablist" aria-label="Start-f">

--- a/libbeat/docs/tab-widgets/start-widget-heartbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-heartbeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Heartbeat
+:beatname_lc: heartbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-h">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-heartbeat"
+            id="deb-start-heartbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-heartbeat"
+            id="rpm-start-heartbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-heartbeat"
+            id="mac-start-heartbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-start-heartbeat"
+            id="brew-start-heartbeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-heartbeat"
+            id="linux-start-heartbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-heartbeat"
+            id="win-start-heartbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-heartbeat"
+       aria-labelledby="deb-start-heartbeat">
+++++
+
+include::start.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-heartbeat"
+       aria-labelledby="rpm-start-heartbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-heartbeat"
+       aria-labelledby="mac-start-heartbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-start-heartbeat"
+       aria-labelledby="brew-start-heartbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-heartbeat"
+       aria-labelledby="linux-start-heartbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-heartbeat"
+       aria-labelledby="win-start-heartbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/start-widget-heartbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-heartbeat.asciidoc
@@ -1,5 +1,6 @@
 :beatname_uc: Heartbeat
 :beatname_lc: heartbeat
+:beatname_pkg: heartbeat
 ++++
 <div class="tabs" data-tab-group="os">
   <div role="tablist" aria-label="Start-h">

--- a/libbeat/docs/tab-widgets/start-widget-metricbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-metricbeat.asciidoc
@@ -1,0 +1,114 @@
+:beatname_uc: Metricbeat
+:beatname_lc: metricbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-m">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-metricbeat"
+            id="deb-start-metricbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-metricbeat"
+            id="rpm-start-metricbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-metricbeat"
+            id="mac-start-metricbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-start-metricbeat"
+            id="brew-start-metricbeat"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-metricbeat"
+            id="linux-start-metricbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-metricbeat"
+            id="win-start-metricbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-metricbeat"
+       aria-labelledby="deb-start-metricbeat">
+++++
+
+include::start.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-metricbeat"
+       aria-labelledby="rpm-start-metricbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-metricbeat"
+       aria-labelledby="mac-start-metricbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-start-metricbeat"
+       aria-labelledby="brew-start-metricbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-metricbeat"
+       aria-labelledby="linux-start-metricbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-metricbeat"
+       aria-labelledby="win-start-metricbeat"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/start-widget-metricbeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-metricbeat.asciidoc
@@ -1,5 +1,6 @@
 :beatname_uc: Metricbeat
 :beatname_lc: metricbeat
+:beatname_pkg: metricbeat
 ++++
 <div class="tabs" data-tab-group="os">
   <div role="tablist" aria-label="Start-m">


### PR DESCRIPTION
This PR adds three Beat specific start widgets: Filebeat, Metricbeat, and Heartbeat. The requirement is to have all three individual widgets on one page (useful for all-in tutorials). Each widget sets the following Asciidoctor attributes: `:beatname_uc:`, `:beatname_lc:`, and `:beatname_pkg:`.

<img width="748" alt="filebeat-start-widget" src="https://user-images.githubusercontent.com/31283375/93885706-61adb480-fcdc-11ea-9c5e-27e95848cdcf.png">
<img width="752" alt="heartbeat-start-widget" src="https://user-images.githubusercontent.com/31283375/93885719-683c2c00-fcdc-11ea-8388-31bc3a3bc45b.png">
<img width="751" alt="metricbeat-start-wiget" src="https://user-images.githubusercontent.com/31283375/93885738-6e320d00-fcdc-11ea-8161-db9722a7fe46.png">

