### PR TITLE
Cherry-pick #21754 to 7.x: Disable writes sync in persistent cache

### DIFF
--- a/x-pack/libbeat/persistentcache/store.go
+++ b/x-pack/libbeat/persistentcache/store.go
@@ -36,10 +36,7 @@ func newStore(logger *logp.Logger, dir, name string) (*Store, error) {
 	// Opinionated options for the use of badger as a store for metadata caches in Beats.
 	options := badger.DefaultOptions(dbPath)
 	options.Logger = badgerLogger{logger.Named("badger")}
-	// TODO: Disabling sync writes gives better performance, and data loss wouldn't
-	// be a problem for caches. But we are not properly closing processors yet, so let
-	// sync on writes by now.
-	// options.SyncWrites = false
+	options.SyncWrites = false
 
 	db, err := badger.Open(options)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #21754 to 7.x branch. Original message: 

## What does this PR do?

Disable sync on writes in badger-based persistent caches.

With default configuration, every write is synced to disk. For the
persistent cache, Beats not need to guarantee that everything is on disk,
as the data can be recovered from the source endpoints, but the database
was not being properly closed, so there could happen that most of the
recent data was lost if the beat is stopped.
Now, the processors can close their resources, so the database is
properly closed in an normal shutdown, so we can go on without syncs on
writes, what gives a much better performance.

## Why is it important?

Reduce overhead caused by persistent caches and increase their performance.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (should be covered by existing tests)
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ (feature not released yet, and not use-facing impact).

## Related issues

- Persistent cache added in #20775.
- Processors can close their resources since #16349. 