### PR TITLE
Docker build resiliance with a retry

### DIFF
--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -246,5 +247,17 @@ func dockerComposeBuildImages() error {
 		os.Stderr,
 		"docker-compose", args...,
 	)
+
+	// This sleep is to avoid hitting the docker build issues when resources are not available.
+	if err != nil {
+		fmt.Println(">> Building docker images again")
+		time.Sleep(10)
+		_, err = sh.Exec(
+			composeEnv,
+			out,
+			os.Stderr,
+			"docker-compose", args...,
+		)
+	}
 	return err
 }


### PR DESCRIPTION
## What does this PR do?

Retry to build docker images when something bad happened.

We could potentially include a retry step in the CI but it might add some overhead, another approach could be creating a specific mage goal to run the docker-compose build rather than just using `mage pythonIntegTest` for everything.

## Why is it important?

Sometimes some third party resources are not accessible temporarily. For instance


```
[2020-10-06T10:53:15.087Z] + mage pythonIntegTest
[2020-10-06T10:54:11.398Z] Generated fields.yml for metricbeat to /var/lib/jenkins/workspace/Beats_beats_master/src/github.com/elastic/beats/metricbeat/fields.yml
[2020-10-06T10:54:26.345Z] >> Building docker images
[2020-10-06T10:54:26.345Z] Building beat
[2020-10-06T10:54:58.493Z] Service 'beat' failed to build: The command '/bin/sh -c cd /usr/lib   && curl -sLo instantclient-basic-linux.zip https://download.oracle.com/otn_software/linux/instantclient/19600/instantclient-basic-linux.x64-19.6.0.0.0dbru.zip   && unzip instantclient-basic-linux.zip   && rm instantclient-basic-linux.zip' returned a non-zero code: 56
[2020-10-06T10:54:58.493Z] Error: running "docker-compose -p metricbeat_8_0_0_0dd24289fa-snapshot build --force-rm --pull" failed with exit code 1
```

## Related issues

Caused by https://github.com/elastic/beats/issues/21563
