### PR TITLE
Add harvester_limit to filestream

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -56,7 +56,11 @@ type readerGroup struct {
 	table map[string]context.CancelFunc
 }
 
-func newReaderGroup(limit uint64) *readerGroup {
+func newReaderGroup() *readerGroup {
+	return newReaderGroupWithLimit(0)
+}
+
+func newReaderGroupWithLimit(limit uint64) *readerGroup {
 	return &readerGroup{
 		limit: limit,
 		table: make(map[string]context.CancelFunc),

--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -47,19 +47,19 @@ func TestReaderGroup(t *testing.T) {
 	}
 
 	t.Run("assert new group is empty", func(t *testing.T) {
-		rg := newReaderGroup(0)
+		rg := newReaderGroup()
 		require.Equal(t, 0, len(rg.table))
 	})
 
 	t.Run("assert non existent key can be removed", func(t *testing.T) {
-		rg := newReaderGroup(0)
+		rg := newReaderGroup()
 		require.Equal(t, 0, len(rg.table))
 		rg.remove("no such id")
 		require.Equal(t, 0, len(rg.table))
 	})
 
 	t.Run("assert inserting existing key returns error", func(t *testing.T) {
-		rg := newReaderGroup(0)
+		rg := newReaderGroup()
 		ctx, cf, err := rg.newContext("test-id", context.Background())
 		requireGroupSuccess(t, ctx, cf, err)
 		require.Equal(t, 1, len(rg.table))
@@ -69,7 +69,7 @@ func TestReaderGroup(t *testing.T) {
 	})
 
 	t.Run("assert new key is added, can be removed and its context is cancelled", func(t *testing.T) {
-		rg := newReaderGroup(0)
+		rg := newReaderGroup()
 		ctx, cf, err := rg.newContext("test-id", context.Background())
 		requireGroupSuccess(t, ctx, cf, err)
 		require.Equal(t, 1, len(rg.table))
@@ -87,7 +87,7 @@ func TestReaderGroup(t *testing.T) {
 	})
 
 	t.Run("assert new harvester cannot be added if limit is reached", func(t *testing.T) {
-		rg := newReaderGroup(1)
+		rg := newReaderGroupWithLimit(1)
 		require.Equal(t, 0, len(rg.table))
 		ctx, cf, err := rg.newContext("test-id", context.Background())
 		requireGroupSuccess(t, ctx, cf, err)
@@ -275,7 +275,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 func testDefaultHarvesterGroup(t *testing.T, mockHarvester Harvester) *defaultHarvesterGroup {
 	return &defaultHarvesterGroup{
-		readers:   newReaderGroup(0),
+		readers:   newReaderGroup(),
 		pipeline:  &pipelinemock.MockPipelineConnector{},
 		harvester: mockHarvester,
 		store:     testOpenStore(t, "test", nil),

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -36,6 +36,7 @@ type managedInput struct {
 	prospector       Prospector
 	harvester        Harvester
 	cleanTimeout     time.Duration
+	harvesterLimit   uint64
 }
 
 // Name is required to implement the v2.Input interface
@@ -62,7 +63,7 @@ func (inp *managedInput) Run(
 
 	hg := &defaultHarvesterGroup{
 		pipeline:     pipeline,
-		readers:      newReaderGroup(),
+		readers:      newReaderGroup(inp.harvesterLimit),
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
 		store:        groupStore,

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -63,7 +63,7 @@ func (inp *managedInput) Run(
 
 	hg := &defaultHarvesterGroup{
 		pipeline:     pipeline,
-		readers:      newReaderGroup(inp.harvesterLimit),
+		readers:      newReaderGroupWithLimit(inp.harvesterLimit),
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
 		store:        groupStore,

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -155,9 +155,10 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 	}
 
 	settings := struct {
-		ID           string        `config:"id"`
-		CleanTimeout time.Duration `config:"clean_timeout"`
-	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout}
+		ID             string        `config:"id"`
+		CleanTimeout   time.Duration `config:"clean_timeout"`
+		HarvesterLimit uint64        `config:"harvester_limit"`
+	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout, HarvesterLimit: 0}
 	if err := config.Unpack(&settings); err != nil {
 		return nil, err
 	}
@@ -190,6 +191,7 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 		harvester:        harvester,
 		sourceIdentifier: sourceIdentifier,
 		cleanTimeout:     settings.CleanTimeout,
+		harvesterLimit:   settings.HarvesterLimit,
 	}, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds `harvester_limit` to the input `filestream` to limit the number of readers started for the input. If the limit has been reached no harvester is started, an error is returned and the input does not wait for other Harvesters to stop.

## Why is it important?

This lets users limit the number of readers which encourage the adoption of the new input.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~