### PR TITLE
Cherry-pick #21758 to 7.x: Fix non-windows fields on system/filesystem

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -415,6 +415,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix remote_write flaky test. {pull}21173[21173]
 - Visualization title fixes in aws, azure and googlecloud compute dashboards. {pull}21098[21098]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
+- Report the correct windows events for system/filesystem {pull}21758[21758]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -151,14 +151,14 @@ func GetFilesystemEvent(fsStat *FSStat) common.MapStr {
 		"mount_point": fsStat.Mount,
 		"total":       fsStat.Total,
 		"available":   fsStat.Avail,
-		"files":       fsStat.Files,
+		"free":        fsStat.Free,
 		"used": common.MapStr{
 			"pct":   fsStat.UsedPercent,
 			"bytes": fsStat.Used,
 		},
 	}
 	if runtime.GOOS != "windows" {
-		evt.Put("free", fsStat.Free)
+		evt.Put("files", fsStat.Files)
 		evt.Put("free_files", fsStat.FreeFiles)
 	}
 	return evt

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -47,7 +47,7 @@ SYSTEM_FILESYSTEM_FIELDS = ["available", "device_name", "type", "files", "free",
                             "free_files", "mount_point", "total", "used.bytes",
                             "used.pct"]
 
-SYSTEM_FILESYSTEM_FIELDS_WINDOWS = ["available", "device_name", "type", "files",
+SYSTEM_FILESYSTEM_FIELDS_WINDOWS = ["available", "device_name", "type", "free",
                                     "mount_point", "total", "used.bytes",
                                     "used.pct"]
 


### PR DESCRIPTION
Cherry-pick of PR #21758 to 7.x branch. Original message: 



## What does this PR do?

This swaps out the `files` and `free` fields that are reported under under any non-windows OSes. `free` should be reported on windows, and `files` _should not be_ reported on windows.

## Why is it important?

We need to report the correct fields in Windows.

## Checklist

- [X] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Pull down PR, build metricbeat on Windows
- On Windows, make sure `filesystem.free` is there, and `filesystem.files` isn't.
