### PR TITLE
Cherry-pick #21425 to 7.x: [Elastic Agent] Add upgrade CLI to initiate upgrade of Agent locally

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -29,3 +29,4 @@
 - Send `fleet.host.id` to Endpoint Security {pull}21042[21042]
 - Add `install` and `uninstall` subcommands {pull}21206[21206]
 - Send updating state {pull}21461[21461]
+- Add `upgrade` subcommand to perform upgrade of installed Elastic Agent {pull}21425[21425]

--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_upgrade.go
@@ -27,5 +27,21 @@ func (h *handlerUpgrade) Handle(ctx context.Context, a action, acker fleetAcker)
 		return fmt.Errorf("invalid type, expected ActionUpgrade and received %T", a)
 	}
 
-	return h.upgrader.Upgrade(ctx, action)
+	return h.upgrader.Upgrade(ctx, &upgradeAction{action}, true)
+}
+
+type upgradeAction struct {
+	*fleetapi.ActionUpgrade
+}
+
+func (a *upgradeAction) Version() string {
+	return a.ActionUpgrade.Version
+}
+
+func (a *upgradeAction) SourceURI() string {
+	return a.ActionUpgrade.SourceURI
+}
+
+func (a *upgradeAction) FleetAction() *fleetapi.ActionUpgrade {
+	return a.ActionUpgrade
 }

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filters"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/upgrade"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configrequest"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -60,6 +61,8 @@ func newLocal(
 	log *logger.Logger,
 	pathConfigFile string,
 	rawConfig *config.Config,
+	reexec reexecManager,
+	uc upgraderControl,
 ) (*Local, error) {
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
@@ -134,6 +137,17 @@ func newLocal(
 	}
 
 	localApplication.source = cfgSource
+
+	// create a upgrader to use in local mode
+	upgrader := upgrade.NewUpgrader(
+		agentInfo,
+		cfg.Settings.DownloadConfig,
+		log,
+		[]context.CancelFunc{localApplication.cancelCtxFn},
+		reexec,
+		newNoopAcker(),
+		reporter)
+	uc.SetUpgrader(upgrader)
 
 	return localApplication, nil
 }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"context"
+	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	downloader "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/localremote"
@@ -16,7 +17,13 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	// do not update source config
 	settings := *u.settings
 	if sourceURI != "" {
-		settings.SourceURI = sourceURI
+		if strings.HasPrefix(sourceURI, "file://") {
+			// update the DropPath so the fs.Downloader can download from this
+			// path instead of looking into the installed downloads directory
+			settings.DropPath = strings.TrimPrefix(sourceURI, "file://")
+		} else {
+			settings.SourceURI = sourceURI
+		}
 	}
 
 	allowEmptyPgp, pgp := release.PGP()

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_mark.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_mark.go
@@ -37,7 +37,7 @@ type updateMarker struct {
 }
 
 // markUpgrade marks update happened so we can handle grace period
