### PR TITLE
Cherry-pick #21219 to 7.x: Add elastic-agent binary to gitignore

### DIFF
--- a/x-pack/elastic-agent/.gitignore
+++ b/x-pack/elastic-agent/.gitignore
@@ -1,5 +1,6 @@
 # agent
 build/
+elastic-agent
 elastic-agent.dev.yml
 pkg/agent/operation/tests/scripts/short--1.0.yml
 pkg/agent/operation/tests/scripts/configurable-1.0-darwin-x86/configurable


### PR DESCRIPTION
Cherry-pick of PR #21219 to 7.x branch. Original message: 

Running `mage build` or `go build` produces the `elastic-agent` binary that shouldn't be tracked by git, add it to gitignore.