### PR TITLE
[Filebeat][S3 Input] Add support for FIPS endpoints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -612,6 +612,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New Cisco Umbrella dataset {pull}21504[21504]
 - New juniper.srx dataset for Juniper SRX logs. {pull}20017[20017]
 - Adding support for Microsoft 365 Defender (Microsoft Threat Protection) {pull}21446[21446]
+- Adding support for FIPS in s3 input {pull}21446[21446]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -43,6 +43,11 @@ The `s3` input supports the following configuration options plus the
 URL of the AWS SQS queue that messages will be received from. Required.
 
 [float]
+==== `fips_enabled`
+
+When enabled this option changes the servicename from s3 to s3-fips for connecting to the correct s3 endpoint
+
+[float]
 ==== `visibility_timeout`
 
 The duration that the received messages are hidden from subsequent

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -45,7 +45,7 @@ URL of the AWS SQS queue that messages will be received from. Required.
 [float]
 ==== `fips_enabled`
 
-When enabled this option changes the servicename from s3 to s3-fips for connecting to the correct s3 endpoint
+Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint. For example: `s3-fips.us-gov-east-1.amazonaws.com`.
 
 [float]
 ==== `visibility_timeout`

--- a/x-pack/filebeat/input/s3/config.go
+++ b/x-pack/filebeat/input/s3/config.go
@@ -15,6 +15,7 @@ import (
 type config struct {
 	QueueURL                 string              `config:"queue_url" validate:"nonzero,required"`
 	VisibilityTimeout        time.Duration       `config:"visibility_timeout"`
+	FipsEnabled              bool                `config:"fips_enabled"`
 	AwsConfig                awscommon.ConfigAWS `config:",inline"`
 	ExpandEventListFromField string              `config:"expand_event_list_from_field"`
 	APITimeout               time.Duration       `config:"api_timeout"`
@@ -32,6 +33,7 @@ func defaultConfig() config {
 	return config{
 		VisibilityTimeout: 300 * time.Second,
 		APITimeout:        120 * time.Second,
+		FipsEnabled:       false,
 	}
 }
 

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -105,6 +105,8 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		s3Servicename = "s3-fips"
 	}
 
+	log.Debug("s3 service name = ", s3Servicename)
+
 	return &s3Collector{
 		cancellation:      ctxtool.FromCanceller(ctx.Cancelation),
 		logger:            log,

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -100,6 +100,11 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 	log.Infof("visibility timeout is set to %v seconds", visibilityTimeout)
 	log.Infof("aws api timeout is set to %v", in.config.APITimeout)
 
+	s3Servicename := "s3"
+	if in.config.FipsEnabled {
+		s3Servicename = "s3-fips"
+	}
+
 	return &s3Collector{
 		cancellation:      ctxtool.FromCanceller(ctx.Cancelation),
 		logger:            log,
@@ -107,7 +112,7 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		publisher:         client,
 		visibilityTimeout: visibilityTimeout,
 		sqs:               sqs.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, "sqs", regionName, awsConfig)),
-		s3:                s3.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, "s3", regionName, awsConfig)),
+		s3:                s3.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, s3Servicename, regionName, awsConfig)),
 	}, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

This adds FIPS endpoint support to connect to FIPS enabled endpoint in AWS.

## Why is it important?

Adds support for connecting to FIPS enabled s3 endpoints, important for customers using govcloud or have similar FIPS requirements.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #21286

