### PR TITLE
[Filebeat] Add event.ingested to Netflow module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -655,6 +655,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update Okta documentation for new stateful restarts. {pull}22091[22091]
 - Copy tag names from MISP data into events. {pull}21664[21664]
 - Added TLS JA3 fingerprint, certificate not_before/not_after, certificate SHA1 hash, and certificate subject fields to Zeek SSL dataset. {pull}21696[21696]
+- Added `event.ingested` field to data from the Netflow module. {pull}22412[22412]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/netflow/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/netflow/log/ingest/pipeline.yml
@@ -2,6 +2,10 @@
 description: Pipeline for Filebeat NetFlow
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
         if: ctx.source?.geo == null


### PR DESCRIPTION

## What does this PR do?

Add event.ingested to the pipeline in the Netflow Filebeat module. It was missed when we updated all modules because there are no automated module tests that ingest flow data (the tests only work with logs).

## Why is it important?

For consistency we want every module to add `event.ingested`.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

