### PR TITLE
Cherry-pick #21525 to 7.x: Release cloudfoundry input and processor as GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -516,6 +516,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Added experimental dataset `sophos/utm`. {pull}20820[20820]
 - Add Cloud Foundry tags in related events. {pull}21177[21177]
 - Add option to select the type of index template to load: legacy, component, index. {pull}21212[21212]
+- Release `add_cloudfoundry_metadata` as GA. {pull}21525[21525]
 
 *Auditbeat*
 
@@ -690,6 +691,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add related.hosts ecs field to all modules {pull}21160[21160]
 - Keep cursor state between httpjson input restarts {pull}20751[20751]
 - Convert aws s3 to v2 input {pull}20005[20005]
+- Release Cloud Foundry input as GA. {pull}21525[21525]
 - New Cisco Umbrella dataset {pull}21504[21504]
 
 *Heartbeat*

--- a/x-pack/filebeat/input/cloudfoundry/input.go
+++ b/x-pack/filebeat/input/cloudfoundry/input.go
@@ -25,7 +25,7 @@ type cloudfoundryEvent interface {
 func Plugin() v2.Plugin {
 	return v2.Plugin{
 		Name:       "cloudfoundry",
-		Stability:  feature.Beta,
+		Stability:  feature.Stable,
 		Deprecated: false,
 		Info:       "collect logs from cloudfoundry loggregator",
 		Manager:    stateless.NewInputManager(configure),

--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>add_cloudfoundry_metadata</titleabbrev>
 ++++
 
-beta[]
-
 The `add_cloudfoundry_metadata` processor annotates each event with relevant metadata
 from Cloud Foundry applications. The events are annotated with Cloud Foundry metadata,
 only if the event contains a reference to a Cloud Foundry application (using field


### PR DESCRIPTION
Cherry-pick of PR #21525 to 7.x branch. Original message: 

Release some Cloud Foundry features as GA in 7.10:
* Filebeat input
* `add_cloudfoundry_metadata` processor.

Cloud foundry features in Metricbeat are kept as beta as there might still be backwards incompatible changes in the near future.