### PR TITLE
[Winlogbeat] Add IP validation to Security module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -363,6 +363,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix invalid IP addresses in DNS query results from Sysmon data. {issue}18432[18432] {pull}18436[18436]
 - Fields from Winlogbeat modules were not being included in index templates and patterns. {pull}18983[18983]
+- Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -1479,11 +1479,12 @@ var security = (function () {
             fields: [
                 {from: "winlog.event_data.AccountName", to: "user.name"},
                 {from: "winlog.event_data.AccountDomain", to: "user.domain"},
-                {from: "winlog.event_data.ClientAddress", to: "source.ip"},
+                {from: "winlog.event_data.ClientAddress", to: "source.ip", type: "ip"},
                 {from: "winlog.event_data.ClientName", to: "source.domain"},
                 {from: "winlog.event_data.LogonID", to: "winlog.logon.id"},
             ],
             ignore_missing: true,
+            fail_on_error: false,
         })
         .Add(function(evt) {
             var user = evt.Get("winlog.event_data.AccountName");


### PR DESCRIPTION
## What does this PR do?

For event 4778 (A session was reconnected to a Window Station) the `winlog.event_data.ClientAddress`
could be "LOCAL" which is obviosuly not a valid IP so we don't want to copy it into `source.ip` in that case.

## Why is it important?

This bug can causes mapping exceptions.

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes elastic/beats#19627

