### PR TITLE
Cherry-pick to 7.9: docs: Update timestamp.asciidoc (#20395)

### DIFF
--- a/libbeat/processors/timestamp/docs/timestamp.asciidoc
+++ b/libbeat/processors/timestamp/docs/timestamp.asciidoc
@@ -50,7 +50,7 @@ If a layout does not contain a year then the current year in the specified
 
 Here is an example that parses the `start_time` field and writes the result
 to the `@timestamp` field then deletes the `start_time` field. When the
-processor is loaded it will immediately validate that the two `test` timestamps
+processor is loaded, it will immediately validate that the two `test` timestamps
 parse with this configuration.
 
 [source,yaml]
@@ -61,9 +61,11 @@ processors:
       layouts:
         - '2006-01-02T15:04:05Z'
         - '2006-01-02T15:04:05.999Z'
+        - '2006-01-02T15:04:05.999-07:00'
       test:
         - '2019-06-22T16:33:51Z'
         - '2019-11-18T04:59:51.123Z'
+        - '2020-08-03T07:10:20.123456+02:00'
   - drop_fields:
       fields: [start_time]
 ----


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: Update timestamp.asciidoc (#20395)