### PR TITLE
Cherry-pick #21776 to 7.x: Add cloud.account.id into add_cloud_metadata for gcp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -529,6 +529,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Add istiod metricset. {pull}21519[21519]
 - Release `add_cloudfoundry_metadata` as GA. {pull}21525[21525]
 - Add support for OpenStack SSL metadata APIs in `add_cloud_metadata`. {pull}21590[21590]
+- Add cloud.account.id for GCP into add_cloud_metadata processor. {pull}21776[21776]
 - Add proxy metricset for istio module. {pull}21751[21751]
 
 *Auditbeat*

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -69,6 +69,9 @@ var gceMetadataFetcher = provider{
 					"project": s.Object{
 						"id": c.Str("projectId"),
 					},
+					"account": s.Object{
+						"id": c.Str("projectId"),
+					},
 				}.ApplyTo(out, project)
 			}
 

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -152,6 +152,9 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 
 	expected := common.MapStr{
 		"cloud": common.MapStr{
+			"account": common.MapStr{
+				"id": "test-dev",
+			},
 			"provider": "gcp",
 			"instance": common.MapStr{
 				"id":   "3910564293633576924",


### PR DESCRIPTION
Cherry-pick of PR #21776 to 7.x branch. Original message: 

## What does this PR do?

Add `cloud.account.id` into `add_cloud_metadata` processor for GCP. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
