### PR TITLE
backport: add 7.10 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/beats",
-  "branches": [ { "name": "7.10"}, { "name": "7.9"}, { "name": "7.8"}, { "name": "7.7"}, { "name": "7.x"}],
+  "branches": [ { "name": "7.x", "checked": true }, "7.10", "7.9", "7.8", "7.7"],
   "labels": ["backport"],
   "autoAssign": true,
   "prTitle": "Cherry-pick to {targetBranch}: {commitMessages}"

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/beats",
-  "branches": [{ "name": "7.9"}, { "name": "7.8"}, { "name": "7.7"}, { "name": "7.x"}],
+  "branches": [ { "name": "7.10"}, { "name": "7.9"}, { "name": "7.8"}, { "name": "7.7"}, { "name": "7.x"}],
   "labels": ["backport"],
   "autoAssign": true,
   "prTitle": "Cherry-pick to {targetBranch}: {commitMessages}"


### PR DESCRIPTION
## What does this PR do?

Add 7.10 branch to the supported list of branches to use the backport tool

## Why is it important?

Help with the automation

## Tests

![image](https://user-images.githubusercontent.com/2871786/95428734-547e0000-0941-11eb-9d2e-b953843dba28.png)
