### PR TITLE
Fixed typo in rename processor docs

### DIFF
--- a/libbeat/processors/actions/docs/rename.asciidoc
+++ b/libbeat/processors/actions/docs/rename.asciidoc
@@ -44,5 +44,5 @@ continues also if an error happened during renaming. Default is `true`.
 
 See <<conditions>> for a list of supported conditions.
 
-You can specify multiple `ignore_missing` processors under the `processors`
+You can specify multiple `rename` processors under the `processors`
 section.


### PR DESCRIPTION
## What does this PR do?

Fix a typo / copy & paste bug on the rename processor page. 
Last paragraph said `ignore_missing` processor, but pretty sure if should say `rename` as this is the rename processor page.

