### PR TITLE
Cherry-pick to 7.10: packaging backports

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -298,7 +298,7 @@ def runE2ETests(){
 def triggerE2ETests(String suite) {
   echo("Triggering E2E tests for PR-${env.CHANGE_ID}. Test suites: ${suite}.")
 
-  def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}"
+  def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}.x"
   def e2eTestsPipeline = "e2e-tests/e2e-testing-mbp/${branchName}"
 
   def parameters = [

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -191,10 +191,14 @@ def pushCIDockerImages(){
   }
 }
 
-def tagAndPush(name){
+def tagAndPush(beatName){
   def libbetaVer = sh(label: 'Get libbeat version', script: 'grep defaultBeatVersion ${BASE_DIR}/libbeat/version/version.go|cut -d "=" -f 2|tr -d \\"', returnStdout: true)?.trim()
+  def aliasVersion = ""
   if("${env.SNAPSHOT}" == "true"){
+    aliasVersion = libbetaVer.substring(0, libbetaVer.lastIndexOf(".")) // remove third number in version
+
     libbetaVer += "-SNAPSHOT"
+    aliasVersion += "-SNAPSHOT"
   }
 
   def tagName = "${libbetaVer}"
@@ -207,25 +211,37 @@ def tagAndPush(name){
   // supported image flavours
   def variants = ["", "-oss", "-ubi8"]
   variants.each { variant ->
-    def oldName = "${DOCKER_REGISTRY}/beats/${name}${variant}:${libbetaVer}"
-    def newName = "${DOCKER_REGISTRY}/observability-ci/${name}${variant}:${tagName}"
-    def commitName = "${DOCKER_REGISTRY}/observability-ci/${name}${variant}:${env.GIT_BASE_COMMIT}"
+    doTagAndPush(beatName, variant, libbetaVer, tagName)
+    doTagAndPush(beatName, variant, libbetaVer, "${env.GIT_BASE_COMMIT}")
 
-    def iterations = 0
-    retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-      iterations++
-      def status = sh(label:'Change tag and push', script: """
-        docker tag ${oldName} ${newName}
-        docker push ${newName}
-        docker tag ${oldName} ${commitName}
-        docker push ${commitName}
-      """, returnStatus: true)
+    if (!isPR() && aliasVersion != "") {
+      doTagAndPush(beatName, variant, libbetaVer, aliasVersion)
+    }
+  }
+}
 
-      if ( status > 0 && iterations < 3) {
-        error('tag and push failed, retry')
-      } else if ( status > 0 ) {
-        log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
-      }
+/**
+* @param beatName name of the Beat
+* @param variant name of the variant used to build the docker image name
+* @param sourceTag tag to be used as source for the docker tag command, usually under the 'beats' namespace
+* @param targetTag tag to be used as target for the docker tag command, usually under the 'observability-ci' namespace
+*/
+def doTagAndPush(beatName, variant, sourceTag, targetTag) {
+  def sourceName = "${DOCKER_REGISTRY}/beats/${beatName}${variant}:${sourceTag}"
+  def targetName = "${DOCKER_REGISTRY}/observability-ci/${beatName}${variant}:${targetTag}"
+
+  def iterations = 0
+  retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+    iterations++
+    def status = sh(label: "Change tag and push ${targetName}", script: """
+      docker tag ${sourceName} ${targetName}
+      docker push ${targetName}
+    """, returnStatus: true)
+
+    if ( status > 0 && iterations < 3) {
+      error("tag and push failed for ${beatName}, retry")
+    } else if ( status > 0 ) {
+      log(level: 'WARN', text: "${beatName} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -2,6 +2,13 @@
 
 @Library('apm@current') _
 
+import groovy.transform.Field
+
+/**
+ This is required to store the test suites we will use to trigger the E2E tests.
+*/
+@Field def e2eTestSuites = []
+
 pipeline {
   agent none
   environment {
@@ -121,7 +128,7 @@ pipeline {
                     release()
                     pushCIDockerImages()
                   }
-                  runE2ETestForPackages()
+                  prepareE2ETestForPackage("${BEATS_FOLDER}")
                 }
               }
               stage('Package Mac OS'){
@@ -150,6 +157,13 @@ pipeline {
                 }
               }
             }
+          }
+        }
+        stage('Run E2E Tests for Packages'){
+          agent { label 'ubuntu && immutable' }
+          options { skipDefaultCheckout() }
+          steps {
+            runE2ETests()
           }
         }
       }
@@ -208,7 +222,7 @@ def tagAndPush(name){
     def commitName = "${DOCKER_REGISTRY}/observability-ci/${name}${variant}:${env.GIT_BASE_COMMIT}"
 
     def iterations = 0
-    retryWithSleep(retries: 3, seconds: 5, backoff: true)
+    retryWithSleep(retries: 3, seconds: 5, backoff: true) {
       iterations++
       def status = sh(label:'Change tag and push', script: """
         docker tag ${oldName} ${newName}
@@ -217,30 +231,27 @@ def tagAndPush(name){
         docker push ${commitName}
       """, returnStatus: true)
 
-    if ( status > 0 && iterations < 3) {
-      error('tag and push failed, retry')
-    } else if ( status > 0 ) {
-      log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
+      if ( status > 0 && iterations < 3) {
+        error('tag and push failed, retry')
+      } else if ( status > 0 ) {
+        log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
+      }
     }
   }
 }
 
-def runE2ETestForPackages(){
-  def suite = ''
-
-  catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
-    if ("${env.BEATS_FOLDER}" == "filebeat" || "${env.BEATS_FOLDER}" == "x-pack/filebeat") {
-      suite = 'helm,fleet'
-    } else if ("${env.BEATS_FOLDER}" == "metricbeat" || "${env.BEATS_FOLDER}" == "x-pack/metricbeat") {
-      suite = ''
-    } else if ("${env.BEATS_FOLDER}" == "x-pack/elastic-agent") {
-      suite = 'fleet'
-    } else {
-      echo("Skipping E2E tests for ${env.BEATS_FOLDER}.")
-      return
-    }
-
-    triggerE2ETests(suite)
+def prepareE2ETestForPackage(String beat){
+  if ("${beat}" == "filebeat" || "${beat}" == "x-pack/filebeat") {
+    e2eTestSuites.push('fleet')
+    e2eTestSuites.push('helm')
+  } else if ("${beat}" == "metricbeat" || "${beat}" == "x-pack/metricbeat") {
+    e2eTestSuites.push('ALL')
+    echo("${beat} adds all test suites to the E2E tests job.")
+  } else if ("${beat}" == "x-pack/elastic-agent") {
+    e2eTestSuites.push('fleet')
+  } else {
+    echo("${beat} does not add any test suite to the E2E tests job.")
+    return
   }
 }
 
@@ -257,8 +268,29 @@ def release(){
   }
 }
 
+def runE2ETests(){
+  if (e2eTestSuites.size() == 0) {
+    echo("Not triggering E2E tests for PR-${env.CHANGE_ID} because the changes does not affect the E2E.")
+    return
+  }
+
+  def suites = '' // empty value represents all suites in the E2E tests
+
+  catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
+    def suitesSet = e2eTestSuites.toSet()
+
+    if (!suitesSet.contains('ALL')) {
+      suitesSet.each { suite ->
+        suites += "${suite},"
+      };
+    }
+
+    triggerE2ETests(suites)
+  }
+}
+
 def triggerE2ETests(String suite) {
-  echo("Triggering E2E tests for ${env.BEATS_FOLDER}. Test suite: ${suite}.")
+  echo("Triggering E2E tests for PR-${env.CHANGE_ID}. Test suites: ${suite}.")
 
   def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}"
   def e2eTestsPipeline = "e2e-tests/e2e-testing-mbp/${branchName}"
