### PR TITLE
Cherry-pick #21493 to 7.x: [libbeat] Add configurable exponential backoff for disk queue write errors

### DIFF
--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -207,10 +207,15 @@ func (segment *queueSegment) getWriter(
 // retry callback returns true. This is used for timed retries when
 // creating a queue segment from the writer loop.
 func (segment *queueSegment) getWriterWithRetry(
-	queueSettings Settings, retry func(error) bool,
+	queueSettings Settings, retry func(err error, firstTime bool) bool,
 ) (*os.File, error) {
+	firstTime := true
 	file, err := segment.getWriter(queueSettings)
-	for err != nil && retry(err) {
+	for err != nil && retry(err, firstTime) {
+		// Set firstTime to false so the retry callback can perform backoff
+		// etc if needed.
+		firstTime = false
+
 		// Try again
 		file, err = segment.getWriter(queueSettings)
 	}


### PR DESCRIPTION
Cherry-pick of PR #21493 to 7.x branch. Original message: 

## What does this PR do?

This PR adds user-configurable fields `retry_interval` and `max_retry_interval` to the disk queue, and uses them to perform exponential backoff when encountering fatal errors writing to disk.

I'm aware that there are some existing helper wrappers for this functionality, e.g. `ExpBackoff` in `libbeat/common/backoff`. Unfortunately they didn't fit the cancellation or error handling model in the queue, so the backoff here is done "by hand." I've tried to restrict the moving parts to self-contained helper functions.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Enable the disk queue (with e.g. `queue.disk.max_size: 1GB` in the beat config) and start the beat. While it's running, remove write permissions to `data/diskqueue`. This should log errors for the writer and deleter (if applicable), e.g.:

```
2020-10-02T13:10:10.844-0400    ERROR   [publisher.diskqueue]   diskqueue/writer_loop.go:251    Writing to segment 9: open /Users/fae/go/src/github.com/elastic/beats/filebeat/data/diskqueue/9.seg: permission denied
2020-10-02T13:10:14.670-0400    ERROR   [publisher.diskqueue]   diskqueue/core_loop.go:204      Deleting segment files {"errors": [{"error": "Couldn't delete segment 4: remove /Users/fae/go/src/github.com/elastic/beats/filebeat/data/diskqueue/4.seg: permission denied"}]}
```

By default, any such errors should start 1 second apart and grow by powers of 2 up to 30 seconds. This default can be changed by setting `queue.disk.{retry_interval, max_retry_interval}`.