### PR TITLE
Cherry-pick #22247 to 7.10: Fix awscloudwatch input documentation

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-awscloudwatch.asciidoc
@@ -88,7 +88,7 @@ will sleep for 1 minute before querying for new logs again.
 ==== `api_timeout`
 The maximum duration of AWS API can take. If it exceeds the timeout, AWS API
 will be interrupted. The default AWS API timeout for a message is 120 seconds.
-The minimum is 0 seconds. The maximum is half of the visibility timeout value.
+The minimum is 0 seconds.
 
 [float]
 ==== `api_sleep`


### PR DESCRIPTION
Cherry-pick of PR #22247 to 7.10 branch. Original message: 

This is a small fix on awscloudwatch input documentation regarding `api_timeout` config parameter.