### PR TITLE
Cherry-pick to 7.x: [CI] Send slack message with build status (#21428)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     OSS_MODULE_PATTERN = '^[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
     PIPELINE_LOG_LEVEL = 'INFO'
     RUNBLD_DISABLE_NOTIFICATIONS = 'true'
+    SLACK_CHANNEL = "#beats-ci-builds"
     TERRAFORM_VERSION = "0.12.24"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
   }
@@ -120,7 +121,7 @@ pipeline {
       runbld(stashedTestReports: stashedTestReports, project: env.REPO)
     }
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: true, slackComment: true)
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Send slack message with build status (#21428)