### PR TITLE
Cherry-pick #22325 to 7.x: Duplicate system.process.cmdline field with process.command_line ECS field name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -869,6 +869,7 @@ field. You can revert this change by configuring tags for the module and omittin
 - Map cloud data filed `cloud.account.id` to azure subscription.  {pull}21483[21483] {issue}21381[21381]
 - Expand unsupported option from namespace to metrics in the azure module. {pull}21486[21486]
 - Move s3_daily_storage and s3_request metricsets to use cloudwatch input. {pull}21703[21703]
+- Duplicate system.process.cmdline field with process.command_line ECS field name. {pull}22325[22325]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/_meta/data.json
+++ b/metricbeat/module/system/process/_meta/data.json
@@ -11,12 +11,10 @@
     },
     "process": {
         "args": [
-            "/usr/lib/systemd/systemd",
-            "--switched-root",
-            "--system",
-            "--deserialize",
-            "28"
+            "/sbin/init",
+            "splash"
         ],
+        "command_line": "/sbin/init splash",
         "name": "systemd",
         "pgid": 1,
         "pid": 1,
@@ -32,8 +30,8 @@
                     "id": "init.scope",
                     "path": "/init.scope",
                     "total": {
-                        "bytes": 7453696,
-                        "ios": 548
+                        "bytes": 573440,
+                        "ios": 140
                     }
                 },
                 "cpu": {
@@ -68,21 +66,29 @@
                     "id": "init.scope",
                     "path": "/init.scope",
                     "percpu": {
-                        "1": 3930656993407,
-                        "2": 4025787490535,
-                        "3": 4064460082910,
-                        "4": 3387847262532
+                        "1": 571119313,
+                        "10": 282248474,
+                        "11": 363773369,
+                        "12": 855691122,
+                        "2": 735154670,
+                        "3": 458174215,
+                        "4": 281192882,
+                        "5": 563599363,
+                        "6": 415888016,
+                        "7": 396270851,
+                        "8": 550242795,
+                        "9": 419970811
                     },
                     "stats": {
                         "system": {
-                            "ns": 4996000000000
+                            "ns": 1700000000
                         },
                         "user": {
-                            "ns": 10329380000000
+                            "ns": 1920000000
                         }
                     },
                     "total": {
-                        "ns": 15408751829384
+                        "ns": 5893325881
                     }
                 },
                 "id": "init.scope",
@@ -94,9 +100,9 @@
                             "bytes": 9223372036854771712
                         },
                         "usage": {
-                            "bytes": 9404416,
+                            "bytes": 16871424,
                             "max": {
-                                "bytes": 14987264
+                                "bytes": 17829888
                             }
                         }
                     },
@@ -118,62 +124,62 @@
                             "bytes": 9223372036854771712
                         },
                         "usage": {
-                            "bytes": 29437952,
+                            "bytes": 21827584,
                             "max": {
-                                "bytes": 70705152
+                                "bytes": 30121984
                             }
                         }
                     },
                     "memsw": {
                         "failures": 0,
                         "limit": {
-                            "bytes": 9223372036854771712
+                            "bytes": 0
                         },
                         "usage": {
-                            "bytes": 30392320,
+                            "bytes": 0,
                             "max": {
-                                "bytes": 70705152
+                                "bytes": 0
                             }
                         }
                     },
                     "path": "/init.scope",
                     "stats": {
                         "active_anon": {
-                            "bytes": 3444736
+                            "bytes": 4055040
                         },
                         "active_file": {
-                            "bytes": 10563584
+                            "bytes": 405504
                         },
                         "cache": {
-                            "bytes": 10752000
+                            "bytes": 643072
                         },
                         "hierarchical_memory_limit": {
                             "bytes": 9223372036854771712
                         },
                         "hierarchical_memsw_limit": {
-                            "bytes": 9223372036854771712
+                            "bytes": 0
                         },
                         "inactive_anon": {
-                            "bytes": 6197248
+                            "bytes": 270336
                         },
                         "inactive_file": {
-                            "bytes": 327680
+                            "bytes": 0
                         },
-                        "major_page_faults": 198,
+                        "major_page_faults": 0,
                         "mapped_file": {
-                            "bytes": 9867264
+                            "bytes": 0
                         },
-                        "page_faults": 3626304,
-                        "pages_in": 1095732,
-                        "pages_out": 1090806,
+                        "page_faults": 117447,
+                        "pages_in": 52008,
+                        "pages_out": 50851,
                         "rss": {
-                            "bytes": 9592832
+                            "bytes": 4009984
                         },
                         "rss_huge": {
                             "bytes": 0
                         },
                         "swap": {
-                            "bytes": 675840
+                            "bytes": 0
                         },
                         "unevictable": {
                             "bytes": 0
@@ -182,24 +188,24 @@
                 },
                 "path": "/init.scope"
             },
-            "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 28",
+            "cmdline": "/sbin/init splash",
             "cpu": {
-                "start_time": "2020-08-27T01:05:16.000Z",
+                "start_time": "2020-11-03T17:55:56.000Z",
                 "total": {
                     "norm": {
-                        "pct": 0.0056
+                        "pct": 0
                     },
-                    "pct": 0.0222,
-                    "value": 15389060
+                    "pct": 0,
+                    "value": 5580
                 }
             },
             "memory": {
                 "rss": {
-                    "bytes": 12853248,
-                    "pct": 0.0008
+                    "bytes": 13414400,
+                    "pct": 0.0004
                 },
-                "share": 7118848,
-                "size": 176881664
+                "share": 8531968,
+                "size": 173076480
             },
             "state": "sleeping"
         }

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -138,6 +138,11 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 			},
 		}
 
+		// Duplicate system.process.cmdline with ECS name process.command_line
+		if v, ok := proc["cmdline"]; ok {
+			rootFields.Put("process.command_line", v)
+		}
+
 		if cwd := getAndRemove(proc, "cwd"); cwd != nil {
 			rootFields.Put("process.working_directory", cwd)
 		}

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -458,7 +458,7 @@ class Test(metricbeat.BaseTest):
 
             self.assertCountEqual(SYSTEM_PROCESS_FIELDS, process.keys())
 
-        self.assertTrue(found_cmdline, "cmdline not found in any process events")
+            self.assertTrue(found_cmdline, "cmdline not found in any process events")
 
     @unittest.skipUnless(re.match("(?i)linux|darwin|freebsd", sys.platform), "os")
     def test_process_unix(self):
@@ -544,6 +544,7 @@ class Test(metricbeat.BaseTest):
 
         assert re.match("(?i)metricbeat.test(.exe)?", output["process.name"])
         assert re.match("(?i).*metricbeat.test(.exe)? -systemTest", output["system.process.cmdline"])
+        assert re.match("(?i).*metricbeat.test(.exe)? -systemTest", output["process.command_line"])
         assert isinstance(output["system.process.state"], six.string_types)
         assert isinstance(output["system.process.cpu.start_time"], six.string_types)
         self.check_username(output["user.name"])

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -116,7 +116,7 @@ class Test(metricbeat.BaseTest):
             }],
             processors=[{
                 "drop_event": {
-                    "when.not": "contains.system.process.cmdline: metricbeat.test",
+                    "when.not": "contains.process.command_line: metricbeat.test",
                 },
             }]
         )


### PR DESCRIPTION
Cherry-pick of PR #22325 to 7.x branch. Original message: 

## What does this PR do?

This PR is to migrate `system.process.cmdline` field to use `process.command_line` ECS field name instead.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
