### PR TITLE
Cherry-pick #21166 to 7.x: Fix timestamp handling in remote_write

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -398,6 +398,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Disable Kafka metricsets based on Jolokia by default. They require a different configuration. {pull}20989[20989]
 - Fix panic index out of range error when getting AWS account name. {pull}21101[21101] {issue}21095[21095]
 - Handle missing counters in the application_pool metricset. {pull}21071[21071]
+- Fix timestamp handling in remote_write. {pull}21166[21166]
 - Fix remote_write flaky test. {pull}21173[21173]
 
 *Packetbeat*

--- a/metricbeat/module/prometheus/remote_write/data.go
+++ b/metricbeat/module/prometheus/remote_write/data.go
@@ -57,13 +57,14 @@ func (p *remoteWriteEventGenerator) GenerateEvents(metrics model.Samples) map[st
 			labels[string(k)] = v
 		}
 
-		// join metrics with same labels in a single event
-		labelsHash := labels.String()
+		// join metrics with same labels and same timestamp in a single event
+		labelsHash := labels.String() + metric.Timestamp.Time().String()
 		if _, ok := eventList[labelsHash]; !ok {
 			eventList[labelsHash] = mb.Event{
 				ModuleFields: common.MapStr{
 					"metrics": common.MapStr{},
 				},
+				Timestamp: metric.Timestamp.Time(),
 			}
 
 			// Add labels
@@ -74,7 +75,6 @@ func (p *remoteWriteEventGenerator) GenerateEvents(metrics model.Samples) map[st
 
 		// Not checking anything here because we create these maps some lines before
 		e := eventList[labelsHash]
-		e.Timestamp = metric.Timestamp.Time()
 		data := common.MapStr{
 			name: val,
 		}

--- a/metricbeat/module/prometheus/remote_write/remote_write_test.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write_test.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package remote_write
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+// TestGenerateEventsCounter tests counter simple cases
+func TestGenerateEventsCounter(t *testing.T) {
+	g := remoteWriteEventGenerator{}
+
+	timestamp := model.Time(424242)
+	timestamp1 := model.Time(424243)
+	labels := common.MapStr{
+		"listener_name": model.LabelValue("http"),
+	}
+
+	// first fetch
+	metrics := model.Samples{
+		&model.Sample{
+			Metric: map[model.LabelName]model.LabelValue{
+				"__name__":      "net_conntrack_listener_conn_closed_total",
+				"listener_name": "http",
+			},
+			Value:     model.SampleValue(42),
+			Timestamp: timestamp,
+		},
+		&model.Sample{
+			Metric: map[model.LabelName]model.LabelValue{
+				"__name__":      "net_conntrack_listener_conn_closed_total",
+				"listener_name": "http",
+			},
+			Value:     model.SampleValue(43),
+			Timestamp: timestamp1,
+		},
+	}
+	events := g.GenerateEvents(metrics)
+
+	expected := common.MapStr{
+		"metrics": common.MapStr{
+			"net_conntrack_listener_conn_closed_total": float64(42),
+		},
+		"labels": labels,
+	}
+	expected1 := common.MapStr{
+		"metrics": common.MapStr{
+			"net_conntrack_listener_conn_closed_total": float64(43),
+		},
+		"labels": labels,
+	}
+
+	assert.Equal(t, len(events), 2)
+	e := events[labels.String()+timestamp.Time().String()]
+	assert.EqualValues(t, e.ModuleFields, expected)
+	assert.EqualValues(t, e.Timestamp, timestamp.Time())
+	e = events[labels.String()+timestamp1.Time().String()]
+	assert.EqualValues(t, e.ModuleFields, expected1)
+	assert.EqualValues(t, e.Timestamp, timestamp1.Time())
+}

--- a/x-pack/metricbeat/module/prometheus/remote_write/remote_write_test.go
+++ b/x-pack/metricbeat/module/prometheus/remote_write/remote_write_test.go
@@ -28,10 +28,10 @@ func TestGenerateEventsCounter(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
-
 	// first fetch
 	metrics := model.Samples{
 		&model.Sample{
@@ -40,7 +40,7 @@ func TestGenerateEventsCounter(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -54,7 +54,7 @@ func TestGenerateEventsCounter(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 	// repeat in order to test the rate
@@ -65,7 +65,7 @@ func TestGenerateEventsCounter(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -79,7 +79,7 @@ func TestGenerateEventsCounter(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 }
@@ -94,6 +94,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
@@ -106,7 +107,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -114,7 +115,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(43),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -132,7 +133,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 	// repeat in order to test the rate
@@ -143,7 +144,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -151,7 +152,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(47),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -169,7 +170,7 @@ func TestGenerateEventsCounterSameLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 }
@@ -184,6 +185,8 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
@@ -200,7 +203,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -208,7 +211,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(43),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -217,7 +220,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(44),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -242,9 +245,9 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 2)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected1)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 
 	// repeat in order to test the rate
@@ -255,7 +258,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -263,7 +266,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(47),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -272,7 +275,7 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(50),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -297,9 +300,9 @@ func TestGenerateEventsCounterDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 2)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected1)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 
 }
@@ -314,6 +317,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
@@ -330,7 +334,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -338,7 +342,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(43),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -347,7 +351,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(44),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -356,7 +360,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(49),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -384,9 +388,9 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 2)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected1)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 
 	// repeat in order to test the rate
@@ -397,7 +401,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -405,7 +409,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(47),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -414,7 +418,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(50),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -423,7 +427,7 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 				"device":        "eth0",
 			},
 			Value:     model.SampleValue(59),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -451,9 +455,9 @@ func TestGenerateEventsGaugeDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 2)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected1)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 
 }
