### PR TITLE
Added retryer backoff

### DIFF
--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -9,7 +9,7 @@
 
 # For more available modules and options, please see the filebeat.reference.yml sample
 # configuration file.
-
+retryer.maxbackoff: 60s
 # ============================== Filebeat inputs ===============================
 
 filebeat.inputs:

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -342,6 +342,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		b.Config.Pipeline,
 		b.processing,
 		b.makeOutputFactory(b.Config.Output),
+		b.RawConfig,
 	)
 
 	if err != nil {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -182,7 +182,7 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 			WaitClose:     0,
 			WaitCloseMode: pipeline.NoWaitOnClose,
 			Processors:    processing,
-		})
+		}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -41,6 +41,7 @@ func TestClient(t *testing.T) {
 			},
 			outputs.Group{},
 			settings,
+			nil,
 		)
 		if err != nil {
 			panic(err)
@@ -127,6 +128,7 @@ func TestClientWaitClose(t *testing.T) {
 			func(queue.ACKListener) (queue.Queue, error) { return qu, nil },
 			outputs.Group{},
 			settings,
+			nil,
 		)
 		if err != nil {
 			panic(err)

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -78,7 +78,8 @@ func newOutputController(
 
 	ctx := &batchContext{}
 	c.consumer = newEventConsumer(monitors.Logger, queue, ctx)
-	c.retryer = newRetryer(monitors.Logger, observer, c.workQueue, c.consumer, cfg)
+	rcfg, _ := cfg.Child("retryer", -1)
+	c.retryer = newRetryer(monitors.Logger, observer, c.workQueue, c.consumer, rcfg)
 
 	ctx.observer = observer
 	ctx.retryer = c.retryer

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -66,6 +66,7 @@ func newOutputController(
 	monitors Monitors,
 	observer outputObserver,
 	queue queue.Queue,
+	cfg *common.Config,
 ) *outputController {
 	c := &outputController{
 		beat:      beat,
@@ -77,7 +78,8 @@ func newOutputController(
 
 	ctx := &batchContext{}
 	c.consumer = newEventConsumer(monitors.Logger, queue, ctx)
-	c.retryer = newRetryer(monitors.Logger, observer, c.workQueue, c.consumer)
+	c.retryer = newRetryer(monitors.Logger, observer, c.workQueue, c.consumer, cfg)
+
 	ctx.observer = observer
 	ctx.retryer = c.retryer
 

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -76,6 +76,7 @@ func TestOutputReload(t *testing.T) {
 					queueFactory,
 					outputs.Group{},
 					Settings{},
+					nil,
 				)
 				require.NoError(t, err)
 				defer pipeline.Close()

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -65,6 +65,7 @@ func Load(
 	config Config,
 	processors processing.Supporter,
 	makeOutput func(outputs.Observer) (string, outputs.Group, error),
+	cfg *common.Config,
 ) (*Pipeline, error) {
 
 	settings := Settings{
@@ -73,7 +74,7 @@ func Load(
 		Processors:    processors,
 	}
 
-	return LoadWithSettings(beatInfo, monitors, config, makeOutput, settings)
+	return LoadWithSettings(beatInfo, monitors, config, makeOutput, settings, cfg)
 }
 
 // LoadWithSettings is the same as Load, but it exposes a Settings object that includes processors and WaitClose behavior
@@ -83,6 +84,7 @@ func LoadWithSettings(
 	config Config,
 	makeOutput func(outputs.Observer) (string, outputs.Group, error),
 	settings Settings,
+	cfg *common.Config,
 ) (*Pipeline, error) {
 	log := monitors.Logger
 	if log == nil {
@@ -105,7 +107,7 @@ func LoadWithSettings(
 		return nil, err
 	}
 
-	p, err := New(beatInfo, monitors, queueBuilder, out, settings)
+	p, err := New(beatInfo, monitors, queueBuilder, out, settings, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/pipeline/output_test.go
+++ b/libbeat/publisher/pipeline/output_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/internal/testutil"
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -53,7 +54,8 @@ func TestMakeClientWorker(t *testing.T) {
 				logger := makeBufLogger(t)
 
 				wqu := makeWorkQueue()
-				retryer := newRetryer(logger, nilObserver, wqu, nil)
+				common.NewConfig()
+				retryer := newRetryer(logger, nilObserver, wqu, nil, nil)
 				defer retryer.close()
 
 				var published atomic.Uint
@@ -115,7 +117,7 @@ func TestReplaceClientWorker(t *testing.T) {
 				logger := makeBufLogger(t)
 
 				wqu := makeWorkQueue()
-				retryer := newRetryer(logger, nilObserver, wqu, nil)
+				retryer := newRetryer(logger, nilObserver, wqu, nil, nil)
 				defer retryer.close()
 
 				var batches []publisher.Batch
@@ -215,7 +217,7 @@ func TestMakeClientTracer(t *testing.T) {
 	logger := makeBufLogger(t)
 
 	wqu := makeWorkQueue()
-	retryer := newRetryer(logger, nilObserver, wqu, nil)
+	retryer := newRetryer(logger, nilObserver, wqu, nil, nil)
 	defer retryer.close()
 
 	var published atomic.Uint

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -142,6 +142,7 @@ func New(
 	queueFactory queueFactory,
 	out outputs.Group,
 	settings Settings,
+	cfg *common.Config,
 ) (*Pipeline, error) {
 	var err error
 
@@ -184,7 +185,7 @@ func New(
 	}
 	p.eventSema = newSema(maxEvents)
 
-	p.output = newOutputController(beat, monitors, p.observer, p.queue)
+	p.output = newOutputController(beat, monitors, p.observer, p.queue, cfg)
 	p.output.Set(out)
 
 	return p, nil

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -98,9 +98,7 @@ func newRetryer(
 		doneWaiter: sync.WaitGroup{},
 	}
 	if cfg.Enabled() {
-		if rcfg, err := cfg.Child("retryer", -1); err == nil && rcfg.Enabled() {
-			rcfg.Unpack(&r)
-		}
+		cfg.Unpack(&r)
 	}
 
 	r.doneWaiter.Add(1)
@@ -184,7 +182,6 @@ func (r *retryer) loop() {
 					r.backoff(&currentBackoff)
 				}
 			}
-
 		case out <- active:
 			r.observer.eventsRetry(activeSize)
 

--- a/libbeat/publisher/pipeline/stress/run.go
+++ b/libbeat/publisher/pipeline/stress/run.go
@@ -79,6 +79,7 @@ func RunTests(
 			out, err := outputs.Load(nil, info, stat, cfg.Name(), cfg.Config())
 			return cfg.Name(), out, err
 		},
+		nil,
 	)
 	if err != nil {
 		return fmt.Errorf("loading pipeline failed: %+v", err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
-->

## What does this PR do?
Retryer now has its own exponential backoff feature, which is a configurable field "retryer.maxbackoff".
Unfortunately, this means changing the signatures of multiple methods to get the configuration values to the retryer constructor.
<!-- Mandatory
-->

## Why is it important?
At the moment, backoff is handled by target output platform, which is wildly inconsistent. For example, if you output to Kafka with GuaranteedSend, you will see infinite retries as follows(note how tight the retries are, with 0.001s difference):

2020-10-25T20:18:08.591+0800	INFO	[publisher]	pipeline/retry.go:238	  done
2020-10-25T20:18:08.591+0800	INFO	[publisher]	pipeline/retry.go:234	retryer: send unwait signal to consumer
2020-10-25T20:18:08.591+0800	INFO	[publisher]	pipeline/retry.go:238	  done
2020-10-25T20:18:08.592+0800	INFO	[publisher]	pipeline/retry.go:234	retryer: send unwait signal to consumer
2020-10-25T20:18:08.592+0800	INFO	[publisher]	pipeline/retry.go:238	  done
2020-10-25T20:18:08.592+0800	INFO	[publisher]	pipeline/retry.go:234	retryer: send unwait signal to consumer

The CPU utilization is also unreasonably high, which is something we do not want on our clients if they cannot reach the output servers.

Hence, exponential backoff feature is implemented in the retryer itself to handle this. With exponential backoff, the retryer retries the batch after every exponential increase in time (eg. 1s, 2s, 4s, 8s, 16s...maxbackoff) as seen below:

2020-10-25T20:18:42.116+0800	INFO	[publisher]	pipeline/retry.go:233	retryer: send unwait signal to consumer
2020-10-25T20:18:42.116+0800	INFO	[publisher]	pipeline/retry.go:237	  done
2020-10-25T20:18:44.118+0800	INFO	[publisher]	pipeline/retry.go:233	retryer: send unwait signal to consumer
2020-10-25T20:18:44.118+0800	INFO	[publisher]	pipeline/retry.go:237	  done
2020-10-25T20:18:48.120+0800	INFO	[publisher]	pipeline/retry.go:233	retryer: send unwait signal to consumer
2020-10-25T20:18:48.120+0800	INFO	[publisher]	pipeline/retry.go:237	  done
2020-10-25T20:18:56.873+0800	INFO	[publisher]	pipeline/retry.go:233	retryer: send unwait signal to consumer
2020-10-25T20:18:56.873+0800	INFO	[publisher]	pipeline/retry.go:237	  done


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding change to the default configuration files

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
This feature works as long as there are problems sending to any output platform. Without configuring anything, you should see a 1s retry interval between consecutive retries.

Alternatively, just add retryer.maxbackoff value to your configuration yml (or args). Example:

[filebeat.yml]
...
retryer.maxbackoff: 10s # <-------------Add this to your yml file!
...
output.kafka: # <-------------Make sure this is unreachable 
  hosts: ["localhost:9092"]
...
And run your beat, making sure the retries interval are close to the value you have set.

## Related issues
There seem to be some discussions with regards to Kafka's retries and backoff[#2945, #4166], but I am not sure if the problem described here is directly or remotely related to them.

## Use cases
Applicable to any scenario that requires more consistent retry behaviours on client side irregardless of target output platform type.

