### PR TITLE
Cherry-pick to 7.x: Clarify input type configuration options (#19284)

### DIFF
--- a/filebeat/docs/reload-configuration.asciidoc
+++ b/filebeat/docs/reload-configuration.asciidoc
@@ -33,9 +33,11 @@ definitions.
  
 TIP: The first line of each external configuration file must be an input
 definition that starts with `- type`. Make sure you omit the line
-+{beatname_lc}.config.inputs+ from this file.
- 
-For example:
++{beatname_lc}.config.inputs+ from this file. All <<filebeat-input-types,`input type configuration options`>> 
+must be specified within each external configuration file.  Specifying these
+configuration options at the global `filebeat.config.inputs` level is not supported.
+
+Example external configuration file:
 
 [source,yaml]
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clarify input type configuration options (#19284)