### PR TITLE
[Ingest Manager] Split index restrictions into type,dataset, namespace parts

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker.go
@@ -5,7 +5,6 @@
 package filters
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -47,11 +46,7 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 		if nsNode, found := inputNode.Find("data_stream.namespace"); found {
 			nsKey, ok := nsNode.(*transpiler.Key)
 			if ok {
-				newNamespace := nsKey.Value().(transpiler.Node).String()
-				if !isValid(newNamespace) {
-					return ErrInvalidNamespace
-				}
-				namespace = newNamespace
+				namespace = nsKey.Value().(transpiler.Node).String()
 			}
 		} else {
 			dsNode, found := inputNode.Find("data_stream")
@@ -63,15 +58,15 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 					if found {
 						nsKey, ok := nsNode.(*transpiler.Key)
 						if ok {
-							newNamespace := nsKey.Value().(transpiler.Node).String()
-							if !isValid(newNamespace) {
-								return ErrInvalidNamespace
-							}
-							namespace = newNamespace
+							namespace = nsKey.Value().(transpiler.Node).String()
 						}
 					}
 				}
 			}
+		}
+
+		if !matchesNamespaceContraints(namespace) {
+			return ErrInvalidNamespace
 		}
 
 		// get the type, longest type for now is metrics
@@ -100,6 +95,10 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 			}
 		}
 
+		if !matchesTypeConstraints(datasetType) {
+			return ErrInvalidIndex
+		}
+
 		streamsNode, ok := inputNode.Find("streams")
 		if ok {
 			streamsList, ok := streamsNode.Value().(*transpiler.List)
@@ -119,11 +118,8 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 					if dsNameNode, found := streamMap.Find("data_stream.dataset"); found {
 						dsKey, ok := dsNameNode.(*transpiler.Key)
 						if ok {
-							newDataset := dsKey.Value().(transpiler.Node).String()
-							if !isValid(newDataset) {
-								return ErrInvalidDataset
-							}
-							datasetName = newDataset
+							datasetName = dsKey.Value().(transpiler.Node).String()
+							break
 						}
 					} else {
 						datasetNode, found := streamMap.Find("data_stream")
@@ -137,11 +133,8 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 							if found {
 								dsKey, ok := dsNameNode.(*transpiler.Key)
 								if ok {
-									newDataset := dsKey.Value().(transpiler.Node).String()
-									if !isValid(newDataset) {
-										return ErrInvalidDataset
-									}
-									datasetName = newDataset
+									datasetName = dsKey.Value().(transpiler.Node).String()
+									break
 								}
 							}
 						}
@@ -149,9 +142,8 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 				}
 			}
 		}
-
-		if indexName := fmt.Sprintf("%s-%s-%s", datasetType, datasetName, namespace); !matchesIndexContraints(indexName) {
-			return ErrInvalidIndex
+		if !matchesDatasetConstraints(datasetName) {
+			return ErrInvalidDataset
 		}
 	}
 
@@ -159,24 +151,13 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 }
 
 // The only two requirement are that it has only characters allowed in an Elasticsearch index name
-// and does NOT contain a `-`.
-func isValid(namespace string) bool {
-	return matchesIndexContraints(namespace) && !strings.Contains(namespace, "-")
-}
-
-// The only two requirement are that it has only characters allowed in an Elasticsearch index name
 // Index names must meet the following criteria:
+//	   Not longer than 100 bytes
 //     Lowercase only
 //     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-//     Cannot start with -, _, +
