### PR TITLE
remove working in progress comment

### DIFF
--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -33,7 +33,8 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 [float]
 === Module configuration
 
-```
+[source,yaml]
+----
 - module: azure
   activitylogs:
     enabled: true
@@ -65,7 +66,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        storage_account_key: ""
        resource_manager_endpoint: ""
 
-```
+----
 
 
 `eventhub` ::

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -108,11 +108,6 @@ include::../include/what-happens.asciidoc[]
 include::../include/gs-link.asciidoc[]
 
 [float]
-=== Compatibility
-
-TODO: document with what versions of the software is this tested
-
-[float]
 === Dashboards
 
 The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -28,7 +28,8 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 [float]
 === Module configuration
 
-```
+[source,yaml]
+----
 - module: azure
   activitylogs:
     enabled: true
@@ -60,7 +61,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
        storage_account_key: ""
        resource_manager_endpoint: ""
 
-```
+----
 
 
 `eventhub` ::
@@ -101,11 +102,6 @@ Users can also use this in case of a Hybrid Cloud model, where one may define th
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
-
-[float]
-=== Compatibility
-
-TODO: document with what versions of the software is this tested
 
 [float]
 === Dashboards


### PR DESCRIPTION
I remove the TODO comment because it shouldn't be left in the 7.9 (current) version.

Same thing needs to be fixed in 7.10 and master.
