### PR TITLE
Include original error when metricbeat fails to connect with Kafka

### DIFF
--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -119,7 +119,7 @@ func (b *Broker) Connect() error {
 	c, err := getClusterWideClient(b.Addr(), b.cfg)
 	if err != nil {
 		closeBroker(b.broker)
-		return fmt.Errorf("Could not get cluster client for advertised broker with address %v", b.Addr())
+		return fmt.Errorf("getting cluster client for advertised broker with address %v: %w", b.Addr(), err)
 	}
 	b.client = c
 


### PR DESCRIPTION
## What does this PR do?

Include error from kafka when Metricbeat cannot connect with broker.

## Why is it important?

It includes the address only, and not the original error, complicating the investigation of connection errors.