@@ -468,6 +472,8 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"runtime":  model.LabelValue("linux"),
 		"quantile": model.LabelValue("0.25"),
@@ -489,7 +495,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.25",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -498,7 +504,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.50",
 			},
 			Value:     model.SampleValue(43),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -506,7 +512,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(44),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -514,7 +520,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -523,7 +529,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.25",
 			},
 			Value:     model.SampleValue(46),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -556,11 +562,11 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 3)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
-	e = events[labels3.String()]
+	e = events[labels3.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected3)
 
 	// repeat in order to test the rate
@@ -572,7 +578,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.25",
 			},
 			Value:     model.SampleValue(52),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -581,7 +587,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.50",
 			},
 			Value:     model.SampleValue(53),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -589,7 +595,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(54),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -597,7 +603,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(55),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -606,7 +612,7 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 				"quantile": "0.25",
 			},
 			Value:     model.SampleValue(56),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -639,11 +645,11 @@ func TestGenerateEventsQuantilesDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 3)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
-	e = events[labels3.String()]
+	e = events[labels3.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected3)
 
 }
@@ -658,6 +664,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 		rateCounters: true,
 	}
 	g.counterCache.Start()
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"runtime": model.LabelValue("linux"),
 	}
@@ -674,7 +681,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -683,7 +690,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(43),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -692,7 +699,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(44),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -700,7 +707,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -708,7 +715,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(46),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		// second histogram same label
 		&model.Sample{
@@ -718,7 +725,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(52),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -727,7 +734,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(53),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -736,7 +743,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(54),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -744,7 +751,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(55),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -752,7 +759,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(56),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		// third histogram different label
 		&model.Sample{
@@ -762,7 +769,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(62),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -771,7 +778,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(63),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -780,7 +787,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(64),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -788,7 +795,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "darwin",
 			},
 			Value:     model.SampleValue(65),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -796,7 +803,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "darwin",
 			},
 			Value:     model.SampleValue(66),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -851,9 +858,9 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(events))
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 
 	// repeat in order to test the rate
@@ -865,7 +872,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(142),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -874,7 +881,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(143),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -883,7 +890,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(144),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -891,7 +898,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(145),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -899,7 +906,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(146),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		// second histogram same label
 		&model.Sample{
@@ -909,7 +916,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(252),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -918,7 +925,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(253),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -927,7 +934,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(254),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -935,7 +942,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(255),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -943,7 +950,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "linux",
 			},
 			Value:     model.SampleValue(256),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		// third histogram different label
 		&model.Sample{
@@ -953,7 +960,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.25",
 			},
 			Value:     model.SampleValue(362),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -962,7 +969,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "0.50",
 			},
 			Value:     model.SampleValue(363),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -971,7 +978,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"le":       "+Inf",
 			},
 			Value:     model.SampleValue(364),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -979,7 +986,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "darwin",
 			},
 			Value:     model.SampleValue(365),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 		&model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -987,7 +994,7 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 				"runtime":  "darwin",
 			},
 			Value:     model.SampleValue(366),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -1042,9 +1049,9 @@ func TestGenerateEventsHistogramsDifferentLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(events))
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
-	e = events[labels2.String()]
+	e = events[labels2.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected2)
 }
 
@@ -1064,6 +1071,8 @@ func TestGenerateEventsCounterWithDefinedPattern(t *testing.T) {
 	}
 
 	g.counterCache.Start()
+
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
@@ -1076,7 +1085,7 @@ func TestGenerateEventsCounterWithDefinedPattern(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -1090,7 +1099,7 @@ func TestGenerateEventsCounterWithDefinedPattern(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 	// repeat in order to test the rate
@@ -1101,7 +1110,7 @@ func TestGenerateEventsCounterWithDefinedPattern(t *testing.T) {
 				"listener_name": "http",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -1115,7 +1124,7 @@ func TestGenerateEventsCounterWithDefinedPattern(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 }
@@ -1136,6 +1145,7 @@ func TestGenerateEventsHistogramWithDefinedPattern(t *testing.T) {
 	}
 
 	g.counterCache.Start()
+	timestamp := model.Time(424242)
 	labels := common.MapStr{
 		"listener_name": model.LabelValue("http"),
 	}
@@ -1149,7 +1159,7 @@ func TestGenerateEventsHistogramWithDefinedPattern(t *testing.T) {
 				"le":            "20",
 			},
 			Value:     model.SampleValue(42),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events := g.GenerateEvents(metrics)
@@ -1165,7 +1175,7 @@ func TestGenerateEventsHistogramWithDefinedPattern(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e := events[labels.String()]
+	e := events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 	// repeat in order to test the rate
@@ -1177,7 +1187,7 @@ func TestGenerateEventsHistogramWithDefinedPattern(t *testing.T) {
 				"le":            "20",
 			},
 			Value:     model.SampleValue(45),
-			Timestamp: model.Time(424242),
+			Timestamp: timestamp,
 		},
 	}
 	events = g.GenerateEvents(metrics)
@@ -1193,7 +1203,7 @@ func TestGenerateEventsHistogramWithDefinedPattern(t *testing.T) {
 	}
 
 	assert.Equal(t, len(events), 1)
-	e = events[labels.String()]
+	e = events[labels.String()+timestamp.Time().String()]
 	assert.EqualValues(t, e.ModuleFields, expected)
 
 }


### PR DESCRIPTION
Cherry-pick of PR #21166 to 7.x branch. Original message: 

## What does this PR do?
Fixes how we handle timestamps when we process Prometheus Samples using remote_write. Before this change it could be possible that we miss some metrics in case of having the same metric in the same received chunk (with different timestamps). Metrics with different timestamps should go in different final events and hence `timestamp` should be taken into account when grouping metrics into events.

## Why is it important?
To avoid losing data due to wrong grouping.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
