### PR TITLE
[packaging] add SNAPSHOT in the metadata labels if required

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -43,11 +43,7 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
-{{- if .Snapshot }}
-  org.label-schema.version="{{ beat_version }}-SNAPSHOT" \
-{{- else }}
-  org.label-schema.version="{{ beat_version }}" \
-{{- end }}
+  org.label-schema.version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -60,11 +56,7 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
-{{- if .Snapshot }}
-  version="{{ beat_version }}-SNAPSHOT" \
-{{- else }}
-  version="{{ beat_version }}" \
-{{- end }}
+  version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -43,7 +43,11 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
+{{- if .Snapshot }}
+  org.label-schema.version="{{ beat_version }}-SNAPSHOT" \
+{{- else }}
   org.label-schema.version="{{ beat_version }}" \
+{{- end }}
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -56,7 +60,11 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
+{{- if .Snapshot }}
+  version="{{ beat_version }}-SNAPSHOT" \
+{{- else }}
   version="{{ beat_version }}" \
+{{- end }}
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -37,11 +37,7 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
-{{- if .Snapshot }}
-  org.label-schema.version="{{ beat_version }}-SNAPSHOT" \
-{{- else }}
-  org.label-schema.version="{{ beat_version }}" \
-{{- end }}
+  org.label-schema.version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -54,11 +50,7 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
-{{- if .Snapshot }}
-  version="{{ beat_version }}-SNAPSHOT" \
-{{- else }}
-  version="{{ beat_version }}" \
-{{- end }}
+  version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -37,7 +37,11 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
+{{- if .Snapshot }}
+  org.label-schema.version="{{ beat_version }}-SNAPSHOT" \
+{{- else }}
   org.label-schema.version="{{ beat_version }}" \
+{{- end }}
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -50,7 +54,11 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
+{{- if .Snapshot }}
+  version="{{ beat_version }}-SNAPSHOT" \
+{{- else }}
   version="{{ beat_version }}" \
+{{- end }}
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \


### PR DESCRIPTION
## What does this PR do?

Add the right metadata when it's a snapshot. I hope I did it right

## Why is it important?

Otherwise, those metadata labels are not useful for snapshot.

Current version does not contain the SNAPSHOT, it seems it's something internal and created somewhere else.

```bash
$ make get-version
8.0.0
```

Thanks @mgreau for reporting this

## Tests

The packaging [build](https://beats-ci.elastic.co/job/Beats/job/packaging/job/PR-22432/2/gcsObjects/) happened as a consequence of the comment https://github.com/elastic/beats/pull/22432#issuecomment-721921450

1) Download https://console.cloud.google.com/storage/beats-ci-artifacts/pull-requests/pr-22432/journalbeat/journalbeat-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz

```bash
$ docker load --input journalbeat-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz
$ docker inspect  -f '{{json .Config.Labels }}' docker.elastic.co/beats/journalbeat:8.0.0-SNAPSHOT | jq . | grep 8.0.0-SNAPSHOT
  "org.label-schema.version": "8.0.0-SNAPSHOT",
  "version": "8.0.0-SNAPSHOT"
```