### PR TITLE
Add missing `scanner` configuration of filestream

### DIFF
--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -34,7 +34,7 @@ type config struct {
 
 	Paths          []string                `config:"paths"`
 	Close          closerConfig            `config:"close"`
-	FileWatcher    *common.ConfigNamespace `config:"file_watcher"`
+	FileWatcher    *common.ConfigNamespace `config:"prospector"`
 	FileIdentity   *common.ConfigNamespace `config:"file_identity"`
 	CleanInactive  time.Duration           `config:"clean_inactive" validate:"min=0"`
 	CleanRemoved   bool                    `config:"clean_removed"`

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -57,9 +57,9 @@ type fileScanner struct {
 
 type fileWatcherConfig struct {
 	// Interval is the time between two scans.
-	Interval time.Duration
+	Interval time.Duration `config:"check_interval"`
 	// Scanner is the configuration of the scanner.
-	Scanner fileScannerConfig
+	Scanner fileScannerConfig `config:",inline"`
 }
 
 // fileWatcher gets the list of files from a FSWatcher and creates events by
@@ -212,10 +212,9 @@ func (w *fileWatcher) Event() loginp.FSEvent {
 }
 
 type fileScannerConfig struct {
-	Paths         []string
-	ExcludedFiles []match.Matcher
-	Symlinks      bool
-	RecursiveGlob bool
+	ExcludedFiles []match.Matcher `config:"exclude_files"`
+	Symlinks      bool            `config:"symlinks"`
+	RecursiveGlob bool            `config:"recursive_glob"`
 }
 
 func defaultFileScannerConfig() fileScannerConfig {


### PR DESCRIPTION
## What does this PR do?

This PR adds the missing configuration annotations to the `scanner` config. 

## Why is it important?

Now the following configuration can be accepted:

```yaml
prospector.scanner.check_interval: 10s
prospector.scanner.exclude_files: ["something"]
```

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~