### PR TITLE
[CI] archive only if failed steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,6 +302,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
             git config --global user.name "beatsmachine"
           fi''')
       }
+      // Skip to upload the generated files by default.
+      def upload = false
       try {
         // Add more stability when dependencies are not accessible temporarily
         // See https://github.com/elastic/beats/issues/21609
@@ -311,9 +313,12 @@ def withBeatsEnv(Map args = [:], Closure body) {
           cmd(label: 'Download modules to local cache - retry', script: 'go mod download', returnStatus: true)
         }
         body()
+      } catch(err) {
+        // Upload the generated files ONLY if the step failed. This will avoid any overhead with Google Storage
+        upload = true
       } finally {
         if (archive) {
-          archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id)
+          archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
         }
         // Tear down the setup for the permamnent workers.
         catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
@@ -391,16 +396,20 @@ def archiveTestOutput(Map args = [:]) {
             script: 'rm -rf ve || true; find . -type d -name vendor -exec rm -r {} \\;')
       } else { log(level: 'INFO', text: 'Delete folders that are causing exceptions (See JENKINS-58421) is disabled for Windows.') }
       junitAndStore(allowEmptyResults: true, keepLongStdio: true, testResults: args.testResults, stashedTestReports: stashedTestReports, id: args.id)
-      tarAndUploadArtifacts(file: "test-build-artifacts-${args.id}.tgz", location: '.')
+      if (args.upload) {
+        tarAndUploadArtifacts(file: "test-build-artifacts-${args.id}.tgz", location: '.')
+      }
     }
-    catchError(buildResult: 'SUCCESS', message: 'Failed to archive the build test results', stageResult: 'SUCCESS') {
-      def folder = cmd(label: 'Find system-tests', returnStdout: true, script: 'python .ci/scripts/search_system_tests.py').trim()
-      log(level: 'INFO', text: "system-tests='${folder}'. If no empty then let's create a tarball")
-      if (folder.trim()) {
-        // TODO: nodeOS() should support ARM
-        def os_suffix = isArm() ? 'linux' : nodeOS()
-        def name = folder.replaceAll('/', '-').replaceAll('\\\\', '-').replaceAll('build', '').replaceAll('^-', '') + '-' + os_suffix
-        tarAndUploadArtifacts(file: "${name}.tgz", location: folder)
+    if (args.upload) {
+      catchError(buildResult: 'SUCCESS', message: 'Failed to archive the build test results', stageResult: 'SUCCESS') {
+        def folder = cmd(label: 'Find system-tests', returnStdout: true, script: 'python .ci/scripts/search_system_tests.py').trim()
+        log(level: 'INFO', text: "system-tests='${folder}'. If no empty then let's create a tarball")
+        if (folder.trim()) {
+          // TODO: nodeOS() should support ARM
+          def os_suffix = isArm() ? 'linux' : nodeOS()
+          def name = folder.replaceAll('/', '-').replaceAll('\\\\', '-').replaceAll('build', '').replaceAll('^-', '') + '-' + os_suffix
+          tarAndUploadArtifacts(file: "${name}.tgz", location: folder)
+        }
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Store only the system tests output if the step failed. This will reduce the total number of artifacts that are stored in the Google Storage bucket and on the other hand we will avoid the existing issue with concurrency in Jenkins -> https://github.com/jenkinsci/google-storage-plugin/issues/61

## Why is it important?

Faster builds, less disposal artifacts for success builds.


## Test

For a successful build then no artifacts are archived in the Google Storage

![image](https://user-images.githubusercontent.com/2871786/97439494-224b3700-191e-11eb-9a1d-d19ca459ce1b.png)
