### PR TITLE
Cherry-pick #21657 to 7.9: Skip publisher flaky tests

### DIFF
--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -31,7 +31,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
-	"github.com/elastic/beats/v7/libbeat/tests/resources"
+
+	//"github.com/elastic/beats/v7/libbeat/tests/resources"
 
 	"github.com/stretchr/testify/require"
 )
@@ -46,8 +47,9 @@ func TestOutputReload(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testutil.SeedPRNG(t)
 
-			goroutines := resources.NewGoroutinesChecker()
-			defer goroutines.Check(t)
+			// Flaky check: https://github.com/elastic/beats/issues/21656
+			//goroutines := resources.NewGoroutinesChecker()
+			//defer goroutines.Check(t)
 
 			err := quick.Check(func(q uint) bool {
 				numEventsToPublish := 15000 + (q % 500) // 15000 to 19999

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -95,6 +95,8 @@ func TestMakeClientWorker(t *testing.T) {
 }
 
 func TestReplaceClientWorker(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/17965")
+
 	tests := map[string]func(mockPublishFn) outputs.Client{
 		"client":         newMockClient,
 		"network_client": newMockNetworkClient,


### PR DESCRIPTION
Cherry-pick of PR #21657 to 7.9 branch. Original message: 

Skip flaky tests:
* Goroutines checker in `TestOutputReload`. (see https://github.com/elastic/beats/issues/21656)
* `TestReplaceClientWorker`. (see https://github.com/elastic/beats/issues/17965)