### PR TITLE
Cherry-pick #21772 to 7.10: [Elastic Agent] Don't perform install until after enroll

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -35,4 +35,6 @@
 - Add `elastic.agent.id` and `elastic.agent.version` to published events from filebeat and metricbeat {pull}21543[21543]
 - Add `upgrade` subcommand to perform upgrade of installed Elastic Agent {pull}21425[21425]
 - Update `fleet.yml` and Kibana hosts when a policy change updates the Kibana hosts {pull}21599[21599]
+- Update `install` command to perform enroll before starting Elastic Agent {pull}21772[21772]
+- Update `fleet.kibana.path` from a POLICY_CHANGE {pull}21804[21804]
 - Removed `install-service.ps1` and `uninstall-service.ps1` from Windows .zip packaging {pull}21694[21694]

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -36,7 +36,7 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 		Args:  cobra.ExactArgs(2),
 		Run: func(c *cobra.Command, args []string) {
 			if err := enroll(streams, c, flags, args); err != nil {
-				fmt.Fprintf(streams.Err, "%v\n", err)
+				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
 		},
@@ -193,7 +193,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 
 	// skip restarting
 	noRestart, _ := cmd.Flags().GetBool("no-restart")
-	if noRestart {
+	if noRestart || fromInstall {
 		return nil
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
@@ -28,7 +28,7 @@ Unless -f is used this command will ask confirmation before performing removal.
 `,
 		Run: func(c *cobra.Command, args []string) {
 			if err := uninstallCmd(streams, c, flags, args); err != nil {
-				fmt.Fprintf(streams.Err, "%v\n", err)
+				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
 		},

--- a/x-pack/elastic-agent/pkg/agent/install/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/install/uninstall.go
@@ -32,15 +32,7 @@ func Uninstall() error {
 		}
 		status = service.StatusStopped
 	}
-	if status == service.StatusStopped {
-		err := svc.Uninstall()
-		if err != nil {
-			return errors.New(
-				err,
-				fmt.Sprintf("failed to uninstall service (%s)", ServiceName),
-				errors.M("service", ServiceName))
-		}
-	}
+	_ = svc.Uninstall()
 
 	// remove, if present on platform
 	if ShellWrapperPath != "" {


### PR DESCRIPTION
Cherry-pick of PR #21772 to 7.10 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This switches the installation to be based on successful enrollment. First agent is installed in the correct location (but is not started), then enrollment is performed. In the case that enrollment fails the installation directory is removed, if enrollment is successful then it starts the persistent service.

This also adds a check to ensure that an Elastic Agent is not already running from the extracted Elastic Agent directory. This is because an already running Elastic Agent in that directory will cause installation to fail because on Windows some of the files will not be able to be opened to be copied to there new location.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It removes the need to restart an already running Elastic Agent that was just started. It removes the requirement to start Elastic Agent in standalone mode first then switching it to Fleet mode. It helps ensure that installation is only successful when enrollment is successful.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #21627
- Closes #21744