### PR TITLE
Remove old TODO on kubernetes node update

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -105,7 +105,6 @@ func (n *node) OnUpdate(obj interface{}) {
 		time.AfterFunc(n.config.CleanupTimeout, func() { n.emit(node, "stop") })
 	} else {
 		n.logger.Debugf("Watcher Node update: %+v", obj)
-		// TODO: figure out how to avoid stop starting when node status is periodically being updated by kubelet
 		n.emit(node, "stop")
 		n.emit(node, "start")
 	}


### PR DESCRIPTION
@exekias @vjsamuel is this TODO https://github.com/elastic/beats/blob/bcb4e0c9c314f04cee3efcc20e7064169ca76616/libbeat/autodiscover/providers/kubernetes/node.go#L108  still valid or should be removed after https://github.com/elastic/beats/pull/19974?