### PR TITLE
[DOCS] Update doc links

### DIFF
--- a/libbeat/docs/getting-started.asciidoc
+++ b/libbeat/docs/getting-started.asciidoc
@@ -13,5 +13,5 @@ Each Beat is a separately installable product. To learn how to get started, see:
 * {winlogbeat-ref}/winlogbeat-installation-configuration.html[Winlogbeat]
 
 If you're planning to use the {metrics-app} or the {logs-app} in {kib},
-also see the {metrics-guide}[Metrics Monitoring Guide]
-and the {logs-guide}[Logs Monitoring Guide].
+see {observability-guide}/analyze-metrics.html[Analyze metrics]
+and {observability-guide}/monitor-logs.html[Monitor logs].

--- a/libbeat/docs/howto/load-dashboards.asciidoc
+++ b/libbeat/docs/howto/load-dashboards.asciidoc
@@ -15,8 +15,8 @@
 ifdef::has_solutions[]
 TIP: For deeper observability into your infrastructure, you can use the
 {metrics-app} and the {logs-app} in {kib}.
-For more details, see the {metrics-guide}[Metrics Monitoring Guide]
-and the {logs-guide}[Logs Monitoring Guide].
+For more details, see {observability-guide}/analyze-metrics.html[Analyze metrics]
+and {observability-guide}/monitor-logs.html[Monitor logs].
 endif::has_solutions[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -28,8 +28,8 @@ To get started, see <<getting-started>>.
 Want to get up and running quickly with infrastructure metrics monitoring and
 centralized log analytics?
 Try out the {metrics-app} and the {logs-app} in {kib}.
-For more details, see the {metrics-guide}[Metrics Monitoring Guide]
-and the {logs-guide}[Logs Monitoring Guide].
+For more details, see {observability-guide}/analyze-metrics.html[Analyze metrics]
+and {observability-guide}/monitor-logs.html[Monitor logs].
 
 [float]
 === Need to capture other kinds of data?


### PR DESCRIPTION
This PR updates links to the Observability Guide. The updates are required due to build failures on this [PR](https://github.com/elastic/docs/pull/1985).

### Related PR

https://github.com/elastic/docs/pull/1985

### Related issue

https://github.com/elastic/observability-docs/issues/189