### PR TITLE
Cherry-pick #21113 to 7.x: libbeat/cmd/instance: report cgroup stats

### DIFF
--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -285,6 +285,10 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 		logp.Err("error getting group status: %v", err)
 		return
 	}
+	// GetStatsForProcess returns a nil selfStats and no error when there's no stats
+	if selfStats == nil {
+		return
+	}
 
 	if cpu := selfStats.CPU; cpu != nil {
 		monitoring.ReportNamespace(V, "cpu", func() {

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/metric/system/cpu"
 	"github.com/elastic/beats/v7/libbeat/metric/system/process"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/gosigar/cgroup"
 )
 
 var (
@@ -65,10 +66,15 @@ func setupMetrics(name string) error {
 }
 
 func setupPlatformSpecificMetrics() {
+	switch runtime.GOOS {
+	case "linux":
+		monitoring.NewFunc(beatMetrics, "cgroup", reportBeatCgroups, monitoring.Report)
+	case "windows":
+		setupWindowsHandlesMetrics()
+	}
+
 	if runtime.GOOS != "windows" {
 		monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
-	} else {
-		setupWindowsHandlesMetrics()
 	}
 
 	setupLinuxBSDFDMetrics()
@@ -253,4 +259,80 @@ func reportRuntime(_ monitoring.Mode, V monitoring.Visitor) {
 	defer V.OnRegistryFinished()
 
 	monitoring.ReportInt(V, "goroutines", int64(runtime.NumGoroutine()))
+}
+
+func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	pid, err := process.GetSelfPid()
+	if err != nil {
+		logp.Err("error getting PID for self process: %v", err)
+		return
+	}
+
+	cgroups, err := cgroup.NewReader("", true)
+	if err != nil {
+		if err == cgroup.ErrCgroupsMissing {
+			logp.Warn("cgroup data collection disabled: %v", err)
+		} else {
+			logp.Err("cgroup data collection disabled: %v", err)
+		}
+		return
+	}
+	selfStats, err := cgroups.GetStatsForProcess(pid)
+	if err != nil {
+		logp.Err("error getting group status: %v", err)
+		return
+	}
+
+	if cpu := selfStats.CPU; cpu != nil {
+		monitoring.ReportNamespace(V, "cpu", func() {
+			if cpu.ID != "" {
+				monitoring.ReportString(V, "id", cpu.ID)
+			}
+			monitoring.ReportNamespace(V, "cfs", func() {
+				monitoring.ReportNamespace(V, "period", func() {
+					monitoring.ReportInt(V, "us", int64(cpu.CFS.PeriodMicros))
+				})
+				monitoring.ReportNamespace(V, "quota", func() {
+					monitoring.ReportInt(V, "us", int64(cpu.CFS.QuotaMicros))
+				})
+			})
+			monitoring.ReportNamespace(V, "stats", func() {
+				monitoring.ReportInt(V, "periods", int64(cpu.Stats.Periods))
+				monitoring.ReportNamespace(V, "throttled", func() {
+					monitoring.ReportInt(V, "periods", int64(cpu.Stats.ThrottledPeriods))
+					monitoring.ReportInt(V, "ns", int64(cpu.Stats.ThrottledTimeNanos))
+				})
+			})
+		})
+	}
+
+	if cpuacct := selfStats.CPUAccounting; cpuacct != nil {
+		monitoring.ReportNamespace(V, "cpuacct", func() {
+			if cpuacct.ID != "" {
+				monitoring.ReportString(V, "id", cpuacct.ID)
+			}
+			monitoring.ReportNamespace(V, "total", func() {
+				monitoring.ReportInt(V, "ns", int64(cpuacct.TotalNanos))
+			})
+		})
+	}
+
+	if memory := selfStats.Memory; memory != nil {
+		monitoring.ReportNamespace(V, "memory", func() {
+			if memory.ID != "" {
+				monitoring.ReportString(V, "id", memory.ID)
+			}
+			monitoring.ReportNamespace(V, "mem", func() {
+				monitoring.ReportNamespace(V, "limit", func() {
+					monitoring.ReportInt(V, "bytes", int64(memory.Mem.Limit))
+				})
+				monitoring.ReportNamespace(V, "usage", func() {
+					monitoring.ReportInt(V, "bytes", int64(memory.Mem.Usage))
+				})
+			})
+		})
+	}
 }


### PR DESCRIPTION
Cherry-pick of PR #21113 to 7.x branch. Original message: 

## What does this PR do?

Report cgroup limits/stats on Linux, similar to what Elasticsearch reports through node stats: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html

Metric names are based on (but not exactly the same as) the [`system.process.cgroup.*`](https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-system.html#_cgroup) fields.

## Why is it important?

This is important for reporting accurate resource usage in containerised environments.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

I couldn't see docs or tests to update - please point me to them if there are any.

## How to test this PR locally

1. Build and run a beat on Linux, with monitoring enabled
2. Observe that cgroup metrics are reported

## Related issues

Closes #14691