### PR TITLE
Cherry-pick to 7.10: Add `add_observer_metadata` `geo.name` to Quickstart (#21501)

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -97,8 +97,42 @@ was started. Heartbeat adds the `@every` keyword to the syntax provided by the
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 [float]
+[[configurelocation]]
+=== Step 4: Configure the Heartbeat location
+
+Heartbeat can be deployed in multiple locations so that you can detect 
+differences in availability and response times across those locations.
+Configure the Heartbeat location to allow {kib} to display location-specific
+information on Uptime maps and perform Uptime anomaly detection based
+on location.
+
+To configure the location of a Heartbeat instance, modify the 
+`add_observer_metadata` processor in +{beatname_lc}.yml+.  The following 
+example specifies the `geo.name` of the `add_observer_metadata` processor as
+`us-east-1a`:
+
+[source,yaml]
+----------------------------------------------------------------------
+# ============================ Processors ============================
+
+processors:
+  - add_observer_metadata:
+      # Optional, but recommended geo settings for the location Heartbeat is running in
+      geo: <1>
+        # Token describing this location
+        name: us-east-1a <2>
+        # Lat, Lon "
+        #location: "37.926868, -78.024902" <3>
+----------------------------------------------------------------------
+<1> Uncomment the `geo` setting.
+<2> Uncomment `name` and assign the name of the location of the Heartbeat server.
+<3> Optionally uncomment `location` and assign the latitude and longitude.
+
+include::{libbeat-dir}/shared/config-check.asciidoc[]
+
+[float]
 [[setup-assets]]
-=== Step 4: Set up assets
+=== Step 5: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:
@@ -128,7 +162,7 @@ environment. If you're using a different output, such as {ls}, see
 
 [float]
 [[start]]
-=== Step 5: Start Heartbeat
+=== Step 6: Start Heartbeat
 
 Before starting {beatname_uc}, modify the user credentials in
 +{beatname_lc}.yml+ and specify a user who is
@@ -145,7 +179,7 @@ events to your defined output.
 
 [float]
 [[view-data]]
-=== Step 6: View your data in {kib}
+=== Step 7: View your data in {kib}
 
 {beatname_uc} comes with pre-built {kib} dashboards and UIs for visualizing the
 status of your services. The dashboards are available in the


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Add `add_observer_metadata` `geo.name` to Quickstart (#21501)