### PR TITLE
[CI] Archive build reasons

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -544,7 +544,7 @@ def isDockerInstalled(){
 */
 def notifyBuildReason() {
   // Archive the build reason here, since the workspace can be deleted when running the parallel stages.
-  archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*')
+  archiveArtifacts(allowEmptyArchive: true, artifacts: 'build-reasons/*.*')
   if (isPR()) {
     echo 'TODO: Add a comment with the build reason (this is required to be implemented in the shared library)'
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,9 +107,7 @@ pipeline {
                 mapParallelTasks["${k}"] = v
               }
             }
-            // Archive the build reason here, since the workspace can be deleted when running the parallel stages.
-            archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*')
-            // TODO: Add a comment with the build reason (this is required to be implemented in the shared library)
+            notifyBuildReason()
             parallel(mapParallelTasks)
           }
         }
@@ -538,6 +536,17 @@ def isDockerInstalled(){
     return sh(label: 'check for Docker', script: 'command -v docker', returnStatus: true)
   } else {
     return false
+  }
+}
+
+/**
+* Notify the build reason.
+*/
+def notifyBuildReason() {
+  // Archive the build reason here, since the workspace can be deleted when running the parallel stages.
+  archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*')
+  if (isPR()) {
+    echo 'TODO: Add a comment with the build reason (this is required to be implemented in the shared library)'
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,15 +107,9 @@ pipeline {
                 mapParallelTasks["${k}"] = v
               }
             }
+            // Archive the build reason here, since the workspace can be deleted when running the parallel stages.
+            archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*')
             parallel(mapParallelTasks)
-          }
-        }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}"){
-            // Archive the markdown files that contain the build reasons
-            archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.md')
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
             }
             // Archive the build reason here, since the workspace can be deleted when running the parallel stages.
             archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*')
+            // TODO: Add a comment with the build reason (this is required to be implemented in the shared library)
             parallel(mapParallelTasks)
           }
         }


### PR DESCRIPTION
## What does this PR do?

Enable to show the build reasons for the given PR based on the different events, such as: a github pr comment, github label, commit, branch, tag and so on.

The build reason will be stored as a markdown file for the time being.


## Why is it important?

The cloud stages reuse the top-level worker and delete the workspace, that's the reason of using it within the step closure rather than in the post build step.

## Tests

[build-reasons file](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-21347/2/artifact/build-reasons/build.md/*view*/) for the CI build.

![image](https://user-images.githubusercontent.com/2871786/94453144-43e2c280-01a8-11eb-8996-0a80023f92d9.png)

## Follow ups

The final notification will be shown as a GitHub PR comment with the build reasons, similar to the ones we already use for the build status, for instance, see the below screenshot

![image](https://user-images.githubusercontent.com/2871786/94444601-67087480-019e-11eb-9e51-9ae7b0b82160.png)

But only with the details that are related to the build reason. 

This is something that we are defining and we will introduce it in the future.