### PR TITLE
[Ingest Manager] Always try snapshot repo for agent upgrade

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/stream.go
+++ b/x-pack/elastic-agent/pkg/agent/application/stream.go
@@ -56,9 +56,9 @@ func streamFactory(ctx context.Context, cfg *configuration.SettingsConfig, srv *
 }
 
 func newOperator(ctx context.Context, log *logger.Logger, id routingKey, config *configuration.SettingsConfig, srv *server.Server, r state.Reporter, m monitoring.Monitor) (*operation.Operator, error) {
-	fetcher := downloader.NewDownloader(log, config.DownloadConfig)
+	fetcher := downloader.NewDownloader(log, config.DownloadConfig, false)
 	allowEmptyPgp, pgp := release.PGP()
-	verifier, err := downloader.NewVerifier(log, config.DownloadConfig, allowEmptyPgp, pgp)
+	verifier, err := downloader.NewVerifier(log, config.DownloadConfig, allowEmptyPgp, pgp, false)
 	if err != nil {
 		return nil, errors.New(err, "initiating verifier")
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
-	download "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/localremote"
+	downloader "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/localremote"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
@@ -27,12 +27,12 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	}
 
 	allowEmptyPgp, pgp := release.PGP()
-	verifier, err := download.NewVerifier(u.log, &settings, allowEmptyPgp, pgp, true)
+	verifier, err := downloader.NewVerifier(u.log, &settings, allowEmptyPgp, pgp, true)
 	if err != nil {
 		return "", errors.New(err, "initiating verifier")
 	}
 
-	fetcher := download.NewDownloader(u.log, &settings, true)
+	fetcher := downloader.NewDownloader(u.log, &settings, true)
 	path, err := fetcher.Download(ctx, agentName, agentArtifactName, version)
 	if err != nil {
 		return "", errors.New(err, "failed upgrade of agent binary")

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
@@ -9,12 +9,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/composed"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/fs"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/http"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/snapshot"
+	download "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/localremote"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
@@ -31,12 +26,13 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		}
 	}
 
-	verifier, err := u.verifier(&settings)
+	allowEmptyPgp, pgp := release.PGP()
+	verifier, err := download.NewVerifier(u.log, &settings, allowEmptyPgp, pgp, true)
 	if err != nil {
 		return "", errors.New(err, "initiating verifier")
 	}
 
-	fetcher := u.downloader(&settings)
+	fetcher := download.NewDownloader(u.log, &settings, true)
 	path, err := fetcher.Download(ctx, agentName, agentArtifactName, version)
 	if err != nil {
 		return "", errors.New(err, "failed upgrade of agent binary")
@@ -51,46 +47,4 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	}
 
 	return path, nil
-}
-
-// gets a downloader for local, official, snapshot in that order
-func (u *Upgrader) downloader(settings *artifact.Config) download.Downloader {
-	downloaders := make([]download.Downloader, 0, 3)
-	downloaders = append(downloaders, fs.NewDownloader(settings), http.NewDownloader(settings))
-
-	snapDownloader, err := snapshot.NewDownloader(settings)
-	if err != nil {
-		u.log.Error(err)
-	} else {
-		downloaders = append(downloaders, snapDownloader)
-	}
-
-	return composed.NewDownloader(downloaders...)
-}
-
-// gets a verifier for local, official, snapshot in that order
-func (u *Upgrader) verifier(settings *artifact.Config) (download.Verifier, error) {
-	allowEmptyPgp, pgp := release.PGP()
-	verifiers := make([]download.Verifier, 0, 3)
-
-	fsVer, err := fs.NewVerifier(settings, allowEmptyPgp, pgp)
-	if err != nil {
-		return nil, err
-	}
-	verifiers = append(verifiers, fsVer)
-
-	remoteVer, err := http.NewVerifier(settings, allowEmptyPgp, pgp)
-	if err != nil {
-		return nil, err
-	}
-	verifiers = append(verifiers, remoteVer)
-
-	snapshotVerifier, err := snapshot.NewVerifier(settings, allowEmptyPgp, pgp)
-	if err != nil {
-		u.log.Error(err)
-	} else {
-		verifiers = append(verifiers, snapshotVerifier)
-	}
-
-	return composed.NewVerifier(verifiers...), nil
 }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -183,9 +183,6 @@ func (u *Upgrader) Ack(ctx context.Context) error {
 }
 
 func (u *Upgrader) sourceURI(version, retrievedURI string) (string, error) {
-	if strings.HasSuffix(version, "-SNAPSHOT") && retrievedURI == "" {
-		return "", errors.New("snapshot upgrade requires source uri", errors.TypeConfig)
-	}
 	if retrievedURI != "" {
 		return retrievedURI, nil
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
@@ -17,12 +17,12 @@ import (
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewDownloader(log *logger.Logger, config *artifact.Config) download.Downloader {
+func NewDownloader(log *logger.Logger, config *artifact.Config, forceSnapshot bool) download.Downloader {
 	downloaders := make([]download.Downloader, 0, 3)
 	downloaders = append(downloaders, fs.NewDownloader(config))
 
 	// try snapshot repo before official
-	if release.Snapshot() {
+	if release.Snapshot() || forceSnapshot {
 		snapDownloader, err := snapshot.NewDownloader(config)
 		if err != nil {
 			log.Error(err)

--- a/x-pack/elastic-agent/pkg/artifact/download/localremote/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/localremote/verifier.go
@@ -17,7 +17,7 @@ import (
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool, pgp []byte) (download.Verifier, error) {
+func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool, pgp []byte, forceSnapshot bool) (download.Verifier, error) {
 	verifiers := make([]download.Verifier, 0, 3)
 
 	fsVer, err := fs.NewVerifier(config, allowEmptyPgp, pgp)
@@ -27,7 +27,7 @@ func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool
 	verifiers = append(verifiers, fsVer)
 
 	// try snapshot repo before official
-	if release.Snapshot() {
+	if release.Snapshot() || forceSnapshot {
 		snapshotVerifier, err := snapshot.NewVerifier(config, allowEmptyPgp, pgp)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
## What does this PR do?

This PR adds ability of agent to download new version from snapshot repo. This makes update from stable version e.g 7.10 to 8.0.0 SNAPSHOT possible. 

## Why is it important?

For this to be possible user needs to initiate upgrade using API and provide sourceURI or Kibana needs to be upgraded from stable to SNAPSHOT before agent, so this is not a very common scenario but we're not blocking it.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


cc @EricDavisX 
