### PR TITLE
[Ingest Manager] Send snapshot flag together with metadata

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
@@ -33,6 +33,10 @@ type AgentECSMeta struct {
 	ID string `json:"id"`
 	// Version specifies current version of an agent.
 	Version string `json:"version"`
+	// Snapshot is a flag specifying that the agent used is a snapshot build.
+	Snapshot bool `json:"snapshot,omitempty"`
+	// BuildOriginal is an extended build information for the agent.
+	BuildOriginal string `json:"build.original"`
 }
 
 // SystemECSMeta is a collection of operating system metadata in ECS compliant object form.
@@ -126,8 +130,10 @@ func (i *AgentInfo) ECSMetadata() (*ECSMeta, error) {
 	return &ECSMeta{
 		Elastic: &ElasticECSMeta{
 			Agent: &AgentECSMeta{
-				ID:      i.agentID,
-				Version: release.Version(),
+				ID:            i.agentID,
+				Version:       release.Version(),
+				Snapshot:      release.Snapshot(),
+				BuildOriginal: release.Info().String(),
 			},
 		},
 		Host: &HostECSMeta{

--- a/x-pack/elastic-agent/pkg/release/version.go
+++ b/x-pack/elastic-agent/pkg/release/version.go
@@ -59,7 +59,7 @@ func Info() VersionInfo {
 }
 
 // String returns the string format for the version information.
-func (v *VersionInfo) String() string {
+func (v VersionInfo) String() string {
 	var sb strings.Builder
 
 	sb.WriteString(v.Version)


### PR DESCRIPTION
## What does this PR do?

For correct Source URI resolution fleet needs to be aware whether or not agent is a SNAPSHOT build or not. 
This PR includes this information in two forms in `local` metadata which is sent during `enroll` and `checkin`
- `elastic.agent.snapshot` - additional field set to true if agent is in snapshot mode
- `elastic.agent.build.original` - long version info, in case of snapshot it will contain it e.g.`8.0.0-SNAPSHOT (build: 3f1e3a5d016487f4cc995b019a846f3f13104f03 at 2020-09-24 08:57:34 +0000 UTC)`

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
