### PR TITLE
[packaging] run on a daily basis for branches only

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -27,6 +27,8 @@ pipeline {
     issueCommentTrigger('(?i)^\\/packag[ing|e]$')
     // disable upstream trigger on a PR basis
     upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+    // enable packaging for branches on a daily basis
+    cron((isPR() || env.TAG_NAME?.trim()) ? '' : 'H 5 * * 1-5')
   }
   parameters {
     booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')
@@ -39,6 +41,7 @@ pipeline {
         beforeAgent true
         anyOf {
           triggeredBy cause: "IssueCommentCause"
+          triggeredBy 'TimerTrigger'
           expression {
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){


### PR DESCRIPTION
## What does this PR do?

As agreed let's run the packaging pipeline for the master/release branches on a daily basis, then snapshot binaries are at least generated once a day in the worst case scenario.

## Why is it important?

Current workflow consists on three different pipelines that run sequentially, if any of those pipelines got broken then the following pipelines won't be triggered.

In other words, for every commit that's merged to master, the multibranch pipeline is triggered, and only if it ran successfully the packaging pipeline will be triggered, and only if that pipeline is successfully the `beats-tester` pipeline will run.