### PR TITLE
Cherry-pick to 7.x: fix: use a fixed version of setuptools (#21393)

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -36,6 +36,7 @@ PyYAML==5.3.1
 redis==2.10.6
 requests==2.20.0
 semver==2.8.1
+setuptools==47.3.2
 six==1.15.0
 stomp.py==4.1.22
 termcolor==1.1.0


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: use a fixed version of setuptools (#21393)