### PR TITLE
[CI] lint stage doesn't produce test reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
       }
       steps {
         withGithubNotify(context: 'Lint') {
-          withBeatsEnv(archive: true, id: 'lint') {
+          withBeatsEnv(archive: false, id: 'lint') {
             dumpVariables()
             cmd(label: 'make check', script: 'make check')
           }


### PR DESCRIPTION
## What does this PR do?

Disable archiving test reports for the lint stage since there are certain build corruption and the BlueOcean view gets broken.

```bash
[2020-10-13T16:50:43.188Z] [Pipeline] junit
[2020-10-13T16:50:43.188Z] WARNING: Unknown parameter(s) found for class type 'hudson.tasks.junit.pipeline.JUnitResultsStep': id,stashedTestReports
[2020-10-13T16:50:43.192Z] Recording test results
[2020-10-13T16:50:43.618Z] None of the test reports contained any result
```

## Why is it important?

@kuisathaverat analysed a support bundle of the `beats-ci` and found 

```
  <entry>
    <string>87</string>
    <Tag plugin="workflow-support@3.5">
      <node class="cps.n.StepStartNode" plugin="workflow-cps@2.82">
        <parentIds>
          <string>86</string>
        </parentIds>
        <id>87</id>
        <descriptorId>org.jenkinsci.plugins.workflow.support.steps.StageStep</descriptorId>
      </node>
      <actions>
        <s.a.LogStorageAction/>
        <cps.a.ArgumentsActionImpl plugin="workflow-cps@2.82">
          <arguments>
            <entry>
              <string>name</string>
              <string>Lint</string>
            </entry>
          </arguments>
          <isUnmodifiedBySanitization>true</isUnmodifiedBySanitization>
        </cps.a.ArgumentsActionImpl>
        <wf.a.TimingAction plugin="workflow-api@2.40">
          <startTime>1602194665277</startTime>
        </wf.a.TimingAction>
      </actions>
    </Tag>
  </entry>
```

3 out of 3 builds got the corruption in the linting stage :/ 

## Issues

See https://github.com/elastic/beats/pull/21466