### PR TITLE
Cherry-pick #21239 to 7.x: Fix librpm installation in auditbeat build

### DIFF
--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -132,13 +132,13 @@ var (
 		"linux/386":      installLinux386,
 		"linux/amd64":    installLinuxAMD64,
 		"linux/arm64":    installLinuxARM64,
-		"linux/armv5":    installLinuxARMLE,
-		"linux/armv6":    installLinuxARMLE,
+		"linux/armv5":    installLinuxARMEL,
+		"linux/armv6":    installLinuxARMEL,
 		"linux/armv7":    installLinuxARMHF,
 		"linux/mips":     installLinuxMIPS,
-		"linux/mipsle":   installLinuxMIPSLE,
-		"linux/mips64le": installLinuxMIPS64LE,
-		"linux/ppc64le":  installLinuxPPC64LE,
+		"linux/mipsle":   installLinuxMIPSEL,
+		"linux/mips64le": installLinuxMIPS64EL,
+		"linux/ppc64le":  installLinuxPPC64EL,
 		"linux/s390x":    installLinuxS390X,
 
 		//"linux/ppc64":  installLinuxPpc64,
@@ -148,49 +148,56 @@ var (
 
 const (
 	librpmDevPkgName = "librpm-dev"
+
+	// Dependency of librpm-dev in ARM architectures, that needs to be explicitly
+	// installed to replace other conflicting packages pre-installed in the image.
+	libicuDevPkgName = "libicu-dev"
 )
 
 func installLinuxAMD64() error {
-	return installDependencies(librpmDevPkgName, "")
+	return installDependencies("", librpmDevPkgName)
 }
 
 func installLinuxARM64() error {
-	return installDependencies(librpmDevPkgName+":arm64", "arm64")
+	return installDependencies("arm64", librpmDevPkgName+":arm64")
 }
 
 func installLinuxARMHF() error {
-	return installDependencies(librpmDevPkgName+":armhf", "armhf")
+	return installDependencies("armhf", librpmDevPkgName+":armhf", libicuDevPkgName+":armhf")
 }
 
-func installLinuxARMLE() error {
-	return installDependencies(librpmDevPkgName+":armel", "armel")
+func installLinuxARMEL() error {
+	return installDependencies("armel", librpmDevPkgName+":armel", libicuDevPkgName+":armel")
 }
 
 func installLinux386() error {
-	return installDependencies(librpmDevPkgName+":i386", "i386")
+	return installDependencies("i386", librpmDevPkgName+":i386")
 }
 
 func installLinuxMIPS() error {
-	return installDependencies(librpmDevPkgName+":mips", "mips")
+	return installDependencies("mips", librpmDevPkgName+":mips")
 }
 
-func installLinuxMIPS64LE() error {
-	return installDependencies(librpmDevPkgName+":mips64el", "mips64el")
+func installLinuxMIPS64EL() error {
+	return installDependencies("mips64el", librpmDevPkgName+":mips64el")
 }
 
-func installLinuxMIPSLE() error {
-	return installDependencies(librpmDevPkgName+":mipsel", "mipsel")
+func installLinuxMIPSEL() error {
+	return installDependencies("mispel", librpmDevPkgName+":mipsel")
 }
 
-func installLinuxPPC64LE() error {
-	return installDependencies(librpmDevPkgName+":ppc64el", "ppc64el")
+func installLinuxPPC64EL() error {
+	return installDependencies("ppc64el", librpmDevPkgName+":ppc64el")
 }
 
 func installLinuxS390X() error {
-	return installDependencies(librpmDevPkgName+":s390x", "s390x")
+	return installDependencies("s390x", librpmDevPkgName+":s390x")
 }
 
-func installDependencies(pkg, arch string) error {
+func installDependencies(arch string, pkgs ...string) error {
+	if len(pkgs) == 0 {
+		return nil
+	}
 	if arch != "" {
 		err := sh.Run("dpkg", "--add-architecture", arch)
 		if err != nil {
@@ -206,5 +213,6 @@ func installDependencies(pkg, arch string) error {
 		return err
 	}
 
-	return sh.Run("apt-get", "install", "-y", "--no-install-recommends", pkg)
+	args := append([]string{"install", "-y", "--no-install-recommends"}, pkgs...)
+	return sh.Run("apt-get", args...)
 }


### PR DESCRIPTION
Cherry-pick of PR #21239 to 7.x branch. Original message: 

## What does this PR do?

Fix installation of `librpm-dev` from the Auditbeat build scripts by forcing the
installation of a dependecy that is already installed for a different architecture.

It fails for some ARM platforms, where requested packages are [already
installed in the base images](https://github.com/elastic/golang-crossbuild/blob/7fe9c7c0bcde40f473473271f8b807557d74c683/go1.14/arm/Dockerfile.tmpl#L19), but for a different architecture.

## Why is it important?

Fixes packaging build, that is now failing because of this.