### PR TITLE
Cherry-pick #21766 to 7.10: Document auditbeat system process module config

### DIFF
--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -77,7 +77,7 @@ This module also supports the
 <<module-standard-options-{modulename},standard configuration options>>
 described later.
 
-*`state.period`*:: The frequency at which the datasets send full state information.
+*`state.period`*:: The interval at which the datasets send full state information.
 This option can be overridden per dataset using `{dataset}.state.period`.
 
 *`user.detect_password_changes`*:: If the `user` dataset is configured and

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -70,7 +70,7 @@ This module also supports the
 <<module-standard-options-{modulename},standard configuration options>>
 described later.
 
-*`state.period`*:: The frequency at which the datasets send full state information.
+*`state.period`*:: The interval at which the datasets send full state information.
 This option can be overridden per dataset using `{dataset}.state.period`.
 
 *`user.detect_password_changes`*:: If the `user` dataset is configured and

--- a/x-pack/auditbeat/module/system/process/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/process/_meta/docs.asciidoc
@@ -2,9 +2,29 @@
 
 beta[]
 
-This is the `process` dataset of the system module.
+This is the `process` dataset of the system module. It generates an event when
+a process starts and stops.
 
 It is implemented for Linux, macOS (Darwin), and Windows.
+
+[float]
+=== Configuration options
+
+*`process.state.period`*:: The interval at which the dataset sends full state
+information. If set this will take precedence over `state.period`. The default
+value is `12h`.
+
+*`process.hash.max_file_size`*:: The maximum size of a file in bytes for which
+{beatname_uc} will compute hashes. Files larger than this size will not be
+hashed. The default value is 100 MiB. For convenience units can be specified as
+a suffix to the value. The supported units are `b` (default), `kib`, `kb`,
+`mib`, `mb`, `gib`, `gb`, `tib`, `tb`, `pib`, `pb`, `eib`, and `eb`.
+
+*`process.hash.hash_types`*:: A list of hash types to compute when the file
+changes. The supported hash types are `blake2b_256`, `blake2b_384`,
+`blake2b_512`, `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`,
+`sha512_224`, `sha512_256`, `sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`, and
+`xxh64`. The default value is `sha1`.
 
 [float]
 ==== Example dashboard


### PR DESCRIPTION
Cherry-pick of PR #21766 to 7.10 branch. Original message: 

## What does this PR do?

The documentation for the system/process dataset was missing information
on the configuration options.

## Why is it important?

So users know about the available tuning options.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation

## Screenshot

<img width="750" alt="Screen Shot 2020-10-13 at 1 51 03 PM" src="https://user-images.githubusercontent.com/4565752/95897336-5b4ead80-0d5b-11eb-827a-e3302dee34c8.png">

