### PR TITLE
[Filebeat S3] Change log.file.path to be nested object

### DIFF
--- a/x-pack/filebeat/input/s3/collector.go
+++ b/x-pack/filebeat/input/s3/collector.go
@@ -556,7 +556,7 @@ func createEvent(log string, offset int, info s3Info, objectHash string, s3Ctx *
 		Fields: common.MapStr{
 			"message": log,
 			"log": common.MapStr{
-				"offset":    int64(offset),
+				"offset": int64(offset),
 				"file": common.MapStr{
 					"path": constructObjectURL(info),
 				},

--- a/x-pack/filebeat/input/s3/collector.go
+++ b/x-pack/filebeat/input/s3/collector.go
@@ -557,7 +557,9 @@ func createEvent(log string, offset int, info s3Info, objectHash string, s3Ctx *
 			"message": log,
 			"log": common.MapStr{
 				"offset":    int64(offset),
-				"file.path": constructObjectURL(info),
+				"file": common.MapStr{
+					"path": constructObjectURL(info),
+				},
 			},
 			"aws": common.MapStr{
 				"s3": common.MapStr{


### PR DESCRIPTION
This PR is to change `log.file.path` to be nested object instead of using `file.path` as field name.