### PR TITLE
[CI] cleanup terraform when errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -517,10 +517,14 @@ def startCloudTestEnv(Map args = [:]) {
     withCloudTestEnv() {
       withBeatsEnv(archive: false, withModule: false) {
         try {
-          for (folder in dirs) {
+          dirs?.each { folder ->
             retryWithSleep(retries: 2, seconds: 5, backoff: true){
               terraformApply(folder)
             }
+          }
+        } catch(err) {
+          dirs?.each { folder ->
+            sh(label: 'Terraform Cleanup', script: ".ci/scripts/terraform-cleanup.sh ${folder}")
           }
         } finally {
           // Archive terraform states in case manual cleanup is needed.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -524,7 +524,8 @@ def startCloudTestEnv(Map args = [:]) {
           }
         } catch(err) {
           dirs?.each { folder ->
-            sh(label: 'Terraform Cleanup', script: ".ci/scripts/terraform-cleanup.sh ${folder}")
+            // If it failed then cleanup without failing the build
+            sh(label: 'Terraform Cleanup', script: ".ci/scripts/terraform-cleanup.sh ${folder}", returnStatus: true)
           }
         } finally {
           // Archive terraform states in case manual cleanup is needed.


### PR DESCRIPTION
## What does this PR do?

Since cloud tests are now executed for ever merge to master, when something bad happens then it should always clean them

## Why is it important?

There was a particular corner case that did not clean them all.


## STacktraces

```
[2020-11-02T13:39:22.448Z] + terraform apply -auto-approve
[2020-11-02T13:39:24.502Z] random_password.db: Refreshing state... [id=none]
[2020-11-02T13:39:24.502Z] random_id.suffix: Refreshing state... [id=algliQ]
[2020-11-02T13:39:26.066Z] aws_sqs_queue.test: Refreshing state... [id=https://sqs.********.amazonaws.com/627286350134/metricbeat-test-6a582589]
[2020-11-02T13:39:26.066Z] aws_s3_bucket.test: Refreshing state... [id=metricbeat-test-6a582589]
[2020-11-02T13:39:32.688Z] aws_s3_bucket_metric.test: Refreshing state... [id=metricbeat-test-6a582589:EntireBucket]
[2020-11-02T13:39:32.688Z] aws_s3_bucket_object.test: Refreshing state... [id=someobject]
[2020-11-02T13:39:36.923Z] aws_db_instance.test: Creating...
[2020-11-02T13:39:37.921Z] 
[2020-11-02T13:39:37.923Z] Error: Error creating DB Instance: InstanceQuotaExceeded: DB Instance quota exceeded
[2020-11-02T13:39:37.923Z] 	status code: 400, request id: c38ef793-efe4-4bdd-8dbf-da184c452612
[2020-11-02T13:39:37.923Z] 
[2020-11-02T13:39:37.923Z]   on terraform.tf line 18, in resource "aws_db_instance" "test":
[2020-11-02T13:39:37.923Z]   18: resource "aws_db_instance" "test" {
[2020-11-02T13:39:37.923Z] 
[2020-11-02T13:39:37.923Z] 
script returned exit code 1
```