### PR TITLE
Cherry-pick to 7.x: [CI] Support Windows-2012 in pipeline 2.0 (#21338)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,9 +231,10 @@ def withBeatsEnv(Map args = [:], Closure body) {
     artifacts = '**/build/TEST*.out'
   } else {
     def chocoPath = 'C:\\ProgramData\\chocolatey\\bin'
+    def mingw64Path = 'C:\\tools\\mingw64\\bin'
     def chocoPython3Path = 'C:\\Python38;C:\\Python38\\Scripts'
     goRoot = "${env.USERPROFILE}\\.gvm\\versions\\go${GO_VERSION}.windows.amd64"
-    path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};${env.PATH}"
+    path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};${env.PATH};${mingw64Path}"
     magefile = "${env.WORKSPACE}\\.magefile"
     testResults = "**\\build\\TEST*.xml"
     artifacts = "**\\build\\TEST*.out"

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -45,3 +45,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -43,3 +43,15 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test heartbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -51,3 +51,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test metricbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -43,3 +43,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test packetbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -30,3 +30,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -44,3 +44,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -43,3 +43,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/elastic-agent for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -44,3 +44,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/filebeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -43,3 +43,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/functionbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -46,3 +46,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/metricbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -29,3 +29,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,3 +29,14 @@ stages:
                 - "windows-2016"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-2012:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2012-r2"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-2012"
+            labels:
+                - "windows-2012"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Support Windows-2012 in pipeline 2.0 (#21338)