### PR TITLE
Cherry-pick #21461 to 7.x: Send updating state 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -28,3 +28,4 @@
 - Add support for EQL based condition on inputs {pull}20994[20994]
 - Send `fleet.host.id` to Endpoint Security {pull}21042[21042]
 - Add `install` and `uninstall` subcommands {pull}21206[21206]
+- Send updating state {pull}21461[21461]

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -204,11 +204,13 @@ func newManaged(
 	}
 
 	managedApplication.upgrader = upgrade.NewUpgrader(
+		agentInfo,
 		cfg.Settings.DownloadConfig,
 		log,
 		[]context.CancelFunc{managedApplication.cancelCtxFn},
 		reexec,
-		acker)
+		acker,
+		combinedReporter)
 
 	actionDispatcher.MustRegister(
 		&fleetapi.ActionPolicyChange{},

--- a/x-pack/elastic-agent/pkg/core/state/state.go
+++ b/x-pack/elastic-agent/pkg/core/state/state.go
@@ -30,6 +30,8 @@ const (
 	Crashed
 	// Restarting is status describing application is restarting.
 	Restarting
+	// Updating is status describing application is updating.
+	Updating
 )
 
 // State wraps the process state and application status.

--- a/x-pack/elastic-agent/pkg/reporter/reporter.go
+++ b/x-pack/elastic-agent/pkg/reporter/reporter.go
@@ -38,6 +38,8 @@ const (
 	EventSubTypeFailed = "FAILED"
 	// EventSubTypeStopping is an event type indicating application is stopping.
 	EventSubTypeStopping = "STOPPING"
+	// EventSubTypeUpdating is an event type indicating update process in progress.
+	EventSubTypeUpdating = "UPDATING"
 )
 
 type agentInfo interface {
@@ -127,6 +129,10 @@ func generateRecord(agentID string, id string, name string, s state.State) event
 	case state.Restarting:
 		subType = EventSubTypeStarting
 		subTypeText = "RESTARTING"
+	case state.Updating:
+		subType = EventSubTypeUpdating
+		subTypeText = EventSubTypeUpdating
+
 	}
 
 	err := errors.New(


### PR DESCRIPTION
Cherry-pick of PR #21461 to 7.x branch. Original message:

## What does this PR do?

This PR reports updating state of application after update process is started and error in case it is finished with failure

Tested with https://github.com/elastic/kibana/pull/78810 after suggested changes (i did them manually) i started agent without starting a file server so UPDATE fails i got this (as expected)

<img width="947" alt="image" src="https://user-images.githubusercontent.com/1522652/94900393-302fa880-0495-11eb-998a-04f1f09274b7.png">

UPDATE is ACK-ed and Error there is reported, under ACK there is line saying STATE was switched to UPDATING
<img width="690" alt="image" src="https://user-images.githubusercontent.com/1522652/95050853-8b0f0d00-06ec-11eb-9378-39cbaea0761f.png">

after i started server and rekicked UPDATE action

<img width="927" alt="image" src="https://user-images.githubusercontent.com/1522652/94900729-c237b100-0495-11eb-9019-7b209d690613.png">

update was ACKed and state switched to RUNNING after it finished.

Status on list page was `ONLINE` then `UPDATING` and then back `ONLINE`. Even though there were errors, so i guess this will be an object of next iteration.

## Why is it important?


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
