### PR TITLE
Add Openshift-crio configuration for filebeat on k8s

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -71,7 +71,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:6.8.11
+        image: docker.elastic.co/beats/auditbeat:6.8.12
         args: [
           "-c", "/etc/auditbeat.yml"
         ]

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -19,6 +19,21 @@ data:
         # Reload module configs as they change:
         reload.enabled: false
 
+    # Uncommnet this part and remove `filebeat.config.inputs` when running in Openshift and cri-o
+    #filebeat.autodiscover:
+    #  providers:
+    #     - type: kubernetes
+    #       include_pod_uid: true
+    #       templates:
+    #         - condition.regexp:
+    #             kubernetes.container.name: '.+'
+    #           config:
+    #             - type: docker
+    #               containers:
+    #                 path: "/var/log/pods/*${data.kubernetes.pod.uid}/"
+    #                 ids:
+    #                   - "${data.kubernetes.container.name}"
+
     # To enable hints based autodiscover, remove `filebeat.config.inputs` configuration and uncomment this:
     #filebeat.autodiscover:
     #  providers:
@@ -69,7 +84,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.8.11
+        image: docker.elastic.co/beats/filebeat:6.8.12
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",
@@ -110,6 +125,9 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -118,6 +136,9 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: varlog
+        hostPath:
+          path: /var/log
       - name: inputs
         configMap:
           defaultMode: 0600

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -19,6 +19,21 @@ data:
         # Reload module configs as they change:
         reload.enabled: false
 
+    # Uncommnet this part and remove `filebeat.config.inputs` when running in Openshift and cri-o
+    #filebeat.autodiscover:
+    #  providers:
+    #     - type: kubernetes
+    #       include_pod_uid: true
+    #       templates:
+    #         - condition.regexp:
+    #             kubernetes.container.name: '.+'
+    #           config:
+    #             - type: docker
+    #               containers:
+    #                 path: "/var/log/pods/*${data.kubernetes.pod.uid}/"
+    #                 ids:
+    #                   - "${data.kubernetes.container.name}"
+
     # To enable hints based autodiscover, remove `filebeat.config.inputs` configuration and uncomment this:
     #filebeat.autodiscover:
     #  providers:

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -56,6 +56,9 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -64,6 +67,9 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: varlog
+        hostPath:
+          path: /var/log
       - name: inputs
         configMap:
           defaultMode: 0600

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -77,7 +77,7 @@ data:
       period: 10s
       host: ${NODE_NAME}
       hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and 
+      # If using Red Hat OpenShift remove the previous hosts entry and
       # uncomment these settings:
       #hosts: ["https://${HOSTNAME}:10250"]
       #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -104,7 +104,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.8.11
+        image: docker.elastic.co/beats/metricbeat:6.8.12
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -242,7 +242,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.8.11
+        image: docker.elastic.co/beats/metricbeat:6.8.12
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -77,7 +77,7 @@ data:
       period: 10s
       host: ${NODE_NAME}
       hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and
+      # If using Red Hat OpenShift remove the previous hosts entry and 
       # uncomment these settings:
       #hosts: ["https://${HOSTNAME}:10250"]
       #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -94,7 +94,7 @@ filebeat.autodiscover:
 
 . Grant the `filebeat` service account access to the privileged SCC:
 +
-[source,yaml]
+[source,shell]
 -----
 oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:filebeat
 -----

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -20,10 +20,10 @@ to ensure there's a running instance on each node of the cluster.
 
 The Docker logs host folder (`/var/lib/docker/containers`) is mounted on the
 {beatname_uc} container. {beatname_uc} starts an input for the files and
-begins harvesting them as soon as they appear in the folder. 
+begins harvesting them as soon as they appear in the folder.
 
 Everything is deployed under the `kube-system` namespace by default. To change
-the namespace, modify the manifest file. 
+the namespace, modify the manifest file.
 
 To download the manifest file, run:
 
@@ -73,9 +73,28 @@ the manifest file and enable the container to run as privileged.
     privileged: true
 -----
 
+. Modify the `ConfigMap` with the proper configuration so as to collect container logs:
++
+[source,yaml]
+-----
+filebeat.autodiscover:
+  providers:
+     - type: kubernetes
+       include_pod_uid: true
+       templates:
+         - condition.regexp:
+             kubernetes.container.name: '.+'
+           config:
+             - type: docker
+               containers:
+                 path: "/var/log/pods/*${data.kubernetes.pod.uid}/"
+                 ids:
+                   - "${data.kubernetes.container.name}"
+-----
+
 . Grant the `filebeat` service account access to the privileged SCC:
 +
-[source,shell]
+[source,yaml]
 -----
 oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:filebeat
 -----
@@ -93,7 +112,7 @@ oc patch namespace kube-system -p \
 ----
 +
 This command sets the node selector for the project to an empty string. If you
-don't run this command, the default node selector will skip master nodes.  
+don't run this command, the default node selector will skip master nodes.
 
 
 [float]


### PR DESCRIPTION
## What does this PR do?
This PR adds an Openshift+crio specific example in Filbeat's k8s manifests.


## Why is it important?
To provide an out-of-the-box way to our users using Filebeat 6.8.x and Openshift+crio

Closes https://github.com/elastic/beats/issues/21189