### PR TITLE
stop monitoring excluded paths

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -208,6 +208,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - auditd: Fix typo in `event.action` of `used-suspicious-link`. {pull}19300[19300]
 - system/socket: Fix kprobe grouping to allow running more than one instance. {pull}20325[20325]
 - system/socket: Fixed a crash due to concurrent map read and write. {issue}21192[21192] {pull}21690[21690]
+- file_integrity: stop monitoring excluded paths {issue}21278[21278] {pull}21282[21282]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -46,7 +46,7 @@ func NewEventReader(c Config) (EventProducer, error) {
 }
 
 func (r *reader) Start(done <-chan struct{}) (<-chan Event, error) {
-	watcher, err := monitor.New(r.config.Recursive)
+	watcher, err := monitor.New(r.config.Recursive, r.config.IsExcludedPath)
 	if err != nil {
 		return nil, err
 	}

--- a/auditbeat/module/file_integrity/monitor/monitor.go
+++ b/auditbeat/module/file_integrity/monitor/monitor.go
@@ -37,15 +37,15 @@ type Watcher interface {
 
 // New creates a new Watcher backed by fsnotify with optional recursive
 // logic.
-func New(recursive bool) (Watcher, error) {
-	fsnotify, err := fsnotify.NewWatcher()
+func New(recursive bool, IsExcludedPath func(path string) bool) (Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 	// Use our simulated recursive watches unless the fsnotify implementation
 	// supports OS-provided recursive watches
-	if recursive && fsnotify.SetRecursive() != nil {
-		return newRecursiveWatcher(fsnotify), nil
+	if recursive && watcher.SetRecursive() != nil {
+		return newRecursiveWatcher(watcher, IsExcludedPath), nil
 	}
-	return (*nonRecursiveWatcher)(fsnotify), nil
+	return (*nonRecursiveWatcher)(watcher), nil
 }

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -305,7 +305,7 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 	// excludes file/dir named "b"
 	selectiveExclude := func(path string) bool {
 		r := filepath.Base(path) == "b"
-		t.Logf("path: %v, result: %v\n", path, r)
+		t.Logf("path: %v, excluded: %v\n", path, r)
 		return r
 	}
 
@@ -348,7 +348,7 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 	}
 
 	// Verify that events for all accessible files are received
-	// File "b/b" is missing as it is excluded
+	// "b" and "b/b" are missing as they are excluded
 
 	expected := map[string]fsnotify.Op{
 		dest:                       fsnotify.Create,

--- a/auditbeat/module/file_integrity/monitor/recursive.go
+++ b/auditbeat/module/file_integrity/monitor/recursive.go
@@ -122,7 +122,7 @@ func (watcher *recursiveWatcher) close() error {
 }
 
 func (watcher *recursiveWatcher) deliver(ev fsnotify.Event) {
-	// skip watching excluded path
+	// skip deliver events for excluded path
 	if watcher.isExcludedPath(ev.Name) {
 		return
 	}


### PR DESCRIPTION
## What does this PR do?

If the files match the excluded pattern, `recursiveWatcher` does not emit events for them, as well as errors if any.

## Why is it important?

This eliminates unnecessary warning logs for file paths that user intends to exclude.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

run test case `TestRecursiveExcludedPaths`

## Related issues

- Closes elastic/beats#21278

