### PR TITLE
[Ingest Manager] Fix incorrect hash when upgrading agent

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/fs/verifier.go
@@ -89,7 +89,7 @@ func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
 	var expectedHash string
 	scanner := bufio.NewScanner(hashFileHandler)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if !strings.HasSuffix(line, filename) {
 			continue
 		}

--- a/x-pack/elastic-agent/pkg/artifact/download/http/verifier.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/verifier.go
@@ -100,12 +100,14 @@ func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
 	var expectedHash string
 	scanner := bufio.NewScanner(hashFileHandler)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if !strings.HasSuffix(line, filename) {
 			continue
 		}
 
-		expectedHash = strings.TrimSpace(strings.TrimSuffix(line, filename))
+		if len(line) > sha512Length {
+			expectedHash = strings.TrimSpace(line[:sha512Length])
+		}
 	}
 
 	if expectedHash == "" {


### PR DESCRIPTION
## What does this PR do?

For some weird special case when `elastic-agent` sha512 file contains a filename prefixed with `./` 
e.g:

```
748e927284f8eac2f5d8724f85a3be34d271b207147024906be4d254c5ff60affc51b191b7895e53bc3a1f4d1e76ef72e97c993d10b4be4804d9d6065ffefb9e  ./elastic-agent-7.11.0-SNAPSHOT-darwin-x86_64.tar.gz
```

elastic agent evaluates hashes incorrectly because it just trims the filename suffix. agent does not consider `./` to be part of the filename so it suspects that hash is 
`748e927284f8eac2f5d8724f85a3be34d271b207147024906be4d254c5ff60affc51b191b7895e53bc3a1f4d1e76ef72e97c993d10b4be4804d9d6065ffefb9e  ./` instead of 
`748e927284f8eac2f5d8724f85a3be34d271b207147024906be4d254c5ff60affc51b191b7895e53bc3a1f4d1e76ef72e97c993d10b4be4804d9d6065ffefb9e`

This PR just finds a correct line in a file and takes hash which is a fixed size string anyway without trimming suffixes. 

## Why is it important?

Fixes: #22306

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
