### PR TITLE
[DOC] Add firewall as possible troubleshooting issue

### DIFF
--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -55,6 +55,22 @@ plugins, see {logstash-ref}/working-with-plugins.html[Working with plugins].
 endif::[]
 
 ifndef::no-output-logstash[]
+[[disconnections-problem]]
+=== {beatname_uc} reports connections being reset by {ls}
+
+If you see errors such as:
+[source,shell]
+----------------------------------------------------------------------
+Failed to publish events caused by: write tcp ... write: connection reset by peer
+----------------------------------------------------------------------
+
+It is possible a firewall might be interfering with the connection between {beatname_uc} and {ls} (it is a persistent TCP connection).
+
+You can solve the problem making sure the firewall is not closing connections between {beatname_uc} and {ls} or configuring the {ls}
+output adding a `ttl` value lower than the maximum allowed time by the firewall. 
+endif::[]
+
+ifndef::no-output-logstash[]
 [[metadata-missing]]
 === @metadata is missing in {ls}
 

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -67,9 +67,12 @@ Failed to publish events caused by: write tcp ... write: connection reset by pee
 ----------------------------------------------------------------------
 
 
-You can solve the problem making sure the firewall is not closing connections between {beatname_uc} and {ls} or configuring the {ls}
-output adding a `ttl` value lower than the maximum allowed time by the firewall and `pipelining` set to 0 (as pipelining cannot be enabled
-when `ttl` is used).
+To solve the problem:
+
+* make sure the firewall is not closing connections between {beatname_uc} and {ls}, or
+* set the `ttl` value in the <<logstash-output,{ls} output>> to a value that's
+lower than the maximum time allowed by the firewall, and set `pipelining` to 0
+(pipelining cannot be enabled when `ttl` is used).
 endif::[]
 
 ifndef::no-output-logstash[]

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -55,8 +55,8 @@ plugins, see {logstash-ref}/working-with-plugins.html[Working with plugins].
 endif::[]
 
 ifndef::no-output-logstash[]
-[[disconnections-problem]]
-=== {beatname_uc} reports connections being reset by {ls}
+[[publishing-ls-fails-connection-reset-by-peer]]
+=== Publishing to {ls} fails with "connection reset by peer" message
 
 {beatname_uc} requires a persistent TCP connection to {ls}. If a firewall interferes
 with the connection, you might see errors like this: 

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -58,7 +58,9 @@ ifndef::no-output-logstash[]
 [[disconnections-problem]]
 === {beatname_uc} reports connections being reset by {ls}
 
-If you see errors such as:
+{beatname_uc} requires a persistent TCP connection to {ls}. If a firewall interferes
+with the connection, you might see errors like this: 
+
 [source,shell]
 ----------------------------------------------------------------------
 Failed to publish events caused by: write tcp ... write: connection reset by peer

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -66,7 +66,6 @@ with the connection, you might see errors like this:
 Failed to publish events caused by: write tcp ... write: connection reset by peer
 ----------------------------------------------------------------------
 
-It is possible a firewall might be interfering with the connection between {beatname_uc} and {ls} (it is a persistent TCP connection).
 
 You can solve the problem making sure the firewall is not closing connections between {beatname_uc} and {ls} or configuring the {ls}
 output adding a `ttl` value lower than the maximum allowed time by the firewall and `pipelining` set to 0 (as pipelining cannot be enabled

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -67,7 +67,8 @@ Failed to publish events caused by: write tcp ... write: connection reset by pee
 It is possible a firewall might be interfering with the connection between {beatname_uc} and {ls} (it is a persistent TCP connection).
 
 You can solve the problem making sure the firewall is not closing connections between {beatname_uc} and {ls} or configuring the {ls}
-output adding a `ttl` value lower than the maximum allowed time by the firewall. 
+output adding a `ttl` value lower than the maximum allowed time by the firewall and `pipelining` set to 0 (as pipelining cannot be enabled
+when `ttl` is used).
 endif::[]
 
 ifndef::no-output-logstash[]


### PR DESCRIPTION
In case a firewall closes long persistent connections between Beats & Logstash, errors such as `write tcp ... write: connection reset by peer` will be reported by a given Beat.
This documentation page should be useful to identify this kind of issues.

## What does this PR do?

Add documentation for troubleshooting Beats to LS connections

## Reviewer Checklist

- [ ] Please review the asciidoc format (I would like to link the Logstash `ttl` setting)
- [ ] Please backport this change to all Beats & versions