### PR TITLE
Add `add_observer_metadata` `geo.name` to Quickstart

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -102,9 +102,9 @@ include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 Heartbeat can be deployed in multiple locations so that you can detect 
 differences in availability and response times across those locations.
-By configuring Heartbeat with the location of the server you will allow the
-Uptime application to display location specific information on a map, and 
-allow the Uptime anomaly detection to detect anomalies based on location.
+Configure the Heartbeat location to allow {kib} to display location-specific
+information on Uptime maps and perform Uptime anomaly detection based
+on location.
 
 To configure the location of a Heartbeat instance, modify the 
 `add_observer_metadata` processor in +{beatname_lc}.yml+.  The following 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -97,8 +97,42 @@ was started. Heartbeat adds the `@every` keyword to the syntax provided by the
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 [float]
+[[configurelocation]]
+=== Step 4: Configure the Heartbeat location
+
+Heartbeat can be deployed in multiple locations so that you can detect 
+differences in availability and response times across those locations.
+By configuring Heartbeat with the location of the server you will allow the
+Uptime application to display location specific information on a map, and 
+allow the Uptime anomaly detection to detect anomalies based on location.
+
+To configure the location of a Heartbeat instance, in +{beatname_lc}.yml+,
+modify the `add_observer_metadata` processor.  The following example 
+specifies the `geo.name` of the `add_observer_metadata` processor as
+`us-east-1a`:
+
+[source,yaml]
+----------------------------------------------------------------------
+# ============================ Processors ============================
+
+processors:
+  - add_observer_metadata:
+      # Optional, but recommended geo settings for the location Heartbeat is running in
+      geo: <1>
+        # Token describing this location
+        name: us-east-1a <2>
+        # Lat, Lon "
+        #location: "37.926868, -78.024902" <3>
+----------------------------------------------------------------------
+<1> Uncomment the `geo` setting.
+<2> Uncomment `name` and assign the name of the location of the Heartbeat server.
+<3> Optionally uncomment `location` and assign the latitude and longitude.
+
+include::{libbeat-dir}/shared/config-check.asciidoc[]
+
+[float]
 [[setup-assets]]
-=== Step 4: Set up assets
+=== Step 5: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:
@@ -128,7 +162,7 @@ environment. If you're using a different output, such as {ls}, see
 
 [float]
 [[start]]
-=== Step 5: Start Heartbeat
+=== Step 6: Start Heartbeat
 
 Before starting {beatname_uc}, modify the user credentials in
 +{beatname_lc}.yml+ and specify a user who is
@@ -145,7 +179,7 @@ events to your defined output.
 
 [float]
 [[view-data]]
-=== Step 6: View your data in {kib}
+=== Step 7: View your data in {kib}
 
 {beatname_uc} comes with pre-built {kib} dashboards and UIs for visualizing the
 status of your services. The dashboards are available in the

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -106,9 +106,9 @@ By configuring Heartbeat with the location of the server you will allow the
 Uptime application to display location specific information on a map, and 
 allow the Uptime anomaly detection to detect anomalies based on location.
 
-To configure the location of a Heartbeat instance, in +{beatname_lc}.yml+,
-modify the `add_observer_metadata` processor.  The following example 
-specifies the `geo.name` of the `add_observer_metadata` processor as
+To configure the location of a Heartbeat instance, modify the 
+`add_observer_metadata` processor in +{beatname_lc}.yml+.  The following 
+example specifies the `geo.name` of the `add_observer_metadata` processor as
 `us-east-1a`:
 
 [source,yaml]


### PR DESCRIPTION
The observer location is very important in the Uptime app and the out-of-the-box machine learning job.


Please label this PR with one of the following labels, depending on the scope of your change:
- Bug


## What does this PR do?

After following the Quickstart the out-of-the-box ML job will not work, as it requires the observer location.  

## Why is it important?

The user experience is not correct if the anomaly does not work, and the user will not know what to do.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist


## How to test this PR locally

Follow the Quickstart and then enable anomaly detection in Uptime, and then add the geo.name and try it again.

## Related issues

- Relates https://github.com/elastic/uptime/issues/259
