### PR TITLE
Cherry-pick to 7.x: disable TestReceiveEventsAndMetadata/TestSocketCleanup/TestReceiveNewEventsConcurrently in Windows (#21750)

### DIFF
--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -33,4 +33,14 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-            #- "windows-2016"  https://github.com/elastic/beats/issues/19641
+    windows-2016:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test filebeat for windows-2016"
+            labels:
+                - "windows-2016"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -60,6 +60,10 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 }
 
 func TestReceiveEventsAndMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test is only supported on non-windows. See https://github.com/elastic/beats/issues/19641")
+		return
+	}
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
 	extraLargeMessages := generateMessages(2, 65*1024)
@@ -255,6 +259,10 @@ func TestSocketOwnershipAndMode(t *testing.T) {
 }
 
 func TestSocketCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test is only supported on non-windows. See https://github.com/elastic/beats/issues/21757")
+		return
+	}
 	path := filepath.Join(os.TempDir(), "test.sock")
 	mockStaleSocket, err := net.Listen("unix", path)
 	require.NoError(t, err)
@@ -298,6 +306,10 @@ func TestSocketCleanupRefusal(t *testing.T) {
 }
 
 func TestReceiveNewEventsConcurrently(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test is only supported on non-windows. See https://github.com/elastic/beats/issues/21757")
+		return
+	}
 	workers := 4
 	eventsCount := 100
 	path := filepath.Join(os.TempDir(), "test.sock")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - disable TestReceiveEventsAndMetadata/TestSocketCleanup/TestReceiveNewEventsConcurrently in Windows (#21750)