### PR TITLE
Cherry-pick to 7.9: [CI] lint stage doesn't produce test reports (#21888)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
       }
       steps {
         withGithubNotify(context: 'Lint') {
-          withBeatsEnv(archive: true, id: 'lint') {
+          withBeatsEnv(archive: false, id: 'lint') {
             dumpVariables()
             cmd(label: 'make check', script: 'make check')
           }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [CI] lint stage doesn't produce test reports (#21888)