### PR TITLE
Cherry-pick to 7.x: [CI] Fix runbld when workspace does not exist (#21350)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,6 +122,8 @@ pipeline {
   }
   post {
     always {
+      deleteDir()
+      unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       runbld(stashedTestReports: stashedTestReports, project: env.REPO)
     }
     cleanup {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Fix runbld when workspace does not exist (#21350)