### PR TITLE
Autodiscover ephemeral containers in kubernetes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update to Golang 1.12.1. {pull}11330[11330]
 - Disable Alibaba Cloud and Tencent Cloud metadata providers by default. {pull}13812[12812]
 - API address is a required setting in `add_cloudfoundry_metadata`. {pull}21759[21759]
+- Autodiscover kubernetes provider will find ephemeral containers. {pull}22389[22389]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -271,6 +271,15 @@ func (p *pod) emit(pod *kubernetes.Pod, flag string) {
 
 	// Emit events for all initContainers
 	p.emitEvents(pod, flag, pod.Spec.InitContainers, pod.Status.InitContainerStatuses)
+
+	// Emit events for all ephemeralContainers
+	// Ephemeral containers are alpha feature in k8s and this code may require some changes, if their
+	// api change in the future.
+	var mappedEphemeralsAsContainers []kubernetes.Container
+	for _, c := range pod.Spec.EphemeralContainers {
+		mappedEphemeralsAsContainers = append(mappedEphemeralsAsContainers, kubernetes.Container(c.EphemeralContainerCommon))
+	}
+	p.emitEvents(pod, flag, mappedEphemeralsAsContainers, pod.Status.EphemeralContainerStatuses)
 }
 
 func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernetes.Container,

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -1024,6 +1024,120 @@ func TestEmitEvent(t *testing.T) {
 				},
 			},
 		},
+		{
+			Message: "Test ephemeral container in common pod",
+			Flag:    "start",
+			Pod: &kubernetes.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Namespace:   namespace,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				TypeMeta: typeMeta,
+				Status: v1.PodStatus{
+					PodIP: podIP,
+					EphemeralContainerStatuses: []kubernetes.PodContainerStatus{
+						{
+							Name:        name,
+							ContainerID: containerID,
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: node,
+					EphemeralContainers: []v1.EphemeralContainer{
+						v1.EphemeralContainer{
+							EphemeralContainerCommon: v1.EphemeralContainerCommon{
+								Image: containerImage,
+								Name:  name,
+							},
+						},
+					},
+				},
+			},
+			Expected: []bus.Event{
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"id":       uid,
+					"provider": UUID,
+					"ports":    common.MapStr{},
+					"kubernetes": common.MapStr{
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+						},
+					},
+					"config": []*common.Config{},
+				},
+				{
+					"start":    true,
+					"host":     "127.0.0.1",
+					"port":     0,
+					"id":       cid,
+					"provider": UUID,
+					"kubernetes": common.MapStr{
+						"container": common.MapStr{
+							"id":      "foobar",
+							"name":    "filebeat",
+							"image":   "elastic/filebeat:6.3.0",
+							"runtime": "docker",
+						},
+						"pod": common.MapStr{
+							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+						},
+						"node": common.MapStr{
+							"name": "node",
+						},
+						"namespace":   "default",
+						"annotations": common.MapStr{},
+					},
+					"meta": common.MapStr{
+						"kubernetes": common.MapStr{
+							"namespace": "default",
+							"pod": common.MapStr{
+								"name": "filebeat",
+								"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+							}, "node": common.MapStr{
+								"name": "node",
+							},
+							"container": common.MapStr{
+								"name":  "filebeat",
+								"image": "elastic/filebeat:6.3.0",
+							},
+						},
+						"container": common.MapStr{
+							"image":   common.MapStr{"name": "elastic/filebeat:6.3.0"},
+							"id":      "foobar",
+							"runtime": "docker",
+						},
+					},
+					"config": []*common.Config{},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Enhancement: Autodiscover ephemeral containers in kubernetes when "scrape_ephemeral_containers" flag is set to True

## What does this PR do?

Adds autodiscovery of kubernetes ephemeral containers. It is disabled by default and needs to set "scrape_ephemeral_containers" flag to "True"

## Why is it important?

I'm using filebeat to scrape logs of pods in my organizations kubernetes clusters, and there is currently no support for collecting logs for ephemeral containers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

1. Set kubernetes cluster with EphemeralContainers feature gate enabled
2. Run filebeat on kubernetes cluster with autodiscovery as in official docs.
3. ~~Add config flag "scrape_ephemeral_containers: True"~~
4. Start ephemeral container and check if filebeat starts collecting logs 

## Related issues
- discussion https://discuss.elastic.co/t/kubernetes-autodiscovery-for-ephemeral-containers/253840

## Use cases

Add support for autodiscovery of ephemeral containers in kubernetes cluster

## Screenshots

## Logs
