### PR TITLE
Cherry-pick to 7.x: [CI] fix 'no matches found within 10000' (#21466)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
       }
       steps {
         withGithubNotify(context: 'Lint') {
-          withBeatsEnv(archive: true) {
+          withBeatsEnv(archive: true, id: 'lint') {
             dumpVariables()
             cmd(label: 'make check', script: 'make check')
           }
@@ -344,8 +344,13 @@ def archiveTestOutput(Map args = [:]) {
     }
     cmd(label: 'Prepare test output', script: 'python .ci/scripts/pre_archive_test.py')
     dir('build') {
+      if (isUnix()) {
+        cmd(label: 'Delete folders that are causing exceptions (See JENKINS-58421)',
+            returnStatus: true,
+            script: 'rm -rf ve || true; find . -type d -name vendor -exec rm -r {} \\;')
+      } else { log(level: 'INFO', text: 'Delete folders that are causing exceptions (See JENKINS-58421) is disabled for Windows.') }
       junitAndStore(allowEmptyResults: true, keepLongStdio: true, testResults: args.testResults, stashedTestReports: stashedTestReports, id: args.id)
-      archiveArtifacts(allowEmptyArchive: true, artifacts: args.artifacts)
+      tar(file: "test-build-artifacts-${args.id}.tgz", dir: '.', archive: true, allowMissing: true)
     }
     catchError(buildResult: 'SUCCESS', message: 'Failed to archive the build test results', stageResult: 'SUCCESS') {
       def folder = cmd(label: 'Find system-tests', returnStdout: true, script: 'python .ci/scripts/search_system_tests.py').trim()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] fix 'no matches found within 10000' (#21466)