### PR TITLE
[Ingest manager] Copy Action store on upgrade

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -10,6 +10,8 @@
 - Docker container is not run as root by default. {pull}21213[21213]
 
 ==== Bugfixes
+- Copy Action store on upgrade {pull}21298[21298]
+- Include inputs in action store actions {pull}21298[21298]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/config.go
+++ b/x-pack/elastic-agent/pkg/agent/application/config.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
@@ -54,7 +55,10 @@ func LoadConfigFromFile(path string) (*config.Config, error) {
 //
 // This must be used to load the Agent configuration, so that variables defined in the inputs are not
 // parsed by go-ucfg. Variables from the inputs should be parsed by the transpiler.
-func LoadConfig(m map[string]interface{}) (*config.Config, error) {
+func LoadConfig(in map[string]interface{}) (*config.Config, error) {
+	// make copy of a map so we dont affect a caller
+	m := common.MapStr(in).Clone()
+
 	inputs, ok := m["inputs"]
 	if ok {
 		// remove the inputs

--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
@@ -25,6 +25,8 @@ func (h *handlerConfigChange) Handle(ctx context.Context, a action, acker fleetA
 		return fmt.Errorf("invalid type, expected ActionConfigChange and received %T", a)
 	}
 
+	rawAction := action
+
 	c, err := LoadConfig(action.Config)
 	if err != nil {
 		return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
@@ -35,5 +37,5 @@ func (h *handlerConfigChange) Handle(ctx context.Context, a action, acker fleetA
 		return err
 	}
 
-	return acker.Ack(ctx, action)
+	return acker.Ack(ctx, rawAction)
 }

--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
@@ -25,8 +25,6 @@ func (h *handlerConfigChange) Handle(ctx context.Context, a action, acker fleetA
 		return fmt.Errorf("invalid type, expected ActionConfigChange and received %T", a)
 	}
 
-	rawAction := action
-
 	c, err := LoadConfig(action.Config)
 	if err != nil {
 		return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
@@ -37,5 +35,5 @@ func (h *handlerConfigChange) Handle(ctx context.Context, a action, acker fleetA
 		return err
 	}
 
-	return acker.Ack(ctx, rawAction)
+	return acker.Ack(ctx, action)
 }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -134,8 +134,6 @@ func (u *Upgrader) Ack(ctx context.Context) error {
 	return ioutil.WriteFile(markerFile, markerBytes, 0600)
 }
 
-// change
-
 func isSubdir(base, target string) (bool, error) {
 	relPath, err := filepath.Rel(base, target)
 	return strings.HasPrefix(relPath, ".."), err

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -14,6 +14,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
@@ -78,6 +79,10 @@ func (u *Upgrader) Upgrade(ctx context.Context, a *fleetapi.ActionUpgrade) error
 		return errors.New("upgrading to same version")
 	}
 
+	if err := copyActionStore(newHash); err != nil {
+		return errors.New(err, "failed to copy action store")
+	}
+
 	if err := u.changeSymlink(ctx, newHash); err != nil {
 		rollbackInstall(newHash)
 		return err
@@ -129,6 +134,8 @@ func (u *Upgrader) Ack(ctx context.Context) error {
 	return ioutil.WriteFile(markerFile, markerBytes, 0600)
 }
 
+// change
+
 func isSubdir(base, target string) (bool, error) {
 	relPath, err := filepath.Rel(base, target)
 	return strings.HasPrefix(relPath, ".."), err
@@ -136,4 +143,22 @@ func isSubdir(base, target string) (bool, error) {
 
 func rollbackInstall(hash string) {
 	os.RemoveAll(filepath.Join(paths.Data(), fmt.Sprintf("%s-%s", agentName, hash)))
+}
+
+func copyActionStore(newHash string) error {
+	currentActionStorePath := info.AgentActionStoreFile()
+
+	newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
+	newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
+
+	currentActionStore, err := ioutil.ReadFile(currentActionStorePath)
+	if os.IsNotExist(err) {
+		// nothing to copy
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(newActionStorePath, currentActionStore, 0600)
 }


### PR DESCRIPTION
## What does this PR do?

In this PR we copy action_store to new version which is currently installed so it can pick a config (fleet does not resend configurations once acked)

Also this PR fixes action store so it includes inputs

## Why is it important?

So we dont lose data and keep monitoring after upgrade

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
