### PR TITLE
[JJBB] Use reference repo for fast checkouts

### DIFF
--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -53,6 +53,7 @@
             recursive: true
             parent-credentials: true
             timeout: 100
+            reference-repo: /var/lib/jenkins/.git-references/beats.git
         timeout: '15'
         use-author: true
         wipe-workspace: true


### PR DESCRIPTION
## What does this PR do?

Use git reference repo to checkout the source code faster

## Why is it important?

Faster builds