### PR TITLE
Cherry-pick #21884 to 7.x: Use ML_SYSTEM to detect if agent is running as a service

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -17,8 +17,6 @@
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
 - Use ML_SYSTEM to detect if agent is running as a service {pull}21884[21884]
-- Use local temp instead of system one {pull}21883[21883]
-- Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 - Fix issue with named pipes on Windows 7 {pull}21931[21931]
 - Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -16,6 +16,9 @@
 - Include inputs in action store actions {pull}21298[21298]
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
+- Use ML_SYSTEM to detect if agent is running as a service {pull}21884[21884]
+- Use local temp instead of system one {pull}21883[21883]
+- Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 - Fix issue with named pipes on Windows 7 {pull}21931[21931]
 - Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 

--- a/x-pack/elastic-agent/pkg/agent/install/svc_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/install/svc_windows.go
@@ -10,10 +10,14 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const (
+	ML_SYSTEM_RID = 0x4000
+)
+
 // RunningUnderSupervisor returns true when executing Agent is running under
 // the supervisor processes of the OS.
 func RunningUnderSupervisor() bool {
-	serviceSid, err := allocSid(windows.SECURITY_SERVICE_RID)
+	serviceSid, err := allocSid(ML_SYSTEM_RID)
 	if err != nil {
 		return false
 	}
@@ -40,7 +44,7 @@ func RunningUnderSupervisor() bool {
 
 func allocSid(subAuth0 uint32) (*windows.SID, error) {
 	var sid *windows.SID
-	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_MANDATORY_LABEL_AUTHORITY,
 		1, subAuth0, 0, 0, 0, 0, 0, 0, 0, &sid)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#21884 to 7.x branch. Original message:

## What does this PR do?

We were using SERVICE token to detect whether or not agent is running as a service. But it turned out that in many cases this token is missing. 

We decided that it would be better to use ML_SYSTEM which should be close enough to detect high elevated runs == service runs.

## Why is it important?

TO make agent upgradeable even on windows.
Fixes: elastic/beats#21822

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
