### PR TITLE
Cherry-pick #21407 to 6.8: Kubernetes events are collected from the api server

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -71,7 +71,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:6.8.11
+        image: docker.elastic.co/beats/auditbeat:6.8.12
         args: [
           "-c", "/etc/auditbeat.yml"
         ]

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.8.11
+        image: docker.elastic.co/beats/filebeat:6.8.12
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -104,7 +104,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.8.11
+        image: docker.elastic.co/beats/metricbeat:6.8.12
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -217,11 +217,13 @@ data:
         - state_replicaset
         - state_pod
         - state_container
-        # Uncomment this to get k8s events:
-        #- event
       period: 10s
       host: ${NODE_NAME}
       hosts: ["kube-state-metrics:8080"]
+    # Uncomment this to get k8s events:
+    #- module: kubernetes
+    #  metricsets:
+    #    - event
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
 apiVersion: apps/v1beta1
@@ -242,7 +244,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.8.11
+        image: docker.elastic.co/beats/metricbeat:6.8.12
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
@@ -41,8 +41,10 @@ data:
         - state_replicaset
         - state_pod
         - state_container
-        # Uncomment this to get k8s events:
-        #- event
       period: 10s
       host: ${NODE_NAME}
       hosts: ["kube-state-metrics:8080"]
+    # Uncomment this to get k8s events:
+    #- module: kubernetes
+    #  metricsets:
+    #    - event


### PR DESCRIPTION
Cherry-pick of PR #21407 to 6.8 branch. Original message: 

In the reference configuration the event metricset was in the block of
configurations for kube-state-metrics.

From discuss: https://discuss.elastic.co/t/why-cant-i-get-k8s-event/250320