### PR TITLE
Cherry-pick #21625 to 7.x: Fix flaky FSWatch/FSScanner tests

### DIFF
--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -38,8 +38,6 @@ var (
 )
 
 func TestFileScanner(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21489")
-
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
@@ -89,7 +87,7 @@ func TestFileScanner(t *testing.T) {
 			for p, _ := range files {
 				paths = append(paths, p)
 			}
-			assert.True(t, checkIfSameContents(test.expectedFiles, paths))
+			assert.ElementsMatch(t, paths, test.expectedFiles)
 		})
 	}
 }
@@ -116,26 +114,7 @@ func removeFilesOfScannerTest(t *testing.T) {
 	}
 }
 
-// only handles sets
-func checkIfSameContents(one, other []string) bool {
-	if len(one) != len(other) {
-		return false
-	}
-
-	mustFind := len(one)
-	for _, oneElem := range one {
-		for _, otherElem := range other {
-			if oneElem == otherElem {
-				mustFind--
-			}
-		}
-	}
-	return mustFind == 0
-}
-
 func TestFileWatchNewDeleteModified(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21489")
-
 	oldTs := time.Now()
 	newTs := oldTs.Add(5 * time.Second)
 	testCases := map[string]struct {
@@ -226,10 +205,13 @@ func TestFileWatchNewDeleteModified(t *testing.T) {
 
 			go w.watch(context.Background())
 
-			for _, expectedEvent := range test.expectedEvents {
-				evt := w.Event()
-				assert.Equal(t, expectedEvent, evt)
+			count := len(test.expectedEvents)
+			actual := make([]loginp.FSEvent, count)
+			for i := 0; i < count; i++ {
+				actual[i] = w.Event()
 			}
+
+			assert.ElementsMatch(t, actual, test.expectedEvents)
 		})
 	}
 }

--- a/filebeat/input/filestream/fswatch_test_non_windows.go
+++ b/filebeat/input/filestream/fswatch_test_non_windows.go
@@ -88,7 +88,7 @@ func TestFileScannerSymlinks(t *testing.T) {
 			for p, _ := range files {
 				paths = append(paths, p)
 			}
-			assert.Equal(t, test.expectedFiles, paths)
+			assert.ElementsMatch(t, test.expectedFiles, paths)
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #21625 to 7.x branch. Original message: 

## What does this PR do?

Unit tests in for `fswatch.go` do not depend on the order of the returned events anymore.

## Why is it important?

The tests have been flaky.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

Closes #21489