### PR TITLE
Cherry-pick to 7.9: [CI] Change x-pack/auditbeat build events (comments, labels) (#21463)

### DIFF
--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -5,11 +5,11 @@ when:
         - "@ci"                ## special token regarding the changeset for the ci
         - "@xpack"             ## special token regarding the changeset for the xpack
     comments:                  ## when PR comment contains any of those entries
-        - "/test auditbeat"
+        - "/test x-pack/auditbeat"
     labels:                    ## when PR labels matches any of those entries
-        - "auditbeat"
+        - "x-pack-auditbeat"
     parameters:                ## when parameter was selected in the UI.
-        - "auditbeat"
+        - "x-pack-auditbeat"
     tags: true                 ## for all the tags
 platform: "linux && ubuntu-18" ## default label for all the stages
 stages:
@@ -22,7 +22,7 @@ stages:
           - "macosx"
         when:                  ## Override the top-level when.
             comments:
-                - "/test auditbeat for macos"
+                - "/test x-pack/auditbeat for macos"
             labels:
                 - "macOS"
             parameters:

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -1,15 +1,15 @@
 when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
-        - "^x-pack/winlogbeat/.*"
+        - "^x-pack/packetbeat/.*"
         - "@ci"                ## special token regarding the changeset for the ci
         - "@xpack"             ## special token regarding the changeset for the xpack
     comments:                  ## when PR comment contains any of those entries
-        - "/test x-pack/winlogbeat"
+        - "/test x-pack/packetbeat"
     labels:                    ## when PR labels matches any of those entries
-        - "x-pack-winlogbeat"
+        - "x-pack-packetbeat"
     parameters:                ## when parameter was selected in the UI.
-        - "x-pack-winlogbeat"
+        - "x-pack-packetbeat"
     tags: true                 ## for all the tags
 platform: "linux && ubuntu-18" ## default label for all the stages
 stages:


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [CI] Change x-pack/auditbeat build events (comments, labels) (#21463)