### PR TITLE
Fix zeek connection pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -287,6 +287,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix checkpoint module when logs contain time field. {pull}20567[20567]
 - Add field limit check for AWS Cloudtrail flattened fields. {pull}21388[21388] {issue}21382[21382]
 - Fix syslog RFC 5424 parsing in the CheckPoint module. {pull}21854[21854]
+- Fix incorrect connection state mapping in zeek connection pipeline. {pull}22151[22151] {issue}22149[22149]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
@@ -115,7 +115,7 @@ processors:
           - connection
           - start
           - end
-      REG:
+      REJ:
         conn_str: "Connection attempt rejected."
         types:
           - connection


### PR DESCRIPTION
## What does this PR do?

- changes connection state for rejected from 'REG' to 'REJ'

https://docs.zeek.org/en/current/scripts/base/protocols/conn/main.zeek.html


## Why is it important?

Rejected connection states weren't matching.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

``` shell
TESTING_FILEBEAT_MODULES=zeek TESTING_FILEBEAT_FILESETS=connection mage -v pythonIntegTest
```

## Related issues

- Closes #22149