### PR TITLE
Cherry-pick #22146 to 7.x: Perfmon - Fix regular expressions to comply to multiple parentheses in instance name and object

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -424,6 +424,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix retrieving resources by ID for the azure module. {pull}21711[21711] {issue}21707[21707]
 - Use timestamp from CloudWatch API when creating events. {pull}21498[21498]
 - Report the correct windows events for system/filesystem {pull}21758[21758]
+- Fix regular expression in windows/permfon. {pull}22146[22146] {issue}21125[21125]
 - Fix azure storage event format. {pull}21845[21845]
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]

--- a/metricbeat/module/windows/perfmon/data.go
+++ b/metricbeat/module/windows/perfmon/data.go
@@ -33,7 +33,7 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
-var processRegexp = regexp.MustCompile(`(.+?)#[1-9]+`)
+var processRegexp = regexp.MustCompile(`(.+?[^\s])(?:#\d+|$)`)
 
 func (re *Reader) groupToEvents(counters map[string][]pdh.CounterValue) []mb.Event {
 	eventMap := make(map[string]*mb.Event)
@@ -73,7 +73,7 @@ func (re *Reader) groupToEvents(counters map[string][]pdh.CounterValue) []mb.Eve
 						Error:           errors.Wrapf(val.Err.Error, "failed on query=%v", counterPath),
 					}
 					if val.Instance != "" {
-						//will ignore instance counter
+						//will ignore instance index
 						if ok, match := matchesParentProcess(val.Instance); ok {
 							eventMap[eventKey].MetricSetFields.Put(counter.InstanceField, match)
 						} else {

--- a/metricbeat/module/windows/perfmon/data_test.go
+++ b/metricbeat/module/windows/perfmon/data_test.go
@@ -159,9 +159,13 @@ func TestGroupToSingleEvent(t *testing.T) {
 
 func TestMatchesParentProcess(t *testing.T) {
 	ok, val := matchesParentProcess("svchost")
-	assert.False(t, ok)
+	assert.True(t, ok)
 	assert.Equal(t, val, "svchost")
 	ok, val = matchesParentProcess("svchost#54")
 	assert.True(t, ok)
 	assert.Equal(t, val, "svchost")
+
+	ok, val = matchesParentProcess("svchost (test) another #54")
+	assert.True(t, ok)
+	assert.Equal(t, val, "svchost (test) another #54")
 }


### PR DESCRIPTION
Cherry-pick of PR #22146 to 7.x branch. Original message:

## What does this PR do?

Perfmon - Fix regular expressions to comply to multiple parentheses in instance name and object

## Why is it important?

Incorrect instance names

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/21125

