### PR TITLE
Fix billing.go aws.GetStartTimeEndTime

### DIFF
--- a/x-pack/metricbeat/module/aws/billing/billing.go
+++ b/x-pack/metricbeat/module/aws/billing/billing.go
@@ -116,7 +116,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	startDate, endDate := getStartDateEndDate(m.Period)
 
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
 
 	// get cost metrics from cost explorer
 	awsConfig := m.MetricSet.AwsConfig.Copy()


### PR DESCRIPTION
This PR is to fix this error introduced in https://github.com/elastic/beats/pull/20875:
```
# github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/billing
../x-pack/metricbeat/module/aws/billing/billing.go:119:47: not enough arguments in call to "github.com/elastic/beats/v7/x-pack/metricbeat/module/aws".GetStartTimeEndTime
	have (time.Duration)
	want (time.Duration, time.Duration)
Error: error getting default metricsets: Error running subcommand to get metricsets: running "go run /home/travis/gopath/src/github.com/elastic/beats/x-pack/metricbeat/scripts/msetlists/main.go" failed with exit code 2
```