### PR TITLE
[CI] changeset from #20603 was not added to CI2.0

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -28,11 +28,13 @@ changeset:
         - "^\\.ci/scripts/.*"
     oss:
         - "^go.mod"
+        - "^pytest.ini"
         - "^dev-tools/.*"
         - "^libbeat/.*"
         - "^testing/.*"
     xpack:
         - "^go.mod"
+        - "^pytest.ini"
         - "^dev-tools/.*"
         - "^libbeat/.*"
         - "^testing/.*"


### PR DESCRIPTION
## What does this PR do?

Add changeset from https://github.com/elastic/beats/pull/20603

## Why is it important?

It was not added to the 2.0 pipeline