### PR TITLE
New processor: urlparse

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -415,6 +415,8 @@ https://github.com/elastic/beats/compare/v7.7.0...v7.8.0[View commits]
 - Add keystore support for autodiscover static configurations. {pull}16306[16306]
 - Add Kerberos support to Elasticsearch output. {pull}17927[17927]
 - Add support for fixed length extraction in `dissect` processor. {pull}17191[17191]
+- Add `urlparse` processor for parsing URL fields. {pull}22147[22147]
+
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -389,6 +389,16 @@ auditbeat.modules:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1255,6 +1255,16 @@ filebeat.inputs:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/filebeat/tests/system/test_processors.py
+++ b/filebeat/tests/system/test_processors.py
@@ -328,6 +328,39 @@ class Test(BaseTest):
             "correct data",
         ], field="decoded")
 
+    def test_urlparse_defaults(self):
+        """
+        Check URL-parsing using defaults
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            processors=[{
+                "urldecode": {
+                    "fields": [{
+                        "from": "message",
+                        "to": "parsed"
+                    }]
+                },
+            }]
+        )
+
+        self._init_and_read_test_input([
+            "https://hello.world.com\n",
+        ])
+
+        self._assert_expected_lines([
+            {
+                "scheme": "https",
+                "opaque": "",
+                "hostname": "hello.world.com",
+                "port": "",
+                "path": "",
+                "raw_path": "",
+                "raw_query": "",
+                "fragment": "",
+            }
+        ], field="parsed")
+
     def test_javascript_processor_add_host_metadata(self):
         """
         Check JS processor with add_host_metadata

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -566,6 +566,16 @@ heartbeat.scheduler:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -331,6 +331,16 @@ setup.template.settings:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/libbeat/_meta/config/processors.reference.yml.tmpl
+++ b/libbeat/_meta/config/processors.reference.yml.tmpl
@@ -160,3 +160,13 @@
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true

--- a/libbeat/cmd/instance/imports_common.go
+++ b/libbeat/cmd/instance/imports_common.go
@@ -37,5 +37,6 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/processors/registered_domain"
 	_ "github.com/elastic/beats/v7/libbeat/processors/translate_sid"
 	_ "github.com/elastic/beats/v7/libbeat/processors/urldecode"
+	_ "github.com/elastic/beats/v7/libbeat/processors/urlparse"
 	_ "github.com/elastic/beats/v7/libbeat/publisher/includes" // Register publisher pipeline modules
 )

--- a/libbeat/processors/urlparse/docs/urlparse.asciidoc
+++ b/libbeat/processors/urlparse/docs/urlparse.asciidoc
@@ -1,0 +1,57 @@
+[[urlparse]]
+=== URL Decode
+
+++++
+<titleabbrev>urlparse</titleabbrev>
+++++
+
+The `urlparse` processor specifies a list of fields to decode from URL encoded format. Under the `fields`
+key, each entry contains a `from: source-field` and a `to: target-field` pair, where:
+
+* `from` is the source field name
+* `to` is the target field name (defaults to the `from` value)
+
+[source,yaml]
+-------
+processors:
+  - urlparse:
+      fields:
+        - from: "field1"
+          to: "field2"
+      ignore_missing: false
+      fail_on_error: true
+-------
+
+In the example above:
+
+- field1 is parsed in field2
+
+The `urlparse` processor has the following configuration settings:
+
+`ignore_missing`:: (Optional) If set to true, no error is logged in case a key
+which should be URL-parsed is missing. Default is `false`.
+
+`fail_on_error`:: (Optional) If set to true, in case of an error the URL-decoding
+of fields is stopped and the original event is returned. If set to false, decoding
+continues also if an error happened during decoding. Default is `true`.
+
+See <<conditions>> for a list of supported conditions.
+
+The fields added to the event look like the following:
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+   "from": "https://hello.world.com:8999/index.html?hello=world#main",
+   "to": {
+        "scheme": "https",
+        "opaque": "",
+        "hostname": "hello.world.com",
+        "port": "8999",
+        "path": "/index.html",
+        "raw_path": "",
+        "raw_query": "hello=world",
+        "fragment": "main"
+    }
+}
+-------------------------------------------------------------------------------

