### PR TITLE
[Ingest Manager] Use local temp instead of system one

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -17,6 +17,7 @@
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
 - Use local temp instead of system one {pull}21883[21883]
+
 ==== New features
 
 - Prepare packaging for endpoint and asc files {pull}20186[20186]

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -16,7 +16,7 @@
 - Include inputs in action store actions {pull}21298[21298]
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
-
+- Use local temp instead of system one {pull}21883[21883]
 ==== New features
 
 - Prepare packaging for endpoint and asc files {pull}20186[20186]

--- a/x-pack/elastic-agent/pkg/agent/application/paths/paths.go
+++ b/x-pack/elastic-agent/pkg/agent/application/paths/paths.go
@@ -14,6 +14,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
+const (
+	tempSubdir = "tmp"
+)
+
 var (
 	topPath    string
 	configPath string
@@ -29,12 +33,20 @@ func init() {
 	fs.StringVar(&topPath, "path.home", topPath, "Agent root path")
 	fs.StringVar(&configPath, "path.config", configPath, "Config path is the directory Agent looks for its config file")
 	fs.StringVar(&logsPath, "path.logs", logsPath, "Logs path contains Agent log output")
+
+	// create tempdir as it probably don't exists
+	os.MkdirAll(TempDir(), 0750)
 }
 
 // Top returns the top directory for Elastic Agent, all the versioned
 // home directories live under this top-level/data/elastic-agent-${hash}
 func Top() string {
 	return topPath
+}
+
+// TempDir returns agent temp dir located within data dir.
+func TempDir() string {
+	return filepath.Join(Data(), tempSubdir)
 }
 
 // Home returns a directory where binary lives

--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 )
 
 type embeddedInstaller interface {
@@ -31,7 +33,7 @@ func NewInstaller(i embeddedInstaller) (*Installer, error) {
 // Install performs installation of program in a specific version.
 func (i *Installer) Install(ctx context.Context, programName, version, installDir string) error {
 	// tar installer uses Dir of installDir to determine location of unpack
-	tempDir, err := ioutil.TempDir(os.TempDir(), "elastic-agent-install")
+	tempDir, err := ioutil.TempDir(paths.TempDir(), "elastic-agent-install")
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +26,7 @@ func TestOKInstall(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	installDir := filepath.Join(os.TempDir(), "install_dir")
+	installDir := filepath.Join(paths.TempDir(), "install_dir")
 
 	wg.Add(1)
 	go func() {
@@ -59,7 +60,7 @@ func TestContextCancelledInstall(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	installDir := filepath.Join(os.TempDir(), "install_dir")
+	installDir := filepath.Join(paths.TempDir(), "install_dir")
 
 	wg.Add(1)
 	go func() {

--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer_test.go
@@ -13,8 +13,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 )
 
 func TestOKInstall(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Using system temp dir might result sometimes in cross-device linking. This should make it ok.

## Why is it important?

Fixes: #21860

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