@@ -285,7 +317,7 @@ def triggerE2ETests(String suite) {
     wait: false
   )
 
-  def notifyContext = "${env.GITHUB_CHECK_E2E_TESTS_NAME} for ${env.BEATS_FOLDER}"
+  def notifyContext = "${env.GITHUB_CHECK_E2E_TESTS_NAME}"
   githubNotify(context: "${notifyContext}", description: "${notifyContext} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${e2eTestsPipeline.replaceAll('/','+')}")
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -215,12 +215,12 @@ def tagAndPush(name){
         docker push ${newName}
         docker tag ${oldName} ${commitName}
         docker push ${commitName}
-      """, returnStatus: true) 
-      if ( status > 0 && iterations < 3) {
-        error('tag and push failed, retry')
-      } else if ( status > 0 ) {
-        log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
-      }
+      """, returnStatus: true)
+
+    if ( status > 0 && iterations < 3) {
+      error('tag and push failed, retry')
+    } else if ( status > 0 ) {
+      log(level: 'WARN', text: "${name} doesn't have ${variant} docker images. See https://github.com/elastic/beats/pull/21621")
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -246,8 +246,12 @@ def runE2ETestForPackages(){
 
 def release(){
   withBeatsEnv(){
-    dir("${env.BEATS_FOLDER}") {
-      sh(label: "Release ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
+    withEnv([
+      "DEV=true"
+    ]) {
+      dir("${env.BEATS_FOLDER}") {
+        sh(label: "Release ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
+      }
     }
     publishPackages("${env.BEATS_FOLDER}")
   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -5,12 +5,14 @@
 pipeline {
   agent none
   environment {
-    BASE_DIR = 'src/github.com/elastic/beats'
+    REPO = 'beats'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
     JOB_GCS_BUCKET = 'beats-ci-artifacts'
     JOB_GCS_BUCKET_STASH = 'beats-ci-temp'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
+    GITHUB_CHECK_E2E_TESTS_NAME = 'E2E Tests'
     SNAPSHOT = "true"
     PIPELINE_LOG_LEVEL = "INFO"
   }
@@ -119,6 +121,7 @@ pipeline {
                     release()
                     pushCIDockerImages()
                   }
+                  runE2ETestForPackages()
                 }
               }
               stage('Package Mac OS'){
@@ -209,6 +212,25 @@ def tagAndPush(name){
   }
 }
 
+def runE2ETestForPackages(){
+  def suite = ''
+
+  catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
+    if ("${env.BEATS_FOLDER}" == "filebeat" || "${env.BEATS_FOLDER}" == "x-pack/filebeat") {
+      suite = 'helm,ingest-manager'
+    } else if ("${env.BEATS_FOLDER}" == "metricbeat" || "${env.BEATS_FOLDER}" == "x-pack/metricbeat") {
+      suite = ''
+    } else if ("${env.BEATS_FOLDER}" == "x-pack/elastic-agent") {
+      suite = 'ingest-manager'
+    } else {
+      echo("Skipping E2E tests for ${env.BEATS_FOLDER}.")
+      return
+    }
+
+    triggerE2ETests(suite)
+  }
+}
+
 def release(){
   withBeatsEnv(){
     dir("${env.BEATS_FOLDER}") {
@@ -216,6 +238,32 @@ def release(){
     }
     publishPackages("${env.BEATS_FOLDER}")
   }
+}
+
+def triggerE2ETests(String suite) {
+  echo("Triggering E2E tests for ${env.BEATS_FOLDER}. Test suite: ${suite}.")
+
+  def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}"
+  def e2eTestsPipeline = "e2e-tests/e2e-testing-mbp/${branchName}"
+  build(job: "${e2eTestsPipeline}",
+    parameters: [
+      booleanParam(name: 'forceSkipGitChecks', value: true),
+      booleanParam(name: 'forceSkipPresubmit', value: true),
+      booleanParam(name: 'notifyOnGreenBuilds', value: !isPR()),
+      booleanParam(name: 'USE_CI_SNAPSHOTS', value: true),
+      string(name: 'ELASTIC_AGENT_VERSION', value: "pr-${env.CHANGE_ID}"),
+      string(name: 'METRICBEAT_VERSION', value: "pr-${env.CHANGE_ID}"),
+      string(name: 'runTestsSuites', value: suite),
+      string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_E2E_TESTS_NAME),
+      string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+      string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT),
+    ],
+    propagate: false,
+    wait: false
+  )
+
+  def notifyContext = "${env.GITHUB_CHECK_E2E_TESTS_NAME} for ${env.BEATS_FOLDER}"
+  githubNotify(context: "${notifyContext}", description: "${notifyContext} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${e2eTestsPipeline.replaceAll('/','+')}")
 }
 
 def withMacOSEnv(Closure body){

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -173,30 +173,20 @@ pipeline {
 
 def pushCIDockerImages(){
   catchError(buildResult: 'UNSTABLE', message: 'Unable to push Docker images', stageResult: 'FAILURE') {
-    if ("${env.BEATS_FOLDER}" == "auditbeat"){
-      tagAndPush('auditbeat-oss')
-    } else if ("${env.BEATS_FOLDER}" == "filebeat") {
-      tagAndPush('filebeat-oss')
-    } else if ("${env.BEATS_FOLDER}" == "heartbeat"){
-      tagAndPush('heartbeat-oss')
+    if (env?.BEATS_FOLDER?.endsWith('auditbeat')) {
+      tagAndPush('auditbeat')
+    } else if (env?.BEATS_FOLDER?.endsWith('filebeat')) {
+      tagAndPush('filebeat')
+    } else if (env?.BEATS_FOLDER?.endsWith('heartbeat')) {
+      tagAndPush('heartbeat')
     } else if ("${env.BEATS_FOLDER}" == "journalbeat"){
       tagAndPush('journalbeat')
-      tagAndPush('journalbeat-oss')
-    } else if ("${env.BEATS_FOLDER}" == "metricbeat"){
-      tagAndPush('metricbeat-oss')
+    } else if (env?.BEATS_FOLDER?.endsWith('metricbeat')) {
+      tagAndPush('metricbeat')
     } else if ("${env.BEATS_FOLDER}" == "packetbeat"){
       tagAndPush('packetbeat')
-      tagAndPush('packetbeat-oss')
-    } else if ("${env.BEATS_FOLDER}" == "x-pack/auditbeat"){
-      tagAndPush('auditbeat')
     } else if ("${env.BEATS_FOLDER}" == "x-pack/elastic-agent") {
       tagAndPush('elastic-agent')
-    } else if ("${env.BEATS_FOLDER}" == "x-pack/filebeat"){
-      tagAndPush('filebeat')
-    } else if ("${env.BEATS_FOLDER}" == "x-pack/heartbeat"){
-        tagAndPush('heartbeat')
-    } else if ("${env.BEATS_FOLDER}" == "x-pack/metricbeat"){
-      tagAndPush('metricbeat')
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -230,11 +230,11 @@ def runE2ETestForPackages(){
 
   catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
     if ("${env.BEATS_FOLDER}" == "filebeat" || "${env.BEATS_FOLDER}" == "x-pack/filebeat") {
-      suite = 'helm,ingest-manager'
+      suite = 'helm,fleet'
     } else if ("${env.BEATS_FOLDER}" == "metricbeat" || "${env.BEATS_FOLDER}" == "x-pack/metricbeat") {
       suite = ''
     } else if ("${env.BEATS_FOLDER}" == "x-pack/elastic-agent") {
-      suite = 'ingest-manager'
+      suite = 'fleet'
     } else {
       echo("Skipping E2E tests for ${env.BEATS_FOLDER}.")
       return

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -245,19 +245,25 @@ def triggerE2ETests(String suite) {
 
   def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}"
   def e2eTestsPipeline = "e2e-tests/e2e-testing-mbp/${branchName}"
+
+  def parameters = [
+    booleanParam(name: 'forceSkipGitChecks', value: true),
+    booleanParam(name: 'forceSkipPresubmit', value: true),
+    booleanParam(name: 'notifyOnGreenBuilds', value: !isPR()),
+    string(name: 'runTestsSuites', value: suite),
+    string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_E2E_TESTS_NAME),
+    string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+    string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT),
+  ]
+  if (isPR()) {
+    def version = "pr-${env.CHANGE_ID}"
+    parameters.push(booleanParam(name: 'USE_CI_SNAPSHOTS', value: true))
+    parameters.push(string(name: 'ELASTIC_AGENT_VERSION', value: "${version}"))
+    parameters.push(string(name: 'METRICBEAT_VERSION', value: "${version}"))
+  }
+
   build(job: "${e2eTestsPipeline}",
-    parameters: [
-      booleanParam(name: 'forceSkipGitChecks', value: true),
-      booleanParam(name: 'forceSkipPresubmit', value: true),
-      booleanParam(name: 'notifyOnGreenBuilds', value: !isPR()),
-      booleanParam(name: 'USE_CI_SNAPSHOTS', value: true),
-      string(name: 'ELASTIC_AGENT_VERSION', value: "pr-${env.CHANGE_ID}"),
-      string(name: 'METRICBEAT_VERSION', value: "pr-${env.CHANGE_ID}"),
-      string(name: 'runTestsSuites', value: suite),
-      string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_E2E_TESTS_NAME),
-      string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-      string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT),
-    ],
+    parameters: parameters,
     propagate: false,
     wait: false
   )


### PR DESCRIPTION
Backports the following commits to 7.10:
 - feat: add a new step to run the e2e tests for certain parts of Beats (#21100)
 - [E2E Tests] fix: set versions ony for PRs (#21608)
 - [CI: Packaging] fix: push ubi8 images too (#21621)
 - fix: remove extra curly brace in script (#21692)
 - fix: update fleet test suite name (#21738)
 - chore: create CI artifacts for DEV usage (#21645)
 - chore: simplify triggering the E2E tests for Beats (#21790)
 - chore: delegate variant pushes to the right method (#21861)
 - feat: package aliases for snapshots (#21960)