### PR TITLE
Cherry-pick #21896 to 7.x: Kubernetes leaderelection improvements

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -249,9 +249,13 @@ func NewLeaderElectionManager(
 	} else {
 		id = "beats-leader-" + uuid.String()
 	}
+	ns, err := kubernetes.InClusterNamespace()
+	if err != nil {
+		ns = "default"
+	}
 	lease := metav1.ObjectMeta{
 		Name:      cfg.LeaderLease,
-		Namespace: "default",
+		Namespace: ns,
 	}
 	metaUID := lease.GetObjectMeta().GetUID()
 	lem.leaderElection = leaderelection.LeaderElectionConfig{
@@ -262,7 +266,7 @@ func NewLeaderElectionManager(
 				Identity: id,
 			},
 		},
-		ReleaseOnCancel: true,
+		ReleaseOnCancel: false,
 		LeaseDuration:   15 * time.Second,
 		RenewDeadline:   10 * time.Second,
 		RetryPeriod:     2 * time.Second,

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -101,7 +101,7 @@ func DiscoverKubernetesNode(log *logp.Logger, host string, inCluster bool, clien
 	}
 	ctx := context.TODO()
 	if inCluster {
-		ns, err := inClusterNamespace()
+		ns, err := InClusterNamespace()
 		if err != nil {
 			log.Errorf("kubernetes: Couldn't get namespace when beat is in cluster with error: %+v", err.Error())
 			return defaultNode
@@ -158,9 +158,9 @@ func machineID() string {
 	return ""
 }
 
-// inClusterNamespace gets namespace from serviceaccount when beat is in cluster.
+// InClusterNamespace gets namespace from serviceaccount when beat is in cluster.
 // code borrowed from client-go with some changes.
-func inClusterNamespace() (string, error) {
+func InClusterNamespace() (string, error) {
 	// get namespace associated with the service account token, if available
 	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #21896 to 7.x branch. Original message: 

## What does this PR do?

1.  Creates leader lease under the same namespace of Beat is running (in case of inCluster mode). If not running inside k8s cluster then it defaults to `default` namespace.
2. Changes `ReleaseOnClose` initialisation value to `false` so as to avoid errors like:
```
E1015 17:07:38.138511       1 leaderelection.go:296] Failed to release lock: Lease.coordination.k8s.io "metricbeat-cluster-leader" is invalid: spec.leaseDurationSeconds: Invalid value: 0: must be greater than 0
```

