### PR TITLE
Cherry-pick #22377 to 7.x: Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,7 +315,6 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix syslog RFC 5424 parsing in the CheckPoint module. {pull}21854[21854]
 - Fix incorrect connection state mapping in zeek connection pipeline. {pull}22151[22151] {issue}22149[22149]
 - Fix handing missing eventtime and assignip field being set to N/A for fortinet module. {pull}22361[22361]
-- Fix Zeek dashboard reference to `zeek.ssl.server.name` field. {pull}21696[21696]
 - Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines. {pull}22377[22377]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,6 +315,8 @@ field. You can revert this change by configuring tags for the module and omittin
 - Fix syslog RFC 5424 parsing in the CheckPoint module. {pull}21854[21854]
 - Fix incorrect connection state mapping in zeek connection pipeline. {pull}22151[22151] {issue}22149[22149]
 - Fix handing missing eventtime and assignip field being set to N/A for fortinet module. {pull}22361[22361]
+- Fix Zeek dashboard reference to `zeek.ssl.server.name` field. {pull}21696[21696]
+- Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines. {pull}22377[22377]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
@@ -201,6 +201,7 @@ processors:
 - geoip:
     field: source.ip
     target_field: source.geo
+    ignore_missing: true
 - geoip:
     database_file: GeoLite2-ASN.mmdb
     field: source.ip

--- a/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
@@ -280,6 +280,7 @@ processors:
 - geoip:
     field: source.ip
     target_field: source.geo
+    ignore_missing: true
 - geoip:
     database_file: GeoLite2-ASN.mmdb
     field: source.ip


### PR DESCRIPTION
Cherry-pick of PR #22377 to 7.x branch. Original message:

## What does this PR do?

Fix field [source] not present as part of path [source.ip] in azure pipelines

## Why is it important?

Fix field [source] not present as part of path [source.ip] in azure pipelines

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
