### PR TITLE
Cherry-pick #21756 to 7.9: [Filebeat][httpjson] Fix date_cursor validation

### DIFF
--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -109,10 +109,15 @@ func (dc *DateCursor) Validate() error {
 	if dc.DateFormat == "" {
 		return nil
 	}
-	now := time.Now().Format(dc.DateFormat)
-	if _, err := time.Parse(dc.DateFormat, now); err != nil {
+
+	const knownTimestamp = 1602601228 // 2020-10-13T15:00:28+00:00 RFC3339
+	knownDate := time.Unix(knownTimestamp, 0).UTC()
+
+	dateStr := knownDate.Format(dc.DateFormat)
+	if _, err := time.Parse(dc.DateFormat, dateStr); err != nil {
 		return errors.New("invalid configuration: date_format is not a valid date layout")
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #21756 to 7.9 branch. Original message: 

## What does this PR do?

It fixes the `httpjson` `date_cursor` config validation by using a fixed date for format validation.

## Why is it important?

Before `now` was used as the date to validate the format against, some formats (like the one used in the tests, which caused a new failing test recently https://github.com/elastic/beats/issues/21748) depending on the current date, would fail or not, causing flaky validation outputs.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes #21748

