### PR TITLE
Cherry-pick to 7.10: [CI] Support Windows-2016 in pipeline 2.0 (#21337)

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -34,3 +34,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -33,3 +33,4 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+            #- "windows-2016"  https://github.com/elastic/beats/issues/19641

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -32,3 +32,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test heartbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -40,3 +40,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test metricbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -32,3 +32,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test packetbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -19,3 +19,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -33,3 +33,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -32,3 +32,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/elastic-agent for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -33,3 +33,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/filebeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -32,3 +32,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/functionbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -35,3 +35,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/metricbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -18,3 +18,14 @@ stages:
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -18,3 +18,14 @@ stages:
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [CI] Support Windows-2016 in pipeline 2.0 (#21337)