### PR TITLE
[Heartbeat]Icmp check failed even targets are reachable

### DIFF
--- a/heartbeat/monitors/active/icmp/config.go
+++ b/heartbeat/monitors/active/icmp/config.go
@@ -35,5 +35,5 @@ var DefaultConfig = Config{
 	Mode: monitors.DefaultIPSettings,
 
 	Timeout: 16 * time.Second,
-	Wait:    1 * time.Second,
+	Wait:    2 * time.Second,
 }

--- a/heartbeat/monitors/active/icmp/stdloop.go
+++ b/heartbeat/monitors/active/icmp/stdloop.go
@@ -180,7 +180,8 @@ func (l *stdICMPLoop) checkNetworkMode(mode string) error {
 func (l *stdICMPLoop) runICMPRecv(conn *icmp.PacketConn, proto int) {
 	for {
 		bytes := make([]byte, 512)
-		conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		// increase timeout to receive the data from Conn
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 		_, addr, err := conn.ReadFrom(bytes)
 		if err != nil {
 			if neterr, ok := err.(*net.OpError); ok {


### PR DESCRIPTION
## What does this PR do?

Move assign `ctx.result` from the channel before check it is nil or not since it may be overridden to nil then skip the loop.

## Why is it important?

Without this change, the ICMP check result will not continue, looks up and down very frequently.
More details please refer to the issue:
https://github.com/elastic/beats/issues/22253

## Checklist


- [x ] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

https://github.com/elastic/beats/issues/22253

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->