### PR TITLE
Cherry-pick #21241 to 7.x: Enabled dev builds 

### DIFF
--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -81,11 +81,34 @@ type Format mg.Namespace
 // Demo runs agent out of container.
 type Demo mg.Namespace
 
+// Dev runs package and build for dev purposes.
+type Dev mg.Namespace
+
 // Env returns information about the environment.
 func (Prepare) Env() {
 	mg.Deps(Mkdir("build"), Build.GenerateConfig)
 	RunGo("version")
 	RunGo("env")
+}
+
+// Build builds the agent binary with DEV flag set.
+func (Dev) Build() {
+	dev := os.Getenv(devEnv)
+	defer os.Setenv(devEnv, dev)
+
+	os.Setenv(devEnv, "true")
+	devtools.DevBuild = true
+	mg.Deps(Build.All)
+}
+
+// Package packages the agent binary with DEV flag set.
+func (Dev) Package() {
+	dev := os.Getenv(devEnv)
+	defer os.Setenv(devEnv, dev)
+
+	os.Setenv(devEnv, "true")
+	devtools.DevBuild = true
+	Package()
 }
 
 // InstallGoLicenser install go-licenser to check license of the files.

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
 func newRunCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
@@ -80,6 +81,10 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
 	if err != nil {
 		return err
+	}
+
+	if allowEmptyPgp, _ := release.PGP(); allowEmptyPgp {
+		logger.Warn("Artifact has been build with security disabled. Elastic Agent will not verify signatures of used artifacts.")
 	}
 
 	execPath, err := os.Executable()


### PR DESCRIPTION
Cherry-pick of PR #21241 to 7.x branch. Original message:

## What does this PR do?

This PR enables dev build and package so packages for dev purposes can be prepared using `mage dev:package` command

## Why is it important?

Mage provides a help describing these commands making the option to disable security more visible.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
