### PR TITLE
[CI] Send slack message with build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
     PYTEST_ADDOPTS = "${params.PYTEST_ADDOPTS}"
     RUNBLD_DISABLE_NOTIFICATIONS = 'true'
+    SLACK_CHANNEL = "#beats-ci-builds"
     TERRAFORM_VERSION = "0.12.24"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
   }
@@ -121,7 +122,7 @@ pipeline {
       runbld(stashedTestReports: stashedTestReports, project: env.REPO)
     }
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: true, slackComment: true)
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/slackComment') _
+@Library('apm@current') _
 
 import groovy.transform.Field
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/slackComment') _
 
 import groovy.transform.Field
 /**


### PR DESCRIPTION
## What does this PR do?

Send slack build messages when the branch/tag builds are failing _ONLY_ (failing means a build failure or test failure or even aborted).

It won't send notifications for PRs

## Why is it important?

Provide enough context when merge to branches builds are failing.

## Tests

![image](https://user-images.githubusercontent.com/2871786/94906362-41c58000-0496-11eb-8143-63aa03d4a90b.png)
