### PR TITLE
Cherry-pick #22126 to 7.x: [filebeat][httpjson] Use default config when creating the input

### DIFF
--- a/x-pack/filebeat/input/httpjson/input_manager.go
+++ b/x-pack/filebeat/input/httpjson/input_manager.go
@@ -36,7 +36,7 @@ func (m inputManager) Init(grp unison.Group, mode v2.Mode) error {
 // Create creates a cursor input manager if the config has a date cursor set up,
 // otherwise it creates a stateless input manager.
 func (m inputManager) Create(cfg *common.Config) (v2.Input, error) {
-	var config config
+	config := newDefaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick of PR #22126 to 7.x branch. Original message: 

## What does this PR do?

Use default config when creating the input.

## Why is it important?

Some config could fail if some required field is not set but has a default value.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

