### PR TITLE
[libbeat] Document the Kafka output backoff settings

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -232,6 +232,19 @@ Set `max_retries` to a value less than 0 to retry until all events are published
 The default is 3.
 endif::[]
 
+===== `backoff.init`
+
+The number of seconds to wait before trying to republish to Kafka
+after a network error. After waiting `backoff.init` seconds, {beatname_uc}
+tries to republish. If the attempt fails, the backoff timer is increased
+exponentially up to `backoff.max`. After a successful publish, the backoff
+timer is reset. The default is 1s.
+
+===== `backoff.max`
+
+The maximum number of seconds to wait before attempting to republish to
+Kafka after a network error. The default is 60s.
+
 ===== `bulk_max_size`
 
 The maximum number of events to bulk in a single Kafka request. The default is 2048.


### PR DESCRIPTION
## What does this PR do?

Copy the documentation for the Kafka output backoff settings added in https://github.com/elastic/beats/pull/17808 from the reference configuration to the generated docs.
