### PR TITLE
Cherry-pick #22287 to 7.10: Change cloud.provider from googlecloud to gcp in billing metricset

### DIFF
--- a/x-pack/metricbeat/module/googlecloud/billing/_meta/data.json
+++ b/x-pack/metricbeat/module/googlecloud/billing/_meta/data.json
@@ -1,12 +1,8 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "cloud": {
-        "account": {
-            "id": "elastic-bi",
-            "name": "elastic-bi"
-        },
-        "provider": "googlecloud"
-    },
+    "cloud.account.id": "elastic-bi",
+    "cloud.account.name": "elastic-bi",
+    "cloud.provider": "gcp",
     "event": {
         "dataset": "googlecloud.billing",
         "duration": 115000,
@@ -15,9 +11,9 @@
     "googlecloud": {
         "billing": {
             "cost_type": "regular",
-            "invoice_month": "202008",
+            "invoice_month": "202010",
             "project_id": "elastic-fin-bi",
-            "total": 170.811692
+            "total": 77.897328
         }
     },
     "metricset": {

--- a/x-pack/metricbeat/module/googlecloud/billing/billing.go
+++ b/x-pack/metricbeat/module/googlecloud/billing/billing.go
@@ -278,7 +278,7 @@ func createEvents(rowItems []bigquery.Value, accountID string) mb.Event {
 	}
 
 	event.RootFields = common.MapStr{
-		"cloud.provider":     "googlecloud",
+		"cloud.provider":     "gcp",
 		"cloud.account.id":   accountID,
 		"cloud.account.name": accountID,
 	}


### PR DESCRIPTION
Cherry-pick of PR #22287 to 7.10 branch. Original message: 

This PR is to change `cloud.provider` from `googlecloud` to `gcp` in billing metricset to match the rest of the metricsets under `googlecloud` module. This is to match the definition of this field in ECS. 

The rest of the metricsets under `googlecloud` module had `cloud.provider` changed to `gcp` in https://github.com/elastic/beats/pull/21775.