### PR TITLE
[CI] install tools failed in some workers

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -26,13 +26,20 @@ IF ERRORLEVEL 1 (
     ) ELSE (
         curl -sL -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-386.exe
     )
+    IF ERRORLEVEL 1 (
+        exit /b 1
+    )
+    dir "%WORKSPACE%\bin" /b
 )
 FOR /f "tokens=*" %%i IN ('"gvm.exe" use %GO_VERSION% --format=batch') DO %%i
 
 go env
 go get github.com/magefile/mage
-mage -version
 where mage
+mage -version
+IF ERRORLEVEL 1 (
+    exit /b 1
+)
 
 IF NOT EXIST C:\Python38\python.exe (
     REM Install python 3.8


### PR DESCRIPTION
## What does this PR do?

Fail fast if something bad happened when installing the required tools

## Why is it important?

Otherwise the failure happens afterward when running the build or the test commands

This should not happen, but it seems the provisioner does not kill some of the existing workers but they get reused, as a consequence the environment might be corrupted, that's my feeling.

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/98257970-37584380-1f78-11eb-97cb-a007c484993a.png)

But it should fail earlier

![image](https://user-images.githubusercontent.com/2871786/98258038-49d27d00-1f78-11eb-969a-bd0a0d75968c.png)
