### PR TITLE
Cherry-pick #21372 to 7.x: Upgrade Action: make source URI optional 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_unpack.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_unpack.go
@@ -23,8 +23,8 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 )
 
-// untar unpacks archive correctly, skips root (symlink, config...) unpacks data/*
-func (u *Upgrader) unpack(ctx context.Context, version, sourceURI, archivePath string) (string, error) {
+// unpack unpacks archive correctly, skips root (symlink, config...) unpacks data/*
+func (u *Upgrader) unpack(ctx context.Context, version, archivePath string) (string, error) {
 	// unpack must occur in directory that holds the installation directory
 	// or the extraction will be double nested
 	var hash string

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -75,12 +75,13 @@ func (u *Upgrader) Upgrade(ctx context.Context, a *fleetapi.ActionUpgrade) error
 				"running under control of the systems supervisor")
 	}
 
-	archivePath, err := u.downloadArtifact(ctx, a.Version, a.SourceURI)
+	sourceURI, err := u.sourceURI(a.Version, a.SourceURI)
+	archivePath, err := u.downloadArtifact(ctx, a.Version, sourceURI)
 	if err != nil {
 		return err
 	}
 
-	newHash, err := u.unpack(ctx, a.Version, a.SourceURI, archivePath)
+	newHash, err := u.unpack(ctx, a.Version, archivePath)
 	if err != nil {
 		return err
 	}
@@ -146,6 +147,16 @@ func (u *Upgrader) Ack(ctx context.Context) error {
 	}
 
 	return ioutil.WriteFile(markerFile, markerBytes, 0600)
+}
+func (u *Upgrader) sourceURI(version, retrievedURI string) (string, error) {
+	if strings.HasSuffix(version, "-SNAPSHOT") && retrievedURI == "" {
+		return "", errors.New("snapshot upgrade requires source uri", errors.TypeConfig)
+	}
+	if retrievedURI != "" {
+		return retrievedURI, nil
+	}
+
+	return u.settings.SourceURI, nil
 }
 
 func rollbackInstall(hash string) {

--- a/x-pack/elastic-agent/pkg/fleetapi/action.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/action.go
@@ -97,7 +97,7 @@ type ActionUpgrade struct {
 	ActionID   string `json:"id" yaml:"id"`
 	ActionType string `json:"type" yaml:"type"`
 	Version    string `json:"version" yaml:"version"`
-	SourceURI  string `json:"source_uri" yaml:"source_uri"`
+	SourceURI  string `json:"source_uri,omitempty" yaml:"source_uri,omitempty"`
 }
 
 func (a *ActionUpgrade) String() string {


### PR DESCRIPTION
Cherry-pick of PR #21372 to 7.x branch. Original message:

## What does this PR do?

This PR makes source URI optional and requires it on snapshot upgrades. Otherwise if it is missing agent uses source URI from elastic-agent configuration.

Making it optional enables us to be prepared for cases when fleet will support snapshot upgrades without a change.

## Why is it important?



## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
