### PR TITLE
Cherry-pick #21482 to 7.x: Fix format of debug messages in tlscommon

### DIFF
--- a/libbeat/common/transport/tlscommon/tls.go
+++ b/libbeat/common/transport/tlscommon/tls.go
@@ -66,7 +66,7 @@ func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 		return nil, err
 	}
 
-	log.Debugf("tls", "loading certificate: %v and key %v", certificate, key)
+	log.Debugf("Loading certificate: %v and key %v", certificate, key)
 	return &cert, nil
 }
 
@@ -169,7 +169,7 @@ func LoadCertificateAuthorities(CAs []string) (*x509.CertPool, []error) {
 			errors = append(errors, fmt.Errorf("%v adding %v to the list of known CAs", ErrNotACertificate, r))
 			continue
 		}
-		log.Debugf("tls", "successfully loaded CA certificate: %v", r)
+		log.Debugf("Successfully loaded CA certificate: %v", r)
 	}
 
 	return roots, errors


### PR DESCRIPTION
Cherry-pick of PR #21482 to 7.x branch. Original message: 

