### PR TITLE
Cherry-pick #21488 to 7.x: Download asc from artifact store specified in spec

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
@@ -31,7 +31,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		return "", errors.New(err, "failed upgrade of agent binary")
 	}
 
-	matches, err := verifier.Verify(agentName, version)
+	matches, err := verifier.Verify(agentName, version, agentArtifactName)
 	if err != nil {
 		return "", errors.New(err, "failed verification of agent binary")
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -143,7 +143,7 @@ var _ download.Downloader = &DummyDownloader{}
 
 type DummyVerifier struct{}
 
-func (*DummyVerifier) Verify(p, v string) (bool, error) {
+func (*DummyVerifier) Verify(p, v, _ string) (bool, error) {
 	return true, nil
 }
 

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -161,7 +161,7 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 			ProgramSpec: program.Spec{
 				Name:     metricsProcessName,
 				Cmd:      metricsProcessName,
-				Artifact: fmt.Sprintf("%s/%s", artifactPrefix, logsProcessName),
+				Artifact: fmt.Sprintf("%s/%s", artifactPrefix, metricsProcessName),
 			},
 			Meta: map[string]interface{}{
 				configrequest.MetaConfigKey: mbConfig,

--- a/x-pack/elastic-agent/pkg/agent/operation/operation_verify.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operation_verify.go
@@ -66,7 +66,7 @@ func (o *operationVerify) Run(_ context.Context, application Application) (err e
 		}
 	}()
 
-	isVerified, err := o.verifier.Verify(o.program.BinaryName(), o.program.Version())
+	isVerified, err := o.verifier.Verify(o.program.BinaryName(), o.program.Version(), o.program.ArtifactName())
 	if err != nil {
 		return errors.New(err,
 			fmt.Sprintf("operation '%s' failed to verify %s.%s", o.Name(), o.program.BinaryName(), o.program.Version()),

--- a/x-pack/elastic-agent/pkg/artifact/download/composed/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/composed/verifier.go
@@ -29,11 +29,11 @@ func NewVerifier(verifiers ...download.Verifier) *Verifier {
 }
 
 // Verify checks the package from configured source.
-func (e *Verifier) Verify(programName, version string) (bool, error) {
+func (e *Verifier) Verify(programName, version, artifactName string) (bool, error) {
 	var err error
 
 	for _, v := range e.vv {
-		b, e := v.Verify(programName, version)
+		b, e := v.Verify(programName, version, artifactName)
 		if e == nil {
 			return b, nil
 		}

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
@@ -51,7 +51,7 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 
 // Verify checks downloaded package on preconfigured
 // location agains a key stored on elastic.co website.
-func (v *Verifier) Verify(programName, version string) (bool, error) {
+func (v *Verifier) Verify(programName, version, artifactName string) (bool, error) {
 	filename, err := artifact.GetArtifactName(programName, version, v.config.OS(), v.config.Arch())
 	if err != nil {
 		return false, errors.New(err, "retrieving package name")

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier_test.go
@@ -65,7 +65,7 @@ func TestFetchVerify(t *testing.T) {
 	// first download verify should fail:
 	// download skipped, as invalid package is prepared upfront
 	// verify fails and cleans download
-	matches, err := verifier.Verify(programName, version)
+	matches, err := verifier.Verify(programName, version, artifactName)
 	assert.NoError(t, err)
 	assert.Equal(t, false, matches)
 
@@ -88,7 +88,7 @@ func TestFetchVerify(t *testing.T) {
 	_, err = os.Stat(hashTargetFilePath)
 	assert.NoError(t, err)
 
-	matches, err = verifier.Verify(programName, version)
+	matches, err = verifier.Verify(programName, version, artifactName)
 	assert.NoError(t, err)
 	assert.Equal(t, true, matches)
 }
@@ -162,7 +162,7 @@ func TestVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	isOk, err := testVerifier.Verify(beatName, version)
+	isOk, err := testVerifier.Verify(beatName, version, artifactName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/http/elastic_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/elastic_test.go
@@ -110,7 +110,7 @@ func TestVerify(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			isOk, err := testVerifier.Verify(beatName, version)
+			isOk, err := testVerifier.Verify(beatName, version, artifactName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/x-pack/elastic-agent/pkg/artifact/download/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/verifier.go
@@ -6,5 +6,5 @@ package download
 
 // Verifier is an interface verifying GPG key of a downloaded artifact
 type Verifier interface {
-	Verify(programName, version string) (bool, error)
+	Verify(programName, version, artifactName string) (bool, error)
 }


### PR DESCRIPTION
Cherry-pick of PR #21488 to 7.x branch. Original message:

## What does this PR do?

For asc atrifact name was hardcoded to beats, which caused issues with endpoint

## Why is it important?

So endpoint can be securely downloaded.
Fixes: https://github.com/elastic/beats/issues/21485

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
