### PR TITLE
[libbeat] Fix position writing in the disk queue

### DIFF
--- a/libbeat/publisher/queue/diskqueue/state_file.go
+++ b/libbeat/publisher/queue/diskqueue/state_file.go
@@ -82,12 +82,14 @@ func writeQueuePositionToHandle(
 	}
 
 	// Want to write: version (0), segment id, segment offset.
-	elems := []interface{}{uint32(0), position.segmentID, position.offset}
-	for _, elem := range elems {
-		err = binary.Write(file, binary.LittleEndian, &elem)
-		if err != nil {
-			return err
-		}
+	err = binary.Write(file, binary.LittleEndian, uint32(0))
+	if err != nil {
+		return err
 	}
-	return nil
+	err = binary.Write(file, binary.LittleEndian, position.segmentID)
+	if err != nil {
+		return err
+	}
+	err = binary.Write(file, binary.LittleEndian, position.offset)
+	return err
 }


### PR DESCRIPTION
Despite appearances, `binary.Write` can't accept `interface{}`-wrapped parameters. This PR switches back to manual sequencing for the serialization.