### PR TITLE
Change path for the Elastic agent on darwin to install in /usr/bin/ the

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@
 - Improve GRPC stop to be more relaxed {pull}20118[20118]
 - Fix Windows service installation script {pull}20203[20203]
 - Fix timeout issue stopping service applications {pull}20256[20256]
+- Install the elastic-agent wrapper in /usr/bin on macOS. {issues}22037[22037]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/install/paths_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/install/paths_darwin.go
@@ -20,7 +20,7 @@ const (
 	ServiceName = "co.elastic.elastic-agent"
 
 	// ShellWrapperPath is the path to the installed shell wrapper.
-	ShellWrapperPath = "/usr/local/bin/elastic-agent"
+	ShellWrapperPath = "/usr/bin/elastic-agent"
 
 	// ShellWrapper is the wrapper that is installed.
 	ShellWrapper = `#!/bin/sh


### PR DESCRIPTION
wrapper.

Previously the install subcommand was installing the elastic agent on
the /usr/local/bin. This path doesn't exist in a default macOS installation
and this path is not added to the $PATH by default.

This PR changes the behavior on darwin to install the elastic agent
wrapper into the /usr/bin directly.


Filebeat debian install their wrapper in /usr/bin/filebeat.

```
winterfell/tmp/o/l(:|✔) % tree
.
└── usr
    └── bin
        └── filebeat

2 directories, 1 file

```

Fixes: #22037

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Install on fresh macOS vm, the install subcommand should succeed and run `elastic-agent` in a terminal should run.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
