### PR TITLE
[CI][flaky] reporting for PRs in GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,9 @@ pipeline {
       runbld(stashedTestReports: stashedTestReports, project: env.REPO)
     }
     cleanup {
-      notifyBuildResult(prComment: true, slackComment: true, slackNotify: (isBranch() || isTag()))
+      notifyBuildResult(prComment: true,
+                        slackComment: true, slackNotify: (isBranch() || isTag())
+                        analyzeFlakey: true, flakyReportIdx: "reporter-beats-pipeline-master")
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Enable the flaky test analyser

## Why is it important?

This will help to automate the flaky test analyser process:
- By tracking test failures and flaky test failures.
- Raising issues for those flaky test failures with the labels: `flaky-test,ci-reported`
- Report the test flaky status as a GitHub comment.

Then contributors and reviewers will be able to understand the whole test context and whether those failures were already reported as flaky in the past.

## Tests

For instance, if there were two test failures which were flaky then you will see something like the below screenshot:

![image](https://user-images.githubusercontent.com/2871786/96142365-eb2a5e00-0ef9-11eb-84b4-7d369e52b003.png)

And a GH issue will be created

![image](https://user-images.githubusercontent.com/2871786/96142379-ef567b80-0ef9-11eb-8c96-921ca2c07f10.png)


## Issues

Consumes https://github.com/elastic/apm-pipeline-library/pull/754