### PR TITLE
Add openstack ssl provider in add_cloud_metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -451,7 +451,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Cloud Foundry metadata is cached to disk. {pull}20775[20775]
 - Add option to select the type of index template to load: legacy, component, index. {pull}21212[21212]
 - Release `add_cloudfoundry_metadata` as GA. {pull}21525[21525]
-- Add TLS support to `add_cloud_metadata`. {pull}21590[21590]
+- Add support for OpenStack SSL metadata APIs in `add_cloud_metadata`. {pull}21590[21590]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -451,6 +451,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Cloud Foundry metadata is cached to disk. {pull}20775[20775]
 - Add option to select the type of index template to load: legacy, component, index. {pull}21212[21212]
 - Release `add_cloudfoundry_metadata` as GA. {pull}21525[21525]
+- Add TLS support to `add_cloud_metadata`. {pull}[]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -451,7 +451,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Cloud Foundry metadata is cached to disk. {pull}20775[20775]
 - Add option to select the type of index template to load: legacy, component, index. {pull}21212[21212]
 - Release `add_cloudfoundry_metadata` as GA. {pull}21525[21525]
-- Add TLS support to `add_cloud_metadata`. {pull}[]
+- Add TLS support to `add_cloud_metadata`. {pull}21590[21590]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/config.go
+++ b/libbeat/processors/add_cloud_metadata/config.go
@@ -29,7 +29,6 @@ type config struct {
 	TLS       *tlscommon.Config `config:"ssl"`       // TLS configuration
 	Overwrite bool              `config:"overwrite"` // Overwrite if cloud.* fields already exist.
 	Providers providerList      `config:"providers"` // List of providers to probe
-
 }
 
 type providerList []string

