### PR TITLE
Cherry-pick #21285 to 7.x: Send snapshot flag together with metadata 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -33,12 +33,12 @@ const (
 
 // Upgrader performs an upgrade
 type Upgrader struct {
-	settings   *artifact.Config
-	log        *logger.Logger
-	closers    []context.CancelFunc
-	reexec     reexecManager
-	acker      acker
-	upgradable bool
+	settings    *artifact.Config
+	log         *logger.Logger
+	closers     []context.CancelFunc
+	reexec      reexecManager
+	acker       acker
+	upgradeable bool
 }
 
 type reexecManager interface {
@@ -53,23 +53,23 @@ type acker interface {
 // NewUpgrader creates an upgrader which is capable of performing upgrade operation
 func NewUpgrader(settings *artifact.Config, log *logger.Logger, closers []context.CancelFunc, reexec reexecManager, a acker) *Upgrader {
 	return &Upgrader{
-		settings:   settings,
-		log:        log,
-		closers:    closers,
-		reexec:     reexec,
-		acker:      a,
-		upgradable: getUpgradable(),
+		settings:    settings,
+		log:         log,
+		closers:     closers,
+		reexec:      reexec,
+		acker:       a,
+		upgradeable: getUpgradable(),
 	}
 }
 
-// Upgradable returns true if the Elastic Agent can be upgraded.
-func (u *Upgrader) Upgradable() bool {
-	return u.upgradable
+// Upgradeable returns true if the Elastic Agent can be upgraded.
+func (u *Upgrader) Upgradeable() bool {
+	return u.upgradeable
 }
 
 // Upgrade upgrades running agent
 func (u *Upgrader) Upgrade(ctx context.Context, a *fleetapi.ActionUpgrade) error {
-	if !u.upgradable {
+	if !u.upgradeable {
 		return fmt.Errorf(
 			"cannot be upgraded; must be installed with install sub-command and " +
 				"running under control of the systems supervisor")
@@ -153,9 +153,9 @@ func rollbackInstall(hash string) {
 }
 
 func getUpgradable() bool {
-	// only upgradable if running from Agent installer and running under the
+	// only upgradeable if running from Agent installer and running under the
 	// control of the system supervisor (or built specifically with upgrading enabled)
-	return release.Upgradable() || (install.RunningInstalled() && install.RunningUnderSupervisor())
+	return release.Upgradeable() || (install.RunningInstalled() && install.RunningUnderSupervisor())
 }
 
 func copyActionStore(newHash string) error {

--- a/x-pack/elastic-agent/pkg/release/upgrade.go
+++ b/x-pack/elastic-agent/pkg/release/upgrade.go
@@ -4,7 +4,7 @@
 
 package release
 
-// Upgradable return true when release is built specifically for upgrading.
-func Upgradable() bool {
+// Upgradeable return true when release is built specifically for upgrading.
+func Upgradeable() bool {
 	return allowUpgrade == "true"
 }

--- a/x-pack/elastic-agent/pkg/release/version.go
+++ b/x-pack/elastic-agent/pkg/release/version.go
@@ -76,7 +76,7 @@ func Info() VersionInfo {
 }
 
 // String returns the string format for the version information.
-func (v *VersionInfo) String() string {
+func (v VersionInfo) String() string {
 	var sb strings.Builder
 
 	sb.WriteString(v.Version)


### PR DESCRIPTION
Cherry-pick of PR #21285 to 7.x branch. Original message:

## What does this PR do?

For correct Source URI resolution fleet needs to be aware whether or not agent is a SNAPSHOT build or not. 
This PR includes this information in two forms in `local` metadata which is sent during `enroll` and `checkin`
- `elastic.agent.snapshot` - additional field set to true if agent is in snapshot mode
- `elastic.agent.build.original` - long version info, in case of snapshot it will contain it e.g.`8.0.0-SNAPSHOT (build: 3f1e3a5d016487f4cc995b019a846f3f13104f03 at 2020-09-24 08:57:34 +0000 UTC)`

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
