### PR TITLE
Cherry-pick #21391 to 7.x: [libbeat] Enable WriteAheadLimit in the disk queue

### DIFF
--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -106,8 +106,8 @@ func DefaultSettings() Settings {
 		MaxSegmentSize: 100 * (1 << 20), // 100MiB
 		MaxBufferSize:  (1 << 30),       // 1GiB
 
-		ReadAheadLimit:  256,
-		WriteAheadLimit: 1024,
+		ReadAheadLimit:  512,
+		WriteAheadLimit: 2048,
 	}
 }
 
@@ -129,6 +129,14 @@ func SettingsForUserConfig(config *common.Config) (Settings, error) {
 		// divided by 10.
 		settings.MaxSegmentSize = uint64(userConfig.MaxSize) / 10
 	}
+
+	if userConfig.ReadAheadLimit != nil {
+		settings.ReadAheadLimit = *userConfig.ReadAheadLimit
+	}
+	if userConfig.WriteAheadLimit != nil {
+		settings.WriteAheadLimit = *userConfig.WriteAheadLimit
+	}
+
 	return settings, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #21391 to 7.x branch. Original message: 

This PR activates the previously inert setting `WriteAheadLimit`, which limits how many events the disk queue will store in memory waiting to be written to disk (this is to prevent unbounded memory use / provide back-pressure when the beat is under extremely high load and is receiving inputs faster than they can be written to disk).