### PR TITLE
Cherry-pick #21474 to 7.x: [docs] [Kubernetes] Fix leftover deployment example

### DIFF
--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -177,11 +177,6 @@ $ kubectl --namespace=kube-system  get ds/metricbeat
 
 NAME       DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE-SELECTOR   AGE
 metricbeat   32        32        0         32           0           <none>          1m
-
-$ kubectl --namespace=kube-system  get deploy/metricbeat
-
-NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-metricbeat                1         1         1            1           1m
 ------------------------------------------------
 
 Metrics should start flowing to Elasticsearch.


### PR DESCRIPTION
Cherry-pick of PR #21474 to 7.x branch. Original message: 

## What does this PR do?
Removes deployment part from example since it's not valid any more. Leftover from https://github.com/elastic/beats/pull/20601