### PR TITLE
Cherry-pick #21755 to 7.10: Increase recommended memory when deploying in Cloud foundry

### DIFF
--- a/deploy/cloudfoundry/filebeat/manifest.yml
+++ b/deploy/cloudfoundry/filebeat/manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: filebeat
-  memory: 256M
+  memory: 512M
   instances: 1
   buildpacks:
   - binary_buildpack

--- a/deploy/cloudfoundry/metricbeat/manifest.yml
+++ b/deploy/cloudfoundry/metricbeat/manifest.yml
@@ -1,6 +1,6 @@
 applications:
   - name: metricbeat
-    memory: 256M
+    memory: 512M
     instances: 1
     buildpacks:
     - binary_buildpack

--- a/filebeat/docs/running-on-cloudfoundry.asciidoc
+++ b/filebeat/docs/running-on-cloudfoundry.asciidoc
@@ -66,7 +66,7 @@ To check the status, run:
 $ cf apps
 
 name       requested state   instances   memory   disk   urls
-filebeat   started           1/1         256M     1G
+filebeat   started           1/1         512M     1G
 ------------------------------------------------
 
 Log events should start flowing to Elasticsearch. The events are annotated with

--- a/metricbeat/docs/running-on-cloudfoundry.asciidoc
+++ b/metricbeat/docs/running-on-cloudfoundry.asciidoc
@@ -66,7 +66,7 @@ To check the status, run:
 $ cf apps
 
 name         requested state   instances   memory   disk   urls
-metricbeat   started           1/1         256M     1G
+metricbeat   started           1/1         512M     1G
 ------------------------------------------------
 
 Metrics should start flowing to Elasticsearch. The events are annotated with


### PR DESCRIPTION
Cherry-pick of PR #21755 to 7.10 branch. Original message: 

Increase recommended memory when deploying in Cloud Foundry from 256M to 512M.