--- a/libbeat/processors/urlparse/urlparse.go
+++ b/libbeat/processors/urlparse/urlparse.go
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package urlparse
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/processors/checks"
+	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
+)
+
+type urlParse struct {
+	config urlParseConfig
+	log    *logp.Logger
+}
+
+type urlParseConfig struct {
+	Fields        []fromTo `config:"fields" validate:"required"`
+	IgnoreMissing bool     `config:"ignore_missing"`
+	FailOnError   bool     `config:"fail_on_error"`
+}
+
+type fromTo struct {
+	From string `config:"from" validate:"required"`
+	To   string `config:"to"`
+}
+
+func init() {
+	processors.RegisterPlugin("urlparse",
+		checks.ConfigChecked(New,
+			checks.RequireFields("fields"),
+			checks.AllowedFields("fields", "ignore_missing", "fail_on_error")))
+	jsprocessor.RegisterPlugin("URLParse", New)
+}
+
+func New(c *common.Config) (processors.Processor, error) {
+	config := urlParseConfig{
+		IgnoreMissing: false,
+		FailOnError:   true,
+	}
+
+	if err := c.Unpack(&config); err != nil {
+		return nil, fmt.Errorf("failed to unpack the configuration of urlparse processor: %s", err)
+	}
+
+	return &urlParse{
+		config: config,
+		log:    logp.NewLogger("urlparse"),
+	}, nil
+
+}
+
+func (p *urlParse) Run(event *beat.Event) (*beat.Event, error) {
+	var backup common.MapStr
+	if p.config.FailOnError {
+		backup = event.Fields.Clone()
+	}
+
+	for _, field := range p.config.Fields {
+		err := p.parseField(field.From, field.To, event)
+		if err != nil {
+			errMsg := fmt.Errorf("failed to parse fields in urlparse processor: %v", err)
+			p.log.Debug(errMsg.Error())
+			if p.config.FailOnError {
+				event.Fields = backup
+				event.PutValue("error.message", errMsg.Error())
+				return event, err
+			}
+		}
+	}
+
+	return event, nil
+}
+
+func (p *urlParse) parseField(from string, to string, event *beat.Event) error {
+	value, err := event.GetValue(from)
+	if err != nil {
+		if p.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return nil
+		}
+		return fmt.Errorf("could not fetch value for key: %s, Error: %v", from, err)
+	}
+
+	parsedString, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid type for `from`, expecting a string received %T", value)
+	}
+	parseData, err := url.Parse(parsedString)
+
+	if err != nil {
+		return fmt.Errorf("error trying to URL-parse %s: %v", parsedString, err)
+	}
+
+	target := to
+	if to == "" {
+		target = from
+	}
+
+	if _, err := event.PutValue(target, common.MapStr{
+		"scheme":    parseData.Scheme,
+		"opaque":    parseData.Opaque,
+		"hostname":  parseData.Hostname(),
+		"port":      parseData.Port(),
+		"path":      parseData.Path,
+		"raw_path":  parseData.RawPath,
+		"raw_query": parseData.RawQuery,
+		"fragment":  parseData.Fragment,
+	}); err != nil {
+		return fmt.Errorf("could not put value: %s: %v, %v", parseData, target, err)
+	}
+
+	return nil
+}
+
+func (p *urlParse) String() string {
+	return "urlparse=" + fmt.Sprintf("%+v", p.config.Fields)
+}

