### PR TITLE
Cherry-pick #21402 to 7.x: [Winlogbeat] Move winlogbeat javascript processor to libbeat

### DIFF
--- a/libbeat/processors/script/javascript/module/include.go
+++ b/libbeat/processors/script/javascript/module/include.go
@@ -24,4 +24,5 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/path"
 	_ "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
 	_ "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/require"
+	_ "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/windows"
 )

--- a/libbeat/processors/script/javascript/module/windows/doc.go
+++ b/libbeat/processors/script/javascript/module/windows/doc.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package winlogbeat registers the winlogbeat module with the javascript script
-// processor. The module has utilities specific to Winlogbeat like parsing
+// Package windows registers the windows module with the javascript script
+// processor. The module has utilities specific to Windows like parsing
 // Windows command lines.
-package winlogbeat
+package windows

--- a/libbeat/processors/script/javascript/module/windows/windows.go
+++ b/libbeat/processors/script/javascript/module/windows/windows.go
@@ -17,7 +17,7 @@
 
 // +build windows
 
-package winlogbeat
+package windows
 
 import (
 	"syscall"
@@ -60,11 +60,11 @@ func commandLineToArgvW(in string) ([]string, error) {
 	return args, nil
 }
 
-// Require registers the winlogbeat module that has utilities specific to
-// Winlogbeat like parsing Windows command lines. It can be accessed using:
+// Require registers the windows module that has utilities specific to
+// Windows like parsing Windows command lines. It can be accessed using:
 //
 //    // javascript
-//    var winlogbeat = require('winlogbeat');
+//    var windows = require('windows');
 //
 func Require(vm *goja.Runtime, module *goja.Object) {
 	o := module.Get("exports").(*goja.Object)
@@ -74,9 +74,11 @@ func Require(vm *goja.Runtime, module *goja.Object) {
 
 // Enable adds path to the given runtime.
 func Enable(runtime *goja.Runtime) {
+	runtime.Set("windows", require.Require(runtime, "windows"))
 	runtime.Set("winlogbeat", require.Require(runtime, "winlogbeat"))
 }
 
 func init() {
+	require.RegisterNativeModule("windows", Require)
 	require.RegisterNativeModule("winlogbeat", Require)
 }

--- a/libbeat/processors/script/javascript/module/windows/windows_test.go
+++ b/libbeat/processors/script/javascript/module/windows/windows_test.go
@@ -17,7 +17,7 @@
 
 // +build windows
 
-package winlogbeat
+package windows
 
 import (
 	"testing"

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -30,7 +30,6 @@ import (
 	// Import processors and supporting modules.
 	_ "github.com/elastic/beats/v7/libbeat/processors/script"
 	_ "github.com/elastic/beats/v7/libbeat/processors/timestamp"
-	_ "github.com/elastic/beats/v7/winlogbeat/processors/script/javascript/module/winlogbeat"
 )
 
 const (

--- a/x-pack/winlogbeat/module/powershell/config/winlogbeat-powershell.js
+++ b/x-pack/winlogbeat/module/powershell/config/winlogbeat-powershell.js
@@ -5,7 +5,7 @@
 var powershell = (function () {
     var path = require("path");
     var processor = require("processor");
-    var winlogbeat = require("winlogbeat");
+    var windows = require("windows");
 
     var normalizeCommonFieldNames = new processor.Convert({
         fields: [
@@ -183,7 +183,7 @@ var powershell = (function () {
         if (!commandLine) {
             return;
         }
-        evt.Put(target, winlogbeat.splitCommandLine(commandLine));
+        evt.Put(target, windows.splitCommandLine(commandLine));
     };
 
     var addProcessArgs = function (evt) {

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -5,7 +5,7 @@
 var security = (function () {
     var path = require("path");
     var processor = require("processor");
-    var winlogbeat = require("winlogbeat");
+    var windows = require("windows");
 
     // Logon Types
     // https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-audit-logon-events
@@ -1669,7 +1669,7 @@ var security = (function () {
             if (!cl) {
                 return;
             }
-            evt.Put("process.args", winlogbeat.splitCommandLine(cl));
+            evt.Put("process.args", windows.splitCommandLine(cl));
             evt.Put("process.command_line", cl);
         })
         .Build();

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -15,7 +15,7 @@ if (!String.prototype.startsWith) {
 var sysmon = (function () {
     var path = require("path");
     var processor = require("processor");
-    var winlogbeat = require("winlogbeat");
+    var windows = require("windows");
     var net = require("net");
 
     // Windows error codes for DNS. This list was generated using
@@ -311,7 +311,7 @@ var sysmon = (function () {
         if (!commandLine) {
             return;
         }
-        evt.Put(target, winlogbeat.splitCommandLine(commandLine));
+        evt.Put(target, windows.splitCommandLine(commandLine));
     };
 
     var splitProcessArgs = function (evt) {

--- a/x-pack/winlogbeat/module/testing_windows.go
+++ b/x-pack/winlogbeat/module/testing_windows.go
@@ -28,7 +28,6 @@ import (
 
 	// Register javascript modules.
 	_ "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module"
-	_ "github.com/elastic/beats/v7/winlogbeat/processors/script/javascript/module/winlogbeat"
 )
 
 var update = flag.Bool("update", false, "update golden files")


### PR DESCRIPTION
Cherry-pick of PR #21402 to 7.x branch. Original message: 

## What does this PR do?

Renames winlogbeat javascript processor to windows and moves it to
libbeat.  Processor can still be loaded as `winlogbeat` for backwards
compatibility.,

## Why is it important?

Needed so Filebeat winlog input can have access to the winlogbeat
javascript processor.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

go test in winlogbeat modules

