### PR TITLE
Disable TestFetch in s3_request_integration_test.go

### DIFF
--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
@@ -33,7 +33,6 @@ func TestFetch(t *testing.T) {
 		mtest.CheckEventField("aws.dimensions.StorageType", "string", event, t)
 		mtest.CheckEventField("aws.s3.metrics.BucketSizeBytes.avg", "float", event, t)
 		mtest.CheckEventField("aws.s3.metrics.NumberOfObjects.avg", "float", event, t)
-		break
 	}
 }
 

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/21826")
 	config := mtest.GetConfigForTest(t, "s3_request", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)


### PR DESCRIPTION
This PR is to disable `TestFetch` in `s3_request_integration_test.go` since it's failing in CI.

Relates: https://github.com/elastic/beats/pull/21828