### PR TITLE
Cherry-pick to 7.x: docs: fix apt/yum formatting (#21362)

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -122,7 +122,7 @@ sudo apt-get update && sudo apt-get install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
-
++
 If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
@@ -224,7 +224,7 @@ sudo yum install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
-
++
 If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
@@ -233,4 +233,3 @@ sudo chkconfig --add {beatname_pkg}
 --------------------------------------------------
 
 endif::[]
-


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: fix apt/yum formatting (#21362)