### PR TITLE
Cherry-pick #22175 to 7.10: Agent fix snapshot download for upgrade 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/stream.go
+++ b/x-pack/elastic-agent/pkg/agent/application/stream.go
@@ -57,9 +57,9 @@ func streamFactory(ctx context.Context, agentInfo *info.AgentInfo, cfg *configur
 }
 
 func newOperator(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, id routingKey, config *configuration.SettingsConfig, srv *server.Server, r state.Reporter, m monitoring.Monitor) (*operation.Operator, error) {
-	fetcher := downloader.NewDownloader(log, config.DownloadConfig, false)
+	fetcher := downloader.NewDownloader(log, config.DownloadConfig)
 	allowEmptyPgp, pgp := release.PGP()
-	verifier, err := downloader.NewVerifier(log, config.DownloadConfig, allowEmptyPgp, pgp, false)
+	verifier, err := downloader.NewVerifier(log, config.DownloadConfig, allowEmptyPgp, pgp)
 	if err != nil {
 		return nil, errors.New(err, "initiating verifier")
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download.go
@@ -9,7 +9,14 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/composed"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/fs"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/http"
 	downloader "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/localremote"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/snapshot"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
@@ -26,13 +33,16 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		}
 	}
 
-	allowEmptyPgp, pgp := release.PGP()
-	verifier, err := downloader.NewVerifier(u.log, &settings, allowEmptyPgp, pgp, true)
+	verifier, err := newVerifier(version, u.log, &settings)
 	if err != nil {
 		return "", errors.New(err, "initiating verifier")
 	}
 
-	fetcher := downloader.NewDownloader(u.log, &settings, true)
+	fetcher, err := newDownloader(version, u.log, &settings)
+	if err != nil {
+		return "", errors.New(err, "initiating fetcher")
+	}
+
 	path, err := fetcher.Download(ctx, agentName, agentArtifactName, version)
 	if err != nil {
 		return "", errors.New(err, "failed upgrade of agent binary")
@@ -47,4 +57,46 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	}
 
 	return path, nil
+}
+
+func newDownloader(version string, log *logger.Logger, settings *artifact.Config) (download.Downloader, error) {
+	if !strings.HasSuffix(version, "-SNAPSHOT") {
+		return downloader.NewDownloader(log, settings), nil
+	}
+
+	// try snapshot repo before official
+	snapDownloader, err := snapshot.NewDownloader(settings, version)
+	if err != nil {
+		return nil, err
+	}
+
+	return composed.NewDownloader(
+		fs.NewDownloader(settings),
+		snapDownloader,
+		http.NewDownloader(settings),
+	), nil
+}
+
+func newVerifier(version string, log *logger.Logger, settings *artifact.Config) (download.Verifier, error) {
+	allowEmptyPgp, pgp := release.PGP()
+	if !strings.HasSuffix(version, "-SNAPSHOT") {
+		return downloader.NewVerifier(log, settings, allowEmptyPgp, pgp)
+	}
+
+	fsVerifier, err := fs.NewVerifier(settings, allowEmptyPgp, pgp)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotVerifier, err := snapshot.NewVerifier(settings, allowEmptyPgp, pgp, version)
+	if err != nil {
+		return nil, err
+	}
+
+	remoteVerifier, err := http.NewVerifier(settings, allowEmptyPgp, pgp)
+	if err != nil {
+		return nil, err
+	}
+
+	return composed.NewVerifier(fsVerifier, snapshotVerifier, remoteVerifier), nil
 }

--- a/x-pack/elastic-agent/pkg/artifact/config.go
+++ b/x-pack/elastic-agent/pkg/artifact/config.go
@@ -47,7 +47,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		SourceURI:       "https://artifacts.elastic.co/downloads/",
 		TargetDirectory: filepath.Join(homePath, "downloads"),
-		Timeout:         30 * time.Second,
+		Timeout:         120 * time.Second, // binaries are a getting bit larger it might take >30s to download them
 		InstallPath:     filepath.Join(homePath, "install"),
 	}
 }

--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	ascSuffix = ".asc"
+	ascSuffix    = ".asc"
+	sha512Length = 128
 )
 
 // Verifier verifies a downloaded package by comparing with public ASC
@@ -93,7 +94,9 @@ func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
 			continue
 		}
 
-		expectedHash = strings.TrimSpace(strings.TrimSuffix(line, filename))
+		if len(line) > sha512Length {
+			expectedHash = strings.TrimSpace(line[:sha512Length])
+		}
 	}
 
 	if expectedHash == "" {

--- a/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
@@ -17,13 +17,13 @@ import (
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewDownloader(log *logger.Logger, config *artifact.Config, forceSnapshot bool) download.Downloader {
+func NewDownloader(log *logger.Logger, config *artifact.Config) download.Downloader {
 	downloaders := make([]download.Downloader, 0, 3)
 	downloaders = append(downloaders, fs.NewDownloader(config))
 
 	// try snapshot repo before official
-	if release.Snapshot() || forceSnapshot {
-		snapDownloader, err := snapshot.NewDownloader(config)
+	if release.Snapshot() {
+		snapDownloader, err := snapshot.NewDownloader(config, "")
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/x-pack/elastic-agent/pkg/artifact/download/localremote/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/localremote/verifier.go
@@ -17,7 +17,7 @@ import (
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool, pgp []byte, forceSnapshot bool) (download.Verifier, error) {
+func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool, pgp []byte) (download.Verifier, error) {
 	verifiers := make([]download.Verifier, 0, 3)
 
 	fsVer, err := fs.NewVerifier(config, allowEmptyPgp, pgp)
@@ -27,8 +27,8 @@ func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool
 	verifiers = append(verifiers, fsVer)
 
 	// try snapshot repo before official
-	if release.Snapshot() || forceSnapshot {
-		snapshotVerifier, err := snapshot.NewVerifier(config, allowEmptyPgp, pgp)
+	if release.Snapshot() {
+		snapshotVerifier, err := snapshot.NewVerifier(config, allowEmptyPgp, pgp, "")
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/verifier.go
@@ -12,8 +12,8 @@ import (
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (download.Verifier, error) {
-	cfg, err := snapshotConfig(config)
+func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte, versionOverride string) (download.Verifier, error) {
+	cfg, err := snapshotConfig(config, versionOverride)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick of PR #22175 to 7.10 branch. Original message:

## What does this PR do?

There was a version mismatch for snapshot downloads. WHen upgrading it tried to download current version snapshot instead of desired one. 

Also as my connection is acting funny today and is not the fastest i run into issue when timeout occurred frequently when downloading elastic-agent snapshot so i increased timeout for this scenario.

## Why is it important?

Snapshot upgrades

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
