### PR TITLE
[build][packaging] Add resilience when docker build

### DIFF
--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -75,8 +75,7 @@ func (b *dockerBuilder) Build() error {
 		fmt.Println(">> Building docker images again (after 10 seconds)")
 		// This sleep is to avoid hitting the docker build issues when resources are not available.
 		time.Sleep(10)
-		tagSecondTry, err := b.dockerBuild()
-		tag = tagSecondTry
+		tag, err = b.dockerBuild()
 		if err != nil {
 			return errors.Wrap(err, "failed to build docker")
 		}

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -75,7 +75,8 @@ func (b *dockerBuilder) Build() error {
 		fmt.Println(">> Building docker images again (after 10 seconds)")
 		// This sleep is to avoid hitting the docker build issues when resources are not available.
 		time.Sleep(10)
-		tag, err = b.dockerBuild()
+		tagSecondTry, err := b.dockerBuild()
+		tag = tagSecondTry
 		if err != nil {
 			return errors.Wrap(err, "failed to build docker")
 		}

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/magefile/mage/sh"
 	"github.com/pkg/errors"
@@ -71,7 +72,13 @@ func (b *dockerBuilder) Build() error {
 
 	tag, err := b.dockerBuild()
 	if err != nil {
-		return errors.Wrap(err, "failed to build docker")
+		fmt.Println(">> Building docker images again (after 10 seconds)")
+		// This sleep is to avoid hitting the docker build issues when resources are not available.
+		time.Sleep(10)
+		tag, err := b.dockerBuild()
+		if err != nil {
+			return errors.Wrap(err, "failed to build docker")
+		}
 	}
 
 	if err := b.dockerSave(tag); err != nil {

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -75,7 +75,7 @@ func (b *dockerBuilder) Build() error {
 		fmt.Println(">> Building docker images again (after 10 seconds)")
 		// This sleep is to avoid hitting the docker build issues when resources are not available.
 		time.Sleep(10)
-		tag, err := b.dockerBuild()
+		tag, err = b.dockerBuild()
 		if err != nil {
 			return errors.Wrap(err, "failed to build docker")
 		}

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -207,7 +207,7 @@ func (d *wrapperDriver) Up(ctx context.Context, opts UpOptions, service string) 
 		build.Stdout = nil
 		build.Stderr = &stderr
 		if err := build.Run(); err != nil {
-			fmt.Println(">> Building docker images failed using docker-compose (let's try now with docker-compose up --build): %s", stderr.String())
+			fmt.Printf(">> Building docker images failed using docker-compose (let's try now with docker-compose up --build): %s", stderr.String())
 		}
 	}
 

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -196,7 +196,6 @@ func (d *wrapperDriver) Up(ctx context.Context, opts UpOptions, service string) 
 	}
 
 	// Try to build the docker images
-	var stderr bytes.Buffer
 	build := d.cmd(ctx, "build", "--pull", service)
 	build.Stdout = nil
 	build.Stderr = &stderr

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -195,22 +195,6 @@ func (d *wrapperDriver) Up(ctx context.Context, opts UpOptions, service string) 
 		return errors.Wrapf(err, "failed to pull images using docker-compose: %s", stderr.String())
 	}
 
-	// Try to build the docker images
-	build := d.cmd(ctx, "build", "--pull", service)
-	build.Stdout = nil
-	build.Stderr = &stderr
-	if err := build.Run(); err != nil {
-		fmt.Println(">> Building docker images again (after 10 seconds)")
-		// This sleep is to avoid hitting the docker build issues when resources are not available.
-		time.Sleep(10)
-		build := d.cmd(ctx, "build", service)
-		build.Stdout = nil
-		build.Stderr = &stderr
-		if err := build.Run(); err != nil {
-			fmt.Printf(">> Building docker images failed using docker-compose (let's try now with docker-compose up --build): %s", stderr.String())
-		}
-	}
-
 	err := d.cmd(ctx, "up", args...).Run()
 	if err != nil {
 		return err

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -195,6 +195,23 @@ func (d *wrapperDriver) Up(ctx context.Context, opts UpOptions, service string) 
 		return errors.Wrapf(err, "failed to pull images using docker-compose: %s", stderr.String())
 	}
 
+	// Try to build the docker images
+	var stderr bytes.Buffer
+	build := d.cmd(ctx, "build", "--pull", service)
+	build.Stdout = nil
+	build.Stderr = &stderr
+	if err := build.Run(); err != nil {
+		fmt.Println(">> Building docker images again (after 10 seconds)")
+		// This sleep is to avoid hitting the docker build issues when resources are not available.
+		time.Sleep(10)
+		build := d.cmd(ctx, "build", service)
+		build.Stdout = nil
+		build.Stderr = &stderr
+		if err := build.Run(); err != nil {
+			fmt.Println(">> Building docker images failed using docker-compose (let's try now with docker-compose up --build): %s", stderr.String())
+		}
+	}
+
 	err := d.cmd(ctx, "up", args...).Run()
 	if err != nil {
 		return err

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -513,8 +513,13 @@ func runAgent(env map[string]string) error {
 		}
 
 		// build docker image
-		if err := sh.Run("docker", "build", "-t", tag, "."); err != nil {
-			return err
+		if err := dockerBuild(tag); err != nil {
+			fmt.Println(">> Building docker images again (after 10 seconds)")
+			// This sleep is to avoid hitting the docker build issues when resources are not available.
+			time.Sleep(10)
+			if err := dockerBuild(tag); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -623,6 +628,10 @@ func copyAll(from, to string) error {
 		// overwrites with current build
 		return sh.Copy(targetFile, path)
 	})
+}
+
+func dockerBuild(tag) string {
+	return sh.Run("docker", "build", "-t", tag, ".")
 }
 
 func dockerTag() string {

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -630,7 +630,7 @@ func copyAll(from, to string) error {
 	})
 }
 
-func dockerBuild(tag) string {
+func dockerBuild(tag string) string {
 	return sh.Run("docker", "build", "-t", tag, ".")
 }
 

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -630,7 +630,7 @@ func copyAll(from, to string) error {
 	})
 }
 
-func dockerBuild(tag string) string {
+func dockerBuild(tag string) error {
 	return sh.Run("docker", "build", "-t", tag, ".")
 }
 


### PR DESCRIPTION
## What does this PR do?

Retry to build docker images when something bad happened.

We could potentially include a retry step in the CI but it might add some overhead, another approach could be creating a specific mage goal to run the `docker build` rather than just using the mage goal for everything.

## Why is it important?

Sometimes some third party resources are not accessible temporarily.

Also the `Unified Release` team will enjoy this particular approach to avoid any issues when pulling docker images or building from scratch. 

## Related issues

Caused by https://github.com/elastic/beats/issues/21563
Closes https://github.com/elastic/beats/pull/22020