### PR TITLE
Bump allow duplicates version check to 7.11

### DIFF
--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -48,8 +48,8 @@ func TestLoadPipeline(t *testing.T) {
 
 	content := map[string]interface{}{
 		"description": "describe pipeline",
-		"processors": []map[string]interface{}{
-			{
+		"processors": []interface{}{
+			map[string]interface{}{
 				"set": map[string]interface{}{
 					"field": "foo",
 					"value": "bar",

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -299,7 +299,7 @@ func modifySetProcessor(esVersion common.Version, pipelineID string, content map
 // modifyAppendProcessor replaces allow_duplicates option with an if statement
 // so ES less than 7.10 will still work
 func modifyAppendProcessor(esVersion common.Version, pipelineID string, content map[string]interface{}) error {
-	flagVersion := common.MustNewVersion("7.10.0")
+	flagVersion := common.MustNewVersion("7.11.0")
 	if !esVersion.LessThan(flagVersion) {
 		return nil
 	}

--- a/filebeat/fileset/pipelines_test.go
+++ b/filebeat/fileset/pipelines_test.go
@@ -402,7 +402,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 		isErrExpected bool
 	}{
 		{
-			name:      "ES < 7.10.0: set to true",
+			name:      "ES < 7.11.0: set to true",
 			esVersion: common.MustNewVersion("7.9.0"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
@@ -427,7 +427,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES < 7.10.0: set to false",
+			name:      "ES < 7.11.0: set to false",
 			esVersion: common.MustNewVersion("7.9.0"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
@@ -453,8 +453,8 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES == 7.10.0",
-			esVersion: common.MustNewVersion("7.10.0"),
+			name:      "ES == 7.11.0",
+			esVersion: common.MustNewVersion("7.11.0"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
 					map[string]interface{}{
@@ -479,7 +479,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES > 7.10.0",
+			name:      "ES > 7.11.0",
 			esVersion: common.MustNewVersion("8.0.0"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
@@ -505,7 +505,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES < 7.10.0: existing if",
+			name:      "ES < 7.11.0: existing if",
 			esVersion: common.MustNewVersion("7.7.7"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
@@ -531,7 +531,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES < 7.10.0: existing if with contains",
+			name:      "ES < 7.11.0: existing if with contains",
 			esVersion: common.MustNewVersion("7.7.7"),
 			content: map[string]interface{}{
 				"processors": []interface{}{
@@ -557,7 +557,7 @@ func TestModifyAppendProcessor(t *testing.T) {
 			isErrExpected: false,
 		},
 		{
-			name:      "ES < 7.10.0: no value",
+			name:      "ES < 7.11.0: no value",
 			esVersion: common.MustNewVersion("7.7.7"),
 			content: map[string]interface{}{
 				"processors": []interface{}{


### PR DESCRIPTION
While we wait for https://github.com/elastic/elasticsearch/pull/63257 to be in the next snapshots, we need to bump the version check to avoid tests to fail. Once the backport is merged we will change it back to its previous value.