### PR TITLE
Prevent panic in cgroups monitoring

### DIFF
--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -285,6 +285,10 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 		logp.Err("error getting group status: %v", err)
 		return
 	}
+	// GetStatsForProcess returns a nil selfStats and no error when there's no stats
+	if selfStats == nil {
+		return
+	}
 
 	if cpu := selfStats.CPU; cpu != nil {
 		monitoring.ReportNamespace(V, "cpu", func() {


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in Beats monitoring under Linux.

Gosigar's cgroups GetStatsForProcesses can return a nil Stats pointer and no error when the ["blkio", "cpu", "cpuacct", "memory"] subsystems are on the root cgroup.

## Why is it important?

Beats snapshots from master are crashing under CentOS 7.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Relates #21113

## Logs

```
2020-09-28T16:53:01.616Z        INFO        [monitoring]        runtime/panic.go:969        Stopping metrics logging.
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x338d528]
goroutine 1337 [running]:
github.com/elastic/beats/v7/libbeat/cmd/instance.reportBeatCgroups(0xc00012e001, 0x5c87a40, 0xc000117480)
/go/src/github.com/elastic/beats/libbeat/cmd/instance/metrics.go:289 +0x328
github.com/elastic/beats/v7/libbeat/monitoring.(*Func).Visit(0xc00076da68, 0x5507d01, 0x5c87a40, 0xc000117480)
/go/src/github.com/elastic/beats/libbeat/monitoring/metrics.go:219 +0x46
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).doVisit(0xc000662080, 0xc0000a7a01, 0x5c87a40, 0xc000117480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:83 +0x1af
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).Visit(0xc000662080, 0x5504601, 0x5c87a40, 0xc000117480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:65 +0x48
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).doVisit(0xc000090a80, 0xc000117401, 0x5c87a40, 0xc000117480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:83 +0x1af
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).Visit(...)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:65
github.com/elastic/beats/v7/libbeat/monitoring.CollectFlatSnapshot(0xc000090a80, 0x7facd2890101, 0x0, 0x0, 0x0, 0x0, 0x0)
/go/src/github.com/elastic/beats/libbeat/monitoring/snapshot.go:63 +0x16c
github.com/elastic/beats/v7/libbeat/monitoring/report/log.makeSnapshot(...)
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:159
github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).snapshotLoop.func1(0xc000734cc0)
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:121 +0x2fc
panic(0x4d5e800, 0x8017a90)
/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/elastic/beats/v7/libbeat/cmd/instance.reportBeatCgroups(0xc00012e001, 0x5c87a40, 0xc000bfe480)
/go/src/github.com/elastic/beats/libbeat/cmd/instance/metrics.go:289 +0x328
github.com/elastic/beats/v7/libbeat/monitoring.(*Func).Visit(0xc00076da68, 0x5507d01, 0x5c87a40, 0xc000bfe480)
/go/src/github.com/elastic/beats/libbeat/monitoring/metrics.go:219 +0x46
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).doVisit(0xc000662080, 0xc0000a7a01, 0x5c87a40, 0xc000bfe480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:83 +0x1af
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).Visit(0xc000662080, 0x5504601, 0x5c87a40, 0xc000bfe480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:65 +0x48
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).doVisit(0xc000090a80, 0xc000bfe401, 0x5c87a40, 0xc000bfe480)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:83 +0x1af
github.com/elastic/beats/v7/libbeat/monitoring.(*Registry).Visit(...)
/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:65
github.com/elastic/beats/v7/libbeat/monitoring.CollectFlatSnapshot(0xc000090a80, 0xc000070101, 0x0, 0x0, 0x0, 0x0, 0x0)
/go/src/github.com/elastic/beats/libbeat/monitoring/snapshot.go:63 +0x16c
github.com/elastic/beats/v7/libbeat/monitoring/report/log.makeSnapshot(...)
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:159
github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).snapshotLoop(0xc000734cc0)
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:135 +0x203
github.com/elastic/beats/v7/libbeat/monitoring/report/log.MakeReporter.func1(0xc000734cc0)
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:107 +0x50
created by github.com/elastic/beats/v7/libbeat/monitoring/report/log.MakeReporter
/go/src/github.com/elastic/beats/libbeat/monitoring/report/log/log.go:105 +0x157
metricbeat.service: main process exited, code=exited, status=2/INVALIDARGUMENT
Unit metricbeat.service entered failed state.
metricbeat.service failed.
```