-func (h *Upgrader) markUpgrade(ctx context.Context, hash string, action *fleetapi.ActionUpgrade) error {
+func (h *Upgrader) markUpgrade(ctx context.Context, hash string, action Action) error {
 	prevVersion := release.Version()
 	prevHash := release.Commit()
 	if len(prevHash) > hashLen {
@@ -49,7 +49,7 @@ func (h *Upgrader) markUpgrade(ctx context.Context, hash string, action *fleetap
 		UpdatedOn:   time.Now(),
 		PrevVersion: prevVersion,
 		PrevHash:    prevHash,
-		Action:      action,
+		Action:      action.FleetAction(),
 	}
 
 	markerBytes, err := yaml.Marshal(marker)

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -68,6 +68,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(run)
 	cmd.AddCommand(newInstallCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newUninstallCommandWithArgs(flags, args, streams))
+	cmd.AddCommand(newUpgradeCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newEnrollCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newInspectCommandWithArgs(flags, args, streams))
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -95,13 +95,13 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	rex := reexec.NewManager(rexLogger, execPath)
 
 	// start the control listener
-	control := server.New(logger.Named("control"), rex)
+	control := server.New(logger.Named("control"), rex, nil)
 	if err := control.Start(); err != nil {
 		return err
 	}
 	defer control.Stop()
 
-	app, err := application.New(logger, pathConfigFile, rex)
+	app, err := application.New(logger, pathConfigFile, rex, control)
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/upgrade.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
+)
+
+func newUpgradeCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade <version>",
+		Short: "Upgrade the currently running Elastic Agent to the specified version",
+		Args:  cobra.ExactArgs(1),
+		Run: func(c *cobra.Command, args []string) {
+			if err := upgradeCmd(streams, c, flags, args); err != nil {
+				fmt.Fprintf(streams.Err, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringP("source-uri", "s", "", "Source URI to download the new version from")
+
+	return cmd
+}
+
+func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+	fmt.Fprintln(streams.Out, "The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production")
+
+	version := args[0]
+	sourceURI, _ := cmd.Flags().GetString("source-uri")
+
+	c := client.New()
+	err := c.Connect(context.Background())
+	if err != nil {
+		return errors.New(err, "Failed communicating to running daemon", errors.TypeNetwork, errors.M("socket", control.Address()))
+	}
+	defer c.Disconnect()
+	version, err = c.Upgrade(context.Background(), version, sourceURI)
+	if err != nil {
+		return errors.New(err, "Failed trigger upgrade of daemon")
+	}
+	fmt.Fprintf(streams.Out, "Upgrade triggered to version %s, Elastic Agent is currently restarting\n", version)
+	return nil
+}

--- a/x-pack/elastic-agent/pkg/agent/control/control_test.go
+++ b/x-pack/elastic-agent/pkg/agent/control/control_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestServerClient_Version(t *testing.T) {
-	srv := server.New(newErrorLogger(t), nil)
+	srv := server.New(newErrorLogger(t), nil, nil)
 	err := srv.Start()
 	require.NoError(t, err)
 	defer srv.Stop()

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
@@ -52,7 +52,7 @@ func TestCmdBinaryOnlyYAML(t *testing.T) {
 }
 
 func TestCmdDaemon(t *testing.T) {
-	srv := server.New(newErrorLogger(t), nil)
+	srv := server.New(newErrorLogger(t), nil, nil)
 	require.NoError(t, srv.Start())
 	defer srv.Stop()
 
@@ -67,7 +67,7 @@ func TestCmdDaemon(t *testing.T) {
 }
 
 func TestCmdDaemonYAML(t *testing.T) {
-	srv := server.New(newErrorLogger(t), nil)
+	srv := server.New(newErrorLogger(t), nil, nil)
 	require.NoError(t, srv.Start())
 	defer srv.Stop()
 


### PR DESCRIPTION
Cherry-pick of PR #21425 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a new `upgrade` CLI command that communicates with the running Elastic Agent to perform self-upgrading. This also allows a local upgrade to a new build using the `--source-uri file://${path}` command line flag.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To allow upgrading of the installed Elastic Agent, as well as to help with testing the upgrade process because of the allowed `file://` prefix in the `--source-uri`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Using a properly installed Elastic Agent with `./elastic-agent install`. You can initiate an upgrade:

```
$ elastic-agent upgrade 8.0.0
```

The above will fail because there is no pushed 8.0.0, but using the same command and the added `--source-uri` upgrading can be tested.

```
$ elastic-agent upgrade 8.0.0 --source-uri file://$PWD/build/distributions
```

This requires that the branch was build with DEV on so that the *.asc files are not required `DEV=true mag package`. You can point it to the same installed version but that will result in the following error:

```
$ elastic-agent upgrade 8.0.0 --source-uri file://$PWD/build/distributions
The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production
Failed trigger upgrade of daemon: upgrading to same version: /go/src/github.com/elastic/beats/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go[103]: unknown error
```

Adding a commit and rebuilding will result in a new version that will successfully upgrade.

```
$ elastic-agent upgrade 8.0.0 --source-uri file://$PWD/build/distributions
The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production
Upgrade triggered to version 8.0.0, Elastic Agent is currently restarting
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20142
