### PR TITLE
Cherry-pick to 7.9: [Metricbeat][test] Disable ec2 flaky test (#20959)

### DIFF
--- a/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/20951")
 	config := mtest.GetConfigForTest(t, "ec2", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [Metricbeat][test] Disable ec2 flaky test (#20959)