### PR TITLE
Cherry-pick to 7.9: [docs] Remove extra word in autodiscover docs (#21871)

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -24,7 +24,7 @@ start/stop events. This ensures you don't need to worry about state, but only de
 The Docker autodiscover provider watches for Docker containers to start and stop.
 
 
-These are the available fields during within config templating. The `docker.*` fields will be available on each emitted event.
+These are the fields available within config templating. The `docker.*` fields will be available on each emitted event.
 event:
 
   * host
@@ -129,7 +129,7 @@ endif::[]
 
 The Kubernetes autodiscover provider watches for Kubernetes nodes, pods, services to start, update, and stop.
 
-These are the available fields during within config templating. The `kubernetes.*` fields will be available on each emitted event.
+These are the fields available within config templating. The `kubernetes.*` fields will be available on each emitted event.
 
 [float]
 ====== Generic fields:


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [docs] Remove extra word in autodiscover docs (#21871)