### PR TITLE
Stop storing stateless kubernetes keystores

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -373,7 +373,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix retrieving resources by ID for the azure module. {pull}21711[21711] {issue}21707[21707]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
-- Protect kubernetes keystore map with mutex {pull}21880[21880]
+- Stop storing stateless kubernetes keystores {pull}21880[21880]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -373,6 +373,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix retrieving resources by ID for the azure module. {pull}21711[21711] {issue}21707[21707]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
+- Protect kubernetes keystore map with mutex {pull}21880[21880]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -373,7 +373,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix retrieving resources by ID for the azure module. {pull}21711[21711] {issue}21707[21707]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
-- Stop storing stateless kubernetes keystores {pull}21880[21880]
+- Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 
 *Packetbeat*
 

--- a/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
+++ b/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
@@ -70,7 +70,6 @@ func (kr *KubernetesKeystoresRegistry) GetKeystore(event bus.Event) keystore.Key
 		namespace = ns.(string)
 	}
 	if namespace != "" {
-		// either retrieve already stored keystore or create a new one for the namespace
 		k8sKeystore, _ := Factoryk8s(namespace, kr.client, kr.logger)
 		return k8sKeystore
 	}

--- a/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
+++ b/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
@@ -79,16 +79,13 @@ func (kr *KubernetesKeystoresRegistry) GetKeystore(event bus.Event) keystore.Key
 	}
 	if namespace != "" {
 		// either retrieve already stored keystore or create a new one for the namespace
-		kr.keystoreMapLock.RLock()
+		kr.keystoreMapLock.Lock()
+		defer kr.keystoreMapLock.Unlock()
 		if storedKeystore, ok := kr.kubernetesKeystores[namespace]; ok {
-			kr.keystoreMapLock.RUnlock()
 			return storedKeystore
 		}
-		kr.keystoreMapLock.RUnlock()
 		k8sKeystore, _ := Factoryk8s(namespace, kr.client, kr.logger)
-		kr.keystoreMapLock.Lock()
 		kr.kubernetesKeystores[namespace] = k8sKeystore
-		kr.keystoreMapLock.Unlock()
 		return k8sKeystore
 	}
 	kr.logger.Debugf("Cannot retrieve kubernetes namespace from event: %s", event)


### PR DESCRIPTION
## What does this PR do?
This PR removes `kubernetesKeystores` since it does not store anything that actually needs to be shared.


## Related issues
- Closes https://github.com/elastic/beats/issues/21843


