### PR TITLE
Add new licence status: expired

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -188,6 +188,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The `o365input` and `o365` module now recover from an authentication problem or other fatal errors, instead of terminating. {pull}21259[21258]
 - Orderly close processors when processing pipelines are not needed anymore to release their resources. {pull}16349[16349]
 - Fix memory leak and events duplication in docker autodiscover and add_docker_metadata. {pull}21851[21851]
+- Fix parsing of expired licences. {issue}21112[21112] {pull}22180[22180]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/licenser/license.go
+++ b/x-pack/libbeat/licenser/license.go
@@ -68,6 +68,11 @@ func (l *License) IsActive() bool {
 	return l.Status == Active
 }
 
+// IsExpired returns true if the licence has expired.
+func (l *License) IsExpired() bool {
+	return l.Status == Expired
+}
+
 // IsTrial returns true if the remote cluster is in trial mode.
 func (l *License) IsTrial() bool {
 	return l.Type == Trial

--- a/x-pack/libbeat/licenser/license_test.go
+++ b/x-pack/libbeat/licenser/license_test.go
@@ -132,6 +132,11 @@ func TestIsActive(t *testing.T) {
 			l:        License{Status: Inactive},
 			expected: false,
 		},
+		{
+			name:     "expired",
+			l:        License{Status: Expired},
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/x-pack/libbeat/licenser/testdata/xpack-with-relax-expired-license-uuid.json
+++ b/x-pack/libbeat/licenser/testdata/xpack-with-relax-expired-license-uuid.json
@@ -1,0 +1,13 @@
+{
+  "build": {
+    "hash": "053779d",
+    "date": "2018-07-20T05:25:16.206115Z"
+  },
+  "license": {
+    "uid": "hello-license",
+    "type": "platinum",
+    "mode": "platinum",
+    "status": "expired",
+    "expiry_date_in_millis": 1588261199999
+  }
+}

--- a/x-pack/libbeat/licenser/types.go
+++ b/x-pack/libbeat/licenser/types.go
@@ -25,11 +25,13 @@ type State int
 const (
 	Inactive State = iota
 	Active
+	Expired
 )
 
 var stateLookup = map[string]State{
 	"inactive": Inactive,
 	"active":   Active,
+	"expired":  Expired,
 }
 
 var licenseLookup = map[string]LicenseType{


### PR DESCRIPTION
## What does this PR do?

This PR adds a new licence state named `Expired`. Previously, this prevented Beats from connecting to ES.

## Why is it important?

Beats were not able to parse expired licences. This problem prevented users from using the features of the software which does not require a licence.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #21112
