### PR TITLE
Fix Elasticsearch behind Kerberos environment

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -26,8 +26,7 @@ services:
       - ES_MONITORING_HOST=elasticsearch_monitoring
       - ES_MONITORING_PORT=9200
       - ES_HOST_SSL=elasticsearchssl
-      # See https://github.com/elastic/beats/issues/21838
-      # - ES_KERBEROS_HOST=elasticsearch_kerberos.elastic
+      - ES_KERBEROS_HOST=elasticsearch_kerberos.elastic
       - ES_PORT_SSL=9200
       - ES_SUPERUSER_USER=admin
       - ES_SUPERUSER_PASS=changeme
@@ -44,8 +43,7 @@ services:
     image: busybox
     depends_on:
       elasticsearch:                  { condition: service_healthy }
-      # See https://github.com/elastic/beats/issues/21838
-      # elasticsearch_kerberos.elastic: { condition: service_healthy }
+      elasticsearch_kerberos.elastic: { condition: service_healthy }
       elasticsearch_monitoring:       { condition: service_healthy }
       elasticsearchssl:               { condition: service_healthy }
       logstash:                       { condition: service_healthy }
@@ -130,34 +128,34 @@ services:
     environment:
       - ADVERTISED_HOST=kafka
 
-  # elasticsearch_kerberos.elastic:
-  #   build: ${ES_BEATS}/testing/environments/docker/elasticsearch_kerberos
-  #   healthcheck:
-  #     test: bash -c "/healthcheck.sh"
-  #     retries: 1200
-  #     interval: 5s
-  #     start_period: 60s
-  #   environment:
-  #     - "TERM=linux"
-  #     - "ELASTIC_PASSWORD=changeme"
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.krb5.conf=/etc/krb5.conf"
-  #     - "network.host="
-  #     - "transport.host=127.0.0.1"
-  #     - "http.host=0.0.0.0"
-  #     - "xpack.security.enabled=true"
-  #     - "indices.id_field_data.enabled=true"
-  #     - "xpack.license.self_generated.type=trial"
-  #     - "xpack.security.authc.realms.kerberos.ELASTIC.order=1"
-  #     - "xpack.security.authc.realms.kerberos.ELASTIC.keytab.path=/usr/share/elasticsearch/config/HTTP_elasticsearch_kerberos.elastic.keytab"
-  #   hostname: elasticsearch_kerberos.elastic
-  #   volumes:
-  #     # This is needed otherwise there won't be enough entropy to generate a new kerberos realm
-  #     - /dev/urandom:/dev/random
-  #   ports:
-  #     - 1088
-  #     - 1749
-  #     - 9200
-  #   command: bash -c "/start.sh"
+  elasticsearch_kerberos.elastic:
+    build: ${ES_BEATS}/testing/environments/docker/elasticsearch_kerberos
+    healthcheck:
+      test: bash -c "/healthcheck.sh"
+      retries: 1200
+      interval: 5s
+      start_period: 60s
+    environment:
+      - "TERM=linux"
+      - "ELASTIC_PASSWORD=changeme"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.krb5.conf=/etc/krb5.conf"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=true"
+      - "indices.id_field_data.enabled=true"
+      - "xpack.license.self_generated.type=trial"
+      - "xpack.security.authc.realms.kerberos.ELASTIC.order=1"
+      - "xpack.security.authc.realms.kerberos.ELASTIC.keytab.path=/usr/share/elasticsearch/config/HTTP_elasticsearch_kerberos.elastic.keytab"
+    hostname: elasticsearch_kerberos.elastic
+    volumes:
+      # This is needed otherwise there won't be enough entropy to generate a new kerberos realm
+      - /dev/urandom:/dev/random
+    ports:
+      - 1088
+      - 1749
+      - 9200
+    command: bash -c "/start.sh"
 
   kibana:
     extends:

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -55,8 +55,6 @@ func TestClientPublishEvent(t *testing.T) {
 }
 
 func TestClientPublishEventKerberosAware(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21295")
-
 	err := setupRoleMapping(t, eslegtest.GetEsKerberosHost())
 	if err != nil {
 		t.Fatal(err)

--- a/testing/environments/docker/elasticsearch/kerberos/installkdc.sh
+++ b/testing/environments/docker/elasticsearch/kerberos/installkdc.sh
@@ -25,8 +25,6 @@ set -e
 LOCALSTATEDIR=/etc
 LOGDIR=/var/log/krb5
 
-#MARKER_FILE=/etc/marker
-
 # Transfer and interpolate krb5.conf
 cp /config/krb5.conf.template $LOCALSTATEDIR/krb5.conf
 sed -i 's/${REALM_NAME}/'$REALM_NAME'/g' $LOCALSTATEDIR/krb5.conf
@@ -48,12 +46,6 @@ mkdir -p $LOGDIR
 touch $LOGDIR/kadmin.log
 touch $LOGDIR/krb5kdc.log
 touch $LOGDIR/krb5lib.log
-
-# Update package manager
-yum update -qqy
-
-# Install krb5 packages
-yum install -qqy krb5-{server,libs,workstation}
 
 # Create kerberos database with stash file and garbage password
 kdb5_util create -s -r $REALM_NAME -P zyxwvutsrpqonmlk9876

--- a/testing/environments/docker/elasticsearch_kerberos/Dockerfile
+++ b/testing/environments/docker/elasticsearch_kerberos/Dockerfile
@@ -1,4 +1,13 @@
+FROM centos:8 AS builder
+RUN yum update -qqy && yum install -qqy krb5-server krb5-libs krb5-workstation
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+
+COPY --from=builder /usr/bin/kadmin  /usr/bin/kadmin
+COPY --from=builder /usr/sbin/kadmin.local  /usr/sbin/kadmin.local
+COPY --from=builder /usr/sbin/kadmind  /usr/sbin/kadmind
+COPY --from=builder /usr/sbin/kdb5_util  /usr/sbin/kdb5_util
+COPY --from=builder /usr/sbin/krb5kdc  /usr/sbin/krb5kdc
 
 ADD scripts /scripts
 ADD config /config
@@ -11,5 +20,8 @@ ENV BUILD_ZONE elastic
 ENV ELASTIC_ZONE $BUILD_ZONE
 
 USER root
+COPY --from=builder /usr/lib64 /tmp/usr/lib64
+RUN cp -R -u /tmp/usr/lib64/* /usr/lib64 && rm -rf /tmp/usr
+
 RUN /scripts/installkdc.sh && /scripts/addprincs.sh
 USER elasticsearch

--- a/testing/environments/docker/elasticsearch_kerberos/Dockerfile
+++ b/testing/environments/docker/elasticsearch_kerberos/Dockerfile
@@ -3,11 +3,13 @@ RUN yum update -qqy && yum install -qqy krb5-server krb5-libs krb5-workstation
 
 FROM docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
 
-COPY --from=builder /usr/bin/kadmin  /usr/bin/kadmin
-COPY --from=builder /usr/sbin/kadmin.local  /usr/sbin/kadmin.local
-COPY --from=builder /usr/sbin/kadmind  /usr/sbin/kadmind
-COPY --from=builder /usr/sbin/kdb5_util  /usr/sbin/kdb5_util
-COPY --from=builder /usr/sbin/krb5kdc  /usr/sbin/krb5kdc
+COPY --from=builder /usr/bin/kadmin /usr/bin/kadmin
+COPY --from=builder /usr/bin/kinit /usr/bin/kinit
+COPY --from=builder /usr/bin/klist /usr/bin/klist
+COPY --from=builder /usr/sbin/kadmin.local /usr/sbin/kadmin.local
+COPY --from=builder /usr/sbin/kadmind /usr/sbin/kadmind
+COPY --from=builder /usr/sbin/kdb5_util /usr/sbin/kdb5_util
+COPY --from=builder /usr/sbin/krb5kdc /usr/sbin/krb5kdc
 
 ADD scripts /scripts
 ADD config /config

--- a/testing/environments/docker/elasticsearch_kerberos/healthcheck.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/healthcheck.sh
@@ -8,4 +8,3 @@ KRB5_CONFIG=/etc/krb5.conf \
 # check if beats user can connect
 echo testing | KRB5_CONFIG=/etc/krb5.conf kinit beats@ELASTIC
 klist
-curl --negotiate -u : -XGET http://elasticsearch_kerberos.elastic:9200/

--- a/testing/environments/docker/elasticsearch_kerberos/scripts/addprinc.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/scripts/addprinc.sh
@@ -44,18 +44,18 @@ USER_KTAB=$LOCALSTATEDIR/$USER.keytab
 
 if [ -f $USER_KTAB ] && [ -z "$PASSWD" ]; then
   echo "Principal '${PRINC}@${REALM}' already exists. Re-copying keytab..."
-  sudo cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
+  cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
 else
   if [ -z "$PASSWD" ]; then
     echo "Provisioning '${PRINC}@${REALM}' principal and keytab..."
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -randkey $USER_PRIN"
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "ktadd -k $USER_KTAB $USER_PRIN"
-    sudo chmod 777 $USER_KTAB
-    sudo cp $USER_KTAB /usr/share/elasticsearch/config
-    sudo chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/$USER.keytab
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -randkey $USER_PRIN"
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "ktadd -k $USER_KTAB $USER_PRIN"
+    chmod 777 $USER_KTAB
+    cp $USER_KTAB /usr/share/elasticsearch/config
+    chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/$USER.keytab
   else
     echo "Provisioning '${PRINC}@${REALM}' principal with password..."
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -pw $PASSWD $PRINC"
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -pw $PASSWD $PRINC"
   fi
 fi
 

--- a/testing/environments/docker/elasticsearch_kerberos/scripts/installkdc.sh
+++ b/testing/environments/docker/elasticsearch_kerberos/scripts/installkdc.sh
@@ -47,12 +47,6 @@ touch $LOGDIR/kadmin.log
 touch $LOGDIR/krb5kdc.log
 touch $LOGDIR/krb5lib.log
 
-# Update package manager
-yum update -qqy
-
-# Install krb5 packages
-yum install -qqy krb5-{server,libs,workstation} sudo
-
 # Create kerberos database with stash file and garbage password
 kdb5_util create -s -r $REALM_NAME -P zyxwvutsrpqonmlk9876
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses the changes introduced in https://github.com/elastic/beats/issues/21838

## Why is it important?

ES behind Kerberos could not be tested.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-~~developer.next.asciidoc`.~~

## Related issues

Closes #21838
