### PR TITLE
Cherry-pick to 7.x: [CI] Enable macOS builds for branches/tags (#21323)

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -21,13 +21,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test auditbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -20,13 +20,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test filebeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/generator/Jenkinsfile.yml
+++ b/generator/Jenkinsfile.yml
@@ -23,21 +23,25 @@ stages:
         make: "make -C generator/_templates/metricbeat test"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test generator for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     macos-beat:
         make: "make -C generator/_templates/beat test"
         platforms:             ## override default label in this specific stage.
             - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test generator for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -19,13 +19,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test heartbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -27,13 +27,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test metricbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -19,13 +19,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test packetbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -20,13 +20,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test auditbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -19,13 +19,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
             - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/elastic-agent for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -20,13 +20,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/filebeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -19,13 +19,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/functionbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -22,13 +22,15 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
           - "macosx"
-        when:                  ## Aggregate when with the top-level one.
+        when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/metricbeat for macos"
             labels:
                 - "macOS"
             parameters:
                 - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Enable macOS builds for branches/tags (#21323)