### PR TITLE
[CI] Report error in the catch section

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -344,6 +344,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
       } catch(err) {
         // Upload the generated files ONLY if the step failed. This will avoid any overhead with Google Storage
         upload = true
+        error("Error '${err.toString()}'")
       } finally {
         if (archive) {
           archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)


### PR DESCRIPTION
## What does this PR do?

#22220 caused a regression in the error reporting, therefore no GH checks are failing but the main one.

## Why is it important?

Restore previous behaviour