### PR TITLE
[DOCS] Update links to Observability apps

### DIFF
--- a/libbeat/docs/shared/obs-apps.asciidoc
+++ b/libbeat/docs/shared/obs-apps.asciidoc
@@ -38,13 +38,13 @@ endif::[]
 |===
 |Elastic apps | Use to
 
-|{kibana-ref}/xpack-infra.html[{metrics-app}]
+|{observability-guide}/analyze-metrics.html[{metrics-app}]
 |Explore metrics about systems and services across your ecosystem
 
-|{kibana-ref}/xpack-logs.html[{logs-app}]
+|{observability-guide}/monitor-logs.html[{logs-app}]
 |Tail related log data in real time
 
-|{kibana-ref}/xpack-uptime.html[{uptime-app}]
+|{observability-guide}/monitor-uptime.html[{uptime-app}]
 |Monitor availability issues across your apps and services
 
 |{kibana-ref}/xpack-apm.html[APM app]


### PR DESCRIPTION
Due to build failures on the [Kibana docs PR](https://github.com/elastic/kibana/pull/79978), this PR updates the links to the Metrics, Logs, and Uptime apps. 

This update gives us the opportunity to link directly to the relevant topics in the Observability guide, rather than to the new content in the Kibana PR. 

Doc build failures are expected until this [Uptime PR](https://github.com/elastic/observability-docs/pull/162) is merged. 

Related PRs

https://github.com/elastic/observability-docs/pull/162
https://github.com/elastic/kibana/pull/79978

