### PR TITLE
Cherry-pick to 7.10: [BUILD][CI] fetch dependencies with retry (#21614)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,6 +269,13 @@ def withBeatsEnv(Map args = [:], Closure body) {
           fi''')
       }
       try {
+        // Add more stability when dependencies are not accessible temporarily
+        // See https://github.com/elastic/beats/issues/21609
+        // retry/try/catch approach reports errors, let's avoid it to keep the
+        // notifications cleaner.
+        if (cmd(label: 'Download modules to local cache', script: 'go mod download', returnStatus: true) > 0) {
+          cmd(label: 'Download modules to local cache - retry', script: 'go mod download', returnStatus: true)
+        }
         body()
       } finally {
         if (archive) {


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [BUILD][CI] fetch dependencies with retry (#21614)