### PR TITLE
Cherry-pick #21845 to 7.x: Azure storage metricset values not inside the metricset name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -419,6 +419,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Visualization title fixes in aws, azure and googlecloud compute dashboards. {pull}21098[21098]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
+- Fix azure storage event format. {pull}21845[21845]
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/azure/storage/storage.go
+++ b/x-pack/metricbeat/module/azure/storage/storage.go
@@ -41,6 +41,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	// set default resource type to indicate this is not the generic monitor metricset
+	ms.Client.Config.DefaultResourceType = defaultStorageAccountNamespace
 	// if no options are entered we will retrieve all the vm's from the entire subscription
 	if len(ms.Client.Config.Resources) == 0 {
 		ms.Client.Config.Resources = []azure.ResourceConfig{


### PR DESCRIPTION
Cherry-pick of PR #21845 to 7.x branch. Original message:

## What does this PR do?

Fixes the azure storage metricset event format

## Why is it important?

Latest changes on moving metricsets to light ones has caused on issue on the storage metricset where metric values were not inside the storage object

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

