### PR TITLE
Cherry-pick #21380 to 7.x: [filebeat] Fix shutdown tracking in s3 input

### DIFF
--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -190,11 +190,11 @@ func (p *s3Input) Run() {
 
 		p.workerWg.Add(1)
 		go p.run(svcSQS, svcS3, visibilityTimeout)
-		p.workerWg.Done()
 	})
 }
 
 func (p *s3Input) run(svcSQS sqsiface.ClientAPI, svcS3 s3iface.ClientAPI, visibilityTimeout int64) {
+	defer p.workerWg.Done()
 	defer p.logger.Infof("s3 input worker for '%v' has stopped.", p.config.QueueURL)
 
 	p.logger.Infof("s3 input worker has started. with queueURL: %v", p.config.QueueURL)


### PR DESCRIPTION
Cherry-pick of PR #21380 to 7.x branch. Original message: 

This is just a short fix -- the s3 input's wait group (used to wait for shutdown) currently calls `wg.Done()` immediately after the (asynchronous) call site, so the `wg.Wait()` on shutdown is always a no-op. This PR moves the `wg.Done()` call to the end of the worker goroutine, which is probably what was intended.
