### PR TITLE
Skip flaky test with oauth2 config in httpjson input

### DIFF
--- a/x-pack/filebeat/input/httpjson/config_test.go
+++ b/x-pack/filebeat/input/httpjson/config_test.go
@@ -362,6 +362,7 @@ func TestConfigOauth2Validation(t *testing.T) {
 				"url": "localhost",
 			},
 		},
+		/* Flaky test: https://github.com/elastic/beats/issues/21748
 		{
 			name:        "date_cursor.date_format will fail if invalid",
 			expectedErr: "invalid configuration: date_format is not a valid date layout accessing 'date_cursor'",
@@ -370,6 +371,7 @@ func TestConfigOauth2Validation(t *testing.T) {
 				"url":         "localhost",
 			},
 		},
+		*/
 		{
 			name: "date_cursor must work with a valid date_format",
 			input: map[string]interface{}{


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/21748