### PR TITLE
Cherry-pick to 7.9: chore: use ubuntu 18 as linux agent (#22084)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -43,7 +43,7 @@ pipeline {
   }
   stages {
     stage('Filter build') {
-      agent { label 'ubuntu && immutable' }
+      agent { label 'ubuntu-18 && immutable' }
       when {
         beforeAgent true
         anyOf {
@@ -98,7 +98,7 @@ pipeline {
             }
             stages {
               stage('Package Linux'){
-                agent { label 'ubuntu && immutable' }
+                agent { label 'ubuntu-18 && immutable' }
                 options { skipDefaultCheckout() }
                 when {
                   beforeAgent true
@@ -160,7 +160,7 @@ pipeline {
           }
         }
         stage('Run E2E Tests for Packages'){
-          agent { label 'ubuntu && immutable' }
+          agent { label 'ubuntu-18 && immutable' }
           options { skipDefaultCheckout() }
           steps {
             runE2ETests()


### PR DESCRIPTION
Backports the following commits to 7.9:
 - chore: use ubuntu 18 as linux agent (#22084)