### PR TITLE
[Ingest Manager] Skip flaky gateway tests

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/fleet_gateway_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_gateway_test.go
@@ -162,6 +162,7 @@ func wrapStrToResp(code int, body string) *http.Response {
 }
 
 func TestFleetGateway(t *testing.T) {
+	t.Skip("Flaky when CI is slower")
 
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{


### PR DESCRIPTION
## What does this PR do?

This test relies on timing and is flaky when CI is slow.

## Why is it important?

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
