### PR TITLE
[Packetbeat] Refactor packetbeat for use with Elastic Agent

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -782,7 +782,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS fields for x509 certs, event categorization, and related IP info. {pull}19167[19167]
 - Add 100-continue support {issue}15830[15830] {pull}19349[19349]
 - Add initial SIP protocol support {pull}21221[21221]
-- Add support for overriding the published index on a per-protoocl/flow basis. {pull}22134[22134]
+- Add support for overriding the published index on a per-protocol/flow basis. {pull}22134[22134]
 - Change build process for x-pack distribution {pull}21979[21979]
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -778,7 +778,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS fields for x509 certs, event categorization, and related IP info. {pull}19167[19167]
 - Add 100-continue support {issue}15830[15830] {pull}19349[19349]
 - Add initial SIP protocol support {pull}21221[21221]
-
+- Add support for overriding the published index on a per-protoocl/flow basis. {pull}22134[22134]
 
 *Functionbeat*
 - Add basic ECS categorization and `cloud` fields. {pull}19174[19174]

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -157,7 +157,9 @@ func (r *RunnerList) Has(hash uint64) bool {
 // HashConfig hashes a given common.Config
 func HashConfig(c *common.Config) (uint64, error) {
 	var config map[string]interface{}
-	c.Unpack(&config)
+	if err := c.Unpack(&config); err != nil {
+		return 0, err
+	}
 	return hashstructure.Hash(config, nil)
 }
 

--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -63,6 +63,9 @@ packetbeat.flows:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where flow events are indexed.
+  #index: my-custom-flow-index
+
 {{header "Transaction protocols"}}
 
 packetbeat.protocols:
@@ -72,6 +75,9 @@ packetbeat.protocols:
 
   # Set to true to publish fields with null values in events.
   #keep_null: false
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-icmp-index
 
 - type: amqp
   # Enable AMQP monitoring. Default: true
@@ -113,6 +119,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-amqp-index
+
 - type: cassandra
   #Cassandra port for traffic monitoring.
   ports: [9042]
@@ -142,6 +151,9 @@ packetbeat.protocols:
 
   # This option indicates which Operator/Operators will be ignored.
   #ignored_ops: ["SUPPORTED","OPTIONS"]
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-cassandra-index
 
 - type: dhcpv4
   # Configure the DHCP for IPv4 ports.
@@ -182,6 +194,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-dhcpv4-index
 
 - type: http
   # Enable HTTP monitoring. Default: true
@@ -257,6 +272,9 @@ packetbeat.protocols:
   # be trimmed to this size. Default is 10 MB.
   #max_message_size: 10485760
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-http-index
+
 - type: memcache
   # Enable memcache monitoring. Default: true
   #enabled: true
@@ -309,6 +327,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-memcache-index
+
 - type: mysql
   # Enable mysql monitoring. Default: true
   #enabled: true
@@ -332,6 +353,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mysql-index
+
 - type: pgsql
   # Enable pgsql monitoring. Default: true
   #enabled: true
@@ -354,6 +378,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-pgsql-index
 
 - type: redis
   # Enable redis monitoring. Default: true
@@ -386,6 +413,9 @@ packetbeat.protocols:
   # of requests or responses that can be buffered for correlation. Set a value
   # large enough to allow for pipelining.
   #queue_max_messages: 20000
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-redis-index
 
 - type: thrift
   # Enable thrift monitoring. Default: true
@@ -445,6 +475,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-thrift-index
+
 - type: mongodb
   # Enable mongodb monitoring. Default: true
   #enabled: true
@@ -478,6 +511,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mongodb-index
+
 - type: nfs
   # Enable NFS monitoring. Default: true
   #enabled: true
@@ -500,6 +536,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-nfs-index
 
 - type: tls
   # Enable TLS monitoring. Default: true
@@ -531,6 +570,9 @@ packetbeat.protocols:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-tls-index
+
 - type: sip
   # Configure the ports where to listen for SIP traffic. You can disable the SIP protocol by commenting out the list of ports.
   ports: [5060]
@@ -543,6 +585,9 @@ packetbeat.protocols:
 
   # Preserve original contents in event.original
   keep_original: true
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-sip-index
 
 {{header "Monitored processes"}}
 

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -18,46 +18,24 @@
 package beater
 
 import (
-	"errors"
 	"flag"
-	"fmt"
-	"sync"
 	"time"
-
-	"github.com/tsg/gopacket/layers"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/service"
 
 	"github.com/elastic/beats/v7/packetbeat/config"
-	"github.com/elastic/beats/v7/packetbeat/decoder"
-	"github.com/elastic/beats/v7/packetbeat/flows"
 	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
-	"github.com/elastic/beats/v7/packetbeat/protos/icmp"
-	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
-	"github.com/elastic/beats/v7/packetbeat/protos/udp"
 	"github.com/elastic/beats/v7/packetbeat/publish"
-	"github.com/elastic/beats/v7/packetbeat/sniffer"
 
 	// Add packetbeat default processors
 	_ "github.com/elastic/beats/v7/packetbeat/processor/add_kubernetes_metadata"
 )
-
-// Beater object. Contains all objects needed to run the beat
-type packetbeat struct {
-	config      config.Config
-	cmdLineArgs flags
-	sniff       *sniffer.Sniffer
-
-	// publisher/pipeline
-	pipeline beat.Pipeline
-	transPub *publish.TransactionPublisher
-	flows    *flows.Flows
-}
 
 type flags struct {
 	file       *string
@@ -79,8 +57,8 @@ func init() {
 	}
 }
 
-func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
-	config := config.Config{
+func initialConfig() config.Config {
+	return config.Config{
 		Interfaces: config.InterfacesConfig{
 			File:       *cmdLineArgs.file,
 			Loop:       *cmdLineArgs.loop,
@@ -89,111 +67,59 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 			Dumpfile:   *cmdLineArgs.dumpfile,
 		},
 	}
+}
+
+// Beater object. Contains all objects needed to run the beat
+type packetbeat struct {
+	config          *common.Config
+	factory         *processorFactory
+	publisher       *publish.TransactionPublisher
+	shutdownTimeout time.Duration
+	done            chan struct{}
+}
+
+func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
+	config := initialConfig()
 	err := rawConfig.Unpack(&config)
 	if err != nil {
 		logp.Err("fails to read the beat config: %v, %v", err, config)
 		return nil, err
 	}
 
-	pb := &packetbeat{
-		config:      config,
-		cmdLineArgs: cmdLineArgs,
-	}
-	err = pb.init(b)
-	if err != nil {
-		return nil, err
-	}
-
-	return pb, nil
-}
-
-// init packetbeat components
-func (pb *packetbeat) init(b *beat.Beat) error {
-	var err error
-	cfg := &pb.config
+	watcher := procs.ProcessesWatcher{}
 	// Enable the process watcher only if capturing live traffic
-	if cfg.Interfaces.File == "" {
-		err = procs.ProcWatcher.Init(cfg.Procs)
+	if config.Interfaces.File == "" {
+		err = watcher.Init(config.Procs)
 		if err != nil {
 			logp.Critical(err.Error())
-			return err
+			return nil, err
 		}
 	} else {
 		logp.Info("Process watcher disabled when file input is used")
 	}
 
-	pb.pipeline = b.Publisher
-	pb.transPub, err = publish.NewTransactionPublisher(
+	publisher, err := publish.NewTransactionPublisher(
 		b.Info.Name,
 		b.Publisher,
-		pb.config.IgnoreOutgoing,
-		pb.config.Interfaces.File == "",
+		config.IgnoreOutgoing,
+		config.Interfaces.File == "",
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	logp.Debug("main", "Initializing protocol plugins")
-	err = protos.Protos.Init(false, pb.transPub, cfg.Protocols, cfg.ProtocolsList)
-	if err != nil {
-		return fmt.Errorf("Initializing protocol analyzers failed: %v", err)
+	factory := newProcessorFactory(b.Info.Name, make(chan error, 1), publisher)
+	if err := factory.CheckConfig(rawConfig); err != nil {
+		return nil, err
 	}
 
-	if err := pb.setupFlows(); err != nil {
-		return err
-	}
-
-	return pb.setupSniffer()
-}
-
-func (pb *packetbeat) setupSniffer() error {
-	config := &pb.config
-
-	icmp, err := pb.icmpConfig()
-	if err != nil {
-		return err
-	}
-
-	withVlans := config.Interfaces.WithVlans
-	withICMP := icmp.Enabled()
-
-	filter := config.Interfaces.BpfFilter
-	if filter == "" && !config.Flows.IsEnabled() {
-		filter = protos.Protos.BpfFilter(withVlans, withICMP)
-	}
-
-	pb.sniff, err = sniffer.New(false, filter, pb.createWorker, config.Interfaces)
-	return err
-}
-
-func (pb *packetbeat) setupFlows() error {
-	config := &pb.config
-	if !config.Flows.IsEnabled() {
-		return nil
-	}
-
-	processors, err := processors.New(config.Flows.Processors)
-	if err != nil {
-		return err
-	}
-
-	client, err := pb.pipeline.ConnectWith(beat.ClientConfig{
-		Processing: beat.ProcessingConfig{
-			EventMetadata: config.Flows.EventMetadata,
-			Processor:     processors,
-			KeepNull:      config.Flows.KeepNull,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	pb.flows, err = flows.NewFlows(client.PublishAll, config.Flows)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return &packetbeat{
+		config:          rawConfig,
+		shutdownTimeout: config.ShutdownTimeout,
+		factory:         factory,
+		publisher:       publisher,
+		done:            make(chan struct{}),
+	}, nil
 }
 
 func (pb *packetbeat) Run(b *beat.Beat) error {
@@ -205,114 +131,63 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 		}
 	}()
 
-	defer pb.transPub.Stop()
+	defer pb.publisher.Stop()
 
-	timeout := pb.config.ShutdownTimeout
+	timeout := pb.shutdownTimeout
 	if timeout > 0 {
 		defer time.Sleep(timeout)
 	}
 
-	if pb.flows != nil {
-		pb.flows.Start()
-		defer pb.flows.Stop()
+	if !b.Manager.Enabled() {
+		return pb.runStatic(b, pb.factory)
 	}
+	return pb.runManaged(b, pb.factory)
+}
 
-	var wg sync.WaitGroup
-	errC := make(chan error, 1)
-
-	// Run the sniffer in background
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		err := pb.sniff.Run()
-		if err != nil {
-			errC <- fmt.Errorf("Sniffer main loop failed: %v", err)
-		}
-	}()
-
-	logp.Debug("main", "Waiting for the sniffer to finish")
-	wg.Wait()
-	select {
-	default:
-	case err := <-errC:
+func (pb *packetbeat) runStatic(b *beat.Beat, factory *processorFactory) error {
+	runner, err := factory.Create(b.Publisher, pb.config)
+	if err != nil {
 		return err
 	}
+	runner.Start()
+	defer runner.Stop()
 
+	logp.Debug("main", "Waiting for the runner to finish")
+
+	select {
+	case <-pb.done:
+	case err := <-factory.err:
+		close(pb.done)
+		return err
+	}
 	return nil
+}
+
+func (pb *packetbeat) runManaged(b *beat.Beat, factory *processorFactory) error {
+	runner := newReloader(management.DebugK, factory, b.Publisher)
+	reload.Register.MustRegister(b.Info.Beat, runner)
+	defer runner.Stop()
+
+	logp.Debug("main", "Waiting for the runner to finish")
+
+	for {
+		select {
+		case <-pb.done:
+			return nil
+		case err := <-factory.err:
+			// when we're managed we don't want
+			// to stop if the sniffer exited without an error
+			// this would happen during a configuration reload
+			if err != nil {
+				close(pb.done)
+				return err
+			}
+		}
+	}
 }
 
 // Called by the Beat stop function
 func (pb *packetbeat) Stop() {
 	logp.Info("Packetbeat send stop signal")
-	pb.sniff.Stop()
-}
-
-func (pb *packetbeat) createWorker(dl layers.LinkType) (sniffer.Worker, error) {
-	var icmp4 icmp.ICMPv4Processor
-	var icmp6 icmp.ICMPv6Processor
-	cfg, err := pb.icmpConfig()
-	if err != nil {
-		return nil, err
-	}
-	if cfg.Enabled() {
-		reporter, err := pb.transPub.CreateReporter(cfg)
-		if err != nil {
-			return nil, err
-		}
-
-		icmp, err := icmp.New(false, reporter, cfg)
-		if err != nil {
-			return nil, err
-		}
-
-		icmp4 = icmp
-		icmp6 = icmp
-	}
-
-	tcp, err := tcp.NewTCP(&protos.Protos)
-	if err != nil {
-		return nil, err
-	}
-
-	udp, err := udp.NewUDP(&protos.Protos)
-	if err != nil {
-		return nil, err
-	}
-
-	worker, err := decoder.New(pb.flows, dl, icmp4, icmp6, tcp, udp)
-	if err != nil {
-		return nil, err
-	}
-
-	return worker, nil
-}
-
-func (pb *packetbeat) icmpConfig() (*common.Config, error) {
-	var icmp *common.Config
-	if pb.config.Protocols["icmp"].Enabled() {
-		icmp = pb.config.Protocols["icmp"]
-	}
-
-	for _, cfg := range pb.config.ProtocolsList {
-		info := struct {
-			Type string `config:"type" validate:"required"`
-		}{}
-
-		if err := cfg.Unpack(&info); err != nil {
-			return nil, err
-		}
-
-		if info.Type != "icmp" {
-			continue
-		}
-
-		if icmp != nil {
-			return nil, errors.New("More then one icmp configurations found")
-		}
-
-		icmp = cfg
-	}
-
-	return icmp, nil
+	close(pb.done)
 }

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
+
+	"github.com/elastic/beats/v7/packetbeat/flows"
+	"github.com/elastic/beats/v7/packetbeat/procs"
+	"github.com/elastic/beats/v7/packetbeat/protos"
+	"github.com/elastic/beats/v7/packetbeat/publish"
+	"github.com/elastic/beats/v7/packetbeat/sniffer"
+)
+
+type processor struct {
+	wg      sync.WaitGroup
+	flows   *flows.Flows
+	sniffer *sniffer.Sniffer
+	err     chan error
+}
+
+func newProcessor(flows *flows.Flows, sniffer *sniffer.Sniffer, err chan error) *processor {
+	return &processor{
+		flows:   flows,
+		sniffer: sniffer,
+		err:     err,
+	}
+}
+
+func (p *processor) String() string {
+	return "packetbeat.processor"
+}
+
+func (p *processor) Start() {
+	if p.flows != nil {
+		p.flows.Start()
+	}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+
+		err := p.sniffer.Run()
+		if err != nil {
+			p.err <- fmt.Errorf("Sniffer loop failed: %v", err)
+		}
+		p.err <- nil
+	}()
+}
+
+func (p *processor) Stop() {
+	p.sniffer.Stop()
+	if p.flows != nil {
+		p.flows.Stop()
+	}
+	p.wg.Wait()
+}
+
+type processorFactory struct {
+	name      string
+	err       chan error
+	publisher *publish.TransactionPublisher
+}
+
+func newProcessorFactory(name string, err chan error, publisher *publish.TransactionPublisher) *processorFactory {
+	return &processorFactory{
+		name:      name,
+		err:       err,
+		publisher: publisher,
+	}
+}
+
+func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *common.Config) (cfgfile.Runner, error) {
+	config := initialConfig()
+	err := cfg.Unpack(&config)
+	if err != nil {
+		logp.Err("fails to read the beat config: %v, %v", err, config)
+		return nil, err
+	}
+
+	// normalize agent-based configuration
+	config, err = config.Normalize()
+	if err != nil {
+		logp.Err("failed to normalize the beat config: %v, %v", err, config)
+		return nil, err
+	}
+
+	watcher := procs.ProcessesWatcher{}
+	// Enable the process watcher only if capturing live traffic
+	if config.Interfaces.File == "" {
+		err = watcher.Init(config.Procs)
+		if err != nil {
+			logp.Critical(err.Error())
+			return nil, err
+		}
+	} else {
+		logp.Info("Process watcher disabled when file input is used")
+	}
+
+	logp.Debug("main", "Initializing protocol plugins")
+	protocols := protos.NewProtocols()
+	err = protocols.Init(false, p.publisher, watcher, config.Protocols, config.ProtocolsList)
+	if err != nil {
+		return nil, fmt.Errorf("Initializing protocol analyzers failed: %v", err)
+	}
+	flows, err := setupFlows(pipeline, watcher, config)
+	if err != nil {
+		return nil, err
+	}
+	sniffer, err := setupSniffer(config, protocols, workerFactory(p.publisher, protocols, watcher, flows, config))
+	if err != nil {
+		return nil, err
+	}
+
+	return newProcessor(flows, sniffer, p.err), nil
+}
+
+func (p *processorFactory) CheckConfig(config *common.Config) error {
+	_, err := p.Create(pipeline.NewNilPipeline(), config)
+	return err
+}

--- a/packetbeat/beater/reloader.go
+++ b/packetbeat/beater/reloader.go
@@ -1,0 +1,100 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/reload"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
+)
+
+type reloader struct {
+	mutex      sync.Mutex
+	factory    cfgfile.RunnerFactory
+	runner     cfgfile.Runner
+	configHash uint64
+	pipeline   beat.PipelineConnector
+	logger     *logp.Logger
+}
+
+func newReloader(name string, factory cfgfile.RunnerFactory, pipeline beat.PipelineConnector) *reloader {
+	return &reloader{
+		factory: factory,
+		logger:  logp.NewLogger(name),
+	}
+}
+
+func (r *reloader) Stop() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.runner != nil {
+		r.runner.Stop()
+	}
+}
+
+func (r *reloader) Reload(config *reload.ConfigWithMeta) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.logger.Debug("Starting reload procedure")
+
+	hash, err := cfgfile.HashConfig(config.Config)
+	if err != nil {
+		r.logger.Errorf("Unable to hash given config: %s", err)
+		return errors.Wrap(err, "Unable to hash given config")
+	}
+
+	if hash == r.configHash {
+		// we have the same config reloaded
+		return nil
+	}
+	// reinitialize config hash
+	r.configHash = 0
+
+	if r.runner != nil {
+		go r.runner.Stop()
+	}
+	// reinitialize runner
+	r.runner = nil
+
+	c, err := common.NewConfigFrom(config.Config)
+	if err != nil {
+		r.logger.Errorf("Unable to create new configuration for factory: %s", err)
+		return errors.Wrap(err, "Unable to create new configuration for factory")
+	}
+	runner, err := r.factory.Create(pipetool.WithDynamicFields(r.pipeline, config.Meta), c)
+	if err != nil {
+		r.logger.Errorf("Unable to create new runner: %s", err)
+		return errors.Wrap(err, "Unable to create new runner")
+	}
+
+	r.logger.Debugf("Starting runner: %s", runner)
+	r.configHash = hash
+	r.runner = runner
+	runner.Start()
+
+	return nil
+}

--- a/packetbeat/beater/reloader.go
+++ b/packetbeat/beater/reloader.go
@@ -18,104 +18,26 @@
 package beater
 
 import (
-	"sort"
-	"sync"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/reload"
-	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
 )
 
 type reloader struct {
-	mutex        sync.Mutex
-	factory      cfgfile.RunnerFactory
-	runner       cfgfile.Runner
-	configHashes []uint64
-	pipeline     beat.PipelineConnector
-	logger       *logp.Logger
-}
-
-func equalHashes(a, b []uint64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
+	*cfgfile.RunnerList
 }
 
 func newReloader(name string, factory cfgfile.RunnerFactory, pipeline beat.PipelineConnector) *reloader {
 	return &reloader{
-		factory: factory,
-		logger:  logp.NewLogger(name),
-	}
-}
-
-func (r *reloader) Stop() {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	if r.runner != nil {
-		r.runner.Stop()
+		RunnerList: cfgfile.NewRunnerList(name, factory, pipeline),
 	}
 }
 
 func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	r.logger.Debug("Starting reload procedure")
-
-	hashes := make([]uint64, len(configs))
-	combined := make([]*common.Config, len(configs))
-	for i, c := range configs {
-		combined[i] = c.Config
-		hash, err := cfgfile.HashConfig(c.Config)
-		if err != nil {
-			r.logger.Errorf("Unable to hash given config: %s", err)
-			return errors.Wrap(err, "unable to hash given config")
-		}
-		hashes[i] = hash
+	if len(configs) > 1 {
+		return errors.New("only a single input is currently supported")
 	}
-	sort.Slice(hashes, func(i, j int) bool { return hashes[i] < hashes[j] })
-
-	config, err := common.NewConfigFrom(combined)
-	if err != nil {
-		r.logger.Errorf("Unable to combine configurations: %s", err)
-		return errors.Wrap(err, "unable to combine configurations")
-	}
-
-	if equalHashes(hashes, r.configHashes) {
-		// we have the same config reloaded
-		return nil
-	}
-	// reinitialize config hash
-	r.configHashes = nil
-
-	if r.runner != nil {
-		go r.runner.Stop()
-	}
-	// reinitialize runner
-	r.runner = nil
-
-	runner, err := r.factory.Create(pipetool.WithDynamicFields(r.pipeline, nil), config)
-	if err != nil {
-		r.logger.Errorf("Unable to create new runner: %s", err)
-		return errors.Wrap(err, "unable to create new runner")
-	}
-
-	r.logger.Debugf("Starting runner: %s", runner)
-	r.configHashes = hashes
-	r.runner = runner
-	runner.Start()
-
-	return nil
+	return r.RunnerList.Reload(configs)
 }

--- a/packetbeat/beater/reloader.go
+++ b/packetbeat/beater/reloader.go
@@ -18,7 +18,7 @@
 package beater
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
@@ -29,15 +29,15 @@ type reloader struct {
 	*cfgfile.RunnerList
 }
 
-func newReloader(name string, factory cfgfile.RunnerFactory, pipeline beat.PipelineConnector) *reloader {
+func newReloader(name string, factory *processorFactory, pipeline beat.PipelineConnector) *reloader {
 	return &reloader{
 		RunnerList: cfgfile.NewRunnerList(name, factory, pipeline),
 	}
 }
 
 func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
-	if len(configs) > 1 {
-		return errors.New("only a single input is currently supported")
+	if len(configs) > maxSniffers {
+		return fmt.Errorf("only %d inputs are currently supported", maxSniffers)
 	}
 	return r.RunnerList.Reload(configs)
 }

--- a/packetbeat/beater/setup.go
+++ b/packetbeat/beater/setup.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/flows"
+	"github.com/elastic/beats/v7/packetbeat/procs"
+	"github.com/elastic/beats/v7/packetbeat/protos"
+	"github.com/elastic/beats/v7/packetbeat/sniffer"
+)
+
+func setupSniffer(cfg config.Config, protocols *protos.ProtocolsStruct, workerFactory sniffer.WorkerFactory) (*sniffer.Sniffer, error) {
+	icmp, err := cfg.ICMP()
+	if err != nil {
+		return nil, err
+	}
+
+	filter := cfg.Interfaces.BpfFilter
+	if filter == "" && !cfg.Flows.IsEnabled() {
+		filter = protocols.BpfFilter(cfg.Interfaces.WithVlans, icmp.Enabled())
+	}
+
+	return sniffer.New(false, filter, workerFactory, cfg.Interfaces)
+}
+
+func setupFlows(pipeline beat.Pipeline, watcher procs.ProcessesWatcher, cfg config.Config) (*flows.Flows, error) {
+	if !cfg.Flows.IsEnabled() {
+		return nil, nil
+	}
+
+	processors, err := processors.New(cfg.Flows.Processors)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig := beat.ClientConfig{
+		Processing: beat.ProcessingConfig{
+			EventMetadata: cfg.Flows.EventMetadata,
+			Processor:     processors,
+			KeepNull:      cfg.Flows.KeepNull,
+		},
+	}
+	if cfg.Flows.Index != "" {
+		clientConfig.Processing.Meta = common.MapStr{"index": cfg.Flows.Index}
+	}
+
+	client, err := pipeline.ConnectWith(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return flows.NewFlows(client.PublishAll, watcher, cfg.Flows)
+}

--- a/packetbeat/beater/worker.go
+++ b/packetbeat/beater/worker.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"github.com/tsg/gopacket/layers"
+
+	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/decoder"
+	"github.com/elastic/beats/v7/packetbeat/flows"
+	"github.com/elastic/beats/v7/packetbeat/procs"
+	"github.com/elastic/beats/v7/packetbeat/protos"
+	"github.com/elastic/beats/v7/packetbeat/protos/icmp"
+	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
+	"github.com/elastic/beats/v7/packetbeat/protos/udp"
+	"github.com/elastic/beats/v7/packetbeat/publish"
+	"github.com/elastic/beats/v7/packetbeat/sniffer"
+)
+
+func workerFactory(publisher *publish.TransactionPublisher, protocols *protos.ProtocolsStruct, watcher procs.ProcessesWatcher, flows *flows.Flows, cfg config.Config) func(dl layers.LinkType) (sniffer.Worker, error) {
+	return func(dl layers.LinkType) (sniffer.Worker, error) {
+		var icmp4 icmp.ICMPv4Processor
+		var icmp6 icmp.ICMPv6Processor
+		config, err := cfg.ICMP()
+		if err != nil {
+			return nil, err
+		}
+		if config.Enabled() {
+			reporter, err := publisher.CreateReporter(config)
+			if err != nil {
+				return nil, err
+			}
+
+			icmp, err := icmp.New(false, reporter, watcher, config)
+			if err != nil {
+				return nil, err
+			}
+
+			icmp4 = icmp
+			icmp6 = icmp
+		}
+
+		tcp, err := tcp.NewTCP(protocols)
+		if err != nil {
+			return nil, err
+		}
+
+		udp, err := udp.NewUDP(protocols)
+		if err != nil {
+			return nil, err
+		}
+
+		worker, err := decoder.New(flows, dl, icmp4, icmp6, tcp, udp)
+		if err != nil {
+			return nil, err
+		}
+
+		return worker, nil
+	}
+}

--- a/packetbeat/config/agent.go
+++ b/packetbeat/config/agent.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+var osDefaultDevices = map[string]string{
+	"darwin": "en0",
+	"linux":  "any",
+}
+
+func defaultDevice() string {
+	if device, found := osDefaultDevices[runtime.GOOS]; found {
+		return device
+	}
+	return "0"
+}
+
+// Normalize allows the packetbeat configuration to understand
+// agent semantics
+func (c Config) Normalize() (Config, error) {
+	logp.Debug("agent", "Normalizing agent configuration")
+	if len(c.Inputs) > 0 {
+		// override everything, we're managed by agent
+		c.Flows = nil
+		c.Protocols = nil
+		c.ProtocolsList = []*common.Config{}
+		// TODO: make this configurable rather than just using the default device in
+		// managed mode
+		c.Interfaces.Device = defaultDevice()
+	}
+
+	for _, input := range c.Inputs {
+		if rawInputType, ok := input["type"]; ok {
+			inputType, ok := rawInputType.(string)
+			if ok && strings.HasPrefix(inputType, "network/") {
+				config, err := common.NewConfigFrom(input)
+				if err != nil {
+					return c, err
+				}
+				protocol := strings.TrimPrefix(inputType, "network/")
+				logp.Debug("agent", fmt.Sprintf("Found agent configuration for %v", protocol))
+				switch protocol {
+				case "flows":
+					if err := config.Unpack(&c.Flows); err != nil {
+						return c, err
+					}
+				default:
+					if err = config.SetString("type", -1, protocol); err != nil {
+						return c, err
+					}
+					c.ProtocolsList = append(c.ProtocolsList, config)
+				}
+			}
+		}
+	}
+	return c, nil
+}

--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -27,19 +27,38 @@ import (
 
 func TestAgentInputNormalization(t *testing.T) {
 	cfg, err := common.NewConfigFrom(`
-- type: network/flows
-  timeout: 10s
-  period: 10s
-  keep_null: false
-  data_stream.namespace: default
-- type: network/amqp
-  ports: [5672]
-  data_stream.namespace: default
+type: packet
+data_stream:
+  namespace: default
+processors:
+  - add_fields:
+      target: 'elastic_agent'
+      fields:
+        id: agent-id
+        version: 8.0.0
+        snapshot: false
+streams:
+  - type: flow
+    timeout: 10s
+    period: 10s
+    keep_null: false
+    data_stream:
+      dataset: packet.flow
+      type: logs
+  - type: icmp
+    data_stream:
+      dataset: packet.icmp
+      type: logs
 `)
 	require.NoError(t, err)
 	config, err := NewAgentConfig(cfg)
 	require.NoError(t, err)
 
 	require.Equal(t, config.Flows.Timeout, "10s")
+	require.Equal(t, config.Flows.Index, "logs-packet.flow-default")
 	require.Len(t, config.ProtocolsList, 1)
+
+	var protocol map[string]interface{}
+	require.NoError(t, config.ProtocolsList[0].Unpack(&protocol))
+	require.Len(t, protocol["processors"].([]interface{}), 3)
 }

--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestAgentInputNormalization(t *testing.T) {
+	cfg, err := common.NewConfigFrom(`
+inputs:
+- type: network/flows
+  timeout: 10s
+  period: 10s
+  keep_null: false
+  data_stream.namespace: default
+- type: network/amqp
+  ports: [5672]
+  data_stream.namespace: default
+`)
+	require.NoError(t, err)
+	config := Config{}
+	require.NoError(t, cfg.Unpack(&config))
+
+	config, err = config.Normalize()
+	require.NoError(t, err)
+
+	require.Equal(t, config.Flows.Timeout, "10s")
+	require.Len(t, config.ProtocolsList, 1)
+}

--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestAgentInputNormalization(t *testing.T) {
 	cfg, err := common.NewConfigFrom(`
-inputs:
 - type: network/flows
   timeout: 10s
   period: 10s
@@ -38,10 +37,7 @@ inputs:
   data_stream.namespace: default
 `)
 	require.NoError(t, err)
-	config := Config{}
-	require.NoError(t, cfg.Unpack(&config))
-
-	config, err = config.Normalize()
+	config, err := NewAgentConfig(cfg)
 	require.NoError(t, err)
 
 	require.Equal(t, config.Flows.Timeout, "10s")

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -34,9 +34,15 @@ type Config struct {
 	Procs           procs.ProcsConfig         `config:"procs"`
 	IgnoreOutgoing  bool                      `config:"ignore_outgoing"`
 	ShutdownTimeout time.Duration             `config:"shutdown_timeout"`
+}
 
-	// agent configuration
-	Inputs []map[string]interface{} `config:"inputs"`
+// FromStatic initializes a configuration given a common.Config
+func (c Config) FromStatic(cfg *common.Config) (Config, error) {
+	err := cfg.Unpack(&c)
+	if err != nil {
+		return c, err
+	}
+	return c, nil
 }
 
 // ICMP returns the ICMP configuration
@@ -60,7 +66,7 @@ func (c Config) ICMP() (*common.Config, error) {
 		}
 
 		if icmp != nil {
-			return nil, errors.New("More then one icmp configurations found")
+			return nil, errors.New("more than one icmp configuration found")
 		}
 
 		icmp = cfg

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -431,6 +431,11 @@ processors in your config.
 If this option is set to true, fields with `null` values will be published in
 the output document. By default, `keep_null` is set to `false`.
 
+[float]
+==== `index`
+
+Overrides the index that flow events are published to.
+
 [[configuration-protocols]]
 == Configure which transaction protocols to monitor
 
@@ -553,6 +558,12 @@ grouped under a `fields` sub-dictionary in the output document. To store the
 custom fields as top-level fields, set the `fields_under_root` option to true.
 If a duplicate field is declared in the general configuration, then its value
 will be overwritten by the value declared here.
+
+[float]
+[[packetbeat-configuration-index]]
+==== `index`
+
+Overrides the index that events for the given protocol are published to.
 
 [source,yaml]
 --------------------------------------------------------------------------------

--- a/packetbeat/flows/flows.go
+++ b/packetbeat/flows/flows.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 type Flows struct {
@@ -41,7 +42,7 @@ const (
 	defaultPeriod  = 10 * time.Second
 )
 
-func NewFlows(pub Reporter, config *config.Flows) (*Flows, error) {
+func NewFlows(pub Reporter, watcher procs.ProcessesWatcher, config *config.Flows) (*Flows, error) {
 	duration := func(s string, d time.Duration) (time.Duration, error) {
 		if s == "" {
 			return d, nil
@@ -67,7 +68,7 @@ func NewFlows(pub Reporter, config *config.Flows) (*Flows, error) {
 
 	counter := &counterReg{}
 
-	worker, err := newFlowsWorker(pub, table, counter, timeout, period)
+	worker, err := newFlowsWorker(pub, watcher, table, counter, timeout, period)
 	if err != nil {
 		logp.Err("failed to configure flows processing intervals: %v", err)
 		return nil, err

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 type flowsChan struct {
@@ -50,7 +51,7 @@ func TestFlowsCounting(t *testing.T) {
 	port1 := []byte{0, 1}
 	port2 := []byte{0, 2}
 
-	module, err := NewFlows(nil, &config.Flows{})
+	module, err := NewFlows(nil, procs.ProcessesWatcher{}, &config.Flows{})
 	assert.NoError(t, err)
 
 	uint1, err := module.NewUint("uint1")

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 var (
@@ -66,7 +67,7 @@ func TestCreateEvent(t *testing.T) {
 	}
 	bif.stats[0] = &flowStats{uintFlags: []uint8{1, 1}, uints: []uint64{10, 1}}
 	bif.stats[1] = &flowStats{uintFlags: []uint8{1, 1}, uints: []uint64{460, 2}}
-	event := createEvent(time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil)
+	event := createEvent(procs.ProcessesWatcher{}, time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil)
 
 	// Validate the contents of the event.
 	validate := lookslike.MustCompile(map[string]interface{}{

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -63,6 +63,9 @@ packetbeat.flows:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where flow events are indexed.
+  #index: my-custom-flow-index
+
 # =========================== Transaction protocols ============================
 
 packetbeat.protocols:
@@ -72,6 +75,9 @@ packetbeat.protocols:
 
   # Set to true to publish fields with null values in events.
   #keep_null: false
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-icmp-index
 
 - type: amqp
   # Enable AMQP monitoring. Default: true
@@ -113,6 +119,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-amqp-index
+
 - type: cassandra
   #Cassandra port for traffic monitoring.
   ports: [9042]
@@ -142,6 +151,9 @@ packetbeat.protocols:
 
   # This option indicates which Operator/Operators will be ignored.
   #ignored_ops: ["SUPPORTED","OPTIONS"]
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-cassandra-index
 
 - type: dhcpv4
   # Configure the DHCP for IPv4 ports.
@@ -182,6 +194,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-dhcpv4-index
 
 - type: http
   # Enable HTTP monitoring. Default: true
@@ -257,6 +272,9 @@ packetbeat.protocols:
   # be trimmed to this size. Default is 10 MB.
   #max_message_size: 10485760
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-http-index
+
 - type: memcache
   # Enable memcache monitoring. Default: true
   #enabled: true
@@ -309,6 +327,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-memcache-index
+
 - type: mysql
   # Enable mysql monitoring. Default: true
   #enabled: true
@@ -332,6 +353,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mysql-index
+
 - type: pgsql
   # Enable pgsql monitoring. Default: true
   #enabled: true
@@ -354,6 +378,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-pgsql-index
 
 - type: redis
   # Enable redis monitoring. Default: true
@@ -386,6 +413,9 @@ packetbeat.protocols:
   # of requests or responses that can be buffered for correlation. Set a value
   # large enough to allow for pipelining.
   #queue_max_messages: 20000
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-redis-index
 
 - type: thrift
   # Enable thrift monitoring. Default: true
@@ -445,6 +475,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-thrift-index
+
 - type: mongodb
   # Enable mongodb monitoring. Default: true
   #enabled: true
@@ -478,6 +511,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mongodb-index
+
 - type: nfs
   # Enable NFS monitoring. Default: true
   #enabled: true
@@ -500,6 +536,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-nfs-index
 
 - type: tls
   # Enable TLS monitoring. Default: true
@@ -531,6 +570,9 @@ packetbeat.protocols:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-tls-index
+
 - type: sip
   # Configure the ports where to listen for SIP traffic. You can disable the SIP protocol by commenting out the list of ports.
   ports: [5060]
@@ -543,6 +585,9 @@ packetbeat.protocols:
 
   # Preserve original contents in event.original
   keep_original: true
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-sip-index
 
 # ============================ Monitored processes =============================
 

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -83,8 +83,6 @@ type ProcessesWatcher struct {
 	impl processWatcherImpl
 }
 
-var ProcWatcher ProcessesWatcher
-
 func (proc *ProcessesWatcher) Init(config ProcsConfig) error {
 	return proc.initWithImpl(config, proc)
 }

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 func (amqp *amqpPlugin) amqpMessageParser(s *amqpStream) (ok bool, complete bool) {
@@ -336,7 +335,7 @@ func (amqp *amqpPlugin) handleAmqp(m *amqpMessage, tcptuple *common.TCPTuple, di
 	debugf("A message is ready to be handled")
 	m.tcpTuple = *tcptuple
 	m.direction = dir
-	m.cmdlineTuple = procs.ProcWatcher.FindProcessesTupleTCP(tcptuple.IPPort())
+	m.cmdlineTuple = amqp.watcher.FindProcessesTupleTCP(tcptuple.IPPort())
 
 	if m.method == "basic.publish" {
 		amqp.handlePublishing(m)

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -45,7 +46,7 @@ func amqpModForTests() (*eventStore, *amqpPlugin) {
 	var amqp amqpPlugin
 	results := &eventStore{}
 	config := defaultConfig
-	amqp.init(results.publish, &config)
+	amqp.init(results.publish, procs.ProcessesWatcher{}, &config)
 	return results, &amqp
 }
 

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -33,6 +33,8 @@ type transactions struct {
 	responses messageList
 
 	onTransaction transactionHandler
+
+	watcher procs.ProcessesWatcher
 }
 
 type transactionConfig struct {
@@ -46,8 +48,9 @@ type messageList struct {
 	head, tail *message
 }
 
-func (trans *transactions) init(c *transactionConfig, cb transactionHandler) {
+func (trans *transactions) init(c *transactionConfig, watcher procs.ProcessesWatcher, cb transactionHandler) {
 	trans.config = c
+	trans.watcher = watcher
 	trans.onTransaction = cb
 }
 
@@ -59,7 +62,7 @@ func (trans *transactions) onMessage(
 	var err error
 	msg.Tuple = *tuple
 	msg.Transport = applayer.TransportTCP
-	msg.CmdlineTuple = procs.ProcWatcher.FindProcessesTupleTCP(&msg.Tuple)
+	msg.CmdlineTuple = trans.watcher.FindProcessesTupleTCP(&msg.Tuple)
 
 	if msg.IsRequest {
 		if isDebug {

--- a/packetbeat/protos/dhcpv4/dhcpv4.go
+++ b/packetbeat/protos/dhcpv4/dhcpv4.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/packetbeat/pb"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/ecs/code/go/ecs"
 )
@@ -45,12 +46,13 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
+	watcher procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
-	return newPlugin(testMode, results, cfg)
+	return newPlugin(testMode, results, watcher, cfg)
 }
 
-func newPlugin(testMode bool, results protos.Reporter, cfg *common.Config) (*dhcpv4Plugin, error) {
+func newPlugin(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher, cfg *common.Config) (*dhcpv4Plugin, error) {
 	config := defaultConfig
 
 	if !testMode {
@@ -62,14 +64,16 @@ func newPlugin(testMode bool, results protos.Reporter, cfg *common.Config) (*dhc
 	return &dhcpv4Plugin{
 		dhcpv4Config: config,
 		report:       results,
+		watcher:      watcher,
 		log:          logp.NewLogger("dhcpv4"),
 	}, nil
 }
 
 type dhcpv4Plugin struct {
 	dhcpv4Config
-	report protos.Reporter
-	log    *logp.Logger
+	report  protos.Reporter
+	watcher procs.ProcessesWatcher
+	log     *logp.Logger
 }
 
 func (p *dhcpv4Plugin) GetPorts() []int {

--- a/packetbeat/protos/dhcpv4/dhcpv4_test.go
+++ b/packetbeat/protos/dhcpv4/dhcpv4_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -81,7 +82,7 @@ var (
 
 func TestParseDHCPRequest(t *testing.T) {
 	logp.TestingSetup()
-	p, err := newPlugin(true, nil, nil)
+	p, err := newPlugin(true, nil, procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +166,7 @@ func TestParseDHCPRequest(t *testing.T) {
 }
 
 func TestParseDHCPACK(t *testing.T) {
-	p, err := newPlugin(true, nil, nil)
+	p, err := newPlugin(true, nil, procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packetbeat/protos/dns/dns_tcp.go
+++ b/packetbeat/protos/dns/dns_tcp.go
@@ -23,7 +23,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
-	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 
@@ -150,7 +149,7 @@ func (dns *dnsPlugin) handleDNS(conn *dnsConnectionData, tcpTuple *common.TCPTup
 	message := conn.data[dir].message
 	dnsTuple := dnsTupleFromIPPort(&message.tuple, transportTCP, decodedData.Id)
 
-	message.cmdlineTuple = procs.ProcWatcher.FindProcessesTupleTCP(tcpTuple.IPPort())
+	message.cmdlineTuple = dns.watcher.FindProcessesTupleTCP(tcpTuple.IPPort())
 	message.data = decodedData
 	message.length += decodeOffset
 

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -111,7 +112,7 @@ func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 		"send_request":        true,
 		"send_response":       true,
 	})
-	dns, err := New(false, callback, cfg)
+	dns, err := New(false, callback, procs.ProcessesWatcher{}, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/packetbeat/protos/dns/dns_udp.go
+++ b/packetbeat/protos/dns/dns_udp.go
@@ -20,7 +20,6 @@ package dns
 import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 
-	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 )
 
@@ -47,7 +46,7 @@ func (dns *dnsPlugin) ParseUDP(pkt *protos.Packet) {
 	dnsMsg := &dnsMessage{
 		ts:           pkt.Ts,
 		tuple:        pkt.Tuple,
-		cmdlineTuple: procs.ProcWatcher.FindProcessesTupleUDP(&pkt.Tuple),
+		cmdlineTuple: dns.watcher.FindProcessesTupleUDP(&pkt.Tuple),
 		data:         dnsPkt,
 		length:       packetSize,
 	}

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -88,7 +89,7 @@ func httpModForTests(store *eventStore) *httpPlugin {
 		callback = store.publish
 	}
 
-	http, err := New(false, callback, common.NewConfig())
+	http, err := New(false, callback, procs.ProcessesWatcher{}, common.NewConfig())
 	if err != nil {
 		panic(err)
 	}

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/beats/v7/packetbeat/flows"
 	"github.com/elastic/beats/v7/packetbeat/pb"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 
 	"github.com/tsg/gopacket/layers"
@@ -45,6 +46,7 @@ type icmpPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter
+	watcher procs.ProcessesWatcher
 }
 
 type ICMPv4Processor interface {
@@ -74,7 +76,7 @@ var (
 	duplicateRequests  = monitoring.NewInt(nil, "icmp.duplicate_requests")
 )
 
-func New(testMode bool, results protos.Reporter, cfg *common.Config) (*icmpPlugin, error) {
+func New(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher, cfg *common.Config) (*icmpPlugin, error) {
 	p := &icmpPlugin{}
 	config := defaultConfig
 	if !testMode {
@@ -83,13 +85,13 @@ func New(testMode bool, results protos.Reporter, cfg *common.Config) (*icmpPlugi
 		}
 	}
 
-	if err := p.init(results, &config); err != nil {
+	if err := p.init(results, watcher, &config); err != nil {
 		return nil, err
 	}
 	return p, nil
 }
 
-func (icmp *icmpPlugin) init(results protos.Reporter, config *icmpConfig) error {
+func (icmp *icmpPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *icmpConfig) error {
 	icmp.setFromConfig(config)
 
 	var err error
@@ -112,6 +114,7 @@ func (icmp *icmpPlugin) init(results protos.Reporter, config *icmpConfig) error 
 	icmp.transactions.StartJanitor(icmp.transactionTimeout)
 
 	icmp.results = results
+	icmp.watcher = watcher
 
 	return nil
 }

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 
 	"github.com/tsg/gopacket"
@@ -60,7 +61,7 @@ func TestIcmpDirection(t *testing.T) {
 func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 	logp.TestingSetup(logp.WithSelectors("icmp", "icmpdetailed"))
 
-	icmp, err := New(true, func(beat.Event) {}, common.NewConfig())
+	icmp, err := New(true, func(beat.Event) {}, procs.ProcessesWatcher{}, common.NewConfig())
 	if err != nil {
 		b.Error("Failed to create ICMP processor")
 		return

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
 )
@@ -38,6 +39,7 @@ import (
 type memcache struct {
 	ports   protos.PortsConfig
 	results protos.Reporter
+	watcher procs.ProcessesWatcher
 	config  parserConfig
 
 	udpMemcache
@@ -131,6 +133,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
+	watcher procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &memcache{}
@@ -141,14 +144,14 @@ func New(
 		}
 	}
 
-	if err := p.init(results, &config); err != nil {
+	if err := p.init(results, watcher, &config); err != nil {
 		return nil, err
 	}
 	return p, nil
 }
 
 // Called to initialize the Plugin
-func (mc *memcache) init(results protos.Reporter, config *memcacheConfig) error {
+func (mc *memcache) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *memcacheConfig) error {
 	debug("init memcache plugin")
 
 	mc.handler = mc
@@ -158,6 +161,7 @@ func (mc *memcache) init(results protos.Reporter, config *memcacheConfig) error 
 
 	mc.udpConnections = make(map[common.HashableIPPortTuple]*udpConnection)
 	mc.results = results
+	mc.watcher = watcher
 	return nil
 }
 

--- a/packetbeat/protos/memcache/memcache_test.go
+++ b/packetbeat/protos/memcache/memcache_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 type memcacheTest struct {
@@ -36,7 +37,7 @@ type memcacheTest struct {
 func newMemcacheTest(config memcacheConfig) *memcacheTest {
 	mct := &memcacheTest{}
 	mc := &memcache{}
-	mc.init(nil, &config)
+	mc.init(nil, procs.ProcessesWatcher{}, &config)
 	mc.handler = mct
 	mct.mc = mc
 	return mct

--- a/packetbeat/protos/memcache/plugin_tcp.go
+++ b/packetbeat/protos/memcache/plugin_tcp.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
-	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
@@ -191,7 +190,7 @@ func (mc *memcache) onTCPMessage(
 ) error {
 	msg.Tuple = *tuple
 	msg.Transport = applayer.TransportTCP
-	msg.CmdlineTuple = procs.ProcWatcher.FindProcessesTupleTCP(tuple)
+	msg.CmdlineTuple = mc.watcher.FindProcessesTupleTCP(tuple)
 
 	if msg.IsRequest {
 		return mc.onTCPRequest(conn, tuple, dir, msg)

--- a/packetbeat/protos/memcache/plugin_udp.go
+++ b/packetbeat/protos/memcache/plugin_udp.go
@@ -27,7 +27,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
-	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
 )
@@ -184,7 +183,7 @@ func (mc *memcache) onUDPMessage(
 	}
 	msg.Tuple = *tuple
 	msg.Transport = applayer.TransportUDP
-	msg.CmdlineTuple = procs.ProcWatcher.FindProcessesTupleUDP(tuple)
+	msg.CmdlineTuple = mc.watcher.FindProcessesTupleUDP(tuple)
 
 	done := false
 	var err error

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 )
 
@@ -46,7 +47,7 @@ func mongodbModForTests() (*eventStore, *mongodbPlugin) {
 	var mongodb mongodbPlugin
 	results := &eventStore{}
 	config := defaultConfig
-	mongodb.init(results.publish, &config)
+	mongodb.init(results.publish, procs.ProcessesWatcher{}, &config)
 	return results, &mongodb
 }
 

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 	"github.com/elastic/beats/v7/packetbeat/publish"
@@ -60,7 +61,7 @@ func mysqlModForTests(store *eventStore) *mysqlPlugin {
 	var mysql mysqlPlugin
 	config := defaultConfig
 	config.Ports = []int{serverPort}
-	mysql.init(callback, &config)
+	mysql.init(callback, procs.ProcessesWatcher{}, &config)
 	return &mysql
 }
 

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 )
@@ -70,6 +71,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
+	_ procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &rpc{}

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -56,7 +57,7 @@ func pgsqlModForTests(store *eventStore) *pgsqlPlugin {
 
 	var pgsql pgsqlPlugin
 	config := defaultConfig
-	pgsql.init(callback, &config)
+	pgsql.init(callback, procs.ProcessesWatcher{}, &config)
 	return &pgsql
 }
 

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 const (
@@ -92,11 +93,12 @@ type ProtocolsStruct struct {
 	udp map[Protocol]UDPPlugin
 }
 
-// Singleton of Protocols type.
-var Protos = ProtocolsStruct{
-	all: map[Protocol]protocolInstance{},
-	tcp: map[Protocol]TCPPlugin{},
-	udp: map[Protocol]UDPPlugin{},
+func NewProtocols() *ProtocolsStruct {
+	return &ProtocolsStruct{
+		all: map[Protocol]protocolInstance{},
+		tcp: map[Protocol]TCPPlugin{},
+		udp: map[Protocol]UDPPlugin{},
+	}
 }
 
 type protocolInstance struct {
@@ -111,6 +113,7 @@ type reporterFactory interface {
 func (s ProtocolsStruct) Init(
 	testMode bool,
 	pub reporterFactory,
+	watcher procs.ProcessesWatcher,
 	configs map[string]*common.Config,
 	listConfigs []*common.Config,
 ) error {
@@ -123,7 +126,7 @@ func (s ProtocolsStruct) Init(
 	}
 
 	for name, config := range configs {
-		if err := s.configureProtocol(testMode, pub, name, config); err != nil {
+		if err := s.configureProtocol(testMode, pub, watcher, name, config); err != nil {
 			return err
 		}
 	}
@@ -136,7 +139,7 @@ func (s ProtocolsStruct) Init(
 			return err
 		}
 
-		if err := s.configureProtocol(testMode, pub, module.Name, config); err != nil {
+		if err := s.configureProtocol(testMode, pub, watcher, module.Name, config); err != nil {
 			return err
 		}
 	}
@@ -147,6 +150,7 @@ func (s ProtocolsStruct) Init(
 func (s ProtocolsStruct) configureProtocol(
 	testMode bool,
 	pub reporterFactory,
+	watcher procs.ProcessesWatcher,
 	name string,
 	config *common.Config,
 ) error {
@@ -182,7 +186,7 @@ func (s ProtocolsStruct) configureProtocol(
 		}
 	}
 
-	inst, err := plugin(testMode, results, config)
+	inst, err := plugin(testMode, results, watcher, config)
 	if err != nil {
 		logp.Err("Failed to register protocol plugin: %v", err)
 		return err

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -55,6 +55,7 @@ type redisPlugin struct {
 	transactionTimeout time.Duration
 	queueConfig        MessageQueueConfig
 
+	watcher procs.ProcessesWatcher
 	results protos.Reporter
 }
 
@@ -75,6 +76,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
+	watcher procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &redisPlugin{}
@@ -85,16 +87,17 @@ func New(
 		}
 	}
 
-	if err := p.init(results, &config); err != nil {
+	if err := p.init(results, watcher, &config); err != nil {
 		return nil, err
 	}
 	return p, nil
 }
 
-func (redis *redisPlugin) init(results protos.Reporter, config *redisConfig) error {
+func (redis *redisPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *redisConfig) error {
 	redis.setFromConfig(config)
 
 	redis.results = results
+	redis.watcher = watcher
 	isDebug = logp.IsDebug("redis")
 
 	return nil
@@ -247,7 +250,7 @@ func (redis *redisPlugin) handleRedis(
 ) {
 	m.tcpTuple = *tcptuple
 	m.direction = dir
-	m.cmdlineTuple = procs.ProcWatcher.FindProcessesTupleTCP(tcptuple.IPPort())
+	m.cmdlineTuple = redis.watcher.FindProcessesTupleTCP(tcptuple.IPPort())
 
 	if m.isRequest {
 		// wait for response

--- a/packetbeat/protos/registry.go
+++ b/packetbeat/protos/registry.go
@@ -22,11 +22,14 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+
+	"github.com/elastic/beats/v7/packetbeat/procs"
 )
 
 type ProtocolPlugin func(
 	testMode bool,
 	results Reporter,
+	watcher procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (Plugin, error)
 

--- a/packetbeat/protos/sip/parser.go
+++ b/packetbeat/protos/sip/parser.go
@@ -87,6 +87,7 @@ const (
 )
 
 type parser struct {
+	watcher procs.ProcessesWatcher
 }
 
 type parsingInfo struct {
@@ -117,15 +118,17 @@ var (
 	nameVia           = []byte("via")
 )
 
-func newParser() *parser {
-	return &parser{}
+func newParser(watcher procs.ProcessesWatcher) *parser {
+	return &parser{
+		watcher: watcher,
+	}
 }
 
 func (parser *parser) parse(pi *parsingInfo) (*message, error) {
 	m := &message{
 		ts:           pi.pkt.Ts,
 		ipPortTuple:  pi.pkt.Tuple,
-		cmdlineTuple: procs.ProcWatcher.FindProcessesTupleTCP(&pi.pkt.Tuple),
+		cmdlineTuple: parser.watcher.FindProcessesTupleTCP(&pi.pkt.Tuple),
 		rawData:      pi.data,
 	}
 	for pi.parseOffset < len(pi.data) {

--- a/packetbeat/protos/sip/plugin_test.go
+++ b/packetbeat/protos/sip/plugin_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 )
 
@@ -114,7 +115,7 @@ func TestParseUDP(t *testing.T) {
 		gotEvent = &evt
 	}
 	const data = "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" <sip:sipp@10.0.2.20:5060>;tag=1\r\nTo: test <sip:test@10.0.2.15:5060>\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n"
-	p, _ := New(true, reporter, nil)
+	p, _ := New(true, reporter, procs.ProcessesWatcher{}, nil)
 	plugin := p.(*plugin)
 	plugin.ParseUDP(&protos.Packet{
 		Ts:      time.Now(),

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ var (
 )
 
 func init() {
-	new := func(_ bool, _ protos.Reporter, _ *common.Config) (protos.Plugin, error) {
+	new := func(_ bool, _ protos.Reporter, _ procs.ProcessesWatcher, _ *common.Config) (protos.Plugin, error) {
 		return &TestProtocol{}, nil
 	}
 

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -26,13 +26,14 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 )
 
 func thriftForTests() *thriftPlugin {
 	t := &thriftPlugin{}
 	config := defaultConfig
-	t.init(true, nil, &config)
+	t.init(true, nil, procs.ProcessesWatcher{}, &config)
 	return t
 }
 

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/publish"
 )
@@ -66,7 +67,7 @@ func testInit() (*eventStore, *tlsPlugin) {
 	logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
 
 	results := &eventStore{}
-	tls, err := New(true, results.publish, nil)
+	tls, err := New(true, results.publish, procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		return nil, nil
 	}

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -84,6 +84,7 @@ func (p *TransactionPublisher) CreateReporter(
 
 	// load and register the module it's fields, tags and processors settings
 	meta := struct {
+		Index      string                  `config:"index"`
 		Event      common.EventMetadata    `config:",inline"`
 		Processors processors.PluginConfig `config:"processors"`
 		KeepNull   bool                    `config:"keep_null"`
@@ -106,6 +107,9 @@ func (p *TransactionPublisher) CreateReporter(
 	}
 	if p.canDrop {
 		clientConfig.PublishMode = beat.DropIfFull
+	}
+	if meta.Index != "" {
+		clientConfig.Processing.Meta = common.MapStr{"index": meta.Index}
 	}
 
 	client, err := p.pipeline.ConnectWith(clientConfig)

--- a/packetbeat/scripts/tcp-protocol/{protocol}/trans.go.tmpl
+++ b/packetbeat/scripts/tcp-protocol/{protocol}/trans.go.tmpl
@@ -16,6 +16,8 @@ type transactions struct {
 	responses messageList
 
 	onTransaction transactionHandler
+
+	watcher procs.ProcessesWatcher
 }
 
 type transactionConfig struct {
@@ -29,8 +31,9 @@ type messageList struct {
 	head, tail *message
 }
 
-func (trans *transactions) init(c *transactionConfig, cb transactionHandler) {
+func (trans *transactions) init(c *transactionConfig, watcher procs.ProcessesWatcher, cb transactionHandler) {
 	trans.config = c
+	trans.watcher = watcher
 	trans.onTransaction = cb
 }
 
@@ -43,7 +46,7 @@ func (trans *transactions) onMessage(
 
 	msg.Tuple = *tuple
 	msg.Transport = applayer.TransportTCP
-	msg.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(&msg.Tuple)
+	msg.CmdlineTuple = trans.watcher.FindProcessesTuple(&msg.Tuple)
 
 	if msg.IsRequest {
 		if isDebug {

--- a/packetbeat/scripts/tcp-protocol/{protocol}/{protocol}.go.tmpl
+++ b/packetbeat/scripts/tcp-protocol/{protocol}/{protocol}.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
+	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 )
@@ -15,6 +16,7 @@ type {plugin_type} struct {
 	ports        protos.PortsConfig
 	parserConfig parserConfig
 	transConfig  transactionConfig
+	watcher      procs.ProcessesWatcher
 	pub          transPub
 }
 
@@ -45,6 +47,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
+	watcher procs.ProcessesWatcher,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &{plugin_type}{}
@@ -55,17 +58,18 @@ func New(
 		}
 	}
 
-	if err := p.init(results, &config); err != nil {
+	if err := p.init(results, watcher, &config); err != nil {
 		return nil, err
 	}
 	return p, nil
 }
 
-func ({plugin_var} *{plugin_type}) init(results protos.Reporter, config *{protocol}Config) error {
+func ({plugin_var} *{plugin_type}) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *{protocol}Config) error {
 	if err := {plugin_var}.setFromConfig(config); err != nil {
 		return err
 	}
 	{plugin_var}.pub.results = results
+	{plugin_var}.watcher = watcher
 
 	isDebug = logp.IsDebug("http")
 	return nil
@@ -162,7 +166,7 @@ func ({plugin_var} *{plugin_type}) ensureConnection(private protos.ProtocolData)
 	conn := getConnection(private)
 	if conn == nil {
 		conn = &connection{}
-		conn.trans.init(&{plugin_var}.transConfig, {plugin_var}.pub.onTransaction)
+		conn.trans.init(&{plugin_var}.transConfig, {plugin_var}.watcher, {plugin_var}.pub.onTransaction)
 	}
 	return conn
 }

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -63,6 +63,9 @@ packetbeat.flows:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where flow events are indexed.
+  #index: my-custom-flow-index
+
 # =========================== Transaction protocols ============================
 
 packetbeat.protocols:
@@ -72,6 +75,9 @@ packetbeat.protocols:
 
   # Set to true to publish fields with null values in events.
   #keep_null: false
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-icmp-index
 
 - type: amqp
   # Enable AMQP monitoring. Default: true
@@ -113,6 +119,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-amqp-index
+
 - type: cassandra
   #Cassandra port for traffic monitoring.
   ports: [9042]
@@ -142,6 +151,9 @@ packetbeat.protocols:
 
   # This option indicates which Operator/Operators will be ignored.
   #ignored_ops: ["SUPPORTED","OPTIONS"]
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-cassandra-index
 
 - type: dhcpv4
   # Configure the DHCP for IPv4 ports.
@@ -182,6 +194,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-dhcpv4-index
 
 - type: http
   # Enable HTTP monitoring. Default: true
@@ -257,6 +272,9 @@ packetbeat.protocols:
   # be trimmed to this size. Default is 10 MB.
   #max_message_size: 10485760
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-http-index
+
 - type: memcache
   # Enable memcache monitoring. Default: true
   #enabled: true
@@ -309,6 +327,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-memcache-index
+
 - type: mysql
   # Enable mysql monitoring. Default: true
   #enabled: true
@@ -332,6 +353,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mysql-index
+
 - type: pgsql
   # Enable pgsql monitoring. Default: true
   #enabled: true
@@ -354,6 +378,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-pgsql-index
 
 - type: redis
   # Enable redis monitoring. Default: true
@@ -386,6 +413,9 @@ packetbeat.protocols:
   # of requests or responses that can be buffered for correlation. Set a value
   # large enough to allow for pipelining.
   #queue_max_messages: 20000
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-redis-index
 
 - type: thrift
   # Enable thrift monitoring. Default: true
@@ -445,6 +475,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-thrift-index
+
 - type: mongodb
   # Enable mongodb monitoring. Default: true
   #enabled: true
@@ -478,6 +511,9 @@ packetbeat.protocols:
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-mongodb-index
+
 - type: nfs
   # Enable NFS monitoring. Default: true
   #enabled: true
@@ -500,6 +536,9 @@ packetbeat.protocols:
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
   #transaction_timeout: 10s
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-nfs-index
 
 - type: tls
   # Enable TLS monitoring. Default: true
@@ -531,6 +570,9 @@ packetbeat.protocols:
   # Set to true to publish fields with null values in events.
   #keep_null: false
 
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-tls-index
+
 - type: sip
   # Configure the ports where to listen for SIP traffic. You can disable the SIP protocol by commenting out the list of ports.
   ports: [5060]
@@ -543,6 +585,9 @@ packetbeat.protocols:
 
   # Preserve original contents in event.original
   keep_original: true
+
+  # Overrides where this protocol's events are indexed.
+  #index: my-custom-sip-index
 
 # ============================ Monitored processes =============================
 


### PR DESCRIPTION
## What does this PR do?

This PR refactors packetbeat to support for agent-based configuration. In order to facilitate control by agent, it does a few things:

1. Gets rid of any global variables that are initialized based on the configuration state
2. Adds handling that overrides any configuration if `packetbeat.inputs` are provided.
3. Makes the index that packetbeat pushes events to overrideable on each input (flows or protocols)
4. Uses centralized configuration management reloading to restart the sniffer and all worker goroutines when configuration changes

## Follow ups

We'll likely want to do a few things in the future, I can create issues if we want:

1. Right now, due to the way a single sniffer gets initialized and then delegates all of the protocol parsing to internally registered protocol handlers, each configuration reload, if even a single input changes, the sniffer needs to be stopped and started--so effectively all inputs are tied together. Not sure if it would make sense to move to some sort of worker routine per protocol or not, but it would get rid of some of the custom reload logic I had to add.
2. Once again, due to the single sniffer, the sniffing interface can really only be configured once. Right now I just choose the "default" interface based off of the OS, but ideally this would be customizable. That said, what it might mean is that we need to make all packetbeat integrations a single package or change packetbeat so we run a sniffer per input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Related: elastic/beats#21979
- Related: elastic/beats#22145
