### PR TITLE
Cherry-pick #21202 to 7.x: Stop running auditbeat container as root by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,6 +34,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Change network.direction values to ECS recommended values (inbound, outbound). {issue}12445[12445] {pull}20695[20695]
+- Docker container needs to be explicitly run as user root for auditing. {pull}21202[21202]
 
 *Filebeat*
 

--- a/auditbeat/docs/running-on-docker.asciidoc
+++ b/auditbeat/docs/running-on-docker.asciidoc
@@ -10,5 +10,5 @@ It is also essential to run {beatname_uc} in the host PID namespace.
 
 ["source","sh",subs="attributes"]
 ----
-docker run --cap-add=AUDIT_CONTROL,AUDIT_READ --pid=host {dockerimage}
+docker run --cap-add=AUDIT_CONTROL --cap-add=AUDIT_READ --user=root --pid=host {dockerimage}
 ----

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -92,7 +92,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages(devtools.WithRootUserContainer())
+	return devtools.TestPackages()
 }
 
 // Update is an alias for running fields, dashboards, config, includes.

--- a/auditbeat/scripts/mage/package.go
+++ b/auditbeat/scripts/mage/package.go
@@ -95,7 +95,6 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 				args.Spec.ReplaceFile("/etc/{{.BeatName}}/{{.BeatName}}.reference.yml", referenceConfig)
 				sampleRulesTarget = "/etc/{{.BeatName}}/" + defaultSampleRulesTarget
 			case devtools.Docker:
-				args.Spec.ExtraVar("user", "root")
 			default:
 				panic(errors.Errorf("unhandled package type: %v", pkgType))
 			}

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -84,7 +84,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages(devtools.WithRootUserContainer())
+	return devtools.TestPackages()
 }
 
 // Update is an alias for running fields, dashboards, config.


### PR DESCRIPTION
Cherry-pick of PR #21202 to 7.x branch. Original message: 

## What does this PR do?

Stop running Auditbeat container as root by default. After this change, when user root is required it will need to be explicitly set on runtime. This is already done in Kubernetes manifests and some other examples in the documentation, so change is probably not so breaking.
Also `USER root` is usually not enough to be fully privileged, so some customization was always expected when running Auditbeat on docker.

## Why is it important?

Using `USER root` in docker images is not a very good practice, and is not allowed in some certification processes (see #20996).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

* Run Auditbeat on docker using a configuration that requires root privileges.

## Related issues

- Part of #20996.
- Related to #19600.