--- a/libbeat/processors/add_cloud_metadata/config.go
+++ b/libbeat/processors/add_cloud_metadata/config.go
@@ -20,12 +20,16 @@ package add_cloud_metadata
 import (
 	"fmt"
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
 type config struct {
-	Timeout   time.Duration `config:"timeout"`   // Amount of time to wait for responses from the metadata services.
-	Overwrite bool          `config:"overwrite"` // Overwrite if cloud.* fields already exist.
-	Providers providerList  `config:"providers"` // List of providers to probe
+	Timeout   time.Duration     `config:"timeout"`   // Amount of time to wait for responses from the metadata services.
+	TLS       *tlscommon.Config `config:"ssl"`       // TLS configuration
+	Overwrite bool              `config:"overwrite"` // Overwrite if cloud.* fields already exist.
+	Providers providerList      `config:"providers"` // List of providers to probe
+
 }
 
 type providerList []string

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -58,6 +58,9 @@ The third optional configuration setting is `overwrite`. When `overwrite` is
 `true`, `add_cloud_metadata` overwrites existing `cloud.*` fields (`false` by
 default).
 
+The `add_cloud_metadata` processor supports SSL options. HTTPS can be enabled by
+setting `ssl.enabled` to `true`. See <<configuration-ssl>> for more information.
+
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.
 

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -52,14 +52,15 @@ List of names the `providers` setting supports:
 - "aws", or "ec2" for Amazon Web Services (enabled by default).
 - "gcp" for Google Copmute Enging (enabled by default).
 - "openstack", or "nova" for Openstack Nova (enabled by default).
+- "openstack-ssl", or "nova-ssl" for Openstack Nova when SSL metadata APIs are enabled (enabled by default).
 - "tencent", or "qcloud" for Tencent Cloud (disabled by default).
 
 The third optional configuration setting is `overwrite`. When `overwrite` is
 `true`, `add_cloud_metadata` overwrites existing `cloud.*` fields (`false` by
 default).
 
-The `add_cloud_metadata` processor supports SSL options. HTTPS can be enabled by
-setting `ssl.enabled` to `true`. See <<configuration-ssl>> for more information.
+The `add_cloud_metadata` processor supports SSL options to configure the http
+client used to query cloud metadata. See <<configuration-ssl>> for more information.
 
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.

--- a/libbeat/processors/add_cloud_metadata/http_fetcher.go
+++ b/libbeat/processors/add_cloud_metadata/http_fetcher.go
@@ -128,6 +128,11 @@ func (f *httpMetadataFetcher) fetchRaw(
 
 // getMetadataURLs loads config and generates the metadata URLs.
 func getMetadataURLs(c *common.Config, defaultHost string, metadataURIs []string) ([]string, error) {
+	return getMetadataURLsWithScheme(c, "http", defaultHost, metadataURIs)
+}
+
+// getMetadataURLsWithScheme loads config and generates the metadata URLs.
+func getMetadataURLsWithScheme(c *common.Config, scheme string, defaultHost string, metadataURIs []string) ([]string, error) {
 	var urls []string
 	config := struct {
 		MetadataHostAndPort string            `config:"host"` // Specifies the host and port of the metadata service (for testing purposes only).
@@ -138,10 +143,6 @@ func getMetadataURLs(c *common.Config, defaultHost string, metadataURIs []string
 	err := c.Unpack(&config)
 	if err != nil {
 		return urls, errors.Wrap(err, "failed to unpack add_cloud_metadata config")
-	}
-	scheme := "http"
-	if config.TLSConfig.IsEnabled() {
-		scheme = "https"
 	}
 	for _, uri := range metadataURIs {
 		urls = append(urls, scheme+"://"+config.MetadataHostAndPort+uri)

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -34,16 +34,16 @@ const (
 var openstackNovaMetadataFetcher = provider{
 	Name:   "openstack-nova",
 	Local:  true,
-	Create: buildCreate("http"),
+	Create: buildOpenstackNovaCreate("http"),
 }
 
 var openstackNovaMetadataFetcherSSL = provider{
 	Name:   "openstack-nova-ssl",
 	Local:  true,
-	Create: buildCreate("https"),
+	Create: buildOpenstackNovaCreate("https"),
 }
 
-func buildCreate(scheme string) func(provider string, c *common.Config) (metadataFetcher, error) {
+func buildOpenstackNovaCreate(scheme string) func(provider string, c *common.Config) (metadataFetcher, error) {
 	return func(provider string, c *common.Config) (metadataFetcher, error) {
 		osSchema := func(m map[string]interface{}) common.MapStr {
 			return common.MapStr(m)

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -37,7 +37,7 @@ var openstackNovaMetadataFetcher = provider{
 	Create: buildOpenstackNovaCreate("http"),
 }
 
-var openstackNovaMetadataFetcherSSL = provider{
+var openstackNovaSSLMetadataFetcher = provider{
 	Name:   "openstack-nova-ssl",
 	Local:  true,
 	Create: buildOpenstackNovaCreate("https"),

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -32,16 +32,24 @@ const (
 // OpenStack Nova Metadata Service
 // Document https://docs.openstack.org/nova/latest/user/metadata-service.html
 var openstackNovaMetadataFetcher = provider{
-	Name: "openstack-nova",
+	Name:   "openstack-nova",
+	Local:  true,
+	Create: buildCreate("http"),
+}
 
-	Local: true,
+var openstackNovaMetadataFetcherSSL = provider{
+	Name:   "openstack-nova-ssl",
+	Local:  true,
+	Create: buildCreate("https"),
+}
 
-	Create: func(provider string, c *common.Config) (metadataFetcher, error) {
+func buildCreate(scheme string) func(provider string, c *common.Config) (metadataFetcher, error) {
+	return func(provider string, c *common.Config) (metadataFetcher, error) {
 		osSchema := func(m map[string]interface{}) common.MapStr {
 			return common.MapStr(m)
 		}
 
-		urls, err := getMetadataURLs(c, metadataHost, []string{
+		urls, err := getMetadataURLsWithScheme(c, scheme, metadataHost, []string{
 			osMetadataInstanceIDURI,
 			osMetadataInstanceTypeURI,
 			osMetadataHostnameURI,
@@ -71,5 +79,5 @@ var openstackNovaMetadataFetcher = provider{
 		}
 		fetcher := &httpMetadataFetcher{"openstack", nil, responseHandlers, osSchema}
 		return fetcher, nil
-	},
+	}
 }

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-func initOpenstackNovaTestServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func openstackNovaMetadataHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == osMetadataInstanceIDURI {
 			w.Write([]byte("i-0000ffac"))
 			return
@@ -49,13 +49,13 @@ func initOpenstackNovaTestServer() *httptest.Server {
 		}
 
 		http.Error(w, "not found", http.StatusNotFound)
-	}))
+	})
 }
 
 func TestRetrieveOpenstackNovaMetadata(t *testing.T) {
 	logp.TestingSetup()
 
-	server := initOpenstackNovaTestServer()
+	server := httptest.NewServer(openstackNovaMetadataHandler())
 	defer server.Close()
 
 	config, err := common.NewConfigFrom(map[string]interface{}{
@@ -66,6 +66,29 @@ func TestRetrieveOpenstackNovaMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertOpenstackNova(t, config)
+}
+
+func TestRetrieveOpenstackNovaMetadataWithHTTPS(t *testing.T) {
+	logp.TestingSetup()
+
+	server := httptest.NewTLSServer(openstackNovaMetadataHandler())
+	defer server.Close()
+
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"host":                  server.Listener.Addr().String(),
+		"ssl.enabled":           true,
+		"ssl.verification_mode": "none",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertOpenstackNova(t, config)
+}
+
+func assertOpenstackNova(t *testing.T, config *common.Config) {
 	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -77,7 +77,6 @@ func TestRetrieveOpenstackNovaMetadataWithHTTPS(t *testing.T) {
 
 	config, err := common.NewConfigFrom(map[string]interface{}{
 		"host":                  server.Listener.Addr().String(),
-		"ssl.enabled":           true,
 		"ssl.verification_mode": "none",
 	})
 

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -138,6 +138,7 @@ func (p *addCloudMetadata) fetchMetadata() *result {
 				Timeout:   p.initData.timeout,
 				KeepAlive: 0,
 			}).DialContext,
+			TLSClientConfig: p.initData.tlsConfig.ToConfig(),
 		},
 	}
 

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -51,17 +51,19 @@ type result struct {
 }
 
 var cloudMetaProviders = map[string]provider{
-	"alibaba":      alibabaCloudMetadataFetcher,
-	"ecs":          alibabaCloudMetadataFetcher,
-	"azure":        azureVMMetadataFetcher,
-	"digitalocean": doMetadataFetcher,
-	"aws":          ec2MetadataFetcher,
-	"ec2":          ec2MetadataFetcher,
-	"gcp":          gceMetadataFetcher,
-	"openstack":    openstackNovaMetadataFetcher,
-	"nova":         openstackNovaMetadataFetcher,
-	"qcloud":       qcloudMetadataFetcher,
-	"tencent":      qcloudMetadataFetcher,
+	"alibaba":       alibabaCloudMetadataFetcher,
+	"ecs":           alibabaCloudMetadataFetcher,
+	"azure":         azureVMMetadataFetcher,
+	"digitalocean":  doMetadataFetcher,
+	"aws":           ec2MetadataFetcher,
+	"ec2":           ec2MetadataFetcher,
+	"gcp":           gceMetadataFetcher,
+	"openstack":     openstackNovaMetadataFetcher,
+	"nova":          openstackNovaMetadataFetcher,
+	"openstack-ssl": openstackNovaMetadataFetcherSSL,
+	"nova-ssl":      openstackNovaMetadataFetcherSSL,
+	"qcloud":        qcloudMetadataFetcher,
+	"tencent":       qcloudMetadataFetcher,
 }
 
 func selectProviders(configList providerList, providers map[string]provider) map[string]provider {

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -60,8 +60,8 @@ var cloudMetaProviders = map[string]provider{
 	"gcp":           gceMetadataFetcher,
 	"openstack":     openstackNovaMetadataFetcher,
 	"nova":          openstackNovaMetadataFetcher,
-	"openstack-ssl": openstackNovaMetadataFetcherSSL,
-	"nova-ssl":      openstackNovaMetadataFetcherSSL,
+	"openstack-ssl": openstackNovaSSLMetadataFetcher,
+	"nova-ssl":      openstackNovaSSLMetadataFetcher,
 	"qcloud":        qcloudMetadataFetcher,
 	"tencent":       qcloudMetadataFetcher,
 }


### PR DESCRIPTION
## What does this PR do?

Add a new provider to query metadata from OpenStack deployments using HTTPS.
Add the usual SSL settings available in other features that support TLS.

## Why is it important?

Some OpenStack deployments are configured to use SSL in the metadata endpoints.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #21392.