### PR TITLE
Cherry-pick to 7.x: [DOCS] Warn about compression and Azure Event Hub for Kafka (#21578)

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -244,6 +244,12 @@ The keep-alive period for an active network connection. If 0s, keep-alives are d
 
 Sets the output compression codec. Must be one of `none`, `snappy`, `lz4` and `gzip`. The default is `gzip`.
 
+[IMPORTANT]
+.Known issue with Azure Event Hub for Kafka
+====
+When targeting Azure Event Hub for Kafka, set `compression` to `none` as the provided codecs are not supported.
+====
+
 ===== `compression_level`
 
 Sets the compression level used by gzip. Setting this value to 0 disables compression.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Warn about compression and Azure Event Hub for Kafka (#21578)