### PR TITLE
[Ingest Manager] Syncing unpacked files

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/install/tar/tar_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/tar/tar_installer.go
@@ -102,6 +102,12 @@ func unpack(r io.Reader, dir string) error {
 			if closeErr := wf.Close(); closeErr != nil && err == nil {
 				err = closeErr
 			}
+
+			// sometimes we try executing binary too fast and run into text file busy after unpacking
+			// syncing prevents this
+			if syncErr := wf.Sync(); syncErr != nil && err == nil {
+				err = syncErr
+			}
 			if err != nil {
 				return fmt.Errorf("TarInstaller: error writing to %s: %v", abs, err)
 			}


### PR DESCRIPTION
## What does this PR do?

This PR adds a sync call after files are unpacked from archives to disk. This seems to help with issues we've seen in tests where agent reported `text file busy` when executing beat. On second try it was able to execute binary. 

## Why is it important?

Gets rid of errors when executing beats and makes spinning beats up faster avoiding unnecessary retries.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
