### PR TITLE
Cherry-pick to 7.9: [CI] archive only if failed steps (#22220)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,6 +282,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
             git config --global user.name "beatsmachine"
           fi''')
       }
+      // Skip to upload the generated files by default.
+      def upload = false
       try {
         // Add more stability when dependencies are not accessible temporarily
         // See https://github.com/elastic/beats/issues/21609
@@ -291,9 +293,12 @@ def withBeatsEnv(Map args = [:], Closure body) {
           cmd(label: 'Download modules to local cache - retry', script: 'go mod download', returnStatus: true)
         }
         body()
+      } catch(err) {
+        // Upload the generated files ONLY if the step failed. This will avoid any overhead with Google Storage
+        upload = true
       } finally {
         if (archive) {
-          archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id)
+          archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
         }
         // Tear down the setup for the permamnent workers.
         catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
@@ -371,14 +376,18 @@ def archiveTestOutput(Map args = [:]) {
             script: 'rm -rf ve || true; find . -type d -name vendor -exec rm -r {} \\;')
       } else { log(level: 'INFO', text: 'Delete folders that are causing exceptions (See JENKINS-58421) is disabled for Windows.') }
       junitAndStore(allowEmptyResults: true, keepLongStdio: true, testResults: args.testResults, stashedTestReports: stashedTestReports, id: args.id)
-      tarAndUploadArtifacts(file: "test-build-artifacts-${args.id}.tgz", location: '.')
+      if (args.upload) {
+        tarAndUploadArtifacts(file: "test-build-artifacts-${args.id}.tgz", location: '.')
+      }
     }
-    catchError(buildResult: 'SUCCESS', message: 'Failed to archive the build test results', stageResult: 'SUCCESS') {
-      def folder = cmd(label: 'Find system-tests', returnStdout: true, script: 'python .ci/scripts/search_system_tests.py').trim()
-      log(level: 'INFO', text: "system-tests='${folder}'. If no empty then let's create a tarball")
-      if (folder.trim()) {
-        def name = folder.replaceAll('/', '-').replaceAll('\\\\', '-').replaceAll('build', '').replaceAll('^-', '') + '-' + nodeOS()
-        tarAndUploadArtifacts(file: "${name}.tgz", location: folder)
+    if (args.upload) {
+      catchError(buildResult: 'SUCCESS', message: 'Failed to archive the build test results', stageResult: 'SUCCESS') {
+        def folder = cmd(label: 'Find system-tests', returnStdout: true, script: 'python .ci/scripts/search_system_tests.py').trim()
+        log(level: 'INFO', text: "system-tests='${folder}'. If no empty then let's create a tarball")
+        if (folder.trim()) {
+          def name = folder.replaceAll('/', '-').replaceAll('\\\\', '-').replaceAll('build', '').replaceAll('^-', '') + '-' + nodeOS()
+          tarAndUploadArtifacts(file: "${name}.tgz", location: folder)
+        }
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [CI] archive only if failed steps (#22220)