### PR TITLE
Cherry-pick #20875 to 7.x: [Metricbeat] Add latency config option into aws module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -812,6 +812,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add billing data collection from Cost Explorer into aws billing metricset. {pull}20527[20527] {issue}20103[20103]
 - Migrate `compute_vm` metricset to a light one, map `cloud.instance.id` field. {pull}20889[20889]
 - Request prometheus endpoints to be gzipped by default {pull}20766[20766]
+- Add latency config parameter into aws module. {pull}20875[20875]
+- Release all kubernetes `state` metricsets as GA {pull}20901[20901]
 - Add billing metricset into googlecloud module. {pull}20812[20812] {issue}20738[20738]
 - Release all kubernetes `state` metricsets as GA {pull}20901[20901]
 - Move `compute_vm_scaleset` to light metricset. {pull}21038[21038] {issue}20985[20985]

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -19,15 +19,26 @@ module. Please see <<aws-api-requests,AWS API requests>> for more details.
 [float]
 == Module-specific configuration notes
 
+* *AWS Credentials*
+
 The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 Please see <<aws-credentials-config,AWS credentials options>> for more details.
 
+* *regions*
+
 This module also accepts optional configuration `regions` to specify which
 AWS regions to query metrics from. If the `regions` parameter is not set in the
 config file, then by default, the `aws` module will query metrics from all available
 AWS regions.
+
+* *latency*
+
+Some AWS services send monitoring metrics to CloudWatch with a latency to
+process larger than Metricbeat collection period. This case, please specify a
+`latency` parameter so collection start time and end time will be shifted by the
+given latency amount.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -44,4 +44,8 @@
   period: 24h
   metricsets:
     - s3_daily_storage
+- module: aws
+  period: 1m
+  latency: 5m
+  metricsets:
     - s3_request

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -11,15 +11,26 @@ module. Please see <<aws-api-requests,AWS API requests>> for more details.
 [float]
 == Module-specific configuration notes
 
+* *AWS Credentials*
+
 The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 Please see <<aws-credentials-config,AWS credentials options>> for more details.
 
+* *regions*
+
 This module also accepts optional configuration `regions` to specify which
 AWS regions to query metrics from. If the `regions` parameter is not set in the
 config file, then by default, the `aws` module will query metrics from all available
 AWS regions.
+
+* *latency*
+
+Some AWS services send monitoring metrics to CloudWatch with a latency to
+process larger than Metricbeat collection period. This case, please specify a
+`latency` parameter so collection start time and end time will be shifted by the
+given latency amount.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -27,6 +27,7 @@ import (
 type Config struct {
 	Period     time.Duration       `config:"period" validate:"nonzero,required"`
 	Regions    []string            `config:"regions"`
+	Latency    time.Duration       `config:"latency"`
 	AWSConfig  awscommon.ConfigAWS `config:",inline"`
 	TagsFilter []Tag               `config:"tags_filter"`
 }
@@ -37,6 +38,7 @@ type MetricSet struct {
 	RegionsList []string
 	Endpoint    string
 	Period      time.Duration
+	Latency     time.Duration
 	AwsConfig   *awssdk.Config
 	AccountName string
 	AccountID   string
@@ -87,6 +89,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	metricSet := MetricSet{
 		BaseMetricSet: base,
 		Period:        config.Period,
+		Latency:       config.Latency,
 		AwsConfig:     &awsConfig,
 		TagsFilter:    config.TagsFilter,
 	}

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -141,7 +141,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	// Check statistic method in config
 	err := m.checkStatistics()

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1357,7 +1357,7 @@ func TestCreateEventsWithIdentifier(t *testing.T) {
 			Value: "test-ec2",
 		},
 	}
-	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
 
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
@@ -1399,7 +1399,7 @@ func TestCreateEventsWithoutIdentifier(t *testing.T) {
 	}
 
 	resourceTypeTagFilters := map[string][]aws.Tag{}
-	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
 
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
@@ -1447,7 +1447,7 @@ func TestCreateEventsWithTagsFilter(t *testing.T) {
 			Value: "foo",
 		},
 	}
