### PR TITLE
Add regex tests to prometheus collector tests

### DIFF
--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -388,7 +388,6 @@ func TestSkipMetricFamily(t *testing.T) {
 	// test with one include and one exclude
 	ms.includeMetrics, _ = p.CompilePatternList(&[]string{"http_request_duration_microseconds_a_*"})
 	ms.excludeMetrics, _ = p.CompilePatternList(&[]string{"http_request_duration_microseconds_a_b_*"})
->>>>>>> bf06ea666... Add regex tests to prometheus collector tests
 	metricsToKeep = 0
 	for _, testFamily := range testFamilies {
 		if !ms.skipFamily(testFamily) {

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -363,9 +363,32 @@ func TestSkipMetricFamily(t *testing.T) {
 	}
 	assert.Equal(t, len(testFamilies)-2, metricsToKeep)
 
-	// test with ine include and one exclude
+	// test with only one regex exclude filter
+	ms.includeMetrics, _ = p.CompilePatternList(&[]string{""})
+	ms.excludeMetrics, _ = p.CompilePatternList(&[]string{"^http_request_duration_microseconds_e_in$"})
+	metricsToKeep = 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep++
+		}
+	}
+	assert.Equal(t, len(testFamilies)-1, metricsToKeep)
+
+	// test with only one regex exclude filter
+	ms.includeMetrics, _ = p.CompilePatternList(&[]string{""})
+	ms.excludeMetrics, _ = p.CompilePatternList(&[]string{"^http_request_duration_microseconds_[a-e]_in$"})
+	metricsToKeep = 0
+	for _, testFamily := range testFamilies {
+		if !ms.skipFamily(testFamily) {
+			metricsToKeep++
+		}
+	}
+	assert.Equal(t, len(testFamilies)-4, metricsToKeep)
+
+	// test with one include and one exclude
 	ms.includeMetrics, _ = p.CompilePatternList(&[]string{"http_request_duration_microseconds_a_*"})
 	ms.excludeMetrics, _ = p.CompilePatternList(&[]string{"http_request_duration_microseconds_a_b_*"})
+>>>>>>> bf06ea666... Add regex tests to prometheus collector tests
 	metricsToKeep = 0
 	for _, testFamily := range testFamilies {
 		if !ms.skipFamily(testFamily) {


### PR DESCRIPTION
- Enhancement


## What does this PR do?
It adds missing regex-based tests for the prometheus collector module.

## Why is it important?
This relates to https://github.com/elastic/beats/pull/16568#issuecomment-696695550

We have issues with excluding based on regex and this validates that it is working in the code as it should.
We don't know why the metricbeat RPM packages from Elastic are failing to work as documented, but at least here it works :-)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
`go test`

## Related issues
- Relates #16568 

## Use cases
N/A

## Screenshots
N/A

## Logs
N/A