### PR TITLE
Cherry-pick #21407 to 7.9: Kubernetes events are collected from the api server

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -234,8 +234,6 @@ data:
         - state_container
         - state_cronjob
         - state_resourcequota
-        # Uncomment this to get k8s events:
-        #- event
       period: 10s
       host: ${NODE_NAME}
       hosts: ["kube-state-metrics:8080"]
@@ -247,6 +245,10 @@ data:
     #  ssl.certificate_authorities:
     #    - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     #  period: 30s
+    # Uncomment this to get k8s events:
+    #- module: kubernetes
+    #  metricsets:
+    #    - event
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
 apiVersion: apps/v1

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
@@ -43,8 +43,6 @@ data:
         - state_container
         - state_cronjob
         - state_resourcequota
-        # Uncomment this to get k8s events:
-        #- event
       period: 10s
       host: ${NODE_NAME}
       hosts: ["kube-state-metrics:8080"]
@@ -56,3 +54,7 @@ data:
     #  ssl.certificate_authorities:
     #    - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     #  period: 30s
+    # Uncomment this to get k8s events:
+    #- module: kubernetes
+    #  metricsets:
+    #    - event


### PR DESCRIPTION
Cherry-pick of PR #21407 to 7.9 branch. Original message: 

In the reference configuration the event metricset was in the block of
configurations for kube-state-metrics.

From discuss: https://discuss.elastic.co/t/why-cant-i-get-k8s-event/250320