### PR TITLE
Cherry-pick to 7.10: Edit 7.9.3 changelog (#22106)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -3,6 +3,31 @@
 :issue: https://github.com/elastic/beats/issues/
 :pull: https://github.com/elastic/beats/pull/
 
+[[release-notes-7.9.3]]
+=== Beats version 7.9.3
+https://github.com/elastic/beats/compare/v7.9.2...v7.9.3[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- The `o365audit` input and `o365` module now recover from an authentication problem or other fatal errors, instead of terminating. {pull}21258[21258]
+
+*Auditbeat*
+
+- system/socket: Fix a crash due to concurrent map read and write. {issue}21192[21192] {pull}21690[21690]
+
+*Filebeat*
+
+- Add field limit check for AWS Cloudtrail flattened fields. {pull}21388[21388] {issue}21382[21382]
+
+*Metricbeat*
+
+- Fix `remote_write` flaky test. {pull}21173[21173]
+- Fix panic in Kubernetes autodiscovery caused by storing stateless keystores. {issue}21843[21843] {pull}21880[21880]
+- Remove redundant dockersock volume mount to avoid problems on Kubernetes deployments that do not use docker as the container runtime. {pull}22009[22009]
+
+
 [[release-notes-7.9.2]]
 === Beats version 7.9.2
 https://github.com/elastic/beats/compare/v7.9.1...v7.9.2[View commits]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Edit 7.9.3 changelog (#22106)