### PR TITLE
Cherry-pick #21406 to 7.x: Split index restrictions into type,dataset, namespace parts 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
@@ -93,25 +93,6 @@ func TestStreamCheck(t *testing.T) {
 			},
 			result: ErrInvalidDataset,
 		},
-
-		{
-			name: "dataset invalid dot - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": "."}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
-		{
-			name: "dataset invalid dotdot- compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": ".."}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
 		{
 			name: "dataset invalid uppercase - compact",
 			configMap: map[string]interface{}{
@@ -140,35 +121,9 @@ func TestStreamCheck(t *testing.T) {
 			result: ErrInvalidDataset,
 		},
 		{
-			name: "dataset invalid invalid prefix- compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"streams": []map[string]interface{}{{"data_stream.dataset": "_isthisvalid"}}},
-				},
-			},
-			result: ErrInvalidDataset,
-		},
-
-		{
 			name: "namespace invalid - compact",
 			configMap: map[string]interface{}{
 				"inputs": []map[string]interface{}{{"data_stream.namespace": ""}},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name 1 - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{"data_stream.namespace": "."},
-				},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name 2 - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{{"data_stream.namespace": ".."}},
 			},
 			result: ErrInvalidNamespace,
 		},
@@ -190,13 +145,6 @@ func TestStreamCheck(t *testing.T) {
 			name: "namespace invalid name invalid char - compact",
 			configMap: map[string]interface{}{
 				"inputs": []map[string]interface{}{{"data_stream.namespace": "isitok?"}},
-			},
-			result: ErrInvalidNamespace,
-		},
-		{
-			name: "namespace invalid name invalid prefix - compact",
-			configMap: map[string]interface{}{
-				"inputs": []map[string]interface{}{{"data_stream.namespace": "+isitok"}},
 			},
 			result: ErrInvalidNamespace,
 		},
@@ -273,6 +221,33 @@ func TestStreamCheck(t *testing.T) {
 				},
 			},
 			result: nil,
+		},
+		{
+			name: "type invalid prefix _",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "_type"},
+				},
+			},
+			result: ErrInvalidIndex,
+		},
+		{
+			name: "type invalid prefix -",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "-type"},
+				},
+			},
+			result: ErrInvalidIndex,
+		},
+		{
+			name: "type invalid prefix +",
+			configMap: map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{"data_stream.type": "+type"},
+				},
+			},
+			result: ErrInvalidIndex,
 		},
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #21406 to 7.x branch. Original message:

## What does this PR do?

This PR does not apply same restrictions set on all parts of resulting index and follows 20/100/100 bytes length requirement for type, dataset and namespace

## Why is it important?

Makes rules in par with the ones applied at fleet level

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
