### PR TITLE
Cherry-pick to 7.x: [CI] enable Windows-2016 and support 32 bits build requirements (#19199)

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -1,15 +1,25 @@
 set GOPATH=%WORKSPACE%
 set MAGEFILE_CACHE=%WORKSPACE%\.magefile
-set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;%PATH%
+set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;C:\tools\mingw64\bin;%PATH%
 
 where /q curl
 IF ERRORLEVEL 1 (
  choco install curl -y --no-progress --skipdownloadcache
 )
 mkdir %WORKSPACE%\bin
+
+REM If 32 bits then install the GVM accordingly
+IF NOT EXIST "%PROGRAMFILES(X86)%" (
+    curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-386.exe
+)
+
 where /q gvm
 IF ERRORLEVEL 1 (
- curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-amd64.exe
+    IF EXIST "%PROGRAMFILES(X86)%" (
+        curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-amd64.exe
+    ) ELSE (
+        curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-386.exe
+    )
 )
 FOR /f "tokens=*" %%i IN ('"gvm.exe" use %GO_VERSION% --format=batch') DO %%i
 
@@ -25,3 +35,9 @@ if not exist C:\Python38\python.exe (
 python --version
 where python
 
+if not exist C:\tools\mingw64\bin\gcc.exe (
+    REM Install mingw 5.3.0
+    choco install mingw -y -r --no-progress --version 5.3.0 || echo ERROR && exit /b
+)
+gcc --version
+where gcc

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -193,8 +193,11 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 	args := []string{"test"}
 	args = append(args, "-v")
 
-	if params.Race {
-		args = append(args, "-race")
+	// -race is only supported on */amd64
+	if os.Getenv("DEV_ARCH") == "amd64" {
+		if params.Race {
+			args = append(args, "-race")
+		}
 	}
 	if len(params.Tags) > 0 {
 		args = append(args, "-tags", strings.Join(params.Tags, " "))


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] enable Windows-2016 and support 32 bits build requirements (#19199)