### PR TITLE
Cherry-pick to 7.10: Do not require sudo to run filebeat in Java tutorial (#22366)

### DIFF
--- a/libbeat/docs/tab-widgets/start-filebeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-filebeat.asciidoc
@@ -1,0 +1,75 @@
+// tag::deb[]
+
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
+["source","sh",subs="attributes"]
+----
+sudo service {beatname_pkg} start
+----
+
+// tag::initd-note[]
+NOTE: If you use an `init.d` script to start {beatname_uc}, you can't specify command
+line flags (see {beatname_url}/command-line-options.html[Command reference]). To specify flags, start {beatname_uc} in
+the foreground.
+
+// end::initd-note[]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+// end::deb[]
+
+// tag::rpm[]
+["source","sh",subs="attributes"]
+----
+sudo service {beatname_pkg} start
+----
+
+include::start.asciidoc[tag=initd-note]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+
+// end::rpm[]
+
+// tag::mac[]
+["source","sh",subs="attributes,callouts"]
+----
+./{beatname_lc} -e
+----
+// end::mac[]
+
+// tag::brew[]
+To have launchd start +elastic/tap/{beatname_lc}+ and then restart it at login,
+run:
+
+["source","sh",subs="attributes"]
+-----
+brew services start elastic/tap/{beatname_lc}-full
+-----
+
+To run {beatname_uc} in the foreground instead of running it as a background
+service, run:
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} -e
+-----
+
+// end::brew[]
+
+// tag::linux[]
+
+["source","sh",subs="attributes,callouts"]
+----
+./{beatname_lc} -e
+----
+
+// end::linux[]
+
+// tag::win[]
+["source","sh",subs="attributes"]
+----
+PS C:{backslash}Program Files{backslash}{beatname_lc}> Start-Service {beatname_lc}
+----
+
+By default, Windows log files are stored in +C:{backslash}ProgramData{backslash}{beatname_lc}\Logs+.
+
+// end::win[]

--- a/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
+++ b/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc
@@ -52,7 +52,7 @@
        aria-labelledby="deb-start-filebeat">
 ++++
 
-include::start.asciidoc[tag=deb]
+include::start-filebeat.asciidoc[tag=deb]
 
 ++++
   </div>
@@ -63,7 +63,7 @@ include::start.asciidoc[tag=deb]
        hidden="">
 ++++
 
-include::start.asciidoc[tag=rpm]
+include::start-filebeat.asciidoc[tag=rpm]
 
 ++++
   </div>
@@ -74,7 +74,7 @@ include::start.asciidoc[tag=rpm]
        hidden="">
 ++++
 
-include::start.asciidoc[tag=mac]
+include::start-filebeat.asciidoc[tag=mac]
 
 ++++
   </div>
@@ -85,7 +85,7 @@ include::start.asciidoc[tag=mac]
        hidden="">
 ++++
 
-include::start.asciidoc[tag=brew]
+include::start-filebeat.asciidoc[tag=brew]
 
 ++++
   </div>
@@ -96,7 +96,7 @@ include::start.asciidoc[tag=brew]
        hidden="">
 ++++
 
-include::start.asciidoc[tag=linux]
+include::start-filebeat.asciidoc[tag=linux]
 
 ++++
   </div>
@@ -107,7 +107,7 @@ include::start.asciidoc[tag=linux]
        hidden="">
 ++++
 
-include::start.asciidoc[tag=win]
+include::start-filebeat.asciidoc[tag=win]
 
 ++++
   </div>


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Do not require sudo to run filebeat in Java tutorial (#22366)