### PR TITLE
Cherry-pick to 7.10: [CI] support windows-7-32 bits (#19797)

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -1,6 +1,12 @@
 set GOPATH=%WORKSPACE%
 set MAGEFILE_CACHE=%WORKSPACE%\.magefile
-set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;%PATH%
+
+REM Configure GCC for either 32 or 64 bits
+set MINGW_ARCH=64
+IF NOT EXIST "%PROGRAMFILES(X86)%" (
+    set MINGW_ARCH=32
+)
+set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;C:\tools\mingw%MINGW_ARCH%\bin;%PATH%
 
 where /q curl
 IF ERRORLEVEL 1 (
@@ -25,3 +31,13 @@ if not exist C:\Python38\python.exe (
 python --version
 where python
 
+where /q gcc
+IF ERRORLEVEL 1 (
+    REM Install mingw 5.3.0
+    choco install mingw -y -r --no-progress --version 5.3.0
+    IF NOT ERRORLEVEL 0 (
+        exit /b 1
+    )
+)
+gcc --version
+where gcc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,15 +284,17 @@ def withBeatsEnv(Map args = [:], Closure body) {
     testResults = '**/build/TEST*.xml'
     artifacts = '**/build/TEST*.out'
   } else {
+    // NOTE: to support Windows 7 32 bits the arch in the mingw and go context paths is required.
+    def mingwArch = is32() ? '32' : '64'
+    def goArch = is32() ? '386' : 'amd64'
     def chocoPath = 'C:\\ProgramData\\chocolatey\\bin'
-    def mingw64Path = 'C:\\tools\\mingw64\\bin'
     def chocoPython3Path = 'C:\\Python38;C:\\Python38\\Scripts'
-    goRoot = "${env.USERPROFILE}\\.gvm\\versions\\go${GO_VERSION}.windows.amd64"
-    path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};${env.PATH};${mingw64Path}"
+    goRoot = "${env.USERPROFILE}\\.gvm\\versions\\go${GO_VERSION}.windows.${goArch}"
+    path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};C:\\tools\\mingw${mingwArch}\\bin;${env.PATH}"
     magefile = "${env.WORKSPACE}\\.magefile"
     testResults = "**\\build\\TEST*.xml"
     artifacts = "**\\build\\TEST*.out"
-    gox_flags = '-arch amd64'
+    gox_flags = '-arch 386'
   }
 
   deleteDir()

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -47,6 +47,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+            #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19831
             #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
     windows-2016:
         mage: "mage build unitTest"

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -69,17 +69,6 @@ stages:
                 - "windows-10"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test filebeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -69,3 +69,25 @@ stages:
                 - "windows-10"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test filebeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test filebeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -89,3 +89,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tag
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test heartbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tag
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test heartbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -89,17 +89,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tag
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test heartbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tag
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -41,6 +41,7 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19800
+            #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19835
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -89,3 +89,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test packetbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    #windows-7-32:  See https://github.com/elastic/beats/issues/22303
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    when:                  ## Override the top-level when.
+    #        comments:
+    #            - "/test packetbeat for windows-7-32"
+    #        labels:
+    #            - "windows-7-32"
+    #        branches: true     ## for all the branches
+    #        tags: true         ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -89,17 +89,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test packetbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     #windows-7-32:  See https://github.com/elastic/beats/issues/22303
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -42,7 +42,7 @@ stages:
                 - "windows-2012"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    # windows-10:  See https://github.com/elastic/beats/issues/22046
+    #windows-10:  See https://github.com/elastic/beats/issues/22046
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-10"
@@ -51,5 +51,27 @@ stages:
     #            - "/test winlogbeat for windows-10"
     #        labels:
     #            - "windows-10"
+    #        branches: true     ## for all the branches
+    #        tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    #windows-7-32:  See https://github.com/elastic/beats/issues/19829
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    when:                  ## Override the top-level when.
+    #        comments:
+    #            - "/test winlogbeat for windows-7-32"
+    #        labels:
+    #            - "windows-7-32"
     #        branches: true     ## for all the branches
     #        tags: true         ## for all the tags

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -53,17 +53,6 @@ stages:
     #            - "windows-10"
     #        branches: true     ## for all the branches
     #        tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test winlogbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     #windows-7-32:  See https://github.com/elastic/beats/issues/19829
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -90,17 +90,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/auditbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -90,3 +90,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/auditbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test auditbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -89,17 +89,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/elastic-agent for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     #windows-7-32:  See https://github.com/elastic/beats/issues/22316
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -89,3 +89,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/elastic-agent for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    #windows-7-32:  See https://github.com/elastic/beats/issues/22316
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    when:                  ## Override the top-level when.
+    #        comments:
+    #            - "/test x-pack/elastic-agent for windows-7-32"
+    #        labels:
+    #            - "windows-7-32"
+    #        branches: true     ## for all the branches
+    #        tags: true         ## for all the tags

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -90,17 +90,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/filebeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     #windows-7-32:  See https://github.com/elastic/beats/issues/22315
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -90,3 +90,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/filebeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    #windows-7-32:  See https://github.com/elastic/beats/issues/22315
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    when:                  ## Override the top-level when.
+    #        comments:
+    #            - "/test x-pack/filebeat for windows-7-32"
+    #        labels:
+    #            - "windows-7-32"
+    #        branches: true     ## for all the branches
+    #        tags: true         ## for all the tags

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -87,17 +87,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/functionbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -87,3 +87,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/functionbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/functionbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -35,6 +35,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+            #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19835
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -62,3 +62,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/packetbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/packetbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -62,17 +62,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/packetbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -62,3 +62,25 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+    windows-8:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-8"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-8"
+            labels:
+                - "windows-8"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    #windows-7-32:  See https://github.com/elastic/beats/issues/19829
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    when:                  ## Override the top-level when.
+    #        comments:
+    #            - "/test x-pack/winlogbeat for windows-7-32"
+    #        labels:
+    #            - "windows-7-32"
+    #        branches: true     ## for all the branches
+    #        tags: true         ## for all the tags

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -62,17 +62,6 @@ stages:
                 - "windows-2008"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    windows-8:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-8"
-        when:                  ## Override the top-level when.
-            comments:
-                - "/test x-pack/winlogbeat for windows-8"
-            labels:
-                - "windows-8"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
     #windows-7-32:  See https://github.com/elastic/beats/issues/19829
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [CI] support windows-7-32 bits (#19797)

Requires https://github.com/elastic/beats/pull/22348

