### PR TITLE
Cherry-pick #22091 to 7.10: [filebeat][okta] Make cursor optional for okta and update docs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -716,6 +716,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - New juniper.srx dataset for Juniper SRX logs. {pull}20017[20017]
 - Adding support for Microsoft 365 Defender (Microsoft Threat Protection) {pull}21446[21446]
 - Adding support for FIPS in s3 input {pull}21446[21446]
+- Update Okta documentation for new stateful restarts. {pull}22091[22091]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/okta.asciidoc
+++ b/filebeat/docs/modules/okta.asciidoc
@@ -32,12 +32,6 @@ the logs while honoring any
 https://developer.okta.com/docs/reference/rate-limits/[rate-limiting] headers
 sent by Okta.
 
-NOTE: This module does not persist the timestamp of the last read event in
-order to facilitate resuming on restart. This feature will be coming in a future
-version. When you restart the module will read events from the beginning of the
-log. To minimize duplicates documents the module uses the event's Okta UUID
-value as the Elasticsearch `_id`.
-
 This is an example configuration for the module.
 
 [source,yaml]
@@ -97,6 +91,15 @@ information.
 ----
     var.ssl:
       supported_protocols: [TLSv1.2]
+----
+
+*`var.initial_interval`*::
+
+An initial interval can be defined. The first time the module starts, will fetch events from the current moment minus the initial interval value. Following restarts will fetch events starting from the last event read. It defaults to `24h`.
++
+[source,yaml]
+----
+    var.initial_interval: 24h # will fetch events starting 24h ago.
 ----
 
 [float]

--- a/x-pack/filebeat/module/okta/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/okta/_meta/docs.asciidoc
@@ -27,12 +27,6 @@ the logs while honoring any
 https://developer.okta.com/docs/reference/rate-limits/[rate-limiting] headers
 sent by Okta.
 
-NOTE: This module does not persist the timestamp of the last read event in
-order to facilitate resuming on restart. This feature will be coming in a future
-version. When you restart the module will read events from the beginning of the
-log. To minimize duplicates documents the module uses the event's Okta UUID
-value as the Elasticsearch `_id`.
-
 This is an example configuration for the module.
 
 [source,yaml]
@@ -92,6 +86,15 @@ information.
 ----
     var.ssl:
       supported_protocols: [TLSv1.2]
+----
+
+*`var.initial_interval`*::
+
+An initial interval can be defined. The first time the module starts, will fetch events from the current moment minus the initial interval value. Following restarts will fetch events starting from the last event read. It defaults to `24h`.
++
+[source,yaml]
+----
+    var.initial_interval: 24h # will fetch events starting 24h ago.
 ----
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #22091 to 7.10 branch. Original message: 

## What does this PR do?

- Update docs to reflect new behaviour after adding the cursor to the module.

## Why is it important?

Previously Okta module pulled up to 7 days of logs every time, which was unconvenient when someone had big amounts of them. This is not the case anymore, and we document it accordingly.

cc @jamiehynds 

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

