### PR TITLE
[CI] kind setup fails sometimes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,19 @@ def k8sTest(Map args = [:]) {
               retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kind", script: ".ci/scripts/install-kind.sh") }
               retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kubectl", script: ".ci/scripts/install-kubectl.sh") }
               try {
-                sh(label: "Setup kind", script: ".ci/scripts/kind-setup.sh")
+                // Add some environmental resilience when setup does not work the very first time.
+                def i = 0
+                retryWithSleep(retries: 3, seconds: 5, backoff: true){
+                  try {
+                    sh(label: "Setup kind", script: ".ci/scripts/kind-setup.sh")
+                  } catch(err) {
+                    i++
+                    sh(label: 'Delete cluster', script: 'kind delete cluster')
+                    if (i > 1) {
+                      error("Setup kind failed with error '${err.toString()}'")
+                    }
+                  }
+                }
                 sh(label: "Integration tests", script: "MODULE=kubernetes make -C metricbeat integration-tests")
                 sh(label: "Deploy to kubernetes",script: "make -C deploy/kubernetes test")
               } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ def k8sTest(Map args = [:]) {
                   } catch(err) {
                     i++
                     sh(label: 'Delete cluster', script: 'kind delete cluster')
-                    if (i > 1) {
+                    if (i > 2) {
                       error("Setup kind failed with error '${err.toString()}'")
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,8 +167,8 @@ def cloud(Map args = [:]) {
 
 def k8sTest(Map args = [:]) {
   def versions = args.versions
-  node(args.label) {
-    versions.each{ v ->
+  versions.each{ v ->
+    node(args.label) {
       stage("${args.context} ${v}"){
         withEnv(["K8S_VERSION=${v}", "KIND_VERSION=v0.7.0", "KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
           withGithubNotify(context: "${args.context} ${v}") {


### PR DESCRIPTION
## What does this PR do?

- Add resilience when the kind setup does not work at first by retrying again.
- Run each k8s version as independent stages

## Why is it important?

- Avoid environmental issues as much as possible
- Avoid fail fast for the k8s stages

## Related issues

Closes elastic/beats#21856 

## Tests

![image](https://user-images.githubusercontent.com/2871786/96249083-8d068500-0fa4-11eb-94d1-e8f0e360e1dd.png)
