### PR TITLE
Cherry-pick #21647 to 7.10: Make o365audit input cancellable

### DIFF
--- a/x-pack/filebeat/input/o365audit/input.go
+++ b/x-pack/filebeat/input/o365audit/input.go
@@ -21,14 +21,12 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/o365audit/poll"
 	"github.com/elastic/go-concert/ctxtool"
+	"github.com/elastic/go-concert/timed"
 )
 
 const (
 	pluginName   = "o365audit"
 	fieldsPrefix = pluginName
-
-	// How long to retry when a fatal error is encountered in the input.
-	failureRetryInterval = time.Minute * 5
 )
 
 type o365input struct {
@@ -126,8 +124,8 @@ func (inp *o365input) Run(
 			}
 			publisher.Publish(event, nil)
 			ctx.Logger.Errorf("Input failed: %v", err)
-			ctx.Logger.Infof("Restarting in %v", failureRetryInterval)
-			time.Sleep(failureRetryInterval)
+			ctx.Logger.Infof("Restarting in %v", inp.config.API.ErrorRetryInterval)
+			timed.Wait(ctx.Cancelation, inp.config.API.ErrorRetryInterval)
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry-pick of PR #21647 to 7.10 branch. Original message: 

## What does this PR do?

- Updates the `o365input` to perform a cancellable wait when an error causes it to restart.
- Also uses the configured `error_retry_interval` for the delay between restarts instead of a hardcoded `5m`.

## Why is it important?

Using `time.Sleep` prevents Filebeat to terminate until the timeout is elapsed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Relates #21258

