### PR TITLE
Cherry-pick #22009 to 7.x: [Kubernetes] Remove redundant dockersock volume mount

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -422,6 +422,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Report the correct windows events for system/filesystem {pull}21758[21758]
 - Fix azure storage event format. {pull}21845[21845]
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
+- [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
 
 *Packetbeat*
 

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -189,8 +189,6 @@ spec:
         - name: modules
           mountPath: /usr/share/metricbeat/modules.d
           readOnly: true
-        - name: dockersock
-          mountPath: /var/run/docker.sock
         - name: proc
           mountPath: /hostfs/proc
           readOnly: true
@@ -204,9 +202,6 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
       - name: config
         configMap:
           defaultMode: 0640

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -64,8 +64,6 @@ spec:
         - name: modules
           mountPath: /usr/share/metricbeat/modules.d
           readOnly: true
-        - name: dockersock
-          mountPath: /var/run/docker.sock
         - name: proc
           mountPath: /hostfs/proc
           readOnly: true
@@ -79,9 +77,6 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
       - name: config
         configMap:
           defaultMode: 0640


### PR DESCRIPTION
Cherry-pick of PR #22009 to 7.x branch. Original message: 

## What does this PR do?
Removes redundant dockersock volume mount which is not currently used out-of-the-box since it is only necessesary for `add_docker_metadata` and `docker` module which are not enabled by default. An additional reason for removing this is that it can cause problems on k8s deployments that do not use docker as container runtime and hence the socket is missing. 

## Why is it important?

1.  Clean manifest
2. Avoid confusion with users running on k8s with runtime other than docker.