### PR TITLE
Cherry-pick #21992 to 7.x: Fix diskio and memory bugs under windows

### DIFF
--- a/metricbeat/module/system/diskio/diskio.go
+++ b/metricbeat/module/system/diskio/diskio.go
@@ -21,6 +21,7 @@ package diskio
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/metric/system/diskio"
@@ -114,7 +115,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		diskWriteBytes += counters.WriteBytes
 
 		//Add linux-only data if agent is off as not to make breaking changes.
-		if !m.IsAgent {
+		if !m.IsAgent && runtime.GOOS == "linux" {
 			result, err := m.statistics.CalcIOStatistics(counters)
 			if err != nil {
 				return errors.Wrap(err, "error calculating iostat")

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -42,7 +42,7 @@ func init() {
 // MetricSet for fetching system memory metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
-	IsFleet bool
+	IsAgent bool
 }
 
 // New is a mb.MetricSetFactory that returns a memory.MetricSet.
@@ -53,7 +53,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("unexpected module type")
 	}
 
-	return &MetricSet{BaseMetricSet: base, IsFleet: systemModule.IsAgent}, nil
+	return &MetricSet{BaseMetricSet: base, IsAgent: systemModule.IsAgent}, nil
 }
 
 // Fetch fetches memory metrics from the OS.
@@ -117,7 +117,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	// for backwards compatibility, only report if we're not in fleet mode
-	if !m.IsFleet {
+	if !m.IsAgent {
 		err := linux.FetchLinuxMemStats(memory)
 		if err != nil {
 			return errors.Wrap(err, "error getting page stats")

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -156,10 +156,12 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		// There's some more Windows memory quirks we need to deal with.
 		// "rss" is a linux concept, but "wss" is a direct match on Windows.
 		// "share" is also unavailable on Windows.
+		if runtime.GOOS == "windows" {
+			proc.Delete("memory.share")
+		}
 
 		if m.IsAgent {
 			if runtime.GOOS == "windows" {
-				proc.Delete("memory.share")
 				if setSize := getAndRemove(proc, "memory.rss"); setSize != nil {
 					proc.Put("memory.wss", setSize)
 				}


### PR DESCRIPTION
Cherry-pick of PR #21992 to 7.x branch. Original message: 


## What does this PR do?

Fixes some Windows bugs found under testing. We need to only call `CalcIOStatistics` under linux, and `memory.share` should be removed outside of agent, since it's a "null zero" metric under windows.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- pull down and build on Windows
- On windows, make sure `system/diskio` works, and `system.process.memory.share` does not work.

