### PR TITLE
Cherry-pick #21616 to 7.x: Prevent reporting ecs version twice 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -15,6 +15,7 @@
 - Copy Action store on upgrade {pull}21298[21298]
 - Include inputs in action store actions {pull}21298[21298]
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
+- Prevent reporting ecs version twice {pull}21616[21616]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
 
 ==== New features

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
@@ -113,7 +113,6 @@ func (b *Monitor) EnrichArgs(process, pipelineID string, args []string, isSideca
 		logFile = fmt.Sprintf("%s-json.log", logFile)
 		appendix = append(appendix,
 			"-E", "logging.json=true",
-			"-E", "logging.ecs=true",
 			"-E", "logging.files.path="+loggingPath,
 			"-E", "logging.files.name="+logFile,
 			"-E", "logging.files.keepfiles=7",


### PR DESCRIPTION
Cherry-pick of PR #21616 to 7.x branch. Original message:

## What does this PR do?

Fixes: #20666

Due to this, we get two `ecs.versions`  in a resulting event.

e.g
```
...

        "ecs": {
            "version": "1.6.0"
        },
        "ecs.version": "1.5.0",
        "event": {
            "dataset": "elastic.agent.metricbeat"
        },
...
```

Funny thing is also that it might differ in version as in the example above. But this may be just due to different builds of agent and beat locally.

## Why is it important?



## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
