### PR TITLE
Cherry-pick #21498 to 7.x: [Metricbeat] Use timestamp from CloudWatch for events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -408,6 +408,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix timestamp handling in remote_write. {pull}21166[21166]
 - Fix remote_write flaky test. {pull}21173[21173]
 - Visualization title fixes in aws, azure and googlecloud compute dashboards. {pull}21098[21098]
+- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
+- Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -408,7 +408,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix timestamp handling in remote_write. {pull}21166[21166]
 - Fix remote_write flaky test. {pull}21173[21173]
 - Visualization title fixes in aws, azure and googlecloud compute dashboards. {pull}21098[21098]
-- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -196,11 +196,14 @@ func StringInSlice(str string, list []string) (bool, int) {
 }
 
 // InitEvent initialize mb.Event with basic information like service.name, cloud.provider
-func InitEvent(regionName string, accountName string, accountID string) mb.Event {
-	event := mb.Event{}
-	event.MetricSetFields = common.MapStr{}
-	event.ModuleFields = common.MapStr{}
-	event.RootFields = common.MapStr{}
+func InitEvent(regionName string, accountName string, accountID string, timestamp time.Time) mb.Event {
+	event := mb.Event{
+		Timestamp:       timestamp,
+		MetricSetFields: common.MapStr{},
+		ModuleFields:    common.MapStr{},
+		RootFields:      common.MapStr{},
+	}
+
 	event.RootFields.Put("cloud.provider", "aws")
 	if regionName != "" {
 		event.RootFields.Put("cloud.region", regionName)

--- a/x-pack/metricbeat/module/aws/billing/billing.go
+++ b/x-pack/metricbeat/module/aws/billing/billing.go
@@ -178,26 +178,28 @@ func (m *MetricSet) getCloudWatchBillingMetrics(
 
 	// Find a timestamp for all metrics in output
 	timestamp := aws.FindTimestamp(metricDataOutput)
-	if !timestamp.IsZero() {
-		for _, output := range metricDataOutput {
-			if len(output.Values) == 0 {
-				continue
-			}
-			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
-			if exists {
-				labels := strings.Split(*output.Label, labelSeparator)
+	if timestamp.IsZero() {
+		return nil
+	}
 
-				event := aws.InitEvent("", m.AccountName, m.AccountID)
-				event.MetricSetFields.Put(labels[0], output.Values[timestampIdx])
+	for _, output := range metricDataOutput {
+		if len(output.Values) == 0 {
+			continue
+		}
+		exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+		if exists {
+			labels := strings.Split(*output.Label, labelSeparator)
 
-				i := 1
-				for i < len(labels)-1 {
-					event.MetricSetFields.Put(labels[i], labels[i+1])
-					i += 2
-				}
-				event.Timestamp = endTime
-				events = append(events, event)
+			event := aws.InitEvent("", m.AccountName, m.AccountID, timestamp)
+			event.MetricSetFields.Put(labels[0], output.Values[timestampIdx])
+
+			i := 1
+			for i < len(labels)-1 {
+				event.MetricSetFields.Put(labels[i], labels[i+1])
+				i += 2
 			}
+			event.Timestamp = endTime
+			events = append(events, event)
 		}
 	}
 	return events
@@ -278,7 +280,7 @@ func (m *MetricSet) getCostGroupBy(svcCostExplorer costexploreriface.ClientAPI, 
 }
 
 func (m *MetricSet) addCostMetrics(metrics map[string]costexplorer.MetricValue, groupDefinition costexplorer.GroupDefinition, startDate string, endDate string) mb.Event {
-	event := aws.InitEvent("", m.AccountName, m.AccountID)
+	event := aws.InitEvent("", m.AccountName, m.AccountID, time.Now())
 
 	// add group definition
 	event.MetricSetFields.Put("group_definition", common.MapStr{

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -499,34 +499,35 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 
 	// Find a timestamp for all metrics in output
 	timestamp := aws.FindTimestamp(metricDataResults)
+	if timestamp.IsZero() {
+		return nil, nil
+	}
 
 	// Create events when there is no tags_filter or resource_type specified.
 	if len(resourceTypeTagFilters) == 0 {
-		if !timestamp.IsZero() {
-			for _, output := range metricDataResults {
-				if len(output.Values) == 0 {
+		for _, output := range metricDataResults {
+			if len(output.Values) == 0 {
+				continue
+			}
+
+			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+			if exists {
+				labels := strings.Split(*output.Label, labelSeparator)
+				if len(labels) != 5 {
+					// when there is no identifier value in label, use region+accountID+namespace instead
+					identifier := regionName + m.AccountID + labels[namespaceIdx]
+					if _, ok := events[identifier]; !ok {
+						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
+					}
+					events[identifier] = insertRootFields(events[identifier], output.Values[timestampIdx], labels)
 					continue
 				}
 
-				exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
-				if exists {
-					labels := strings.Split(*output.Label, labelSeparator)
-					if len(labels) != 5 {
-						// when there is no identifier value in label, use region+accountID+namespace instead
-						identifier := regionName + m.AccountID + labels[namespaceIdx]
-						if _, ok := events[identifier]; !ok {
-							events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
-						}
-						events[identifier] = insertRootFields(events[identifier], output.Values[timestampIdx], labels)
-						continue
-					}
-
-					identifierValue := labels[identifierValueIdx]
-					if _, ok := events[identifierValue]; !ok {
-						events[identifierValue] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
-					}
-					events[identifierValue] = insertRootFields(events[identifierValue], output.Values[timestampIdx], labels)
+				identifierValue := labels[identifierValueIdx]
+				if _, ok := events[identifierValue]; !ok {
+					events[identifierValue] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
 				}
+				events[identifierValue] = insertRootFields(events[identifierValue], output.Values[timestampIdx], labels)
 			}
 		}
 		return events, nil
@@ -556,45 +557,43 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 			m.logger.Debugf("In region %s, service %s tags match tags_filter", regionName, identifier)
 		}
 
-		if !timestamp.IsZero() {
-			for _, output := range metricDataResults {
-				if len(output.Values) == 0 {
-					continue
-				}
+		for _, output := range metricDataResults {
+			if len(output.Values) == 0 {
+				continue
+			}
 
-				exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
-				if exists {
-					labels := strings.Split(*output.Label, labelSeparator)
-					if len(labels) != 5 {
-						// if there is no tag in labels but there is a tagsFilter, then no event should be reported.
-						if len(tagsFilter) != 0 {
-							continue
-						}
-
-						// when there is no identifier value in label, use region+accountID+namespace instead
-						identifier := regionName + m.AccountID + labels[namespaceIdx]
-						if _, ok := events[identifier]; !ok {
-							events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
-						}
-						events[identifier] = insertRootFields(events[identifier], output.Values[timestampIdx], labels)
+			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+			if exists {
+				labels := strings.Split(*output.Label, labelSeparator)
+				if len(labels) != 5 {
+					// if there is no tag in labels but there is a tagsFilter, then no event should be reported.
+					if len(tagsFilter) != 0 {
 						continue
 					}
 
-					identifierValue := labels[identifierValueIdx]
-					if _, ok := events[identifierValue]; !ok {
-						// when tagsFilter is not empty but no entry in
-						// resourceTagMap for this identifier, do not initialize
-						// an event for this identifier.
-						if len(tagsFilter) != 0 && resourceTagMap[identifierValue] == nil {
-							continue
-						}
-						events[identifierValue] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
+					// when there is no identifier value in label, use region+accountID+namespace instead
+					identifier := regionName + m.AccountID + labels[namespaceIdx]
+					if _, ok := events[identifier]; !ok {
+						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
 					}
-					events[identifierValue] = insertRootFields(events[identifierValue], output.Values[timestampIdx], labels)
-
-					// add tags to event based on identifierValue
-					insertTags(events, identifierValue, resourceTagMap)
+					events[identifier] = insertRootFields(events[identifier], output.Values[timestampIdx], labels)
+					continue
 				}
+
+				identifierValue := labels[identifierValueIdx]
+				if _, ok := events[identifierValue]; !ok {
+					// when tagsFilter is not empty but no entry in
+					// resourceTagMap for this identifier, do not initialize
+					// an event for this identifier.
+					if len(tagsFilter) != 0 && resourceTagMap[identifierValue] == nil {
+						continue
+					}
+					events[identifierValue] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
+				}
+				events[identifierValue] = insertRootFields(events[identifierValue], output.Values[timestampIdx], labels)
+
+				// add tags to event based on identifierValue
+				insertTags(events, identifierValue, resourceTagMap)
 			}
 		}
 	}

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/metricbeat/mb"
-
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/cloudwatchiface"
@@ -22,12 +19,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws"
 )
 
 var (
 	regionName  = "us-west-1"
-	timestamp   = time.Now()
+	timestamp   = time.Date(2020, 10, 06, 00, 00, 00, 0, time.UTC)
 	accountID   = "123456789012"
 	accountName = "test"
 
@@ -1466,9 +1465,9 @@ func TestInsertTags(t *testing.T) {
 	tagValue3 := "dev"
 
 	events := map[string]mb.Event{}
-	events[identifier1] = aws.InitEvent(regionName, accountName, accountID)
-	events[identifier2] = aws.InitEvent(regionName, accountName, accountID)
-	events[identifierContainsArn] = aws.InitEvent(regionName, accountName, accountID)
+	events[identifier1] = aws.InitEvent(regionName, accountName, accountID, timestamp)
+	events[identifier2] = aws.InitEvent(regionName, accountName, accountID, timestamp)
+	events[identifierContainsArn] = aws.InitEvent(regionName, accountName, accountID, timestamp)
 
 	resourceTagMap := map[string][]resourcegroupstaggingapi.Tag{}
 	resourceTagMap["test-s3-1"] = []resourcegroupstaggingapi.Tag{
@@ -1568,4 +1567,30 @@ func TestConfigDimensionValueContainsWildcard(t *testing.T) {
 			assert.Equal(t, c.expectedResult, result)
 		})
 	}
+}
+
+func TestCreateEventsTimestamp(t *testing.T) {
+	m := MetricSet{
+		logger:            logp.NewLogger("test"),
+		CloudwatchConfigs: []Config{{Statistic: []string{"Average"}}},
+		MetricSet:         &aws.MetricSet{Period: 5, AccountID: accountID},
+	}
+
+	listMetricWithStatsTotal := []metricsWithStatistics{
+		{
+			cloudwatch.Metric{
+				MetricName: awssdk.String("CPUUtilization"),
+				Namespace:  awssdk.String("AWS/EC2"),
+			},
+			[]string{"Average"},
+			nil,
+		},
+	}
+
+	resourceTypeTagFilters := map[string][]aws.Tag{}
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
+
+	events, err := m.createEvents(&MockCloudWatchClientWithoutDim{}, &MockResourceGroupsTaggingClient{}, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
+	assert.NoError(t, err)
+	assert.Equal(t, timestamp, events[regionName+accountID+namespace].Timestamp)
 }

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -175,115 +175,117 @@ func constructMetricQueries(listMetricsOutput []cloudwatch.Metric, instanceID st
 }
 
 func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, instanceOutput map[string]ec2.Instance, regionName string) (map[string]mb.Event, error) {
-	// Initialize events and metricSetFieldResults per instanceID
-	events := map[string]mb.Event{}
-	metricSetFieldResults := map[idStat]map[string]interface{}{}
-	for instanceID := range instanceOutput {
-		for _, statistic := range statistics {
-			events[instanceID] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
-			metricSetFieldResults[idStat{instanceID: instanceID, statistic: statistic}] = map[string]interface{}{}
-		}
-	}
-
 	// monitoring state for each instance
 	monitoringStates := map[string]string{}
 
 	// Find a timestamp for all metrics in output
 	timestamp := aws.FindTimestamp(getMetricDataResults)
-	if !timestamp.IsZero() {
-		for _, output := range getMetricDataResults {
-			if len(output.Values) == 0 {
+	if timestamp.IsZero() {
+		return nil, nil
+	}
+
+	// Initialize events and metricSetFieldResults per instanceID
+	events := map[string]mb.Event{}
+	metricSetFieldResults := map[idStat]map[string]interface{}{}
+	for instanceID := range instanceOutput {
+		for _, statistic := range statistics {
+			events[instanceID] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
+			metricSetFieldResults[idStat{instanceID: instanceID, statistic: statistic}] = map[string]interface{}{}
+		}
+	}
+
+	for _, output := range getMetricDataResults {
+		if len(output.Values) == 0 {
+			continue
+		}
+
+		exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+		if exists {
+			label, err := newLabelFromJSON(*output.Label)
+			if err != nil {
+				m.logger.Errorf("convert cloudwatch MetricDataResult label failed for label = %s: %w", *output.Label, err)
 				continue
 			}
 
-			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
-			if exists {
-				label, err := newLabelFromJSON(*output.Label)
-				if err != nil {
-					m.logger.Errorf("convert cloudwatch MetricDataResult label failed for label = %s: %w", *output.Label, err)
+			instanceID := label.InstanceID
+			statistic := label.Statistic
+
+			// Add tags
+			tags := instanceOutput[instanceID].Tags
+			if m.TagsFilter != nil {
+				// Check with each tag filter
+				// If tag filter doesn't exist in tagKeys/tagValues,
+				// then do not report this event/instance.
+				if exists := aws.CheckTagFiltersExist(m.TagsFilter, tags); !exists {
+					// if tag filter doesn't exist, remove this event initial
+					// entry to avoid report an empty event.
+					delete(events, instanceID)
 					continue
 				}
-
-				instanceID := label.InstanceID
-				statistic := label.Statistic
-
-				// Add tags
-				tags := instanceOutput[instanceID].Tags
-				if m.TagsFilter != nil {
-					// Check with each tag filter
-					// If tag filter doesn't exist in tagKeys/tagValues,
-					// then do not report this event/instance.
-					if exists := aws.CheckTagFiltersExist(m.TagsFilter, tags); !exists {
-						// if tag filter doesn't exist, remove this event initial
-						// entry to avoid report an empty event.
-						delete(events, instanceID)
-						continue
-					}
-				}
-
-				// By default, replace dot "." using underscore "_" for tag keys.
-				// Note: tag values are not dedotted.
-				for _, tag := range tags {
-					events[instanceID].ModuleFields.Put("tags."+common.DeDot(*tag.Key), *tag.Value)
-					// add cloud.instance.name and host.name into ec2 events
-					if *tag.Key == "Name" {
-						events[instanceID].RootFields.Put("cloud.instance.name", *tag.Value)
-						events[instanceID].RootFields.Put("host.name", *tag.Value)
-					}
-				}
-
-				machineType, err := instanceOutput[instanceID].InstanceType.MarshalValue()
-				if err != nil {
-					return events, errors.Wrap(err, "instance.InstanceType.MarshalValue failed")
-				}
-
-				events[instanceID].RootFields.Put("cloud.instance.id", instanceID)
-				events[instanceID].RootFields.Put("cloud.machine.type", machineType)
-
-				placement := instanceOutput[instanceID].Placement
-				if placement != nil {
-					events[instanceID].RootFields.Put("cloud.availability_zone", *placement.AvailabilityZone)
-				}
-
-				if len(output.Values) > timestampIdx {
-					metricSetFieldResults[idStat{instanceID: instanceID, statistic: statistic}][label.MetricName] = fmt.Sprint(output.Values[timestampIdx])
-				}
-
-				instanceStateName, err := instanceOutput[instanceID].State.Name.MarshalValue()
-				if err != nil {
-					return events, errors.Wrap(err, "instance.State.Name.MarshalValue failed")
-				}
-
-				monitoringState, err := instanceOutput[instanceID].Monitoring.State.MarshalValue()
-				if err != nil {
-					return events, errors.Wrap(err, "instance.Monitoring.State.MarshalValue failed")
-				}
-
-				monitoringStates[instanceID] = monitoringState
-
-				cpuOptions := instanceOutput[instanceID].CpuOptions
-				if cpuOptions != nil {
-					events[instanceID].MetricSetFields.Put("instance.core.count", *cpuOptions.CoreCount)
-					events[instanceID].MetricSetFields.Put("instance.threads_per_core", *cpuOptions.ThreadsPerCore)
-				}
-
-				publicIP := instanceOutput[instanceID].PublicIpAddress
-				if publicIP != nil {
-					events[instanceID].MetricSetFields.Put("instance.public.ip", *publicIP)
-				}
-
-				privateIP := instanceOutput[instanceID].PrivateIpAddress
-				if privateIP != nil {
-					events[instanceID].MetricSetFields.Put("instance.private.ip", *privateIP)
-				}
-
-				events[instanceID].MetricSetFields.Put("instance.image.id", *instanceOutput[instanceID].ImageId)
-				events[instanceID].MetricSetFields.Put("instance.state.name", instanceStateName)
-				events[instanceID].MetricSetFields.Put("instance.state.code", *instanceOutput[instanceID].State.Code)
-				events[instanceID].MetricSetFields.Put("instance.monitoring.state", monitoringState)
-				events[instanceID].MetricSetFields.Put("instance.public.dns_name", *instanceOutput[instanceID].PublicDnsName)
-				events[instanceID].MetricSetFields.Put("instance.private.dns_name", *instanceOutput[instanceID].PrivateDnsName)
 			}
+
+			// By default, replace dot "." using underscore "_" for tag keys.
+			// Note: tag values are not dedotted.
+			for _, tag := range tags {
+				events[instanceID].ModuleFields.Put("tags."+common.DeDot(*tag.Key), *tag.Value)
+				// add cloud.instance.name and host.name into ec2 events
+				if *tag.Key == "Name" {
+					events[instanceID].RootFields.Put("cloud.instance.name", *tag.Value)
+					events[instanceID].RootFields.Put("host.name", *tag.Value)
+				}
+			}
+
+			machineType, err := instanceOutput[instanceID].InstanceType.MarshalValue()
+			if err != nil {
+				return events, errors.Wrap(err, "instance.InstanceType.MarshalValue failed")
+			}
+
+			events[instanceID].RootFields.Put("cloud.instance.id", instanceID)
+			events[instanceID].RootFields.Put("cloud.machine.type", machineType)
+
+			placement := instanceOutput[instanceID].Placement
+			if placement != nil {
+				events[instanceID].RootFields.Put("cloud.availability_zone", *placement.AvailabilityZone)
+			}
+
+			if len(output.Values) > timestampIdx {
+				metricSetFieldResults[idStat{instanceID: instanceID, statistic: statistic}][label.MetricName] = fmt.Sprint(output.Values[timestampIdx])
+			}
+
+			instanceStateName, err := instanceOutput[instanceID].State.Name.MarshalValue()
+			if err != nil {
+				return events, errors.Wrap(err, "instance.State.Name.MarshalValue failed")
+			}
+
+			monitoringState, err := instanceOutput[instanceID].Monitoring.State.MarshalValue()
+			if err != nil {
+				return events, errors.Wrap(err, "instance.Monitoring.State.MarshalValue failed")
+			}
+
+			monitoringStates[instanceID] = monitoringState
+
+			cpuOptions := instanceOutput[instanceID].CpuOptions
+			if cpuOptions != nil {
+				events[instanceID].MetricSetFields.Put("instance.core.count", *cpuOptions.CoreCount)
+				events[instanceID].MetricSetFields.Put("instance.threads_per_core", *cpuOptions.ThreadsPerCore)
+			}
+
+			publicIP := instanceOutput[instanceID].PublicIpAddress
+			if publicIP != nil {
+				events[instanceID].MetricSetFields.Put("instance.public.ip", *publicIP)
+			}
+
+			privateIP := instanceOutput[instanceID].PrivateIpAddress
+			if privateIP != nil {
+				events[instanceID].MetricSetFields.Put("instance.private.ip", *privateIP)
+			}
+
+			events[instanceID].MetricSetFields.Put("instance.image.id", *instanceOutput[instanceID].ImageId)
+			events[instanceID].MetricSetFields.Put("instance.state.name", instanceStateName)
+			events[instanceID].MetricSetFields.Put("instance.state.code", *instanceOutput[instanceID].State.Code)
+			events[instanceID].MetricSetFields.Put("instance.monitoring.state", monitoringState)
+			events[instanceID].MetricSetFields.Put("instance.public.dns_name", *instanceOutput[instanceID].PublicDnsName)
+			events[instanceID].MetricSetFields.Put("instance.private.dns_name", *instanceOutput[instanceID].PrivateDnsName)
 		}
 	}
 

--- a/x-pack/metricbeat/module/aws/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/rds/rds.go
@@ -274,69 +274,71 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 
 	// Find a timestamp for all metrics in output
 	timestamp := aws.FindTimestamp(getMetricDataResults)
-	if !timestamp.IsZero() {
-		for _, output := range getMetricDataResults {
-			if len(output.Values) == 0 {
-				continue
+	if timestamp.IsZero() {
+		return nil, nil
+	}
+
+	for _, output := range getMetricDataResults {
+		if len(output.Values) == 0 {
+			continue
+		}
+		exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+		if exists {
+			labels := strings.Split(*output.Label, " ")
+			// Collect dimension values from the labels and initialize events and metricSetFieldResults with dimValues
+			var dimValues string
+			for i := 1; i < len(labels); i += 2 {
+				dimValues = dimValues + labels[i+1]
 			}
-			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
-			if exists {
-				labels := strings.Split(*output.Label, " ")
-				// Collect dimension values from the labels and initialize events and metricSetFieldResults with dimValues
-				var dimValues string
+
+			if _, ok := events[dimValues]; !ok {
+				events[dimValues] = aws.InitEvent(regionName, m.AccountName, m.AccountID, timestamp)
+			}
+
+			if _, ok := metricSetFieldResults[dimValues]; !ok {
+				metricSetFieldResults[dimValues] = map[string]interface{}{}
+			}
+
+			if len(output.Values) > timestampIdx && len(labels) > 0 {
+				if labels[metricNameIdx] == "CPUUtilization" {
+					metricSetFieldResults[dimValues][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx] / 100)
+				} else {
+					metricSetFieldResults[dimValues][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx])
+				}
+
 				for i := 1; i < len(labels); i += 2 {
-					dimValues = dimValues + labels[i+1]
+					if labels[i] == "DBInstanceIdentifier" {
+						dbIdentifier := labels[i+1]
+						if _, found := events[dbIdentifier]; found {
+							if _, found := dbInstanceMap[dbIdentifier]; !found {
+								delete(metricSetFieldResults, dimValues)
+								continue
+							}
+							events[dbIdentifier].RootFields.Put("cloud.availability_zone", dbInstanceMap[dbIdentifier].dbAvailabilityZone)
+							events[dbIdentifier].MetricSetFields.Put("db_instance.arn", dbInstanceMap[dbIdentifier].dbArn)
+							events[dbIdentifier].MetricSetFields.Put("db_instance.class", dbInstanceMap[dbIdentifier].dbClass)
+							events[dbIdentifier].MetricSetFields.Put("db_instance.identifier", dbInstanceMap[dbIdentifier].dbIdentifier)
+							events[dbIdentifier].MetricSetFields.Put("db_instance.status", dbInstanceMap[dbIdentifier].dbStatus)
+
+							for _, tag := range dbInstanceMap[dbIdentifier].tags {
+								events[dbIdentifier].ModuleFields.Put("tags."+tag.Key, tag.Value)
+							}
+						}
+					}
+					metricSetFieldResults[dimValues][labels[i]] = fmt.Sprint(labels[(i + 1)])
 				}
 
-				if _, ok := events[dimValues]; !ok {
-					events[dimValues] = aws.InitEvent(regionName, m.AccountName, m.AccountID)
-				}
-
-				if _, ok := metricSetFieldResults[dimValues]; !ok {
-					metricSetFieldResults[dimValues] = map[string]interface{}{}
-				}
-
-				if len(output.Values) > timestampIdx && len(labels) > 0 {
-					if labels[metricNameIdx] == "CPUUtilization" {
-						metricSetFieldResults[dimValues][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx] / 100)
-					} else {
-						metricSetFieldResults[dimValues][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx])
+				// if tags_filter is given, then only return metrics with DBInstanceIdentifier as dimension
+				if m.TagsFilter != nil {
+					if len(labels) == 1 {
+						delete(events, dimValues)
+						delete(metricSetFieldResults, dimValues)
 					}
 
 					for i := 1; i < len(labels); i += 2 {
-						if labels[i] == "DBInstanceIdentifier" {
-							dbIdentifier := labels[i+1]
-							if _, found := events[dbIdentifier]; found {
-								if _, found := dbInstanceMap[dbIdentifier]; !found {
-									delete(metricSetFieldResults, dimValues)
-									continue
-								}
-								events[dbIdentifier].RootFields.Put("cloud.availability_zone", dbInstanceMap[dbIdentifier].dbAvailabilityZone)
-								events[dbIdentifier].MetricSetFields.Put("db_instance.arn", dbInstanceMap[dbIdentifier].dbArn)
-								events[dbIdentifier].MetricSetFields.Put("db_instance.class", dbInstanceMap[dbIdentifier].dbClass)
-								events[dbIdentifier].MetricSetFields.Put("db_instance.identifier", dbInstanceMap[dbIdentifier].dbIdentifier)
-								events[dbIdentifier].MetricSetFields.Put("db_instance.status", dbInstanceMap[dbIdentifier].dbStatus)
-
-								for _, tag := range dbInstanceMap[dbIdentifier].tags {
-									events[dbIdentifier].ModuleFields.Put("tags."+tag.Key, tag.Value)
-								}
-							}
-						}
-						metricSetFieldResults[dimValues][labels[i]] = fmt.Sprint(labels[(i + 1)])
-					}
-
-					// if tags_filter is given, then only return metrics with DBInstanceIdentifier as dimension
-					if m.TagsFilter != nil {
-						if len(labels) == 1 {
+						if labels[i] != "DBInstanceIdentifier" && i == len(labels)-2 {
 							delete(events, dimValues)
 							delete(metricSetFieldResults, dimValues)
-						}
-
-						for i := 1; i < len(labels); i += 2 {
-							if labels[i] != "DBInstanceIdentifier" && i == len(labels)-2 {
-								delete(events, dimValues)
-								delete(metricSetFieldResults, dimValues)
-							}
 						}
 					}
 				}

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
@@ -186,8 +186,6 @@ func createMetricDataQuery(metric cloudwatch.Metric, period time.Duration, index
 }
 
 func createCloudWatchEvents(outputs []cloudwatch.MetricDataResult, regionName string, bucketName string, accountName string, accountID string) (event mb.Event, err error) {
-	event = aws.InitEvent(regionName, accountName, accountID)
-
 	// AWS s3_daily_storage metrics
 	mapOfMetricSetFieldResults := make(map[string]interface{})
 
@@ -214,6 +212,7 @@ func createCloudWatchEvents(outputs []cloudwatch.MetricDataResult, regionName st
 		return
 	}
 
+	event = aws.InitEvent(regionName, accountName, accountID, timestamp)
 	event.MetricSetFields = resultMetricSetFields
 	event.RootFields.Put("aws.s3.bucket.name", bucketName)
 	return

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -188,8 +188,6 @@ func constructMetricQueries(listMetricsOutputs []cloudwatch.Metric, period time.
 
 // CreateS3Events creates s3_request and s3_daily_storage events from Cloudwatch metric data.
 func createS3RequestEvents(outputs []cloudwatch.MetricDataResult, regionName string, bucketName string, accountName string, accountID string) (event mb.Event, err error) {
-	event = aws.InitEvent(regionName, accountName, accountID)
-
 	// AWS s3_request metrics
 	mapOfMetricSetFieldResults := make(map[string]interface{})
 
@@ -216,6 +214,7 @@ func createS3RequestEvents(outputs []cloudwatch.MetricDataResult, regionName str
 		return
 	}
 
+	event = aws.InitEvent(regionName, accountName, accountID, timestamp)
 	event.MetricSetFields = resultMetricSetFields
 	event.RootFields.Put("aws.s3.bucket.name", bucketName)
 	return

--- a/x-pack/metricbeat/module/aws/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs.go
@@ -175,9 +175,7 @@ func createMetricDataQuery(metric cloudwatch.Metric, index int, period time.Dura
 	return
 }
 
-func createEventPerQueue(getMetricDataResults []cloudwatch.MetricDataResult, queueName string, metricsetName string, regionName string, schemaMetricFields s.Schema, accountName string, accountID string) (event mb.Event, err error) {
-	event = aws.InitEvent(regionName, accountName, accountID)
-
+func createEventPerQueue(getMetricDataResults []cloudwatch.MetricDataResult, queueName string, regionName string, schemaMetricFields s.Schema, accountName string, accountID string) (event mb.Event, err error) {
 	// AWS sqs metrics
 	mapOfMetricSetFieldResults := make(map[string]interface{})
 
@@ -204,6 +202,7 @@ func createEventPerQueue(getMetricDataResults []cloudwatch.MetricDataResult, que
 		return
 	}
 
+	event = aws.InitEvent(regionName, accountName, accountID, timestamp)
 	event.MetricSetFields = resultMetricSetFields
 	event.MetricSetFields.Put("queue.name", queueName)
 	return
@@ -213,7 +212,7 @@ func createSQSEvents(queueURLs []string, metricDataResults []cloudwatch.MetricDa
 	for _, queueURL := range queueURLs {
 		queueURLParsed := strings.Split(queueURL, "/")
 		queueName := queueURLParsed[len(queueURLParsed)-1]
-		event, err := createEventPerQueue(metricDataResults, queueName, metricsetName, regionName, schemaRequestFields, accountName, accountID)
+		event, err := createEventPerQueue(metricDataResults, queueName, regionName, schemaRequestFields, accountName, accountID)
 		if err != nil {
 			event.Error = err
 			report.Event(event)


### PR DESCRIPTION
Cherry-pick of PR #21498 to 7.x branch. Original message: 

This PR is to use timestamp from CloudWatch ListMetric API instead of the current timestamp to construct events.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ]~~I have commented my code, particularly in hard-to-understand areas~~
- [ ]~~I have made corresponding changes to the documentation~~
- [ ]~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
