### PR TITLE
Cherry-pick #21490 to 7.x: Skip filestream flaky tests

### DIFF
--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -38,6 +38,8 @@ var (
 )
 
 func TestFileScanner(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21489")
+
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
@@ -132,6 +134,8 @@ func checkIfSameContents(one, other []string) bool {
 }
 
 func TestFileWatchNewDeleteModified(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21489")
+
 	oldTs := time.Now()
 	newTs := oldTs.Add(5 * time.Second)
 	testCases := map[string]struct {


### PR DESCRIPTION
Cherry-pick of PR #21490 to 7.x branch. Original message: 

More info: https://github.com/elastic/beats/issues/21489