### PR TITLE
Cherry-pick to 7.10: [packaging] add SNAPSHOT in the metadata labels if required (#22432)

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -45,7 +45,7 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
-  org.label-schema.version="{{ beat_version }}" \
+  org.label-schema.version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -58,7 +58,7 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
-  version="{{ beat_version }}" \
+  version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -37,7 +37,7 @@ LABEL \
   org.label-schema.vendor="{{ .BeatVendor }}" \
   org.label-schema.license="{{ .License }}" \
   org.label-schema.name="{{ .BeatName }}" \
-  org.label-schema.version="{{ beat_version }}" \
+  org.label-schema.version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   org.label-schema.url="{{ .BeatURL }}" \
   org.label-schema.vcs-url="{{ $repoInfo.RootImportPath }}" \
   org.label-schema.vcs-ref="{{ commit }}" \
@@ -50,7 +50,7 @@ LABEL \
   name="{{ .BeatName }}" \
   maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
-  version="{{ beat_version }}" \
+  version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   release="1" \
   url="{{ .BeatURL }}" \
   summary="{{ .BeatName }}" \


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [packaging] add SNAPSHOT in the metadata labels if required (#22432)