-//     Cannot be . or ..
-func matchesIndexContraints(namespace string) bool {
-	// Cannot be . or ..
-	if namespace == "." || namespace == ".." {
-		return false
-	}
-
-	if len(namespace) <= 0 || len(namespace) > 255 {
+func matchesNamespaceContraints(namespace string) bool {
+	// length restriction is in bytes, not characters
+	if len(namespace) <= 0 || len(namespace) > 100 {
 		return false
 	}
 
@@ -186,14 +167,54 @@ func matchesIndexContraints(namespace string) bool {
 	}
 
 	// Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-	if strings.ContainsAny(namespace, "\\/*?\"<>| ,#") {
+	if strings.ContainsAny(namespace, "\\/*?\"<>| ,#:") {
 		return false
 	}
 
-	// Cannot start with -, _, +
-	if strings.HasPrefix(namespace, "-") || strings.HasPrefix(namespace, "_") || strings.HasPrefix(namespace, "+") {
+	return true
+}
+
+// matchesTypeConstraints fails for following rules. As type is first element of resulting index prefix restrictions need to be applied.
+//	   Not longer than 20 bytes
+//     Lowercase only
+//     Cannot start with -, _, +
+//     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
+func matchesTypeConstraints(dsType string) bool {
+	// length restriction is in bytes, not characters
+	if len(dsType) <= 0 || len(dsType) > 20 {
 		return false
 	}
 
+	if strings.ToLower(dsType) != dsType {
+		return false
+	}
+
+	if strings.HasPrefix(dsType, "-") || strings.HasPrefix(dsType, "_") || strings.HasPrefix(dsType, "+") {
+		return false
+	}
+
+	if strings.ContainsAny(dsType, "\\/*?\"<>| ,#:") {
+		return false
+	}
+	return true
+}
+
+// matchesDatasetConstraints fails for following rules
+//	   Not longer than 100 bytes
+//     Lowercase only
+//     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
+func matchesDatasetConstraints(dataset string) bool {
+	// length restriction is in bytes, not characters
+	if len(dataset) <= 0 || len(dataset) > 100 {
+		return false
+	}
+
+	if strings.ToLower(dataset) != dataset {
+		return false
+	}
+
+	if strings.ContainsAny(dataset, "\\/*?\"<>| ,#:") {
+		return false
+	}
 	return true
 }

--- a/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker.go
@@ -152,7 +152,7 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 
 // The only two requirement are that it has only characters allowed in an Elasticsearch index name
 // Index names must meet the following criteria:
-//	   Not longer than 100 bytes
+//     Not longer than 100 bytes
 //     Lowercase only
 //     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
 func matchesNamespaceContraints(namespace string) bool {
@@ -161,21 +161,11 @@ func matchesNamespaceContraints(namespace string) bool {
 		return false
 	}
 
-	// Lowercase only
-	if strings.ToLower(namespace) != namespace {
-		return false
-	}
-
-	// Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-	if strings.ContainsAny(namespace, "\\/*?\"<>| ,#:") {
-		return false
-	}
-
-	return true
+	return isCharactersetValid(namespace)
 }
 
 // matchesTypeConstraints fails for following rules. As type is first element of resulting index prefix restrictions need to be applied.
-//	   Not longer than 20 bytes
+//     Not longer than 20 bytes
 //     Lowercase only
 //     Cannot start with -, _, +
 //     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
@@ -185,22 +175,15 @@ func matchesTypeConstraints(dsType string) bool {
 		return false
 	}
 
-	if strings.ToLower(dsType) != dsType {
-		return false
-	}
-
 	if strings.HasPrefix(dsType, "-") || strings.HasPrefix(dsType, "_") || strings.HasPrefix(dsType, "+") {
 		return false
 	}
 
-	if strings.ContainsAny(dsType, "\\/*?\"<>| ,#:") {
-		return false
-	}
-	return true
+	return isCharactersetValid(dsType)
 }
 
 // matchesDatasetConstraints fails for following rules
-//	   Not longer than 100 bytes
+//     Not longer than 100 bytes
 //     Lowercase only
 //     Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
 func matchesDatasetConstraints(dataset string) bool {
@@ -209,12 +192,17 @@ func matchesDatasetConstraints(dataset string) bool {
 		return false
 	}
 
-	if strings.ToLower(dataset) != dataset {
+	return isCharactersetValid(dataset)
+}
+
+func isCharactersetValid(input string) bool {
+	if strings.ToLower(input) != input {
 		return false
 	}
 
-	if strings.ContainsAny(dataset, "\\/*?\"<>| ,#:") {
+	if strings.ContainsAny(input, "\\/*?\"<>| ,#:") {
 		return false
 	}
+
 	return true
 }

--- a/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
@@ -93,25 +93,6 @@ func TestStreamCheck(t *testing.T) {
 			},
 			result: ErrInvalidDataset,
 		},
-
-		{
-			name: "dataset invalid dot - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": "."}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
-		{
-			name: "dataset invalid dotdot- compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": ".."}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
 		{
 			name: "dataset invalid uppercase - compact",
 			configMap: map[string]interface{}{
@@ -140,35 +121,9 @@ func TestStreamCheck(t *testing.T) {
 			result: ErrInvalidDataset,
 		},
 		{
-			name: "dataset invalid invalid prefix- compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": "_isthisvalid"}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
-
-		{
 			name: "namespace invalid - compact",
 			configMap: map[string]interface{}{
 				"inputs": []map[string]interface{}{{"data_stream.namespace": ""}},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name 1 - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"data_stream.namespace": "."},
-				},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name 2 - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{{"data_stream.namespace": ".."}},
 			},
 			result: ErrInvalidNamespace,
 		},
@@ -190,13 +145,6 @@ func TestStreamCheck(t *testing.T) {
 			name: "namespace invalid name invalid char - compact",
 			configMap: map[string]interface{}{
 				"inputs": []map[string]interface{}{{"data_stream.namespace": "isitok?"}},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name invalid prefix - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{{"data_stream.namespace": "+isitok"}},
 			},
 			result: ErrInvalidNamespace,
 		},
@@ -273,6 +221,33 @@ func TestStreamCheck(t *testing.T) {
 				},
 			},
 			result: nil,
+		},
+		{
+			name: "type invalid prefix _",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "_type"},
+				},
+			},
+			result: ErrInvalidIndex,
+		},
+		{
+			name: "type invalid prefix -",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "-type"},
+				},
+			},
+			result: ErrInvalidIndex,
+		},
+		{
+			name: "type invalid prefix +",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "+type"},
+				},
+			},
+			result: ErrInvalidIndex,
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR does not apply same restrictions set on all parts of resulting index and follows 20/100/100 bytes length requirement for type, dataset and namespace

## Why is it important?

Makes rules in par with the ones applied at fleet level

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
