### PR TITLE
Update users.asciidoc

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -71,6 +71,10 @@ endif::has_ml_jobs[]
 |`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
 
+|Index
+|`write` on +{beat_default_index_prefix}-*+ indices
+|Write {beatname_uc} indices in order to index, update, and delete documents
+
 ifdef::has_ml_jobs[]
 |Index
 |`read` on +{beat_default_index_prefix}-*+ indices
@@ -96,6 +100,11 @@ need to set up {beatname_uc}:
 
 |`ingest_admin`
 |Set up index templates and, if available, ingest pipelines
+
+ifdef::has_ml_jobs[]
+|`machine_learning_admin`
+|Provides full use of the machine learning APIs and grants read/write access to all machine learning indices
+endif::has_ml_jobs[]
 
 ifdef::apm-server[]
 |`ingest_admin`

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -103,7 +103,7 @@ need to set up {beatname_uc}:
 
 ifdef::has_ml_jobs[]
 |`machine_learning_admin`
-|Provides full use of the machine learning APIs and grants read/write access to all machine learning indices
+|Provide full use of the machine learning APIs and grant read/write access to all machine learning indices
 endif::has_ml_jobs[]
 
 ifdef::apm-server[]


### PR DESCRIPTION
## What does this PR do?

I have discovered a few issues with the instructions to set up a [Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/privileges-to-setup-beats.html), [Metricbeat](https://www.elastic.co/guide/en/beats/metricbeat/current/privileges-to-setup-beats.html), and [Auditbeat](https://www.elastic.co/guide/en/beats/auditbeat/current/privileges-to-setup-beats.html) user for installation. 

None of these documented instructions support their intended purpose, as-is. Users will not be able to accomplish the intended goal by using them.

With Filebeat, the user needs an additional role, and with Filebeat, Metricbeat, and Auditbeat, their respective indices need an additional `write` permission. 

I have not validated if `write` permissions on the index is needed for every beat, but it is for the three tested, so I am assuming this elevated permission holds true for all Beats. 

More details are in the: [Filebeat user settings don't allow install elastic/beats#21697 GitHub ticket for reference](https://github.com/elastic/beats/issues/21697) GitHub ticket worked on with a couple engineers.

From several conversations with two of the obs engineers, we believe this is a simple doc change that is needed, unless someone from security would prefer to re-engineer the Beats.

## Why is it important?

Without these changes to the instructions, then users will not be able to follow them to accomplish their set goal. This most likely will result in support cases, or at a minimum, frustrated users. 

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

I have validated the changes work for creating the role/user for Filebeat, Metricbeat, and Auditbeat. The changes are adding additional level of permissions - `write` to the respective index, and for those Beats which have the **ml_job** flag, the `machine_learning_admin` role to the user. 


## How to test this PR locally
Follow the process or any Beat, where you click through the [Grant privileges and roles for setup](https://www.elastic.co/guide/en/beats/filebeat/current/privileges-to-setup-beats.html#privileges-to-setup-beats) steps. You can reproduce the user failures when running the `beat setup` command, and then the role-index error when running the beat. See screenshots on errors below.


## Related issues

- Closes #[21697](https://github.com/elastic/beats/issues/21697)

## Use cases

Any user should follow the best practice and not use the `elastic` superuser with the Beats configuration. A unique user should be provided. Without proper instructions, users are not able to follow a best practice. 

## Screenshots

![add-write-permission](https://user-images.githubusercontent.com/66136604/96001878-7fb39400-0e06-11eb-8ed5-ab14784443a8.png)

![beats-installer-user](https://user-images.githubusercontent.com/66136604/96005469-77f5ee80-0e0a-11eb-9788-e59573387999.png)

## Logs

Error seen in Beats with **ml_job** before adding the `machine_learning_admin` role to the user:
`Exiting: 1 error: Error setting up ML for apache_ecs: cannot set up ML with prefix: filebeat-apache_ecs-access-, response: {"statusCode":404,"error":"Not Found","message":"Not Found"}`

Error seen after running the Beat if `write` is not added as permission to index:
`"security_exception","reason":"action [indices:data/write/bulk] is unauthorized for user`
