### PR TITLE
Cherry-pick #22153 to 7.10: [Elastic Agent] Fix deb/rpm installation

### DIFF
--- a/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl
@@ -9,10 +9,8 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
-Environment="BEAT_LOG_OPTS="
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
-Environment="BEAT_PATH_OPTS=--path.home /var/lib/{{.BeatName}} --path.config /etc/{{.BeatName}} --path.data /var/lib/{{.BeatName}}/data --path.logs /var/log/{{.BeatName}}"
-ExecStart=/usr/share/{{.BeatName}}/bin/{{.BeatName}} --environment systemd $BEAT_LOG_OPTS $BEAT_CONFIG_OPTS $BEAT_PATH_OPTS
+ExecStart=/usr/bin/{{.BeatName}} run --environment systemd $BEAT_CONFIG_OPTS
 Restart=always
 
 [Install]

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -23,6 +23,7 @@
 - Rename monitoring index from `elastic.agent` to `elastic_agent` {pull}21932[21932]
 - Fix missing elastic_agent event data {pull}21994[21994]
 - Ensure shell wrapper path exists before writing wrapper on install {pull}22144[22144]
+- Fix deb/rpm packaging for Elastic Agent {pull}22153[22153]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #22153 to 7.10 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the installation of Elastic Agent using the .deb and .rpm.

This fixes the issue of the Elastic Agent .deb not working on Ubuntu because the starting parameters of `--environment systemd` cannot be used on the root cmd, it can only be used on the `run` subcommand.

This fixes the issue of the Elastic Agent .rpm not working on Fedora because SELinux prevents a systemd unit from starting a binary inside of `/usr/share`. This switches the command of the unit to `/usr/bin/elastic-agent` which will already provide the wrapper command args for the paths and not prevent SELinux from starting the binary.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows Elastic Agent to work from a .deb and .rpm installation.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #21200 
