### PR TITLE
Cherry-pick #21374 to 7.x: Add UBI 8 image to Beats dependencies report

### DIFF
--- a/dev-tools/dependencies-report
+++ b/dev-tools/dependencies-report
@@ -41,3 +41,14 @@ go list -m -json all $@ | go run go.elastic.co/go-licence-detector \
 		-noticeTemplate "$SRCPATH/notice/dependencies.csv.tmpl" \
 		-noticeOut "$outfile" \
 		-depsOut ""
+
+
+# Fill-in required values for UBI images
+# Check headers in $SRCPATH/notice/dependencies.csv.tmpl:
+# name,url,version,revision,license
+ubi8url='https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8'
+ubi8source='https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+ubilicense='Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+cat <<EOF >> $outfile
+Red Hat Universal Base Image,$ubi8url,8,,$ubilicense,$ubi8source
+EOF

--- a/dev-tools/notice/dependencies.csv.tmpl
+++ b/dev-tools/notice/dependencies.csv.tmpl
@@ -1,7 +1,7 @@
 {{- define "depInfo" -}}
 {{- range $i, $dep := . }}
-{{ $dep.Name }},{{ $dep.URL }},{{ $dep.Version | canonicalVersion }},{{ $dep.Version | revision }},{{ $dep.LicenceType }}
+{{ $dep.Name }},{{ $dep.URL }},{{ $dep.Version | canonicalVersion }},{{ $dep.Version | revision }},{{ $dep.LicenceType }},{{ $dep.URL }}
 {{- end -}}
 {{- end -}}
 
-name,url,version,revision,license{{ template "depInfo" .Direct }}{{ template "depInfo" .Indirect }}
+name,url,version,revision,license,sourceURL{{ template "depInfo" .Direct }}{{ template "depInfo" .Indirect }}


### PR DESCRIPTION
Cherry-pick of PR #21374 to 7.x branch. Original message: 

Red Hat certification process for docker images requires to include
the base UBI image in the list of dependencies for the project.
Append it to the current list of dependencies.
This requires to include a new sourceURL column in the CSV, because
UBI images have a different url and source url. This is kept the same
for existing dependencies.

*Delimited* diff of the generated dependencies csv:
```
--- dependencies.csv	2020-09-29 11:28:46.136240003 +0200
+++ dependencies.new.csv	2020-09-29 11:27:13.007140360 +0200
@@ -1,373 +1,374 @@
-name,url,version,revision,license
-4d63.com/tz,https://4d63.com/tz,v1.1.1,6d37baae851b,MIT
-cloud.google.com/go,https://cloud.google.com/go,v0.51.0,,Apache-2.0
...
+name,url,version,revision,license,sourceURL
+4d63.com/tz,https://4d63.com/tz,v1.1.1,6d37baae851b,MIT,https://4d63.com/tz
+cloud.google.com/go,https://cloud.google.com/go,v0.51.0,,Apache-2.0,https://cloud.google.com/go
...
+Red Hat Universal Base Image,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,8,,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
```