### PR TITLE
[repo] Add docs + cleanup labels to the categories in the incoming PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Please label this PR with one of the following labels, depending on the scope of
 - Enhancement
 - Breaking change
 - Deprecation
+- Cleanup
 - Docs
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Please label this PR with one of the following labels, depending on the scope of
 - Enhancement
 - Breaking change
 - Deprecation
+- Docs
 -->
 
 ## What does this PR do?


### PR DESCRIPTION
Add two labels to the github template for incoming Beats PRs, representing common PR types that don't fit in the current model:
- docs (PRs that add or update documentation)
- cleanup (PRs that improve the code without changing functionality)