### PR TITLE
Cherry-pick #22344 to 7.x: [Elastic Agent] Fix agent composable processor promotion to fix duplicates

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -25,6 +25,7 @@
 - Fix missing elastic_agent event data {pull}21994[21994]
 - Ensure shell wrapper path exists before writing wrapper on install {pull}22144[22144]
 - Fix deb/rpm packaging for Elastic Agent {pull}22153[22153]
+- Fix composable input processor promotion to fix duplicates {pull}22344[22344]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/emitter.go
+++ b/x-pack/elastic-agent/pkg/agent/application/emitter.go
@@ -180,7 +180,7 @@ func renderInputs(inputs transpiler.Node, varsArray []*transpiler.Vars) (transpi
 	if !ok {
 		return nil, fmt.Errorf("inputs must be an array")
 	}
-	nodes := []transpiler.Node{}
+	nodes := []*transpiler.Dict{}
 	nodesMap := map[string]*transpiler.Dict{}
 	for _, vars := range varsArray {
 		for _, node := range l.Value().([]transpiler.Node) {
@@ -202,7 +202,6 @@ func renderInputs(inputs transpiler.Node, varsArray []*transpiler.Vars) (transpi
 				continue
 			}
 			dict = n.(*transpiler.Dict)
-			dict = promoteProcessors(dict)
 			hash := string(dict.Hash())
 			_, exists := nodesMap[hash]
 			if !exists {
@@ -211,7 +210,11 @@ func renderInputs(inputs transpiler.Node, varsArray []*transpiler.Vars) (transpi
 			}
 		}
 	}
-	return transpiler.NewList(nodes), nil
+	nInputs := []transpiler.Node{}
+	for _, node := range nodes {
+		nInputs = append(nInputs, promoteProcessors(node))
+	}
+	return transpiler.NewList(nInputs), nil
 }
 
 func promoteProcessors(dict *transpiler.Dict) *transpiler.Dict {

--- a/x-pack/elastic-agent/pkg/agent/application/emitter_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/emitter_test.go
@@ -654,6 +654,76 @@ func TestRenderInputs(t *testing.T) {
 					}),
 			},
 		},
+		"same var result with different processors": {
+			input: transpiler.NewKey("inputs", transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/${var1.name}.log"),
+							})),
+						}),
+					})),
+				}),
+			})),
+			expected: transpiler.NewList([]transpiler.Node{
+				transpiler.NewDict([]transpiler.Node{
+					transpiler.NewKey("type", transpiler.NewStrVal("logfile")),
+					transpiler.NewKey("streams", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("paths", transpiler.NewList([]transpiler.Node{
+								transpiler.NewStrVal("/var/log/value1.log"),
+							})),
+						}),
+					})),
+					transpiler.NewKey("processors", transpiler.NewList([]transpiler.Node{
+						transpiler.NewDict([]transpiler.Node{
+							transpiler.NewKey("add_fields", transpiler.NewDict([]transpiler.Node{
+								transpiler.NewKey("fields", transpiler.NewDict([]transpiler.Node{
+									transpiler.NewKey("custom", transpiler.NewStrVal("value1")),
+								})),
+								transpiler.NewKey("to", transpiler.NewStrVal("dynamic")),
+							})),
+						}),
+					})),
+				}),
+			}),
+			varsArray: []*transpiler.Vars{
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value1",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value2",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+			},
+		},
 	}
 
 	for name, test := range testcases {


### PR DESCRIPTION
Cherry-pick of PR #22344 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Moves the processor promotion from a dynamic composable inputs provider to after duplicate checking has occurred. This ensures that the same input is not duplicated with different processors added from dynamic input.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

With the `kubernetes` dynamic composable input provider, it can cause duplicate inputs to be created because it can match on `kubernetes.pod.id` across all containers, each with different processors information. Only the very first one should be matched the duplicates should be ignored (even though the processor information is different).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #21842
