### PR TITLE
Update commands used in the quick start

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent-configuration.asciidoc
@@ -21,8 +21,8 @@ When running the agent standalone, specify configuration settings in the
 the `elastic-agent.yml` file. Instead, use {fleet} in {kib} to change
 settings.
 
-TIP: To get started quickly, you can use {fleet} to generate a standalone
-configuration. For more information, see <<agent-standalone-mode>>.
+//TIP: To get started quickly, you can use {fleet} to generate a standalone
+//configuration. For more information, see <<agent-standalone-mode>>.
 
 [discrete]
 [[elastic-agent-output-configuration]]

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc
@@ -3,18 +3,6 @@
   <div role="tablist" aria-label="Enroll">
     <button role="tab"
             aria-selected="true"
-            aria-controls="deb-tab-enroll"
-            id="deb-enroll">
-      DEB
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="rpm-tab-enroll"
-            id="rpm-enroll">
-      RPM
-    </button>
-    <button role="tab"
-            aria-selected="false"
             aria-controls="mac-tab-enroll"
             id="mac-enroll">
       MacOS
@@ -33,33 +21,25 @@
             tabindex="-1">
       Windows
     </button>
-  </div>
-  <div tabindex="0"
-       role="tabpanel"
-       id="deb-tab-enroll"
-       aria-labelledby="deb-enroll">
-++++
-
-include::enroll.asciidoc[tag=deb]
-
-++++
-  </div> 
-  <div tabindex="0"
-       role="tabpanel"
-       id="rpm-tab-enroll"
-       aria-labelledby="rpm-enroll"
-       hidden="">
-++++
-
-include::enroll.asciidoc[tag=rpm]
-
-++++
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="deb-tab-enroll"
+            id="deb-enroll"
+            tabindex="-1">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-enroll"
+            id="rpm-enroll"
+            tabindex="-1">
+      RPM
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
        id="mac-tab-enroll"
-       aria-labelledby="mac-enroll"
-       hidden="">
+       aria-labelledby="mac-enroll">
 ++++
 
 include::enroll.asciidoc[tag=mac]
@@ -85,6 +65,28 @@ include::enroll.asciidoc[tag=linux]
 ++++
 
 include::enroll.asciidoc[tag=win]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-enroll"
+       aria-labelledby="deb-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-enroll"
+       aria-labelledby="rpm-enroll"
+       hidden="">
+++++
+
+include::enroll.asciidoc[tag=rpm]
 
 ++++
   </div>

--- a/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/enroll.asciidoc
@@ -7,7 +7,7 @@ integrations require root privileges to collect sensitive data.
 // end::enroll-tip[]
 [source,shell]
 ----
-elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+elastic-agent install -f --kibana-url=KIBANA_URL --enrollment-token=ENROLLMENT_KEY
 ----
 
 include::enroll.asciidoc[tag=where-description]
@@ -19,7 +19,7 @@ include::enroll.asciidoc[tag=enroll-tip]
 
 [source,shell]
 ----
-elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+elastic-agent install -f --kibana-url=KIBANA_URL --enrollment-token=ENROLLMENT_KEY
 ----
 
 include::enroll.asciidoc[tag=where-description]
@@ -31,7 +31,7 @@ include::enroll.asciidoc[tag=enroll-tip]
 
 [source,shell]
 ----
-./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+./elastic-agent install -f --kibana-url=KIBANA_URL --enrollment-token=ENROLLMENT_KEY
 ----
 
 include::enroll.asciidoc[tag=where-description]
@@ -43,7 +43,7 @@ include::enroll.asciidoc[tag=enroll-tip]
 
 [source,shell]
 ----
-./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
+./elastic-agent install -f --kibana-url=KIBANA_URL --enrollment-token=ENROLLMENT_KEY
 ----
 
 include::enroll.asciidoc[tag=where-description]
@@ -58,7 +58,7 @@ and run:
 
 [source,shell]
 ----
-.\elastic-agent.exe enroll KIBANA_URL ENROLLMENT_KEY
+.\elastic-agent.exe install -f --kibana-url=KIBANA_URL --enrollment-token=ENROLLMENT_KEY
 ----
 
 include::enroll.asciidoc[tag=where-description]

--- a/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc
@@ -3,18 +3,6 @@
   <div role="tablist" aria-label="Install">
     <button role="tab"
             aria-selected="true"
-            aria-controls="deb-tab-install"
-            id="deb-install">
-      DEB
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="rpm-tab-install"
-            id="rpm-install">
-      RPM
-    </button>
-    <button role="tab"
-            aria-selected="false"
             aria-controls="mac-tab-install"
             id="mac-install">
       MacOS
@@ -33,33 +21,25 @@
             tabindex="-1">
       Windows
     </button>
-  </div>
-  <div tabindex="0"
-       role="tabpanel"
-       id="deb-tab-install"
-       aria-labelledby="deb-install">
-++++
-
-include::install.asciidoc[tag=deb]
-
-++++
-  </div> 
-  <div tabindex="0"
-       role="tabpanel"
-       id="rpm-tab-install"
-       aria-labelledby="rpm-install"
-       hidden="">
-++++
-
-include::install.asciidoc[tag=rpm]
-
-++++
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="deb-tab-install"
+            id="deb-install"
+            tabindex="-1">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install"
+            id="rpm-install"
+            tabindex="-1">
+      RPM
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
        id="mac-tab-install"
-       aria-labelledby="mac-install"
-       hidden="">
+       aria-labelledby="mac-install">
 ++++
 
 include::install.asciidoc[tag=mac]
@@ -85,6 +65,29 @@ include::install.asciidoc[tag=linux]
 ++++
 
 include::install.asciidoc[tag=win]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install"
+       aria-labelledby="deb-install"
+       hidden="">
+
+++++
+
+include::install.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install"
+       aria-labelledby="rpm-install"
+       hidden="">
+++++
+
+include::install.asciidoc[tag=rpm]
 
 ++++
   </div>

--- a/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
@@ -29,7 +29,7 @@ endif::[]
 ifeval::["{release-state}"!="unreleased"]
 
 IMPORTANT: To simplify upgrading to future versions of {agent}, we recommended
-that you use the tarball distribution instead of the DEB distribution.
+that you use the tarball distribution instead of the RPM distribution.
 
 ["source","sh",subs="attributes"]
 ----

--- a/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/install.asciidoc
@@ -7,6 +7,9 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
+IMPORTANT: To simplify upgrading to future versions of {agent}, we recommended
+that you use the tarball distribution instead of the DEB distribution.
+
 ["source","sh",subs="attributes"]
 ----
 curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-amd64.deb
@@ -24,6 +27,9 @@ Version {version} of {agent} has not yet been released.
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
+
+IMPORTANT: To simplify upgrading to future versions of {agent}, we recommended
+that you use the tarball distribution instead of the DEB distribution.
 
 ["source","sh",subs="attributes"]
 ----
@@ -65,10 +71,6 @@ ifeval::["{release-state}"!="unreleased"]
 curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
 tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
 ----
-
-NOTE: We recommend that you use the DEB or RPM distribution, instead of the
-tarball, to ensure that {agent} restarts automatically if the system is
-rebooted.
 
 endif::[]
 // end::linux[]


### PR DESCRIPTION
This PR updates the commands in the agent docs that get pulled into the quick start topic. It must be merged to fix the build issues in https://github.com/elastic/observability-docs/pull/207.

(There are more changes to the agent docs that I can make in a follow-up PR, or add to this PR, if you prefer.)

It also changes the notes to advise against using DEB and RPM.

In the widgets, I changed the order of the items so that DEB and RPM appear last (hidden).