### PR TITLE
Fix Google Cloud Function configuration file issues

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -397,6 +397,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Do not need Google credentials if not required for the operation. {issue}17329[17329] {pull}21072[21072]
 - Fix dependency issues of GCP functions. {issue}20830[20830] {pull}21070[21070]
 - Fix catchall bucket config errors by adding more validation. {issue}17572[16282] {pull}20887[16287]
+- Fix Google Cloud Function configuration issue. {issue}20864[20864] {pull}22156[22156]
 
 ==== Added
 

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -205,6 +205,10 @@ func LoadList(file string) ([]*common.Config, error) {
 	return c, nil
 }
 
+func SetConfigPath(path string) {
+	*configPath = path
+}
+
 // GetPathConfig returns ${path.config}. If ${path.config} is not set, ${path.home} is returned.
 func GetPathConfig() string {
 	if *configPath != "" {

--- a/x-pack/functionbeat/provider/gcp/pubsub/pubsub.go
+++ b/x-pack/functionbeat/provider/gcp/pubsub/pubsub.go
@@ -29,6 +29,7 @@ func RunPubSub(ctx context.Context, m gpubsub.Message) error {
 		ConfigOverrides: config.FunctionOverrides,
 	}
 
+	cfgfile.SetConfigPath("/srv/src/pubsub")
 	cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 
 	return instance.Run(settings, initFunctionbeat(ctx, m))

--- a/x-pack/functionbeat/provider/gcp/storage/storage.go
+++ b/x-pack/functionbeat/provider/gcp/storage/storage.go
@@ -27,6 +27,7 @@ func RunCloudStorage(ctx context.Context, e gcp.StorageEvent) error {
 		ConfigOverrides: config.FunctionOverrides,
 	}
 
+	cfgfile.SetConfigPath("/srv/src/storage")
 	cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 
 	return instance.Run(settings, initFunctionbeat(ctx, e))

--- a/x-pack/functionbeat/scripts/mage/update.go
+++ b/x-pack/functionbeat/scripts/mage/update.go
@@ -74,6 +74,9 @@ func (Update) VendorBeats() error {
 				Exclude: []string{
 					".*_test.go$",
 					".*.yml",
+					// XXX GCP function metadata lib must be removed to avoid build failures
+					// GH issue: https://github.com/googleapis/google-cloud-go/issues/1947
+					".*cloud.google.com/go.*/functions/metadata.*",
 				},
 			}
 			err = cp.Execute()


### PR DESCRIPTION
## What does this PR do?

This PR adds a new function to to `cfgfile` to set the path to the configuration file of a Beat. This fixes the issue on GCP with Functionbeat.

## Why is it important?

ATM Functionbeat cannot run on GCP.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #20864