### PR TITLE
[CI] Setup git config globally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,8 +265,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
         // See https://github.com/elastic/beats/issues/17787.
         sh(label: 'check git config', script: '''
           if [ -z "$(git config --get user.email)" ]; then
-            git config user.email "beatsmachine@users.noreply.github.com"
-            git config user.name "beatsmachine"
+            git config --global user.email "beatsmachine@users.noreply.github.com"
+            git config --global user.name "beatsmachine"
           fi''')
       }
       try {


### PR DESCRIPTION
## What does this PR do?

There are some scenarios where the git config is not setup correctly, this will enforce the global setup for the CI workers to be set.

## Why is it important?

Reduce build errors related to this.
As far as I see the issue with `--global` could be with the static CI workers, but it's solved since the `HOME` is set to `WORKSPACE`.

## Issues

Closes https://github.com/elastic/beats/issues/21561
