### PR TITLE
docs: fix apt/yum formatting

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -122,7 +122,7 @@ sudo apt-get update && sudo apt-get install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
-
++
 If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
@@ -224,7 +224,7 @@ sudo yum install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
-
++
 If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
@@ -233,4 +233,3 @@ sudo chkconfig --add {beatname_pkg}
 --------------------------------------------------
 
 endif::[]
-


### PR DESCRIPTION
## Summary

Adds two missing `+` to fix formatting on the APT/YUM installation page.

**Before:**
<img width="842" alt="Screen Shot 2020-09-28 at 1 46 50 PM" src="https://user-images.githubusercontent.com/5618806/94484389-3241f080-0191-11eb-884b-70a4469ce60a.png">
