### PR TITLE
[Ingest Manager] Prompt only when agent is already enrolled

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -119,7 +119,9 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 	if fromInstall {
 		force = true
 	}
-	if !force {
+
+	// prompt only when it is not forced and is already enrolled
+	if !force && (cfg.Fleet != nil && cfg.Fleet.Enabled == true) {
 		confirm, err := c.Confirm("This will replace your current settings. Do you want to continue?", true)
 		if err != nil {
 			return errors.New(err, "problem reading prompt response")


### PR DESCRIPTION
## What does this PR do?

Currently when you install Elastic Agent for the first time and then issue the enroll command it prompts the user "This will replace your current settings. Do you want to continue? [Y/n]" However, there are no current settings so it should not show this prompt. It should only be shown when overwriting existing settings.

## Why is it important?

Fixes #20068

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
