### PR TITLE
Cherry-pick to 7.x: [beats-tester][packaging] store packages in another location (#21903)

### DIFF
--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -54,6 +54,7 @@ pipeline {
           options { skipDefaultCheckout() }
           when { branch 'master' }
           steps {
+            // TODO: to use the git commit that triggered the upstream build
             runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
           }
         }
@@ -61,6 +62,7 @@ pipeline {
           options { skipDefaultCheckout() }
           when { branch '*.x' }
           steps {
+            // TODO: to use the git commit that triggered the upstream build
             runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
           }
         }
@@ -84,6 +86,7 @@ pipeline {
             }
            }
           steps {
+            // TODO: to use the git commit that triggered the upstream build
             runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT")
           }
         }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -234,7 +234,16 @@ def publishPackages(baseDir){
     bucketUri = "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}"
   }
   def beatsFolderName = getBeatsName(baseDir)
-  googleStorageUpload(bucket: "${bucketUri}/${beatsFolderName}",
+  uploadPackages("${bucketUri}/${beatsFolderName}", baseDir)
+
+  // Copy those files to another location with the sha commit to test them
+  // aftewords.
+  bucketUri = "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}"
+  uploadPackages("${bucketUri}/${beatsFolderName}", baseDir)
+}
+
+def uploadPackages(bucketUri, baseDir){
+  googleStorageUpload(bucket: bucketUri,
     credentialsId: "${JOB_GCS_CREDENTIALS}",
     pathPrefix: "${baseDir}/build/distributions/",
     pattern: "${baseDir}/build/distributions/**/*",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [beats-tester][packaging] store packages in another location (#21903)