### PR TITLE
Cherry-pick #21628 to 7.x: [Elastic Agent] Fix issue where inputs without processors defined would panic

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -14,6 +14,7 @@
 - Thread safe sorted set {pull}21290[21290]
 - Copy Action store on upgrade {pull}21298[21298]
 - Include inputs in action store actions {pull}21298[21298]
+- Fix issue where inputs without processors defined would panic {pull}21628[21628]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/emitter.go
+++ b/x-pack/elastic-agent/pkg/agent/application/emitter.go
@@ -219,17 +219,20 @@ func promoteProcessors(dict *transpiler.Dict) *transpiler.Dict {
 	if p == nil {
 		return dict
 	}
+	var currentList *transpiler.List
 	current, ok := dict.Find("processors")
-	currentList, isList := current.Value().(*transpiler.List)
-	if !isList {
-		return dict
+	if ok {
+		currentList, ok = current.Value().(*transpiler.List)
+		if !ok {
+			return dict
+		}
 	}
 	ast, _ := transpiler.NewAST(map[string]interface{}{
 		"processors": p,
 	})
 	procs, _ := transpiler.Lookup(ast, "processors")
 	nodes := nodesFromList(procs.Value().(*transpiler.List))
-	if ok {
+	if ok && currentList != nil {
 		nodes = append(nodes, nodesFromList(currentList)...)
 	}
 	dictNodes := dict.Value().([]transpiler.Node)

--- a/x-pack/elastic-agent/pkg/agent/application/emitter_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/emitter_test.go
@@ -479,6 +479,181 @@ func TestRenderInputs(t *testing.T) {
 					}),
 			},
 		},
+		"inputs without processors and vars with processors": {
+			input: transpiler.NewKey("inputs", transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/${var1.name}.log"),
+							})),
+						}),
+					})),
+				}),
+			})),
+			expected: transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/value1.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+								transpiler.NewKey("fields", transpiler.NewDict([]transpiler.Node{
+									transpiler.NewKey("custom", transpiler.NewStrVal("value1")),
+								})),
+								transpiler.NewKey("to", transpiler.NewStrVal("dynamic")),
+							})),
+						}),
+					})),
+				}),
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/value2.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+								transpiler.NewKey("fields", transpiler.NewDict([]transpiler.Node{
+									transpiler.NewKey("custom", transpiler.NewStrVal("value2")),
+								})),
+								transpiler.NewKey("to", transpiler.NewStrVal("dynamic")),
+							})),
+						}),
+					})),
+				}),
+			}),
+			varsArray: []*transpiler.Vars{
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value1",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value2",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value2",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+			},
+		},
+		"processors incorrectly a map": {
+			input: transpiler.NewKey("inputs", transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/${var1.name}.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewDict([]transpiler.Node{
+						transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("invalid", transpiler.NewStrVal("value")),
+						})),
+					})),
+				}),
+			})),
+			expected: transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/value1.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewDict([]transpiler.Node{
+						transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("invalid", transpiler.NewStrVal("value")),
+						})),
+					})),
+				}),
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/value2.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewDict([]transpiler.Node{
+						transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("invalid", transpiler.NewStrVal("value")),
+						})),
+					})),
+				}),
+			}),
+			varsArray: []*transpiler.Vars{
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value1",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value2",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value2",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+			},
+		},
 	}
 
 	for name, test := range testcases {


### PR DESCRIPTION
Cherry-pick of PR #21628 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where inputs without processors defined would panic when promoting processors from a dynamic provider.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So using a dynamic provider on an input without any processors doesn't panic.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #21581
