### PR TITLE
[CI] set env variable for the params

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
   agent { label 'ubuntu-18 && immutable' }
   environment {
     AWS_ACCOUNT_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
+    AWS_REGION = "${params.awsRegion}"
     REPO = 'beats'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
@@ -431,7 +432,7 @@ def withCloudTestEnv(Closure body) {
       error("${AWS_ACCOUNT_SECRET} doesn't contain 'secret_key'")
     }
     maskedVars.addAll([
-      [var: "AWS_REGION", password: params.awsRegion],
+      [var: "AWS_REGION", password: "${env.AWS_REGION}"],
       [var: "AWS_ACCESS_KEY_ID", password: aws.access_key],
       [var: "AWS_SECRET_ACCESS_KEY", password: aws.secret_key],
     ])


### PR DESCRIPTION
## What does this PR do?

Parameters will be empty for the very first build, setting an environment variable with the same name will workaround the issue.

## Why is it important?

This will avoid the cases where the build fails for that particular empty value :/

For instance

![image](https://user-images.githubusercontent.com/2871786/97174728-63aadd80-178a-11eb-98dd-3ea9eaeaf937.png)


## Issues
Caused by [JENKINS-41929](https://issues.jenkins-ci.org/browse/JENKINS-41929)
