### PR TITLE
Cherry-pick to 7.x: Update endpoint-related terminology in Elastic Agent docs (#21458)

### DIFF
--- a/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc
@@ -94,7 +94,7 @@ rm /Library/Launchdaemons/co.elastic.agent.plist
 . <<unenroll-elastic-agent,Unenroll the agent from {fleet}>>.
 +
 Unenrolling the agent should stop {agent} and any other programs started by
-the agent, such as Elastic {endpoint-sec} and data shippers.
+the agent, such as {elastic-sec} and data shippers.
 
 . If necessary, manually kill the `elastic-agent` process and any other
 processes started by the agent. 

--- a/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/run.asciidoc
@@ -92,7 +92,7 @@ cd 'C:\Program Files\Elastic-Agent'
 .\install-service-elastic-agent.ps1 <1> <2>
 ----
 <1> You must run {agent} under the SYSTEM account if you plan
-to use the {elastic-endpoint} integration.
+to use the {elastic-endpoint-integration} integration.
 <2> If script execution is disabled on your system, set the execution policy for
 the current session to allow the script to run. For example:
 `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update endpoint-related terminology in Elastic Agent docs (#21458)