### PR TITLE
Cherry-pick #22236 to 7.10: [Winlogbeat] protect against accessing undefined variables in sysmon module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -438,6 +438,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix `event.outcome` in the security module for non-English languages. {issue}20079[20079] {pull}20564[2056
 - Fix duplicated field error when exporting index-pattern with migration.6_to_7.enabled. {issue}20521[20521] {pull}20540[20540]
 - Fields from Winlogbeat modules were not being included in index templates and patterns. {pull}18983[18983]
+- Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -303,6 +303,9 @@ var sysmon = (function () {
             return;
         }
         var exe = evt.Get(pathField);
+        if (!exe) {
+            return;
+        }
         evt.Put(nameField, path.basename(exe));
     };
 
@@ -327,7 +330,11 @@ var sysmon = (function () {
     };
 
     var addUser = function (evt) {
-        var userParts = evt.Get("winlog.event_data.User").split("\\");
+        var userParts = evt.Get("winlog.event_data.User");
+        if (!userParts) {
+            return;
+        }
+        userParts = userParts.split("\\");
         if (userParts.length === 2) {
             evt.Delete("user");
             evt.Put("user.domain", userParts[0]);
@@ -406,6 +413,9 @@ var sysmon = (function () {
     // in the specified namespace. It also adds all the hashes to 'related.hash'.
     var addHashes = function (evt, namespace, hashField) {
         var hashes = evt.Get(hashField);
+        if (!hashes) {
+            return;
+        }
         evt.Delete(hashField);
         hashes.split(",").forEach(function (hash) {
             var parts = hash.split("=");


### PR DESCRIPTION
Cherry-pick of PR #22236 to 7.10 branch. Original message: 

## What does this PR do?

protects against type error when trying to use string functions on
null data type

## Why is it important?

Sysmon events fail to index with TypeError

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` shell
go test
```

## Related issues

- Closes #22219