### PR TITLE
[Elastic Agent] Ensure shell wrapper path exists on install.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -22,6 +22,7 @@
 - Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 - Fix issue with named pipes on Windows 7 {pull}21931[21931]
 - Fix missing elastic_agent event data {pull}21994[21994]
+- Ensure shell wrapper path exists before writing wrapper on install {pull}22144[22144]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/install/install.go
+++ b/x-pack/elastic-agent/pkg/agent/install/install.go
@@ -53,7 +53,10 @@ func Install() error {
 
 	// place shell wrapper, if present on platform
 	if ShellWrapperPath != "" {
-		err = ioutil.WriteFile(ShellWrapperPath, []byte(ShellWrapper), 0755)
+		err = os.MkdirAll(filepath.Dir(ShellWrapperPath), 0755)
+		if err == nil {
+			err = ioutil.WriteFile(ShellWrapperPath, []byte(ShellWrapper), 0755)
+		}
 		if err != nil {
 			return errors.New(
 				err,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Ensures that the path for the shell wrapper that get install on macOS and Linux exists before writing to that directory.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

On a fresh installation of macOS `/usr/local/bin` does not exist, but can be created for binaries.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #22037 
