### PR TITLE
[Winlogbeat] Remove brittle configuration validation from wineventlog

### DIFF
--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -40,9 +40,6 @@ const (
 	eventLoggingAPIName = "eventlogging"
 )
 
-var eventLoggingConfigKeys = common.MakeStringSet(append(commonConfigKeys,
-	"ignore_older", "read_buffer_size", "format_buffer_size")...)
-
 type eventLoggingConfig struct {
 	ConfigCommon     `config:",inline"`
 	IgnoreOlder      time.Duration `config:"ignore_older"`
@@ -284,7 +281,7 @@ func newEventLogging(options *common.Config) (EventLog, error) {
 		ReadBufferSize:   win.MaxEventBufferSize,
 		FormatBufferSize: win.MaxFormatMessageBufferSize,
 	}
-	if err := readConfig(options, &c, eventLoggingConfigKeys); err != nil {
+	if err := readConfig(options, &c); err != nil {
 		return nil, err
 	}
 

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -22,13 +22,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/joeshaw/multierror"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 )
-
-var commonConfigKeys = []string{"type", "api", "name", "fields", "fields_under_root",
-	"tags", "processors", "index", "id", "meta", "revision"}
 
 // ConfigCommon is the common configuration data used to instantiate a new
 // EventLog. Each implementation is free to support additional configuration
@@ -42,33 +37,18 @@ type validator interface {
 	Validate() error
 }
 
-func readConfig(
-	c *common.Config,
-	config interface{},
-	validKeys common.StringSet,
-) error {
+func readConfig(c *common.Config, config interface{}) error {
 	if err := c.Unpack(config); err != nil {
 		return fmt.Errorf("failed unpacking config. %v", err)
 	}
 
-	var errs multierror.Errors
-	if len(validKeys) > 0 {
-		// Check for invalid keys.
-		for _, k := range c.GetFields() {
-			if !validKeys.Has(k) {
-				errs = append(errs, fmt.Errorf("invalid event log key '%s' "+
-					"found. Valid keys are %s", k, strings.Join(validKeys.ToSlice(), ", ")))
-			}
-		}
-	}
-
 	if v, ok := config.(validator); ok {
 		if err := v.Validate(); err != nil {
-			errs = append(errs, err)
+			return err
 		}
 	}
 
-	return errs.Err()
+	return nil
 }
 
 // Producer produces a new event log instance for reading event log records.
@@ -114,7 +94,7 @@ func New(options *common.Config) (EventLog, error) {
 	}
 
 	var config ConfigCommon
-	if err := readConfig(options, &config, nil); err != nil {
+	if err := readConfig(options, &config); err != nil {
 		return nil, err
 	}
 

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -47,10 +47,6 @@ const (
 	winEventLogAPIName = "wineventlog"
 )
 
-var winEventLogConfigKeys = common.MakeStringSet(append(commonConfigKeys,
-	"batch_read_size", "ignore_older", "include_xml", "event_id", "forwarded",
-	"level", "provider", "no_more_events")...)
-
 type winEventLogConfig struct {
 	ConfigCommon  `config:",inline"`
 	BatchReadSize int                `config:"batch_read_size"` // Maximum number of events that Read will return.
@@ -366,7 +362,7 @@ func (l *winEventLog) buildRecordFromXML(x []byte, recoveredErr error) (Record, 
 // using the Windows Event Log.
 func newWinEventLog(options *common.Config) (EventLog, error) {
 	c := defaultWinEventLogConfig
-	if err := readConfig(options, &c, winEventLogConfigKeys); err != nil {
+	if err := readConfig(options, &c); err != nil {
 		return nil, err
 	}
 

--- a/winlogbeat/eventlog/wineventlog_expirimental.go
+++ b/winlogbeat/eventlog/wineventlog_expirimental.go
@@ -243,7 +243,7 @@ func newWinEventLogExp(options *common.Config) (EventLog, error) {
 	cfgwarn.Experimental("The %s event log reader is experimental.", winEventLogExpAPIName)
 
 	c := winEventLogConfig{BatchReadSize: 512}
-	if err := readConfig(options, &c, winEventLogConfigKeys); err != nil {
+	if err := readConfig(options, &c); err != nil {
 		return nil, err
 	}
 

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -156,25 +156,6 @@ class Test(WriteReadTest):
         self.assertEqual(evts[0]["winlog.event_id"], 10)
         self.assertEqual(evts[0]["event.code"], 10)
 
-    def test_unknown_eventlog_config(self):
-        """
-        eventlogging - Unknown config parameter
-        """
-        self.render_config_template(
-            event_logs=[
-                {
-                    "name": self.providerName,
-                    "api": self.api,
-                    "event_id": "10, 12",
-                    "level": "info",
-                    "provider": ["me"],
-                    "include_xml": True,
-                }
-            ]
-        )
-        self.start_beat().check_wait(exit_code=1)
-        assert self.log_contains("4 errors: invalid event log key")
-
     def test_utf16_characters(self):
         """
         eventlogging - UTF-16 characters

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -311,23 +311,6 @@ class Test(WriteReadTest):
         self.assertTrue(len(evts), 1)
         self.assertEqual(evts[0]["message"], "selected")
 
-    def test_unknown_eventlog_config(self):
-        """
-        wineventlog - Unknown config parameter
-        """
-        self.render_config_template(
-            event_logs=[
-                {
-                    "name": self.providerName,
-                    "api": self.api,
-                    "forwarded": False,
-                    "invalid": "garbage"}
-            ]
-        )
-        self.start_beat().check_wait(exit_code=1)
-        assert self.log_contains(
-            "1 error: invalid event log key 'invalid' found.")
-
     def test_utf16_characters(self):
         """
         wineventlog - UTF-16 characters


### PR DESCRIPTION
## What does this PR do?

Removes brittle configuration keys validation from wineventlog


## Why is it important?

configuration keys are different between winlogbeat, filebeat &
agent.  The presence of the different keys doesn't affect the validity
of the configuration.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Run winlogbeat locally

## Related issues

- Closes #21220
