### PR TITLE
Cherry-pick #21487 to 7.x: Increase index pattern size check to 10MiB

### DIFF
--- a/libbeat/tests/system/beat/common_tests.py
+++ b/libbeat/tests/system/beat/common_tests.py
@@ -4,6 +4,12 @@ import yaml
 
 from beat.beat import INTEGRATION_TESTS
 
+# Fail if the exported index pattern is larger than 10MiB
+# This is to avoid problems with Kibana when the payload
+# of the request to install the index pattern exceeds the
+# default limit.
+index_pattern_size_limit = 10 * 1024 * 1024
+
 
 class TestExportsMixin:
 
@@ -56,7 +62,7 @@ class TestExportsMixin:
         js = json.loads(output)
         assert "objects" in js
         size = len(output.encode('utf-8'))
-        assert size < 1024 * 1024, "Kibana index pattern must be less than 1MiB " \
+        assert size < index_pattern_size_limit, "Kibana index pattern must be less than 10MiB " \
             "to keep the Beat setup request size below " \
             "Kibana's server.maxPayloadBytes."
 
@@ -68,7 +74,7 @@ class TestExportsMixin:
         js = json.loads(output)
         assert "objects" in js
         size = len(output.encode('utf-8'))
-        assert size < 1024 * 1024, "Kibana index pattern must be less than 1MiB " \
+        assert size < index_pattern_size_limit, "Kibana index pattern must be less than 10MiB " \
             "to keep the Beat setup request size below " \
             "Kibana's server.maxPayloadBytes."
 


### PR DESCRIPTION
Cherry-pick of PR #21487 to 7.x branch. Original message: 

## What does this PR do?

Updates the test on `beatname export index-pattern` to apply an index pattern size limit of 10MiB instead of the original 1MiB, since [Kibana has raised this limit](https://github.com/elastic/kibana/pull/77409) for 7.10 onwards.

## Why is it important?

Because we're already over the limit and tests won't pass.
