### PR TITLE
Cherry-pick #21880 to 7.10: Stop storing stateless kubernetes keystores

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -417,6 +417,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Visualization title fixes in aws, azure and googlecloud compute dashboards. {pull}21098[21098]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
+- Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 
 *Packetbeat*
 

--- a/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
+++ b/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
@@ -30,14 +30,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-type KubernetesKeystores map[string]keystore.Keystore
-
-// KubernetesKeystoresRegistry holds KubernetesKeystores for known namespaces. Once a Keystore for one k8s namespace
-// is initialized it will be reused every time it is needed.
+// KubernetesKeystoresRegistry implements a Provider for Keystore.
 type KubernetesKeystoresRegistry struct {
-	kubernetesKeystores KubernetesKeystores
-	logger              *logp.Logger
-	client              k8s.Interface
+	logger *logp.Logger
+	client k8s.Interface
 }
 
 // KubernetesSecretsKeystore allows to retrieve passwords from Kubernetes secrets for a given namespace
@@ -56,9 +52,8 @@ func Factoryk8s(keystoreNamespace string, ks8client k8s.Interface, logger *logp.
 // NewKubernetesKeystoresRegistry initializes a KubernetesKeystoresRegistry
 func NewKubernetesKeystoresRegistry(logger *logp.Logger, client k8s.Interface) keystore.Provider {
 	return &KubernetesKeystoresRegistry{
-		kubernetesKeystores: KubernetesKeystores{},
-		logger:              logger,
-		client:              client,
+		logger: logger,
+		client: client,
 	}
 }
 
@@ -75,12 +70,7 @@ func (kr *KubernetesKeystoresRegistry) GetKeystore(event bus.Event) keystore.Key
 		namespace = ns.(string)
 	}
 	if namespace != "" {
-		// either retrieve already stored keystore or create a new one for the namespace
-		if storedKeystore, ok := kr.kubernetesKeystores[namespace]; ok {
-			return storedKeystore
-		}
 		k8sKeystore, _ := Factoryk8s(namespace, kr.client, kr.logger)
-		kr.kubernetesKeystores["namespace"] = k8sKeystore
 		return k8sKeystore
 	}
 	kr.logger.Debugf("Cannot retrieve kubernetes namespace from event: %s", event)


### PR DESCRIPTION
Cherry-pick of PR #21880 to 7.10 branch. Original message: 

## What does this PR do?
This PR removes `kubernetesKeystores` since it does not store anything that actually needs to be shared.


## Related issues
- Closes https://github.com/elastic/beats/issues/21843