-	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
 
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -88,7 +88,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	for _, regionName := range m.MetricSet.RegionsList {
 		awsConfig := m.MetricSet.AwsConfig.Copy()

--- a/x-pack/metricbeat/module/aws/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/rds/rds.go
@@ -79,7 +79,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	for _, regionName := range m.MetricSet.RegionsList {
 		awsConfig := m.MetricSet.AwsConfig.Copy()

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
@@ -69,7 +69,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	namespace := "AWS/S3"
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	// GetMetricData for AWS S3 from Cloudwatch
 	for _, regionName := range m.MetricSet.RegionsList {

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -69,7 +69,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	namespace := "AWS/S3"
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	// GetMetricData for AWS S3 from Cloudwatch
 	for _, regionName := range m.MetricSet.RegionsList {

--- a/x-pack/metricbeat/module/aws/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs.go
@@ -67,7 +67,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	namespace := "AWS/SQS"
 	// Get startTime and endTime
-	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period, m.Latency)
+	m.Logger().Debugf("startTime = %s, endTime = %s", startTime, endTime)
 
 	for _, regionName := range m.MetricSet.RegionsList {
 		awsConfig := m.MetricSet.AwsConfig.Copy()

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -22,8 +22,13 @@ import (
 )
 
 // GetStartTimeEndTime function uses durationString to create startTime and endTime for queries.
-func GetStartTimeEndTime(period time.Duration) (time.Time, time.Time) {
+func GetStartTimeEndTime(period time.Duration, latency time.Duration) (time.Time, time.Time) {
 	endTime := time.Now()
+	if latency != 0 {
+		// add latency if config is not 0
+		endTime = endTime.Add(latency * -1)
+	}
+
 	// Set startTime double the period earlier than the endtime in order to
 	// make sure GetMetricDataRequest gets the latest data point for each metric.
 	return endTime.Add(period * -2), endTime

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -176,7 +176,7 @@ func TestGetListMetricsOutputWithWildcard(t *testing.T) {
 }
 
 func TestGetMetricDataPerRegion(t *testing.T) {
-	startTime, endTime := GetStartTimeEndTime(10 * time.Minute)
+	startTime, endTime := GetStartTimeEndTime(10*time.Minute, 0)
 
 	mockSvc := &MockCloudWatchClient{}
 	var metricDataQueries []cloudwatch.MetricDataQuery
@@ -205,7 +205,7 @@ func TestGetMetricDataPerRegion(t *testing.T) {
 }
 
 func TestGetMetricDataResults(t *testing.T) {
-	startTime, endTime := GetStartTimeEndTime(10 * time.Minute)
+	startTime, endTime := GetStartTimeEndTime(10*time.Minute, 0)
 
 	mockSvc := &MockCloudWatchClient{}
 	metricInfo := cloudwatch.Metric{

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -47,4 +47,8 @@
   period: 24h
   metricsets:
     - s3_daily_storage
+- module: aws
+  period: 1m
+  latency: 5m
+  metricsets:
     - s3_request


### PR DESCRIPTION
Cherry-pick of PR #20875 to 7.x branch. Original message: 

## What does this PR do?

This PR adds the `latency` config parameter for `aws` module. With this config parameter, users can collect CloudWatch metrics with a latency larger than Metricbeat collection period. For example, for S3 request metrics, the latency can be 3 minutes. The recommended collection period is 1min. Without the `latency` config parameter, no data points will be collected ever. 

In this screenshot: current timestamp is 14:21 but we only see the latest data at 14:18 with a 3-minute delay. In this case, without this fix, our Metricbeat module will keep trying to collect data from the last 2-minute time frame, which will always be empty:
<img width="499" alt="Screenshot 2020-09-03 at 16 22 19" src="https://user-images.githubusercontent.com/14081635/92127724-d5842d80-edbe-11ea-842a-a71210bc4df2.png">

(@gbanasiak Thank you for your screenshot!)

## Why is it important?

`latency` config sets CloudWatch API start time and end time with a delay. For example, if the current time is `2020-08-31T18:30:00.000Z` with collection period `1m`. 

Without `latency`:
startTime = `2020-08-31T18:29:00.000Z`
endTime = `2020-08-31T18:30:00.000Z`

With `latency` set to `5min`:
startTime = `2020-08-31T18:24:00.000Z`
endTime = `2020-08-31T18:25:00.000Z`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Enable aws module: `./metricbeat modules enable aws`
2. Change `modules.d/aws.yml` to:
```
- module: aws
  period: 5m
  credential_profile_name: elastic-beats
  latency: 5m
  metricsets:
    - ec2
```
3. Start Metricbeat with debug level logging: `./metricbeat -e -d "*"`
4. You should see the startTime and endTime in debug log with a latency of 5 minutes applied.