### PR TITLE
Cherry-pick #21932 to 7.10: [Elastic Agent] Fix index for Agent monitoring to to elastic_agent.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -16,6 +16,8 @@
 - Include inputs in action store actions {pull}21298[21298]
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
+- Use local temp instead of system one {pull}21883[21883]
+- Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -16,7 +16,6 @@
 - Include inputs in action store actions {pull}21298[21298]
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
-- Use local temp instead of system one {pull}21883[21883]
 - Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 
 ==== New features

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -186,14 +186,14 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 			"paths": []string{
 				filepath.Join(paths.Home(), "logs", "elastic-agent-json.log"),
 			},
-			"index": "logs-elastic.agent-default",
+			"index": "logs-elastic_agent-default",
 			"processors": []map[string]interface{}{
 				{
 					"add_fields": map[string]interface{}{
 						"target": "data_stream",
 						"fields": map[string]interface{}{
 							"type":      "logs",
-							"dataset":   "elastic.agent",
+							"dataset":   "elastic_agent",
 							"namespace": "default",
 						},
 					},
@@ -202,7 +202,7 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 					"add_fields": map[string]interface{}{
 						"target": "event",
 						"fields": map[string]interface{}{
-							"dataset": "elastic.agent",
+							"dataset": "elastic_agent",
 						},
 					},
 				},
@@ -220,14 +220,14 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 					"message_key":     "message",
 				},
 				"paths": paths,
-				"index": fmt.Sprintf("logs-elastic.agent.%s-default", name),
+				"index": fmt.Sprintf("logs-elastic_agent.%s-default", name),
 				"processors": []map[string]interface{}{
 					{
 						"add_fields": map[string]interface{}{
 							"target": "data_stream",
 							"fields": map[string]interface{}{
 								"type":      "logs",
-								"dataset":   fmt.Sprintf("elastic.agent.%s", name),
+								"dataset":   fmt.Sprintf("elastic_agent.%s", name),
 								"namespace": "default",
 							},
 						},
@@ -236,7 +236,7 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 						"add_fields": map[string]interface{}{
 							"target": "event",
 							"fields": map[string]interface{}{
-								"dataset": fmt.Sprintf("elastic.agent.%s", name),
+								"dataset": fmt.Sprintf("elastic_agent.%s", name),
 							},
 						},
 					},
@@ -270,14 +270,14 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 			"metricsets": []string{"stats", "state"},
 			"period":     "10s",
 			"hosts":      endpoints,
-			"index":      fmt.Sprintf("metrics-elastic.agent.%s-default", name),
+			"index":      fmt.Sprintf("metrics-elastic_agent.%s-default", name),
 			"processors": []map[string]interface{}{
 				{
 					"add_fields": map[string]interface{}{
 						"target": "data_stream",
 						"fields": map[string]interface{}{
 							"type":      "metrics",
-							"dataset":   fmt.Sprintf("elastic.agent.%s", name),
+							"dataset":   fmt.Sprintf("elastic_agent.%s", name),
 							"namespace": "default",
 						},
 					},
@@ -286,7 +286,7 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 					"add_fields": map[string]interface{}{
 						"target": "event",
 						"fields": map[string]interface{}{
-							"dataset": fmt.Sprintf("elastic.agent.%s", name),
+							"dataset": fmt.Sprintf("elastic_agent.%s", name),
 						},
 					},
 				},


### PR DESCRIPTION
Cherry-pick of PR #21932 to 7.10 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Changes the index and dataset from `elastic.agent` to `elastic_agent`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

See #21862

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #21862 
