### PR TITLE
Remove data.json registry info

### DIFF
--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -35,12 +35,6 @@ filebeat.registry.path: registry
 NOTE: The registry is only updated when new events are flushed and not on a predefined period.
 That means in case there are some states where the TTL expired, these are only removed when new events are processed.
 
-NOTE: The registry stores its data in the subdirectory filebeat/data.json. It
-also contains a meta data file named filebeat/meta.json. The meta file contains
-the file format version number.
-
-NOTE: The content stored in filebeat/data.json is compatible with the old registry file data format.
-
 [float]
 ==== `registry.file_permissions`
 


### PR DESCRIPTION
The behavior of the Filebeat registry changed in 7.9. The registry no longer uses a file called data.json. 

I've removed the places where we mention the file, but someone on the dev team needs to confirm that the registry settings have not changed.

