### PR TITLE
Cherry-pick to 7.x: [CI] Support skip-ci label (#21377)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,13 +104,17 @@ pipeline {
           script {
             def mapParallelTasks = [:]
             def content = readYaml(file: 'Jenkinsfile.yml')
-            content['projects'].each { projectName ->
-              generateStages(project: projectName, changeset: content['changeset']).each { k,v ->
-                mapParallelTasks["${k}"] = v
+            if (content?.disabled?.when?.labels && beatsWhen(project: 'top-level', content: content?.disabled?.when)) {
+              error 'Pull Request has been configured to be disabled when there is a skip-ci label match'
+            } else {
+              content['projects'].each { projectName ->
+                generateStages(project: projectName, changeset: content['changeset']).each { k,v ->
+                  mapParallelTasks["${k}"] = v
+                }
               }
+              notifyBuildReason()
+              parallel(mapParallelTasks)
             }
-            notifyBuildReason()
-            parallel(mapParallelTasks)
           }
         }
       }

--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -40,10 +40,9 @@ changeset:
         - "^testing/.*"
         - "^x-pack/libbeat/.*"
 
-## Proposal
-## TBC: This will allow to configure what to do based on the PR configuration
 disabled:
     when:
-        labels:      ## Skip the GitHub Pull Request builds if there is a GitHub label match
-            - "skip-ci"
+        labels:      ## Skip the GitHub Pull Request builds if any of the given GitHub labels match with the assigned labels in the PR.
+            - skip-ci
+        ## TODO: This will allow to configure what to do based on the PR configuration
         draft: true  ## Skip the GitHub Pull Request builds with Draft PRs.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Support skip-ci label (#21377)

## Tests

![image](https://user-images.githubusercontent.com/2871786/95978786-8fd17080-0e12-11eb-9fd7-58e8f8561861.png)
