### PR TITLE
[libbeat] Update error message for regenerating files during build

### DIFF
--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -47,7 +47,7 @@ import (
 // It checks .go source files using 'go vet'.
 func Check() error {
 	fmt.Println(">> check: Checking source code for common problems")
-
+	asdf
 	mg.Deps(GoVet, CheckPythonTestNotExecutable, CheckYAMLNotExecutable, CheckDashboardsFormat)
 
 	changes, err := GitDiffIndex()
@@ -61,7 +61,7 @@ func Check() error {
 		}
 
 		return errors.Errorf("some files are not up-to-date. "+
-			"Run 'mage fmt update' then review and commit the changes. "+
+			"Run 'make update' then review and commit the changes. "+
 			"Modified: %v", changes)
 	}
 	return nil

--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -47,7 +47,6 @@ import (
 // It checks .go source files using 'go vet'.
 func Check() error {
 	fmt.Println(">> check: Checking source code for common problems")
-	asdf
 	mg.Deps(GoVet, CheckPythonTestNotExecutable, CheckYAMLNotExecutable, CheckDashboardsFormat)
 
 	changes, err := GitDiffIndex()

--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -47,6 +47,7 @@ import (
 // It checks .go source files using 'go vet'.
 func Check() error {
 	fmt.Println(">> check: Checking source code for common problems")
+
 	mg.Deps(GoVet, CheckPythonTestNotExecutable, CheckYAMLNotExecutable, CheckDashboardsFormat)
 
 	changes, err := GitDiffIndex()


### PR DESCRIPTION
When the CI notices that some files haven't been regenerated, it says to run `mage fmt update` which is no longer a valid command. This PR changes the error message to recommend `make update`, which is the current way to regenerate files.