### PR TITLE
Fix panic on add_docker_metadata close

### DIFF
--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -213,7 +213,10 @@ func (d *addDockerMetadata) Close() error {
 	if d.cgroups != nil {
 		d.cgroups.StopJanitor()
 	}
-	d.watcher.Stop()
+	// Watcher can be nil if processor failed on creation
+	if d.watcher != nil {
+		d.watcher.Stop()
+	}
 	err := processors.Close(d.sourceProcessor)
 	if err != nil {
 		return errors.Wrap(err, "closing source processor of add_docker_metadata")


### PR DESCRIPTION
If the processor was not properly initialized, for example because it
couldn't access the docker socket, then the watcher will be nil. Avoid
trying to stop the watcher in that case.

No changelog needed as the change introducing this issue hasn't
been released.

## Related issues

- Fixes #21869
- Issue introduced in #16349 