### PR TITLE
Cherry-pick #21478 to 7.x: Use new form of fleet API paths 

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -14,8 +14,8 @@ set -eo pipefail
 # KIBANA_USERNAME - username for accessing kibana API [elastic]
 
 function setup(){
-  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/setup -H 'kbn-xsrf: true' -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
-  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/setup \
+  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/fleet/setup -H 'kbn-xsrf: true' -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
+ curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/fleet/agents/setup \
     -H 'Content-Type: application/json' \
     -H 'kbn-xsrf: true' \
     -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
@@ -28,7 +28,7 @@ function enroll(){
     if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]]; then
       apikey="${FLEET_ENROLLMENT_TOKEN}"
     else
-      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys \
+      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys \
         -H 'Content-Type: application/json' \
         -H 'kbn-xsrf: true' \
         -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )
@@ -41,7 +41,7 @@ function enroll(){
       local apikeyId=$(echo $enrollResp | jq -r '.list[0].id')
       echo $apikeyId
 
-      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/ingest_manager/fleet/enrollment-api-keys/$apikeyId \
+      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys/$apikeyId \
         -H 'Content-Type: application/json' \
         -H 'kbn-xsrf: true' \
         -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -28,6 +28,8 @@
 - Add support for EQL based condition on inputs {pull}20994[20994]
 - Send `fleet.host.id` to Endpoint Security {pull}21042[21042]
 - Add `install` and `uninstall` subcommands {pull}21206[21206]
+- Use new form of fleet API paths {pull}21478[21478]
+- Add `kubernetes` composable dynamic provider. {pull}21480[21480]
 - Send updating state {pull}21461[21461]
 - Add `elastic.agent.id` and `elastic.agent.version` to published events from filebeat and metricbeat {pull}21543[21543]
 - Add `upgrade` subcommand to perform upgrade of installed Elastic Agent {pull}21425[21425]

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd_test.go
@@ -49,7 +49,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("fail to save is propagated", withTLSServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`
 {
@@ -102,7 +102,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("successfully enroll with TLS and save access api key in the store", withTLSServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`
 {
@@ -163,7 +163,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("successfully enroll when a slash is defined at the end of host", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`
 {
@@ -223,7 +223,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("successfully enroll without TLS and save access api key in the store", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`
 {
@@ -283,7 +283,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("fail to enroll without TLS", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(`
 {

--- a/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 )
 
-const ackPath = "/api/ingest_manager/fleet/agents/%s/acks"
+const ackPath = "/api/fleet/agents/%s/acks"
 
 // AckEvent is an event sent in an ACK request.
 type AckEvent struct {

--- a/x-pack/elastic-agent/pkg/fleetapi/ack_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/ack_cmd_test.go
@@ -22,7 +22,7 @@ func TestAck(t *testing.T) {
 		func(t *testing.T) *http.ServeMux {
 			raw := `{"action": "ack"}`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/acks", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/acks", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 

--- a/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 )
 
-const checkingPath = "/api/ingest_manager/fleet/agents/%s/checkin"
+const checkingPath = "/api/fleet/agents/%s/checkin"
 
 // CheckinRequest consists of multiple events reported to fleet ui.
 type CheckinRequest struct {

--- a/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd_test.go
@@ -34,7 +34,7 @@ func TestCheckin(t *testing.T) {
 	}
 	`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(w, raw)
@@ -83,7 +83,7 @@ func TestCheckin(t *testing.T) {
 	}
 	`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintf(w, raw)
@@ -144,7 +144,7 @@ func TestCheckin(t *testing.T) {
 	}
 	`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintf(w, raw)
@@ -176,7 +176,7 @@ func TestCheckin(t *testing.T) {
 		func(t *testing.T) *http.ServeMux {
 			raw := `{ "actions": [] }`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintf(w, raw)
@@ -199,7 +199,7 @@ func TestCheckin(t *testing.T) {
 		func(t *testing.T) *http.ServeMux {
 			raw := `{"actions": []}`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				type Request struct {
 					Metadata *info.ECSMeta `json:"local_metadata"`
@@ -233,7 +233,7 @@ func TestCheckin(t *testing.T) {
 		func(t *testing.T) *http.ServeMux {
 			raw := `{"actions": []}`
 			mux := http.NewServeMux()
-			path := fmt.Sprintf("/api/ingest_manager/fleet/agents/%s/checkin", agentInfo.AgentID())
+			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				type Request struct {
 					Metadata *info.ECSMeta `json:"local_metadata"`

--- a/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
@@ -71,7 +71,7 @@ func (p EnrollType) MarshalJSON() ([]byte, error) {
 // EnrollRequest is the data required to enroll the elastic-agent into Fleet.
 //
 // Example:
-// POST /api/ingest_manager/fleet/agents/enroll
+// POST /api/fleet/agents/enroll
 // {
 // 	"type": "PERMANENT",
 //   "metadata": {
@@ -168,7 +168,7 @@ type EnrollCmd struct {
 
 // Execute enroll the Agent in the Fleet.
 func (e *EnrollCmd) Execute(ctx context.Context, r *EnrollRequest) (*EnrollResponse, error) {
-	const p = "/api/ingest_manager/fleet/agents/enroll"
+	const p = "/api/fleet/agents/enroll"
 	const key = "Authorization"
 	const prefix = "ApiKey "
 

--- a/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd_test.go
@@ -23,7 +23,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("Successful enroll", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Header().Set("Content-Type", "application/json")
 
@@ -92,7 +92,7 @@ func TestEnroll(t *testing.T) {
 	t.Run("Raise back any server errors", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/api/ingest_manager/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Header().Set("Content-Type", "application/json")
 				w.Write([]byte(`{"statusCode": 500, "error":"Something is really bad here"}`))


### PR DESCRIPTION
Cherry-pick of PR #21478 to 7.x branch. Original message:

## What does this PR do?

Aligning paths to be even with https://github.com/elastic/kibana/pull/79193

## Why is it important?


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
