### PR TITLE
[DOCS] Warn about compression and Azure Event Hub for Kafka

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -261,6 +261,12 @@ The keep-alive period for an active network connection. If 0s, keep-alives are d
 
 Sets the output compression codec. Must be one of `none`, `snappy`, `lz4` and `gzip`. The default is `gzip`.
 
+[IMPORTANT]
+.Known issue with Azure Event Hub for Kafka
+====
+When targeting Azure Event Hub for Kafka, set `compression` to `none` as the provided codecs are not supported.
+====
+
 ===== `compression_level`
 
 Sets the compression level used by gzip. Setting this value to 0 disables compression.


### PR DESCRIPTION
As stated at https://github.com/Azure/azure-event-hubs-for-kafka/issues/37#issuecomment-464117020, it seems Azure Event Hub for Kafka do not support compression.

I've not been able to find a public facing documentation except https://docs.microsoft.com/en-us/azure/event-hubs/apache-kafka-configurations (which can be included in the PR).

## What does this PR do?

Add some details on integrations with Azure Event Hub for Kafka.

## Why is it important?

It can be useful to know which settings to use in case of integration with Azure Event Hub

## Author's Checklist

- [ ] Review the wording and format
- [ ] Decide if we should include the link to Microsoft documentation
- [ ] Backporting to first inclusion of Kafka output

## Related issues

Collateral issue to raise log level of the error we face when using Filebeat with Kafka output and Azure Event Hub with default `compression`: https://github.com/elastic/beats/issues/21577
