### PR TITLE
Cherry-pick to 7.x: docs: add link to release notes for 7.9.2 (#21405)

### DIFF
--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,7 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-7.9.2>>
 * <<release-notes-7.9.1>>
 * <<release-notes-7.9.0>>
 * <<release-notes-7.8.1>>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add link to release notes for 7.9.2 (#21405)