### PR TITLE
Cherry-pick #21214 to 7.x: [Filebeat][httpjson] Add recursive split to httpjson

### DIFF
--- a/x-pack/filebeat/input/httpjson/requester_test.go
+++ b/x-pack/filebeat/input/httpjson/requester_test.go
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitEventsBy(t *testing.T) {
+	event := map[string]interface{}{
+		"this": "is kept",
+		"alerts": []interface{}{
+			map[string]interface{}{
+				"this_is": "also kept",
+				"entities": []interface{}{
+					map[string]interface{}{
+						"something": "something",
+					},
+					map[string]interface{}{
+						"else": "else",
+					},
+				},
+			},
+			map[string]interface{}{
+				"this_is": "also kept 2",
+				"entities": []interface{}{
+					map[string]interface{}{
+						"something": "something 2",
+					},
+					map[string]interface{}{
+						"else": "else 2",
+					},
+				},
+			},
+		},
+	}
+
+	expectedEvents := []map[string]interface{}{
+		{
+			"this": "is kept",
+			"alerts": map[string]interface{}{
+				"this_is": "also kept",
+				"entities": map[string]interface{}{
+					"something": "something",
+				},
+			},
+		},
+		{
+			"this": "is kept",
+			"alerts": map[string]interface{}{
+				"this_is": "also kept",
+				"entities": map[string]interface{}{
+					"else": "else",
+				},
+			},
+		},
+		{
+			"this": "is kept",
+			"alerts": map[string]interface{}{
+				"this_is": "also kept 2",
+				"entities": map[string]interface{}{
+					"something": "something 2",
+				},
+			},
+		},
+		{
+			"this": "is kept",
+			"alerts": map[string]interface{}{
+				"this_is": "also kept 2",
+				"entities": map[string]interface{}{
+					"else": "else 2",
+				},
+			},
+		},
+	}
+
+	const key = "alerts..entities"
+
+	got := splitEvent(key, event)
+
+	assert.Equal(t, expectedEvents, got)
+}


### PR DESCRIPTION
Cherry-pick of PR #21214 to 7.x branch. Original message: 

## What does this PR do?

Adds ability to split recursively to have more than one level of split events by functionality.

NOTE: uses the `..` notation instead of `.` to avoid breaking users using `.` notation currently.

## Why is it important?

This will unblock the development of some modules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

__We do not want to add it to the changelog since is only for internal use and to be removed soon__