### PR TITLE
Cherry-pick #22152 to 7.x: Add interval documentation to `monitor` metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -429,7 +429,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
 - Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
-- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -429,6 +429,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
 - Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
+- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
+- Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/azure.asciidoc
+++ b/metricbeat/docs/modules/azure.asciidoc
@@ -97,7 +97,7 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 [float]
 === `monitor`
 This metricset allows users to retrieve metrics from specified resources. Added filters can apply here as the interval of retrieving these metrics, metric names,
-aggregation list, namespaces and metric dimensions.
+aggregation list, namespaces and metric dimensions. The monitor metrics will have a minimum timegrain of 5 minutes, so the `period` for `monitor` metricset should be `300s` or multiples of `300s`.
 
 [float]
 === `compute_vm`

--- a/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
@@ -89,7 +89,7 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 [float]
 === `monitor`
 This metricset allows users to retrieve metrics from specified resources. Added filters can apply here as the interval of retrieving these metrics, metric names,
-aggregation list, namespaces and metric dimensions.
+aggregation list, namespaces and metric dimensions. The monitor metrics will have a minimum timegrain of 5 minutes, so the `period` for `monitor` metricset should be `300s` or multiples of `300s`.
 
 [float]
 === `compute_vm`


### PR DESCRIPTION
Cherry-pick of PR #22152 to 7.x branch. Original message:

## What does this PR do?

Add interval documentation to `monitor` metricset

## Why is it important?

Not confuse users

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


