### PR TITLE
Cherry-pick to 7.10: Fix typo (#19585)

### DIFF
--- a/heartbeat/docs/monitors/monitor-http.asciidoc
+++ b/heartbeat/docs/monitors/monitor-http.asciidoc
@@ -161,7 +161,7 @@ Under `check.response`, specify these options:
 
 *`status`*:: A list of expected status codes. 4xx and 5xx codes are considered `down` by default. Other codes are considered `up`.
 *`headers`*:: The required response headers.
-*`body`*:: A list of regular expressions to match the the body output. Only a single expression needs to match. HTTP response
+*`body`*:: A list of regular expressions to match the body output. Only a single expression needs to match. HTTP response
 bodies of up to 100MiB are supported.
 
 Example configuration:


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Fix typo (#19585)