### PR TITLE
[Filebeat] Add fips_enabled into all aws filesets

### DIFF
--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -51,6 +51,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/s3.yml
@@ -37,6 +37,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/ec2/config/s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/s3.yml
@@ -37,6 +37,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/elb/config/s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/s3.yml
@@ -37,6 +37,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/s3access/config/s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/s3.yml
@@ -37,6 +37,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -39,6 +39,10 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .fips_enabled }}
+fips_enabled: {{ .fips_enabled }}
+{{ end }}
+
 {{ else if eq .input "file" }}
 
 type: log


### PR DESCRIPTION
This is a followup PR for https://github.com/elastic/beats/pull/21585 to add `fips_enabled` config into all aws filesets.