### PR TITLE
Cherry-pick to 7.10: docs: move kerberos include (#22109)

### DIFF
--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -42,6 +42,10 @@ include::./reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -44,6 +44,10 @@ include::./reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::../../libbeat/docs/shared-ilm.asciidoc[]

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -38,6 +38,10 @@ include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/journalbeat/docs/configuring-howto.asciidoc
+++ b/journalbeat/docs/configuring-howto.asciidoc
@@ -34,6 +34,10 @@ include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/libbeat/docs/outputs-list.asciidoc
+++ b/libbeat/docs/outputs-list.asciidoc
@@ -83,9 +83,5 @@ ifdef::requires_xpack[]
 endif::[]
 include::{libbeat-outputs-dir}/codec/docs/codec.asciidoc[]
 endif::[]
-ifndef::no_kerberos[]
-include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
-endif::[]
-
 
 //# end::outputs-include[]

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -40,6 +40,10 @@ include::{docdir}/../docs/reload-configuration.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -38,6 +38,10 @@ include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -35,6 +35,10 @@ include::{libbeat-dir}/shared-path-config.asciidoc[]
 
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 
 include::{libbeat-dir}/shared-ilm.asciidoc[]

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -35,6 +35,10 @@ include::./general-options.asciidoc[]
 [role="xpack"]
 include::{libbeat-dir}/outputconfig.asciidoc[]
 
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
+
 [role="xpack"]
 include::{libbeat-dir}/shared-ssl-config.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: move kerberos include (#22109)