### PR TITLE
[Filebeat] Optionally check compatibility of field types in pythonIntegTest

### DIFF
--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -214,11 +214,12 @@ func GoIntegTest(ctx context.Context) error {
 // Use GENERATE=true to generate expected log files.
 // Use TESTING_FILEBEAT_MODULES=module[,module] to limit what modules to test.
 // Use TESTING_FILEBEAT_FILESETS=fileset[,fileset] to limit what fileset to test.
+// Use TESTING_FIELD_TYPES=True to check field/es types
 func PythonIntegTest(ctx context.Context) error {
 	if !devtools.IsInIntegTestEnv() {
 		mg.Deps(Fields)
 	}
-	runner, err := devtools.NewDockerIntegrationRunner(append(devtools.ListMatchingEnvVars("TESTING_FILEBEAT_", "PYTEST_"), "GENERATE")...)
+	runner, err := devtools.NewDockerIntegrationRunner(append(devtools.ListMatchingEnvVars("TESTING_", "PYTEST_"), "GENERATE")...)
 	if err != nil {
 		return err
 	}

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -134,5 +134,5 @@ class BaseTest(TestCase):
 
     def setUp(self):
 
-        self.expected_fields, self.dict_fields, _ = self.load_fields()
+        self.expected_fields, self.dict_fields, unused_aliases, unused_types = self.load_fields()
         super(BaseTest, self).setUp()

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -170,11 +170,12 @@ func GoIntegTest(ctx context.Context) error {
 // Use GENERATE=true to generate expected log files.
 // Use TESTING_FILEBEAT_MODULES=module[,module] to limit what modules to test.
 // Use TESTING_FILEBEAT_FILESETS=fileset[,fileset] to limit what fileset to test.
+// Use TESTING_FIELD_TYPES=True to check field/es types
 func PythonIntegTest(ctx context.Context) error {
 	if !devtools.IsInIntegTestEnv() {
 		mg.Deps(Fields)
 	}
-	runner, err := devtools.NewDockerIntegrationRunner(append(devtools.ListMatchingEnvVars("TESTING_FILEBEAT_", "PYTEST_"), "GENERATE")...)
+	runner, err := devtools.NewDockerIntegrationRunner(append(devtools.ListMatchingEnvVars("TESTING_", "PYTEST_"), "GENERATE")...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

Adds an optional new test for Filebeat.

The test checks to see if the types of JSON fields of indexed
documents match the types listed in fields.yml.  For example if a
field is type `long`, the JSON type should be a number not a string.

Test is enabled by setting the environment variable
`TESTING_FIELD_TYPES=True` and running the `pythonIntegTest`

## Why is it important?

We have had several bugs in painless scripts where the type is
supposed to be numeric but data was stored as a string.  This can lead
to interesting errors, for example `+` is concatenation for strings,
but addition for numbers.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

``` bash
`TESTING_FIELD_TYPES=True mage pythonIntegTest`
```


## Logs

Example from the apache module

``` bash
raise Exception("Documentation Errors:\n{}".format('\n'.join(errors)))
      Exception: Documentation Errors:
      Key 'source.port' found in event has incompatible type expected 'long' got '<class 'str'>'!
```

With the test enabled errors are flagged in the following modules.
Most are when the data is supposed to be a numeric type but it is
stored as a string.

- apache
- elasticsearch
- mysql
- nats
- nginx
- aws
- cef
- checkpoint
- cisco
- crowdstrike
- fortinet
- gsuite
- ibmmq
- juniper
- o365
- sophos
- zoom