### PR TITLE
[CI] Support Windows-8

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -86,3 +86,14 @@ stages:
                 - "windows-10"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -74,3 +74,14 @@ stages:
                 - "windows-10"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test filebeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -94,3 +94,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tag
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test heartbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tag

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -79,3 +79,14 @@ stages:
                 - "windows-10"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test metricbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -94,3 +94,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test packetbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -58,3 +58,14 @@ stages:
     #            - "windows-10"
     #        branches: true     ## for all the branches
     #        tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -95,3 +95,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/auditbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -94,3 +94,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/elastic-agent for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -95,3 +95,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/filebeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -92,3 +92,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/functionbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -84,3 +84,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/metricbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -95,3 +95,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/packetbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -69,3 +69,14 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags


### PR DESCRIPTION
## What does this PR do?

- Add support for windows-8 in the CI

## Status

Directory | OS | Mage Target | Status CI |
-- | -- | -- | -- |
auditbeat | windows-8 | build unitTest | 💚 |
filebeat | windows-8 | build unitTest | 💚  |
heartbeat | windows-8 | build unitTest |  💚  | 
metricbeat | windows-8 | build unitTest |  💚 | 
packetbeat | windows-8 | build unitTest | 💚  |
winlogBeat | windows-8 | build unitTest | 💚  |
x-pack/auditbeat | windows-8 | build unitTest | 💚  |
x-pack/elastic-agent | windows-8 | build unitTest | 💚  |
x-pack/filebeat | windows-8 | build unitTest | 💚  |
x-pack/functionbeat | windows-8 | build unitTest | 💚  |
x-pack/metricbeat | windows-8 | build unitTest | 💚  |
x-pack/packetbeat | windows-8 | build unitTest | 💚 |
x-pack/winlogBeat | windows-8 | build unitTest | 💚  |

