### PR TITLE
Cherry-pick #22237 to 7.10: [Metricbeat] Remove io.time from windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -426,9 +426,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
 - Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
-- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
 - Remove io.time from windows {pull}22237[22237]
-- Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -426,6 +426,9 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix panic in kubernetes autodiscover related to keystores {issue}21843[21843] {pull}21880[21880]
 - [Kubernetes] Remove redundant dockersock volume mount {pull}22009[22009]
 - Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
+- Add a switch to the driver definition on SQL module to use pretty names {pull}17378[17378]
+- Remove io.time from windows {pull}22237[22237]
+- Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/diskio/_meta/data.json
+++ b/metricbeat/module/system/diskio/_meta/data.json
@@ -15,7 +15,7 @@
     "system": {
         "diskio": {
             "io": {
-                "time": 601740
+                "time": 1296
             },
             "iostat": {
                 "await": 0,
@@ -48,16 +48,16 @@
                     }
                 }
             },
-            "name": "sdb1",
+            "name": "sda6",
             "read": {
-                "bytes": 25128030208,
-                "count": 3146154,
-                "time": 833872
+                "bytes": 335872,
+                "count": 82,
+                "time": 1296
             },
             "write": {
-                "bytes": 34401640448,
-                "count": 861040,
-                "time": 11224168
+                "bytes": 0,
+                "count": 0,
+                "time": 0
             }
         }
     }

--- a/metricbeat/module/system/diskio/diskio.go
+++ b/metricbeat/module/system/diskio/diskio.go
@@ -105,9 +105,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 				"time":  counters.WriteTime,
 				"bytes": counters.WriteBytes,
 			},
-			"io": common.MapStr{
-				"time": counters.IoTime,
-			},
 		}
 
 		// accumulate values from all interfaces
@@ -121,6 +118,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 				return errors.Wrap(err, "error calculating iostat")
 			}
 			event["iostat"] = iostat.AddLinuxIOStat(result)
+		}
+
+		if runtime.GOOS != "windows" {
+			event.Put("io.time", counters.IoTime)
 		}
 
 		if counters.SerialNumber != "" {

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -36,7 +36,7 @@ SYSTEM_CORE_FIELDS_ALL = SYSTEM_CORE_FIELDS + ["idle.ticks", "iowait.ticks", "ir
                                                "softirq.norm.pct", "steal.norm.pct", "system.norm.pct", "user.norm.pct"]
 
 SYSTEM_DISKIO_FIELDS = ["name", "read.count", "write.count", "read.bytes",
-                        "write.bytes", "read.time", "write.time", "io.time"]
+                        "write.bytes", "read.time", "write.time"]
 
 SYSTEM_DISKIO_FIELDS_LINUX = ["name", "read.count", "write.count", "read.bytes",
                               "write.bytes", "read.time", "write.time", "io.time",


### PR DESCRIPTION
Cherry-pick of PR #22237 to 7.10 branch. Original message: 

## What does this PR do?

It looks like `diskio.io.time` is a unix-only field that reports an incorrect zero. We accidentally marked it as "no incorrect zero" on our massive spreadsheet of metrics inventory, so it was overlooked until now.

## Why is it important?

We don't want to report "incorrect zero" metrics.

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Pull and build on a Windows machine 
- Run the `diskio` metricset and insure that `diskio.io.time` is not reported.
- Pull and build on linux, insure that `diskio.io.time` is reported.

## Related issues

- https://github.com/elastic/beats/issues/22176

