### PR TITLE
Cherry-pick #21482 to 7.9: Fix format of debug messages in tlscommon

### DIFF
--- a/libbeat/common/transport/tlscommon/tls.go
+++ b/libbeat/common/transport/tlscommon/tls.go
@@ -63,7 +63,7 @@ func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 		return nil, err
 	}
 
-	log.Debugf("tls", "loading certificate: %v and key %v", certificate, key)
+	log.Debugf("Loading certificate: %v and key %v", certificate, key)
 	return &cert, nil
 }
 
@@ -152,7 +152,7 @@ func LoadCertificateAuthorities(CAs []string) (*x509.CertPool, []error) {
 			errors = append(errors, fmt.Errorf("%v adding %v to the list of known CAs", ErrNotACertificate, path))
 			continue
 		}
-		log.Debugf("tls", "successfully loaded CA certificate: %v", path)
+		log.Debugf("Successfully loaded CA certificate: %v", path)
 	}
 
 	return roots, errors


### PR DESCRIPTION
Cherry-pick of PR #21482 to 7.9 branch. Original message: 

