### PR TITLE
Kubernetes events are collected from the api server

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -39,13 +39,15 @@ data:
                 - module: kubernetes
                   metricsets:
                     - apiserver
-                    # Uncomment this to get k8s events:
-                    #- event
                   hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
                   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                   ssl.certificate_authorities:
                     - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   period: 30s
+                # Uncomment this to get k8s events:
+                #- module: kubernetes
+                #  metricsets:
+                #    - event
         # To enable hints based autodiscover uncomment this:
         #- type: kubernetes
         #  node: ${NODE_NAME}

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -36,11 +36,11 @@ data:
                     - state_cronjob
                     - state_resourcequota
                     - state_statefulset
-                    # Uncomment this to get k8s events:
-                    #- event
                 - module: kubernetes
                   metricsets:
                     - apiserver
+                    # Uncomment this to get k8s events:
+                    #- event
                   hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
                   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                   ssl.certificate_authorities:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -39,13 +39,15 @@ data:
                 - module: kubernetes
                   metricsets:
                     - apiserver
-                    # Uncomment this to get k8s events:
-                    #- event
                   hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
                   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                   ssl.certificate_authorities:
                     - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   period: 30s
+                # Uncomment this to get k8s events:
+                #- module: kubernetes
+                #  metricsets:
+                #    - event
         # To enable hints based autodiscover uncomment this:
         #- type: kubernetes
         #  node: ${NODE_NAME}

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -36,11 +36,11 @@ data:
                     - state_cronjob
                     - state_resourcequota
                     - state_statefulset
-                    # Uncomment this to get k8s events:
-                    #- event
                 - module: kubernetes
                   metricsets:
                     - apiserver
+                    # Uncomment this to get k8s events:
+                    #- event
                   hosts: ["https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"]
                   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                   ssl.certificate_authorities:


### PR DESCRIPTION
In the reference configuration the event metricset was in the block of
configurations for kube-state-metrics.

From discuss: https://discuss.elastic.co/t/why-cant-i-get-k8s-event/250320