### PR TITLE
fix: remove extra curly brace in script

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -221,7 +221,6 @@ def tagAndPush(name){
       } else if ( status > 0 ) {
         log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
       }
-    }
   }
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -215,12 +215,13 @@ def tagAndPush(name){
         docker push ${newName}
         docker tag ${oldName} ${commitName}
         docker push ${commitName}
-      """, returnStatus: true) 
-      if ( status > 0 && iterations < 3) {
-        error('tag and push failed, retry')
-      } else if ( status > 0 ) {
-        log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
-      }
+      """, returnStatus: true)
+
+    if ( status > 0 && iterations < 3) {
+      error('tag and push failed, retry')
+    } else if ( status > 0 ) {
+      log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
It removes one extra curly brace added while reviewing #21621  directly on Github.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Without this fix, the job does not compile (See https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackaging/detail/master/703/pipeline)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds elastic/beats#123
-->
- Relates elastic/beats#21621



<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```log
[2020-10-08T15:02:24.868Z] Obtained .ci/packaging.groovy from 5b69349d02b3fc92605ccfe796b6dd558fa18846
[2020-10-08T15:02:24.868Z] Resume disabled by user, switching to high-performance, low-durability mode.
[2020-10-08T15:02:24.903Z] org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
[2020-10-08T15:02:24.903Z] WorkflowScript: 226: unexpected token: } @ line 226, column 1.
[2020-10-08T15:02:24.903Z]    }
[2020-10-08T15:02:24.903Z]    ^
[2020-10-08T15:02:24.903Z] 
[2020-10-08T15:02:24.904Z] 1 error
[2020-10-08T15:02:24.904Z] 
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.ErrorCollector.addFatalError(ErrorCollector.java:150)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.ErrorCollector.addError(ErrorCollector.java:120)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.ErrorCollector.addError(ErrorCollector.java:132)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.SourceUnit.addError(SourceUnit.java:350)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.antlr.AntlrParserPlugin.transformCSTIntoAST(AntlrParserPlugin.java:144)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.antlr.AntlrParserPlugin.parseCST(AntlrParserPlugin.java:110)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.SourceUnit.parse(SourceUnit.java:234)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.CompilationUnit$1.call(CompilationUnit.java:168)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:943)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
[2020-10-08T15:02:24.904Z] 	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
[2020-10-08T15:02:24.904Z] 	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
[2020-10-08T15:02:24.904Z] 	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
[2020-10-08T15:02:24.904Z] 	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
[2020-10-08T15:02:24.904Z] 	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
[2020-10-08T15:02:24.904Z] 	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:142)
[2020-10-08T15:02:24.904Z] 	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
[2020-10-08T15:02:24.904Z] 	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:561)
[2020-10-08T15:02:24.904Z] 	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:522)
[2020-10-08T15:02:24.904Z] 	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:337)
[2020-10-08T15:02:24.904Z] 	at hudson.model.ResourceController.execute(ResourceController.java:97)
[2020-10-08T15:02:24.904Z] 	at hudson.model.Executor.run(Executor.java:428)
[2020-10-08T15:02:24.904Z] Finished: FAILURE
```
<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->