--- a/libbeat/processors/urlparse/urlparse_test.go
+++ b/libbeat/processors/urlparse/urlparse_test.go
@@ -1,0 +1,237 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package urlparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func TestURLParse(t *testing.T) {
+	var testCases = []struct {
+		description string
+		config      urlParseConfig
+		Input       common.MapStr
+		Output      common.MapStr
+		error       bool
+	}{
+		{
+			description: "simple field urlparse",
+			config: urlParseConfig{
+				Fields: []fromTo{{
+					From: "field1", To: "field2",
+				}},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https://hello.world.com:8999/index.html?hello=world#main",
+			},
+			Output: common.MapStr{
+				"field1": "https://hello.world.com:8999/index.html?hello=world#main",
+				"field2": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "8999",
+					"path":      "/index.html",
+					"raw_path":  "",
+					"raw_query": "hello=world",
+					"fragment":  "main",
+				},
+			},
+			error: false,
+		},
+		{
+			description: "simple multiple fields urlparse",
+			config: urlParseConfig{
+				Fields: []fromTo{
+					{From: "field1", To: "field2"},
+					{From: "field3", To: "field4"},
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https://hello.world.com/youjiantaolovewangping",
+				"field3": "https://hello.world.com/bonsailovesarah",
+			},
+			Output: common.MapStr{
+				"field1": "https://hello.world.com/youjiantaolovewangping",
+				"field2": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "",
+					"path":      "/youjiantaolovewangping",
+					"raw_path":  "",
+					"raw_query": "",
+					"fragment":  "",
+				},
+				"field3": "https://hello.world.com/bonsailovesarah",
+				"field4": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "",
+					"path":      "/bonsailovesarah",
+					"raw_path":  "",
+					"raw_query": "",
+					"fragment":  "",
+				},
+			},
+			error: false,
+		},
+		{
+			description: "simple field urlparse To empty",
+			config: urlParseConfig{
+				Fields: []fromTo{{
+					From: "field1", To: "",
+				}},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https://hello.world.com",
+			},
+			Output: common.MapStr{
+				"field1": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "",
+					"path":      "",
+					"raw_path":  "",
+					"raw_query": "",
+					"fragment":  "",
+				},
+			},
+			error: false,
+		},
+		{
+			description: "simple field urlparse from and to equals",
+			config: urlParseConfig{
+				Fields: []fromTo{{
+					From: "field1", To: "field1",
+				}},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https://hello.world.com",
+			},
+			Output: common.MapStr{
+				"field1": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "",
+					"path":      "",
+					"raw_path":  "",
+					"raw_query": "",
+					"fragment":  "",
+				},
+			},
+			error: false,
+		},
+		{
+			description: "simple field urlparse with opaque",
+			config: urlParseConfig{
+				Fields: []fromTo{{
+					From: "field1", To: "field1",
+				}},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https:%2f%2fhello.world.com",
+			},
+			Output: common.MapStr{
+				"field1": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "%2f%2fhello.world.com",
+					"hostname":  "",
+					"port":      "",
+					"path":      "",
+					"raw_path":  "",
+					"raw_query": "",
+					"fragment":  "",
+				},
+			},
+			error: false,
+		},
+		{
+			description: "simple field urlparse with raw_path",
+			config: urlParseConfig{
+				Fields: []fromTo{{
+					From: "field1", To: "field1",
+				}},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "https://hello.world.com/%47%6f",
+			},
+			Output: common.MapStr{
+				"field1": common.MapStr{
+					"scheme":    "https",
+					"opaque":    "",
+					"hostname":  "hello.world.com",
+					"port":      "",
+					"path":      "/Go",
+					"raw_path":  "/%47%6f",
+					"raw_query": "",
+					"fragment":  "",
+				},
+			},
+			error: false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			f := &urlParse{
+				log:    logp.NewLogger("urlparse"),
+				config: test.config,
+			}
+
+			event := &beat.Event{
+				Fields: test.Input,
+			}
+
+			newEvent, err := f.Run(event)
+			if !test.error {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+
+			assert.Equal(t, test.Output, newEvent.Fields)
+
+		})
+	}
+
+}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1157,6 +1157,16 @@ metricbeat.modules:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -828,6 +828,16 @@ packetbeat.ignore_outgoing: false
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -311,6 +311,16 @@ winlogbeat.event_logs:
 #          to: "field2"
 #      ignore_missing: false
 #      fail_on_error: true
+#
+# The following example URL-parses the value of field1 to field2
+#
+#processors:
+#  - urlparse:
+#      fields:
+#        - from: "field1"
+#          to: "field2"
+#      ignore_missing: false
+#      fail_on_error: true
 
 # =============================== Elastic Cloud ================================
 


### PR DESCRIPTION
Signed-off-by: OhBonsai <letbonsaibe@gmail.com>

## What does this PR do?
This PR introduces a new processor `urlparse`. To parse fields from URL use this processor with `net/url.Urlparse`.

## Why is it important?
This PR makes Filebeat can parse URL strings itself and then write to different outputs.  The fields added to the event look like the following:
```
{
   "from": "https://hello.world.com:8999/index.html?hello=world#main",
   "to": {
        "scheme": "https",
        "opaque": "",
        "hostname": "hello.world.com",
        "port": "8999",
        "path": "/index.html",
        "raw_path": "",
        "raw_query": "hello=world",
        "fragment": "main"
    }
}
```


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


