### PR TITLE
Cherry-pick #15741 to 7.x: [bug] add replicasets.apps to ClusterRole to avoid permission issue

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -258,6 +258,7 @@ rules:
   resources:
   - statefulsets
   - deployments
+  - replicasets
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
   - statefulsets
   - deployments
+  - replicasets
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""


### PR DESCRIPTION
Cherry-pick of PR #15741 to 7.x branch. Original message: 

- Bug

Logs
E0120 09:24:12.769663 1 reflector.go:125] github.com/elastic/beats/libbeat/common/kubernetes/watcher.go:235: Failed to list *v1beta1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "replicasets" in API group "apps" at the cluster scope
Why is it important?
You need this permission to make metricbeat work properly. Otherwise, it won't work