### PR TITLE
Cherry-pick #21213 to 7.x: Stop running agent container as root by default

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -340,7 +340,7 @@ shared:
       buildFrom: 'centos:7'
       dockerfile: 'Dockerfile.elastic-agent.tmpl'
       docker_entrypoint: 'docker-entrypoint.elastic-agent.tmpl'
-      user: 'root'
+      user: '{{ .BeatName }}'
       linux_capabilities: ''
     files:
       'elastic-agent.yml':

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -12,6 +12,8 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
     chown -R root:root {{ $beatHome }} && \
     find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
     find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
+    find {{ $beatHome }}/data -type d -exec chmod 0770 {} \; && \
+    find {{ $beatHome }}/data -type f -exec chmod 0660 {} \; && \
     rm {{ $beatBinary }} && \
     ln -s {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent {{ $beatBinary }} && \
     chmod 0750 {{ $beatHome }}/data/elastic-agent-*/elastic-agent && \
@@ -21,7 +23,7 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
 {{- range $i, $modulesd := .ModulesDirs }}
     chmod 0770 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
-    chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/logs
+    true
 
 FROM {{ .from }}
 
@@ -70,6 +72,10 @@ COPY docker-entrypoint /usr/local/bin/docker-entrypoint
 RUN chmod 755 /usr/local/bin/docker-entrypoint
 
 COPY --from=home {{ $beatHome }} {{ $beatHome }}
+
+# Elastic Agent needs group permissions in the home itself to be able to
+# create fleet.yml when running as non-root.
+RUN chmod 0770 {{ $beatHome }}
 
 RUN mkdir /licenses
 COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -7,6 +7,8 @@
 
 ==== Breaking changes
 
+- Docker container is not run as root by default. {pull}21213[21213]
+
 ==== Bugfixes
 
 ==== New features

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -311,7 +311,7 @@ func requiredPackagesPresent(basePath, beat, version string, requiredPackages []
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages(devtools.WithRootUserContainer())
+	return devtools.TestPackages()
 }
 
 // RunGo runs go command and output the feedback to the stdout and the stderr.


### PR DESCRIPTION
Cherry-pick of PR #21213 to 7.x branch. Original message: 

## What does this PR do?

Stop running Elastic Agent as root by default on docker image. When root user or other privileges are required, they will need to be explicitly configured at run time. This already happens now, except for the root user.
Provided Kubernetes manifests already use security context to run as user 0.

## Why is it important?

Using `USER root` in docker images is not a very good practice, and is not allowed in some certification processes (see #20996).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Confirm that this is not related to https://github.com/elastic/beats/issues/21120. (Confirmed by using a file lock to synchronize check and run methods of the install operations).

## Related issues

* Part of #20996.
* Related to #19600.