### PR TITLE
Cherry-pick #22359 to 7.x: Treat session ID as a string in system/users

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -432,6 +432,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Revert change to report `process.memory.rss` as `process.memory.wss` on Windows. {pull}22055[22055]
 - Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 - Remove io.time from windows {pull}22237[22237]
+- Change Session ID type from int to string {pull}22359[22359]
 
 *Packetbeat*
 
@@ -925,3 +926,5 @@ field. You can revert this change by configuring tags for the module and omittin
 ==== Known Issue
 
 *Journalbeat*
+
+

--- a/metricbeat/module/system/users/dbus.go
+++ b/metricbeat/module/system/users/dbus.go
@@ -48,7 +48,7 @@ type sessionInfo struct {
 
 // loginSession contains basic information on a login session
 type loginSession struct {
-	ID   uint64
+	ID   string
 	UID  uint32
 	User string
 	Seat string
@@ -167,14 +167,9 @@ func formatSessionList(props [][]dbus.Variant) ([]loginSession, error) {
 		if len(session) < 5 {
 			return nil, fmt.Errorf("wrong number of fields in session: %v", session)
 		}
-		idStr, ok := session[0].Value().(string)
+		id, ok := session[0].Value().(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast user ID to string")
-		}
-
-		id, err := strconv.ParseUint(idStr, 10, 32)
-		if err != nil {
-			return nil, errors.Wrap(err, "error parsing ID to int")
 		}
 
 		uid, ok := session[1].Value().(uint32)

--- a/metricbeat/module/system/users/users_test.go
+++ b/metricbeat/module/system/users/users_test.go
@@ -61,7 +61,7 @@ func TestFormatSessionList(t *testing.T) {
 	}
 
 	goodOut := []loginSession{{
-		ID:   uint64(6),
+		ID:   "6",
 		UID:  uint32(1000),
 		User: "user",
 		Seat: "",


### PR DESCRIPTION
Cherry-pick of PR #22359 to 7.x branch. Original message: 



## What does this PR do?

We should be treating the session ID we get from DBus as a string:
```
      struct {
         string "106"
         uint32 1000
         string "alexk"
         string ""
         object path "/org/freedesktop/login1/session/_3106"
      }
```

The value seems to be an int 95% of the time, which is why I probably missed this. I'm still not sure under what circumstances we see a character thrown into the Session ID, but it does happen.

## Why is it important?

If the Session ID isn't an int, we'll get an error.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Pull down and build
- On a linux/systemd box, run this metricset and insure that the `system.users.id` value is a string.
