### PR TITLE
[CI] Fix runbld when workspace does not exist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,6 +123,8 @@ pipeline {
   }
   post {
     always {
+      deleteDir()
+      unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       runbld(stashedTestReports: stashedTestReports, project: env.REPO)
     }
     cleanup {


### PR DESCRIPTION
## What does this PR do?

Cloud stage reuses the top-level worker and the workspace gets deleted. Let's prepare the context to run `runbld`

## Why is it important?

Fixes the runbld dependency to run within the git workspace context:

```
[2020-09-28T13:05:56.771Z] runbld>>> Error: The source clone was not found in /var/lib/jenkins/workspace/Beats_beats_master/src/github.com/elastic/beats.  The most common cause is that Jenkins and runbld are configured with different working directories (referred to as 'basedir' in JJB and 'cwd' in runbld config).
script returned exit code 1
```
