### PR TITLE
Cherry-pick #21854 to 7.x: Fix syslog RFC 5424 parsing in CheckPoint module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -308,6 +308,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Provide backwards compatibility for the `append` processor when Elasticsearch is less than 7.10.0. {pull}21159[21159]
 - Fix checkpoint module when logs contain time field. {pull}20567[20567]
 - Add field limit check for AWS Cloudtrail flattened fields. {pull}21388[21388] {issue}21382[21382]
+- Fix syslog RFC 5424 parsing in the CheckPoint module. {pull}21854[21854]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/checkpoint.asciidoc
+++ b/filebeat/docs/modules/checkpoint.asciidoc
@@ -12,17 +12,18 @@ This file is generated! See scripts/docs_collector.py
 == Check Point module
 beta[]
 
-This is a module for Check Point firewall logs. It supports logs from the Log Exporter in the Syslog format.
+This is a module for Check Point firewall logs. It supports logs from the Log
+Exporter in the Syslog RFC 5424 format. If you need to ingest Check Point logs
+in CEF format then please use the <<filebeat-module-cef, `CEF module`>> (more
+fields are provided in the syslog output).
 
-To configure a Log Exporter, please refer to the documentation by https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk122323[Check Point].
+To configure a Log Exporter, please refer to the documentation by
+https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk122323[Check
+Point].
 
-Example below:
+Example Log Exporter config:
 
 `cp_log_export add name testdestination target-server 192.168.1.1 target-port 9001 protocol udp format syslog`
-
-The module that supports Check Point firewall logs sent in the CEF format requires the <<filebeat-module-cef, `CEF module`>>
-
-The Check Point and ECS fields that are the same between both modules will be mapped to the same names for compability between modules, though not all fields are included in CEF. Please reference the supported fields in the CEF documentation.
 
 include::../include/gs-link.asciidoc[]
 
@@ -30,7 +31,8 @@ include::../include/gs-link.asciidoc[]
 [float]
 === Compatibility
 
-This module has been tested against Check Point Log Exporter on R80.X but should also work with R77.30.
+This module has been tested against Check Point Log Exporter on R80.X but should
+also work with R77.30.
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
@@ -7,17 +7,18 @@
 == Check Point module
 beta[]
 
-This is a module for Check Point firewall logs. It supports logs from the Log Exporter in the Syslog format.
+This is a module for Check Point firewall logs. It supports logs from the Log
+Exporter in the Syslog RFC 5424 format. If you need to ingest Check Point logs
+in CEF format then please use the <<filebeat-module-cef, `CEF module`>> (more
+fields are provided in the syslog output).
 
-To configure a Log Exporter, please refer to the documentation by https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk122323[Check Point].
+To configure a Log Exporter, please refer to the documentation by
+https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk122323[Check
+Point].
 
-Example below:
+Example Log Exporter config:
 
 `cp_log_export add name testdestination target-server 192.168.1.1 target-port 9001 protocol udp format syslog`
-
-The module that supports Check Point firewall logs sent in the CEF format requires the <<filebeat-module-cef, `CEF module`>>
-
-The Check Point and ECS fields that are the same between both modules will be mapped to the same names for compability between modules, though not all fields are included in CEF. Please reference the supported fields in the CEF documentation.
 
 include::../include/gs-link.asciidoc[]
 
@@ -25,7 +26,8 @@ include::../include/gs-link.asciidoc[]
 [float]
 === Compatibility
 
-This module has been tested against Check Point Log Exporter on R80.X but should also work with R77.30.
+This module has been tested against Check Point Log Exporter on R80.X but should
+also work with R77.30.
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
@@ -1,8 +1,7 @@
 {{ if eq .input "syslog" }}
 
-type: syslog
-protocol.udp:
-  host: "{{.syslog_host}}:{{.syslog_port}}"
+type: udp
+host: "{{.syslog_host}}:{{.syslog_port}}"
 
 {{ else if eq .input "file" }}
 


### PR DESCRIPTION
Cherry-pick of PR #21854 to 7.x branch. Original message: 



## What does this PR do?

Change the input type in the CheckPoint module to `udp` from `syslog`
so the syslog parsing happens in the ingest node pipeline rather than
in the Filebeat syslog input that only support RFC 3164.

## Why is it important?

The module was causing warnings while parsing data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Enable module.
1. `echo -n '<134>1 2020-03-29T13:19:21Z gw-da58d3 CheckPoint 1930 - [flags:"133440"; ifdir:"inbound"; ifname:"daemon"; loguid:"{0x5e80a059,0x2,0x6401a8c0,0x3c7878a}"; origin:"192.168.1.100"; sequencenum:"2"; version:"5"; product:"System Monitor"; sys_message::"installed Standard"]' | nc -4u -w1  localhost 9001`
1. Check Elasticsearch.

## Related issues

- Relates https://github.com/elastic/beats/issues/6872

## Logs

I manually tested the syslog parsing using the steps above and this is the event that landed in ES.

```json
{
          "checkpoint" : {
            "sys_message" : "installed Standard"
          },
          "agent" : {
            "name" : "mac",
            "id" : "a92a047c-c6c6-4025-8933-1672a1b99ae1",
            "type" : "filebeat",
            "ephemeral_id" : "658300b1-a9a5-45b9-b9ab-14c09edcee16",
            "version" : "8.0.0"
          },
          "log" : {
            "source" : {
              "address" : "127.0.0.1:60816"
            }
          },
          "fileset" : {
            "name" : "firewall"
          },
          "tags" : [
            "checkpoint-firewall",
            "forwarded"
          ],
          "network" : {
            "direction" : "inbound"
          },
          "input" : {
            "type" : "udp"
          },
          "observer" : {
            "ingress" : {
              "interface" : {
                "name" : "daemon"
              }
            },
            "product" : "System Monitor",
            "vendor" : "Checkpoint",
            "name" : "192.168.1.100",
            "type" : "firewall"
          },
          "@timestamp" : "2020-03-29T13:19:21.000Z",
          "ecs" : {
            "version" : "1.6.0"
          },
          "service" : {
            "type" : "checkpoint"
          },
          "event" : {
            "sequence" : 2,
            "ingested" : "2020-10-15T13:41:59.409604500Z",
            "timezone" : "-04:00",
            "created" : "2020-10-15T13:41:55.836Z",
            "kind" : "event",
            "module" : "checkpoint",
            "id" : "{0x5e80a059,0x2,0x6401a8c0,0x3c7878a}",
            "category" : [
              "network"
            ],
            "dataset" : "checkpoint.firewall"
          }
        }
```
