### PR TITLE
[CI][flaky] Support 7.x branches and PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,14 +129,40 @@ pipeline {
     cleanup {
       // Required to enable the flaky test reporting with GitHub. Workspace exists since the post/always runs earlier
       dir("${BASE_DIR}"){
-        // TODO analyzeFlakey does not support other release branches but the master branch.
         notifyBuildResult(prComment: true,
                           slackComment: true, slackNotify: (isBranch() || isTag()),
-                          analyzeFlakey: true, flakyReportIdx: "reporter-beats-beats-master")
+                          analyzeFlakey: !isTag(), flakyReportIdx: "reporter-beats-beats-${getIdSuffix()}")
       }
     }
   }
 }
+
+/**
+* There are only two supported branches, master and 7.x
+*/
+def getIdSuffix() {
+  if(isPR()) {
+    return getBranchIndice(env.CHANGE_TARGET)
+  }
+  if(isBranch()) {
+    return getBranchIndice(env.BRANCH_NAME)
+  }
+}
+
+/**
+* There are only two supported branches, master and 7.x
+*/
+def getBranchIndice(String compare) {
+  if (compare?.equals('master') || compare.equals('7.x')) {
+    return compare
+  } else {
+    if (compare.startsWith('7.')) {
+      return '7.x'
+    }
+  }
+  return 'master'
+}
+
 
 /**
 * This method is the one used for running the parallel stages, therefore


### PR DESCRIPTION
## What does this PR do?

Enable 7.x branches and disable flaky test analyser for `tags`

## Why is it important?

Use the index that matches either the master or the 7.x branch or the target branch to which the PR could be merged. Default `master`

## Related issues

Relates https://github.com/elastic/beats/pull/21853
