### PR TITLE
Cherry-pick to 7.10: docs: Fixed typo (#22386)

### DIFF
--- a/libbeat/processors/actions/docs/rename.asciidoc
+++ b/libbeat/processors/actions/docs/rename.asciidoc
@@ -44,5 +44,5 @@ continues also if an error happened during renaming. Default is `true`.
 
 See <<conditions>> for a list of supported conditions.
 
-You can specify multiple `ignore_missing` processors under the `processors`
+You can specify multiple `rename` processors under the `processors`
 section.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: Fixed typo (#22386)