### PR TITLE
ci: set git user to be able to use git init

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,8 +265,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
         // See https://github.com/elastic/beats/issues/17787.
         sh(label: 'check git config', script: '''
           if [ -z "$(git config --get user.email)" ]; then
-            git config user.email "beatsmachine@users.noreply.github.com"
-            git config user.name "beatsmachine"
+            git config global user.email "beatsmachine@users.noreply.github.com"
+            git config global user.name "beatsmachine"
           fi''')
       }
       try {
@@ -441,7 +441,7 @@ def terraformApply(String directory) {
 }
 
 /**
-* Tear down the terraform environments, by looking for all terraform states in directory 
+* Tear down the terraform environments, by looking for all terraform states in directory
 * then it runs terraform destroy for each one.
 * It uses terraform states previously stashed by startCloudTestEnv.
 */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,8 +265,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
         // See https://github.com/elastic/beats/issues/17787.
         sh(label: 'check git config', script: '''
           if [ -z "$(git config --get user.email)" ]; then
-            git config global user.email "beatsmachine@users.noreply.github.com"
-            git config global user.name "beatsmachine"
+            git config --global user.email "beatsmachine@users.noreply.github.com"
+            git config --global user.name "beatsmachine"
           fi''')
       }
       try {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
it configures the git user globally to be able to use `git init` command

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
The generators module do something with git and it is falling

```
[2020-10-06T11:50:42.905Z] + make -C generator/_templates/beat test
[2020-10-06T11:50:42.905Z] rm -fr /var/lib/jenkins/workspace/Beats_beats_master/src/beatpath/testbeat
[2020-10-06T11:50:42.905Z] mkdir -p /var/lib/jenkins/workspace/Beats_beats_master/src/beatpath/testbeat
[2020-10-06T11:50:42.905Z] cd /var/lib/jenkins/workspace/Beats_beats_master/src/github.com/elastic/beats/ ; \

...

[2020-10-06T11:55:02.344Z] go: downloading github.com/prometheus/procfs v0.2.0
[2020-10-06T11:55:02.824Z] go: downloading howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5
[2020-10-06T11:56:59.868Z] Generated fields.yml for testbeat to /private/var/lib/jenkins/workspace/Beats_beats_master/src/beatpath/testbeat/fields.yml
[2020-10-06T11:57:08.663Z] 
[2020-10-06T11:57:08.663Z] *** Please tell me who you are.
[2020-10-06T11:57:08.663Z] 
[2020-10-06T11:57:08.663Z] Run
[2020-10-06T11:57:08.663Z] 
[2020-10-06T11:57:08.663Z]   git config --global user.email "you@example.com"
[2020-10-06T11:57:08.663Z]   git config --global user.name "Your Name"
[2020-10-06T11:57:08.663Z] 
[2020-10-06T11:57:08.663Z] to set your account's default identity.
[2020-10-06T11:57:08.663Z] Omit --global to set the identity only in this repository.
[2020-10-06T11:57:08.663Z] 
[2020-10-06T11:57:08.663Z] fatal: unable to auto-detect email address (got 'jenkins@worker-c07ll940dwyl.(none)')
[2020-10-06T11:57:08.663Z] Error: running "git commit -q -m Initial commit, Add generated files" failed with exit code 128
[2020-10-06T11:57:08.663Z] make: *** [prepare-test] Error 128
script returned exit code 2
```
