### PR TITLE
Cherry-pick to 7.x: fix: mark flaky tests (#21300)

### DIFF
--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -41,6 +41,7 @@ func init() {
 const ErrorSharingViolation syscall.Errno = 32
 
 func TestEventReader(t *testing.T) {
+	t.Skip("Flaky test: about 1/10 of bulds fails https://github.com/elastic/beats/issues/21302")
 	// Make dir to monitor.
 	dir, err := ioutil.TempDir("", "audit")
 	if err != nil {
@@ -240,6 +241,7 @@ func TestEventReader(t *testing.T) {
 }
 
 func TestRaces(t *testing.T) {
+	t.Skip("Flaky test: about 1/20 of bulds fails https://github.com/elastic/beats/issues/21303")
 	const (
 		fileMode os.FileMode = 0640
 		N                    = 100

--- a/filebeat/tests/system/test_reload_inputs.py
+++ b/filebeat/tests/system/test_reload_inputs.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import time
 from filebeat import BaseTest
 
@@ -249,6 +250,8 @@ class Test(BaseTest):
         assert output[0]["message"] == first_line
         assert output[1]["message"] == second_line
 
+    # 1/20 build fails https://github.com/elastic/beats/issues/21307
+    @pytest.mark.flaky(reruns=1, reruns_delay=10)
     def test_reload_same_config(self):
         """
         Test reload same config with same file but different config. Makes sure reloading also works on conflicts.

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -1,6 +1,7 @@
 import jinja2
 import os
 import platform
+import pytest
 import sys
 import time
 import unittest
@@ -42,6 +43,8 @@ class Test(AuditbeatXPackTest):
         # Metricset is beta and that generates a warning, TODO: remove later
         self.check_metricset("system", "login", COMMON_FIELDS + fields, config, warnings_allowed=True)
 
+    # 1/20 build fails https://github.com/elastic/beats/issues/21308
+    @pytest.mark.flaky(reruns=1, reruns_delay=10)
     @unittest.skipIf(sys.platform == "win32", "Not implemented for Windows")
     @unittest.skipIf(sys.platform.startswith('linux') and not (os.path.isdir("/var/lib/dpkg") or os.path.isdir("/var/lib/rpm")),
                      "Only implemented for dpkg and rpm")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: mark flaky tests (#21300)