### PR TITLE
Cherry-pick to 7.x: [CI] changeset from #20603 was not added to CI2.0 (#21464)

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -28,11 +28,13 @@ changeset:
         - "^\\.ci/scripts/.*"
     oss:
         - "^go.mod"
+        - "^pytest.ini"
         - "^dev-tools/.*"
         - "^libbeat/.*"
         - "^testing/.*"
     xpack:
         - "^go.mod"
+        - "^pytest.ini"
         - "^dev-tools/.*"
         - "^libbeat/.*"
         - "^testing/.*"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] changeset from #20603 was not added to CI2.0 (#21464)