### PR TITLE
Cherry-pick #19265 to 7.x: [DOC] Typo in Kerberos

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -665,7 +665,7 @@ Elasticsearch.
 See the <<securing-communication-elasticsearch,secure communication with {es}>> guide
 or <<configuration-ssl,SSL configuration reference>> for more information.
 
-===== `kebreros`
+===== `kerberos`
 
 Configuration options for Kerberos authentication.
 


### PR DESCRIPTION
Cherry-pick of PR #19265 to 7.x branch. Original message: 

#  What does this PR do?

Removes a typo in the docs
