### PR TITLE
libbeat/logp: introduce Logger.WithOptions

### DIFF
--- a/libbeat/logp/logger.go
+++ b/libbeat/logp/logger.go
@@ -50,6 +50,12 @@ func NewLogger(selector string, options ...LogOption) *Logger {
 	return newLogger(loadLogger().rootLogger, selector, options...)
 }
 
+// WithOptions returns a clone of l with options applied.
+func (l *Logger) WithOptions(options ...LogOption) *Logger {
+	cloned := l.logger.WithOptions(options...)
+	return &Logger{cloned, cloned.Sugar()}
+}
+
 // With creates a child logger and adds structured context to it. Fields added
 // to the child don't affect the parent, and vice versa.
 func (l *Logger) With(args ...interface{}) *Logger {

--- a/libbeat/logp/logger_test.go
+++ b/libbeat/logp/logger_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package logp
 
 import (

--- a/libbeat/logp/logger_test.go
+++ b/libbeat/logp/logger_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -40,28 +41,12 @@ func TestLoggerWithOptions(t *testing.T) {
 	logger1.Info("hello logger1")             // should just go to the first observer
 	logger2.Info("hello logger1 and logger2") // should go to both observers
 
-	assert.Equal(t, []observer.LoggedEntry{{
-		Context: []zapcore.Field{},
-		Entry: zapcore.Entry{
-			Level:      zapcore.InfoLevel,
-			LoggerName: "bo",
-			Message:    "hello logger1",
-		},
-	}, {
-		Context: []zapcore.Field{},
-		Entry: zapcore.Entry{
-			Level:      zapcore.InfoLevel,
-			LoggerName: "bo",
-			Message:    "hello logger1 and logger2",
-		},
-	}}, observed1.AllUntimed())
+	observedEntries1 := observed1.All()
+	require.Len(t, observedEntries1, 2)
+	assert.Equal(t, "hello logger1", observedEntries1[0].Message)
+	assert.Equal(t, "hello logger1 and logger2", observedEntries1[1].Message)
 
-	assert.Equal(t, []observer.LoggedEntry{{
-		Context: []zapcore.Field{},
-		Entry: zapcore.Entry{
-			Level:      zapcore.InfoLevel,
-			LoggerName: "bo",
-			Message:    "hello logger1 and logger2",
-		},
-	}}, observed2.AllUntimed())
+	observedEntries2 := observed2.All()
+	require.Len(t, observedEntries2, 1)
+	assert.Equal(t, "hello logger1 and logger2", observedEntries2[0].Message)
 }

--- a/libbeat/logp/logger_test.go
+++ b/libbeat/logp/logger_test.go
@@ -1,0 +1,50 @@
+package logp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestLoggerWithOptions(t *testing.T) {
+	core1, observed1 := observer.New(zapcore.DebugLevel)
+	core2, observed2 := observer.New(zapcore.DebugLevel)
+
+	logger1 := NewLogger("bo", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core1)
+	}))
+	logger2 := logger1.WithOptions(zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core2)
+	}))
+
+	logger1.Info("hello logger1")             // should just go to the first observer
+	logger2.Info("hello logger1 and logger2") // should go to both observers
+
+	assert.Equal(t, []observer.LoggedEntry{{
+		Context: []zapcore.Field{},
+		Entry: zapcore.Entry{
+			Level:      zapcore.InfoLevel,
+			LoggerName: "bo",
+			Message:    "hello logger1",
+		},
+	}, {
+		Context: []zapcore.Field{},
+		Entry: zapcore.Entry{
+			Level:      zapcore.InfoLevel,
+			LoggerName: "bo",
+			Message:    "hello logger1 and logger2",
+		},
+	}}, observed1.AllUntimed())
+
+	assert.Equal(t, []observer.LoggedEntry{{
+		Context: []zapcore.Field{},
+		Entry: zapcore.Entry{
+			Level:      zapcore.InfoLevel,
+			LoggerName: "bo",
+			Message:    "hello logger1 and logger2",
+		},
+	}}, observed2.AllUntimed())
+}


### PR DESCRIPTION
## What does this PR do?

Add a Logger.WithOptions method, which clones the logger and applies given options. For example, this can be used to obtain a clone of the logger with sampling/rate limiting applied (e.g. using https://godoc.org/go.uber.org/zap/zapcore#NewSampler).

## Why is it important?

In APM Server we have several would like to log a warning when a limit is reached, but only periodically thereafter to avoid flooding the logs and burning CPU.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

None.