### PR TITLE
feat: Update test environments 7.10.1

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -109,7 +109,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:7.10.0
+        image: docker.elastic.co/beats/auditbeat:7.10.1
         args: [
           "-c", "/etc/auditbeat.yml",
           "-e",

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -64,7 +64,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:7.10.0
+        image: docker.elastic.co/beats/filebeat:7.10.1
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -146,7 +146,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.10.0
+        image: docker.elastic.co/beats/metricbeat:7.10.1
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -15,7 +15,7 @@ services:
     - "http.host=0.0.0.0"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.10.0-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.10.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -16,7 +16,7 @@ services:
     - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.10.0-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.1-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600


### PR DESCRIPTION
Update test environment versions to the correct Elastic Stack version.

Merge after the release 7.10.0.

Merge after first [7.10.1-SNAPSHOT Docker image](https://artifacts-api.elastic.co/v1/versions/7.10.1-SNAPSHOT)