### PR TITLE
Cherry-pick #21835 to 7.x: Use symlink path for reexecutions 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -17,6 +17,7 @@
 - Fix issue where inputs without processors defined would panic {pull}21628[21628]
 - Prevent reporting ecs version twice {pull}21616[21616]
 - Partial extracted beat result in failure to spawn beat {issue}21718[21718]
+- Use symlink path for reexecutions {pull}21835[21835]
 - Use ML_SYSTEM to detect if agent is running as a service {pull}21884[21884]
 - Use local temp instead of system one {pull}21883[21883]
 - Fix issue with named pipes on Windows 7 {pull}21931[21931]

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
+
+const (
+	agentName = "elastic-agent"
 )
 
 func newRunCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
@@ -87,7 +92,7 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 		logger.Warn("Artifact has been build with security disabled. Elastic Agent will not verify signatures of used artifacts.")
 	}
 
-	execPath, err := os.Executable()
+	execPath, err := reexecPath()
 	if err != nil {
 		return err
 	}
@@ -145,4 +150,17 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	}
 	rex.ShutdownComplete()
 	return err
+}
+
+func reexecPath() (string, error) {
+	// set executable path to symlink instead of binary
+	// in case of updated symlinks we should spin up new agent
+	potentialReexec := filepath.Join(paths.Top(), agentName)
+
+	// in case it does not exists fallback to executable
+	if _, err := os.Stat(potentialReexec); os.IsNotExist(err) {
+		return os.Executable()
+	}
+
+	return potentialReexec, nil
 }


### PR DESCRIPTION
Cherry-pick of PR #21835 to 7.x branch. Original message:

## What does this PR do?

This PR initiates reexec manager with the path to symlink instead of `os.Executable` which might point to actual executable even if executed using symlink.  This behavior leads to reexecing into same binary/version even after upgrade is done.

Tested on linux/windows.
This happens on some OSes as behavior differs in evaluating symlinks. Some refer to symlink file as a process executable some follow symlink and refer to an actual executable.

This is visible during upgrade when upgrade is successfully finished but after reboot it boots up same process (visible as version unchanged in fleet UI).

## Why is it important?

Upgrade scenario
Fixes: #21935

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
