### PR TITLE
Statsd do not ignore error on startup

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -376,6 +376,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
+- Fix statsd server startup producing a panic if it fails to bind the port number. {issue}21733[21733]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/statsd/server/server_test.go
+++ b/x-pack/metricbeat/module/statsd/server/server_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package server
 
 import (
@@ -7,8 +11,9 @@ import (
 	"testing"
 	"time"
 
-	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 )
 
 func TestServerStart(t *testing.T) {

--- a/x-pack/metricbeat/module/statsd/server/server_test.go
+++ b/x-pack/metricbeat/module/statsd/server/server_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerStart(t *testing.T) {
+	origSetupRetryInterval := setupRetryInterval
+	setupRetryInterval = 10 * time.Millisecond
+	defer func() {
+		setupRetryInterval = origSetupRetryInterval
+	}()
+
+	t.Run("succees", func(t *testing.T) {
+		ms := newTestMetricset(t)
+		err := ms.startServer(context.TODO())
+		require.NoError(t, err)
+		ms.stopServer()
+	})
+
+	t.Run("retry if port is in use", func(t *testing.T) {
+		fakeServer, port, teardown := newTestUDPListener(t)
+		defer teardown()
+
+		ms := newTestMetricset(t, map[string]interface{}{"port": port})
+
+		var serverErr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			serverErr = ms.startServer(context.TODO())
+			if serverErr == nil {
+				defer ms.stopServer()
+			}
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+		fakeServer.Close()
+		wg.Wait() // this blocks if server did not startup
+		require.NoError(t, serverErr)
+	})
+
+	t.Run("cancel retry during shutdown", func(t *testing.T) {
+		_, port, teardown := newTestUDPListener(t)
+		defer teardown()
+
+		ms := newTestMetricset(t, map[string]interface{}{"port": port})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var serverErr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			serverErr = ms.startServer(ctx)
+			if serverErr == nil {
+				defer ms.stopServer()
+			}
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		wg.Wait()
+		require.Equal(t, context.Canceled, serverErr)
+	})
+
+	t.Run("no panic on shutdown if not started", func(t *testing.T) {
+		_, port, teardown := newTestUDPListener(t)
+		defer teardown()
+
+		ms := newTestMetricset(t, map[string]interface{}{"port": port})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ms.Run(ctx, nil)
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		wg.Wait()
+	})
+}
+
+func newTestMetricset(t *testing.T, extraSettings ...map[string]interface{}) *MetricSet {
+	settings := map[string]interface{}{
+		"module":     "statsd",
+		"metricsets": []string{"server"},
+	}
+
+	for _, other := range extraSettings {
+		for k, v := range other {
+			settings[k] = v
+		}
+	}
+
+	ms := mbtest.NewPushMetricSetV2WithContext(t, settings)
+	return ms.(*MetricSet)
+}
+
+func newTestUDPListener(t *testing.T) (*net.UDPConn, string, func()) {
+	fakeServer, err := net.ListenUDP("udp4", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := fakeServer.LocalAddr().String()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("Fake UDP server with invalid address: %v", addr)
+	}
+
+	return fakeServer, port, func() {
+		fakeServer.Close()
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

This PR will retry the statsd server startup every
minute, until it is eventually running. The server is only stopped if it
was running. The retry loop is automatically stopped once the metricset
is stopped or metricbeat is shutdown.

## Why is it important?

The statsd server input ignores errors on startup and attempts to
publish events thereafter. At runtime this somewhat gets unnoticed, as
no error was reported. But no events will be reported. On shutdown the
statsd metricset will panic, because it tries to Stop a non-existend
server.

In case the error is resolved on the host machine (e.g. port becomes
available), the statsd server metricset was not able to recover.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/21733