### PR TITLE
Remove dot from file.extension value in Auditbeat FIM

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change event.kind=error to event.kind=event to comply with ECS. {issue}18870[18870] {pull}20685[20685]
 - Change network.direction values to ECS recommended values (inbound, outbound). {issue}12445[12445] {pull}20695[20695]
 - Docker container needs to be explicitly run as user root for auditing. {pull}21202[21202]
+- File integrity dataset no longer includes the leading dot in `file.extension` values (e.g. it will report "png" instead of ".png") to comply with ECS. {pull}21644[21644]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -257,7 +257,7 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 
 		if e.Info.Type == FileType {
 			if extension := filepath.Ext(e.Path); extension != "" {
-				file["extension"] = extension
+				file["extension"] = strings.TrimLeft(extension, ".")
 			}
 			if mimeType := getMimeType(e.Path); mimeType != "" {
 				file["mime_type"] = mimeType

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 )
@@ -295,7 +296,11 @@ func TestBuildEvent(t *testing.T) {
 		assertHasKey(t, fields, "event.type")
 
 		assertHasKey(t, fields, "file.path")
-		assertHasKey(t, fields, "file.extension")
+		if assertHasKey(t, fields, "file.extension") {
+			ext, err := fields.GetValue("file.extension")
+			require.NoError(t, err)
+			assert.Equal(t, ext, "txt")
+		}
 		assertHasKey(t, fields, "file.target_path")
 		assertHasKey(t, fields, "file.inode")
 		assertHasKey(t, fields, "file.uid")
@@ -427,10 +432,12 @@ func mustDecodeHex(v string) []byte {
 	return data
 }
 
-func assertHasKey(t testing.TB, m common.MapStr, key string) {
+func assertHasKey(t testing.TB, m common.MapStr, key string) bool {
 	t.Helper()
 	found, err := m.HasKey(key)
 	if err != nil || !found {
 		t.Errorf("key %v not found: %v", key, err)
+		return false
 	}
+	return true
 }


### PR DESCRIPTION
## What does this PR do?

The ECS file.extension field should not include the dot. For example the value should be "png" and not ".png".

## Why is it important?

It's important to have all `file.extension` values conform to the same format declared by ECS.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates elastic/ecs#1016