### PR TITLE
Cherry-pick #20450 to 7.x: Check if Filebeat log harvester tries to open named pipe

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -515,6 +515,14 @@ func (h *Harvester) shouldExportLine(line string) bool {
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
 func (h *Harvester) openFile() error {
+	fi, err := os.Stat(h.state.Source)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file %s: %v", h.state.Source, err)
+	}
+	if fi.Mode()&os.ModeNamedPipe != 0 {
+		return fmt.Errorf("failed to open file %s, named pipes are not supported", h.state.Source)
+	}
+
 	f, err := file_helper.ReadOpen(h.state.Source)
 	if err != nil {
 		return fmt.Errorf("Failed opening %s: %s", h.state.Source, err)


### PR DESCRIPTION
Cherry-pick of PR #20450 to 7.x branch. Original message: 

## What does this PR do?

This PR adds a check before opening a file for harvester Filebeat. If the file is a named pipe, an error is returned and the file is not opened.

## Why is it important?

Previously if someone wanted to open a named pipe without a writer, Filebeat hangs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #18682
