### PR TITLE
Change cloud.provider from googlecloud to gcp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ECS compliance of user.id field in system/users  metricset {pull}19019[19019]
 - Rename googlecloud stackdriver metricset to metrics. {pull}19718[19718]
 - Remove "invalid zero" metrics on Windows and Darwin, don't report linux-only memory and diskio metrics when running under agent. {pull}21457[21457]
+- Change cloud.provider from googlecloud to gcp. {pull}21775[21775]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/googlecloud/metrics/_meta/data.json
+++ b/x-pack/metricbeat/module/googlecloud/metrics/_meta/data.json
@@ -2,15 +2,20 @@
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "cloud": {
         "account": {
-            "id": "elastic-apm"
+            "id": "elastic-observability",
+            "name": "elastic-observability"
         },
         "instance": {
-            "id": "8867356942891823986",
-            "name": "apm-ui-dev"
+            "id": "2029454349697438698",
+            "name": "nchaulet-loadtest-elasticsearch"
         },
-        "provider": "googlecloud"
+        "machine": {
+            "type": "n1-standard-8"
+        },
+        "provider": "gcp"
     },
-    "cloud.availability_zone": "europe-west4-a",
+    "cloud.availability_zone": "us-central1-a",
+    "cloud.region": "us-central1",
     "event": {
         "dataset": "googlecloud.metrics",
         "duration": 115000,
@@ -21,10 +26,14 @@
         "metrics": {
             "instance": {
                 "uptime": {
-                    "value": 60
+                    "value": 60.00000000093132
                 }
             }
         }
+    },
+    "host": {
+        "id": "2029454349697438698",
+        "name": "nchaulet-loadtest-elasticsearch"
     },
     "metricset": {
         "name": "metrics",

--- a/x-pack/metricbeat/module/googlecloud/timeseries_metadata_collector.go
+++ b/x-pack/metricbeat/module/googlecloud/timeseries_metadata_collector.go
@@ -58,7 +58,7 @@ func (s *StackdriverTimeSeriesMetadataCollector) Metadata(ctx context.Context, i
 				ECSCloudAccountID:   accountID,
 				ECSCloudAccountName: accountID,
 			},
-			ECSCloudProvider: "googlecloud",
+			ECSCloudProvider: "gcp",
 		},
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to change `cloud.provider` value from `googlecloud` to `gcp` to match the value from `add_cloud_metadata` processor.

Also in [ECS documentation](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html), `gcp` is used as an example under `cloud.provider` field.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
