### PR TITLE
Refactor docker watcher to fix flaky test and other small issues

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -186,6 +186,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `libbeat.output.write.bytes` and `libbeat.output.read.bytes` metrics of the Elasticsearch output. {issue}20752[20752] {pull}21197[21197]
 - The `o365input` and `o365` module now recover from an authentication problem or other fatal errors, instead of terminating. {pull}21259[21258]
 - Orderly close processors when processing pipelines are not needed anymore to release their resources. {pull}16349[16349]
+- Fix memory leak and events duplication in docker autodiscover and add_docker_metadata. {pull}21851[21851]
 
 *Auditbeat*
 

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -246,7 +246,7 @@ func (w *watcher) watch() {
 	lastValidTimestamp := time.Now()
 
 	watch := func() bool {
-		lastWatchReceivedEventTime := time.Now()
+		lastReceivedEventTime := time.Now()
 
 		w.log.Debugf("Fetching events since %s", lastValidTimestamp)
 
@@ -264,7 +264,7 @@ func (w *watcher) watch() {
 			case event := <-events:
 				w.log.Debugf("Got a new docker event: %v", event)
 				lastValidTimestamp = time.Unix(event.Time, event.TimeNano)
-				lastWatchReceivedEventTime = time.Now()
+				lastReceivedEventTime = time.Now()
 
 				switch event.Action {
 				case "start", "update":
@@ -287,7 +287,7 @@ func (w *watcher) watch() {
 				}
 				return false
 			case <-tickChan.C:
-				if time.Since(lastWatchReceivedEventTime) > dockerEventsWatchPityTimerTimeout {
+				if time.Since(lastReceivedEventTime) > dockerEventsWatchPityTimerTimeout {
 					w.log.Infof("No events received within %s, restarting watch call", dockerEventsWatchPityTimerTimeout)
 					return false
 				}
@@ -303,6 +303,7 @@ func (w *watcher) watch() {
 		if done {
 			return
 		}
+		// Wait before trying to reconnect
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -86,6 +86,11 @@ type watcher struct {
 	shortID        bool // whether to store short ID in "containers" too
 }
 
+// clock is an interface used to provide mocked time on testing
+type clock interface {
+	Now() time.Time
+}
+
 // Container info retrieved by the watcher
 type Container struct {
 	ID          string
@@ -461,10 +466,6 @@ func (w *watcher) ListenStart() bus.Listener {
 // ListenStop returns a bus listener to receive container stopped events, with a `container` key holding it
 func (w *watcher) ListenStop() bus.Listener {
 	return w.bus.Subscribe("stop")
-}
-
-type clock interface {
-	Now() time.Time
 }
 
 type systemClock struct{}

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -91,6 +91,12 @@ type clock interface {
 	Now() time.Time
 }
 
+// systemClock implements the clock interface using the system clock via the time package
+type systemClock struct{}
+
+// Now returns the current time
+func (*systemClock) Now() time.Time { return time.Now() }
+
 // Container info retrieved by the watcher
 type Container struct {
 	ID          string
@@ -467,7 +473,3 @@ func (w *watcher) ListenStart() bus.Listener {
 func (w *watcher) ListenStop() bus.Listener {
 	return w.bus.Subscribe("stop")
 }
-
-type systemClock struct{}
-
-func (*systemClock) Now() time.Time { return time.Now() }

--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -358,8 +358,6 @@ func TestWatcherUpdateEventShortID(t *testing.T) {
 }
 
 func TestWatcherDie(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/7906")
-
 	watcher := runWatcher(t, false,
 		[][]types.Container{
 			[]types.Container{
@@ -404,8 +402,6 @@ func TestWatcherDie(t *testing.T) {
 }
 
 func TestWatcherDieShortID(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/7906")
-
 	watcher := runWatcherShortID(t, false,
 		[][]types.Container{
 			[]types.Container{

--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -21,6 +21,7 @@ package docker
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,7 +38,7 @@ type MockClient struct {
 	containers [][]types.Container
 	// event list to send on Events call
 	events []interface{}
-
+	// done channel is closed when the client has sent all events
 	done chan interface{}
 }
 
@@ -71,7 +72,7 @@ func (m *MockClient) ContainerInspect(ctx context.Context, container string) (ty
 }
 
 func TestWatcherInitialization(t *testing.T) {
-	watcher := runWatcher(t, true,
+	watcher := runAndWait(testWatcher(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -90,7 +91,8 @@ func TestWatcherInitialization(t *testing.T) {
 				},
 			},
 		},
-		nil)
+		nil,
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
@@ -109,7 +111,7 @@ func TestWatcherInitialization(t *testing.T) {
 }
 
 func TestWatcherInitializationShortID(t *testing.T) {
-	watcher := runWatcherShortID(t, true,
+	watcher := runAndWait(testWatcherShortID(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -128,7 +130,9 @@ func TestWatcherInitializationShortID(t *testing.T) {
 				},
 			},
 		},
-		nil, true)
+		nil,
+		true,
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"1234567890123": &Container{
@@ -154,7 +158,7 @@ func TestWatcherInitializationShortID(t *testing.T) {
 }
 
 func TestWatcherAddEvents(t *testing.T) {
-	watcher := runWatcher(t, true,
+	watcher := runAndWait(testWatcher(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -188,7 +192,7 @@ func TestWatcherAddEvents(t *testing.T) {
 				},
 			},
 		},
-	)
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
@@ -207,7 +211,7 @@ func TestWatcherAddEvents(t *testing.T) {
 }
 
 func TestWatcherAddEventsShortID(t *testing.T) {
-	watcher := runWatcherShortID(t, true,
+	watcher := runAndWait(testWatcherShortID(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -242,7 +246,7 @@ func TestWatcherAddEventsShortID(t *testing.T) {
 			},
 		},
 		true,
-	)
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"1234567890123": &Container{
@@ -261,7 +265,7 @@ func TestWatcherAddEventsShortID(t *testing.T) {
 }
 
 func TestWatcherUpdateEvent(t *testing.T) {
-	watcher := runWatcher(t, true,
+	watcher := runAndWait(testWatcher(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -295,7 +299,7 @@ func TestWatcherUpdateEvent(t *testing.T) {
 				},
 			},
 		},
-	)
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
@@ -309,7 +313,7 @@ func TestWatcherUpdateEvent(t *testing.T) {
 }
 
 func TestWatcherUpdateEventShortID(t *testing.T) {
-	watcher := runWatcherShortID(t, true,
+	watcher := runAndWait(testWatcherShortID(t, true,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -344,7 +348,7 @@ func TestWatcherUpdateEventShortID(t *testing.T) {
 			},
 		},
 		true,
-	)
+	))
 
 	assert.Equal(t, map[string]*Container{
 		"1234567890123": &Container{
@@ -358,7 +362,7 @@ func TestWatcherUpdateEventShortID(t *testing.T) {
 }
 
 func TestWatcherDie(t *testing.T) {
-	watcher := runWatcher(t, false,
+	watcher, clientDone := testWatcher(t, false,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -379,30 +383,37 @@ func TestWatcherDie(t *testing.T) {
 			},
 		},
 	)
+
+	clock := newTestClock()
+	watcher.clock = clock
+
+	stopListener := watcher.ListenStop()
+
+	watcher.Start()
 	defer watcher.Stop()
 
 	// Check it doesn't get removed while we request meta for the container
 	for i := 0; i < 18; i++ {
 		watcher.Container("0332dbd79e20")
-		assert.Equal(t, 1, len(watcher.Containers()))
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	// Checks a max of 10s for the watcher containers to be updated
-	for i := 0; i < 100; i++ {
-		// Now it should get removed
-		time.Sleep(100 * time.Millisecond)
-
-		if len(watcher.Containers()) == 0 {
+		clock.Sleep(watcher.cleanupTimeout / 2)
+		watcher.runCleanup()
+		if !assert.Equal(t, 1, len(watcher.Containers())) {
 			break
 		}
 	}
 
+	// Wait to be sure that the delete event has been processed
+	<-clientDone
+	<-stopListener.Events()
+
+	// Check that after the cleanup period the container is removed
+	clock.Sleep(watcher.cleanupTimeout + 1*time.Second)
+	watcher.runCleanup()
 	assert.Equal(t, 0, len(watcher.Containers()))
 }
 
 func TestWatcherDieShortID(t *testing.T) {
-	watcher := runWatcherShortID(t, false,
+	watcher, clientDone := testWatcherShortID(t, false,
 		[][]types.Container{
 			[]types.Container{
 				types.Container{
@@ -424,33 +435,40 @@ func TestWatcherDieShortID(t *testing.T) {
 		},
 		true,
 	)
+
+	clock := newTestClock()
+	watcher.clock = clock
+
+	stopListener := watcher.ListenStop()
+
+	watcher.Start()
 	defer watcher.Stop()
 
 	// Check it doesn't get removed while we request meta for the container
 	for i := 0; i < 18; i++ {
 		watcher.Container("0332dbd79e20")
-		assert.Equal(t, 1, len(watcher.Containers()))
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	// Checks a max of 10s for the watcher containers to be updated
-	for i := 0; i < 100; i++ {
-		// Now it should get removed
-		time.Sleep(100 * time.Millisecond)
-
-		if len(watcher.Containers()) == 0 {
+		clock.Sleep(watcher.cleanupTimeout / 2)
+		watcher.runCleanup()
+		if !assert.Equal(t, 1, len(watcher.Containers())) {
 			break
 		}
 	}
 
+	// Wait to be sure that the delete event has been processed
+	<-clientDone
+	<-stopListener.Events()
+
+	// Check that after the cleanup period the container is removed
+	clock.Sleep(watcher.cleanupTimeout + 1*time.Second)
+	watcher.runCleanup()
 	assert.Equal(t, 0, len(watcher.Containers()))
 }
 
-func runWatcher(t *testing.T, kill bool, containers [][]types.Container, events []interface{}) *watcher {
-	return runWatcherShortID(t, kill, containers, events, false)
+func testWatcher(t *testing.T, kill bool, containers [][]types.Container, events []interface{}) (*watcher, chan interface{}) {
+	return testWatcherShortID(t, kill, containers, events, false)
 }
 
-func runWatcherShortID(t *testing.T, kill bool, containers [][]types.Container, events []interface{}, enable bool) *watcher {
+func testWatcherShortID(t *testing.T, kill bool, containers [][]types.Container, events []interface{}, enable bool) (*watcher, chan interface{}) {
 	logp.TestingSetup()
 
 	client := &MockClient{
@@ -468,16 +486,37 @@ func runWatcherShortID(t *testing.T, kill bool, containers [][]types.Container, 
 		t.Fatal("'watcher' was supposed to be pointer to the watcher structure")
 	}
 
-	err = watcher.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
+	return watcher, client.done
+}
 
-	<-client.done
-	if kill {
-		watcher.Stop()
-		watcher.stopped.Wait()
-	}
+func runAndWait(w *watcher, done chan interface{}) *watcher {
+	w.Start()
+	<-done
+	w.Stop()
+	return w
+}
 
-	return watcher
+type testClock struct {
+	sync.Mutex
+
+	now time.Time
+}
+
+func newTestClock() *testClock {
+	return &testClock{now: time.Time{}}
+}
+
+func (c *testClock) Now() time.Time {
+	c.Lock()
+	defer c.Unlock()
+
+	c.now = c.now.Add(1)
+	return c.now
+}
+
+func (c *testClock) Sleep(d time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.now = c.now.Add(d)
 }


### PR DESCRIPTION
## What does this PR do?

Refactor docker watcher to fix some small issues and improve testability:
* Actually release resources of previous connections when reconnecting.
* Watcher uses a clock that can be mocked in tests for time-sensitive functionality.
* Use nanoseconds-precision from events timestamps, this is important to avoid duplicated events on reconnection.
* Fix logger initialization (it was being initialized as `docker.docker`).
* Refactor test helpers to have more control on test watcher when needed.
* Some other code refactors.

## Why is it important?

* Fixes flaky test #7906.
* Watch loop relied on deferred calls to do cleanups, but the watch loop never finished, so resources associated to each reconnection were never released. On reconnections caused by not receiving events, previous connections were not being closed, so several connections were kept alive, but all except the last one were ignored.
* Fix duplication of events on reconnections. Each reconnection asks for events since last received events, using seconds granularity made each reconnection to retrieve again the events happened during the second the last event was received, including the event itself. API supports nanosecond granularity, that avoids this problem.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #7906.
```
$ go test -count 10000 ./libbeat/common/docker/
ok  	github.com/elastic/beats/v7/libbeat/common/docker	5.220s
```