### PR TITLE
Cherry-pick #19560 to 7.x: filebeat: add SSL options to checkpoint module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -725,6 +725,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Adding support for FIPS in s3 input {pull}21446[21446]
 - Add max_number_of_messages config into s3 input. {pull}21993[21993]
 - Update Okta documentation for new stateful restarts. {pull}22091[22091]
+- Add SSL option to checkpoint module {pull}19560[19560]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/checkpoint.asciidoc
+++ b/filebeat/docs/modules/checkpoint.asciidoc
@@ -70,6 +70,18 @@ A list of tags to include in events. Including `forwarded` indicates that the
 events did not originate on this host and causes `host.name` to not be added to
 events. Defaults to `[checkpoint-firewall, forwarded]`.
 
+*`var.ssl`*::
+
+The SSL/TLS configuration for the filebeat instance. This can be used to enforce mutual TLS.
+```yaml
+ssl:
+  enabled: true
+  certificate_authorities: ["my-ca.pem"]
+  certificate: "filebeat-cert.pem"
+  key: "filebeat-key.pem"
+  client_authentication: "required"
+```
+
 [float]
 ==== Check Point devices
 

--- a/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
@@ -65,6 +65,18 @@ A list of tags to include in events. Including `forwarded` indicates that the
 events did not originate on this host and causes `host.name` to not be added to
 events. Defaults to `[checkpoint-firewall, forwarded]`.
 
+*`var.ssl`*::
+
+The SSL/TLS configuration for the filebeat instance. This can be used to enforce mutual TLS.
+```yaml
+ssl:
+  enabled: true
+  certificate_authorities: ["my-ca.pem"]
+  certificate: "filebeat-cert.pem"
+  key: "filebeat-key.pem"
+  client_authentication: "required"
+```
+
 [float]
 ==== Check Point devices
 

--- a/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
@@ -1,4 +1,10 @@
-{{ if eq .input "syslog" }}
+{{ if .ssl }}
+
+type: tcp
+host: "{{.syslog_host}}:{{.syslog_port}}"
+ssl: {{ .ssl | tojson }}
+
+{{ else if eq .input "syslog" }}
 
 type: udp
 host: "{{.syslog_host}}:{{.syslog_port}}"

--- a/x-pack/filebeat/module/checkpoint/firewall/manifest.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/manifest.yml
@@ -9,6 +9,7 @@ var:
     default: 9001
   - name: input
     default: syslog
+  - name: ssl
 
 ingest_pipeline:
   - ingest/pipeline.yml


### PR DESCRIPTION
Cherry-pick of PR #19560 to 7.x branch. Original message: 

## What does this PR do?

This adds a `var.input` type `tls`, which will use tcp + tls for mutual TLS authentication.

## Why is it important?

Syslog udp is plaintext and does not guarantee CIA.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
https://github.com/elastic/beats/pull/17682
CC @P1llus @adriansr   @andrewstucki
