### PR TITLE
Cherry-pick #21462 to 7.x: Remove duplicated sources url in dependencies report

### DIFF
--- a/dev-tools/dependencies-report
+++ b/dev-tools/dependencies-report
@@ -48,7 +48,7 @@ go list -m -json all $@ | go run go.elastic.co/go-licence-detector \
 # name,url,version,revision,license
 ubi8url='https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8'
 ubi8source='https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
-ubilicense='Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+ubilicense='Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf'
 cat <<EOF >> $outfile
 Red Hat Universal Base Image,$ubi8url,8,,$ubilicense,$ubi8source
 EOF


### PR DESCRIPTION
Cherry-pick of PR #21462 to 7.x branch. Original message: 

It was added by mistake as part of the license URL in #21374.