### PR TITLE
revert WSS process reporting for windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -378,6 +378,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix azure storage event format. {pull}21845[21845]
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
+- Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -150,22 +150,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 			rootFields.Put("process.args", args)
 		}
 
-		// This is a temporary fix until we make these changes global across libbeat
-		// This logic should happen in libbeat getProcessEvent()
-
-		// There's some more Windows memory quirks we need to deal with.
-		// "rss" is a linux concept, but "wss" is a direct match on Windows.
-		// "share" is also unavailable on Windows.
+		// "share" is unavailable on Windows.
 		if runtime.GOOS == "windows" {
 			proc.Delete("memory.share")
-		}
-
-		if m.IsAgent {
-			if runtime.GOOS == "windows" {
-				if setSize := getAndRemove(proc, "memory.rss"); setSize != nil {
-					proc.Put("memory.wss", setSize)
-				}
-			}
 		}
 
 		e := mb.Event{


### PR DESCRIPTION
## What does this PR do?

This reverts the change to report `system.process.memory.rss` as `wss` on windows.

## Why is it important?

@mukeshelastic and I decided that this change was unnecessary. We're reporting what is fundamentally the same metric as two different fields depending on the OS. This is particularly burdensome for users wanting to make queries against these fiends across OS. When we have the opportunity to make breaking changes, we may want to rename this to `system.process.memory.pct` or something similar.

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Pull down PR and build on windows
- Ensure that `memory.rss` is present on the system/process metricset
