### PR TITLE
Refactoring of filestream input backend

### DIFF
--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -358,6 +358,8 @@ instead and let {beatname_uc} pick up the file again.
 Different `file_identity` methods can be configured to suit the
 environment where you are collecting log messages.
 
+WARNING: Changing `file_identity` methods between runs may result in
+duplicated events in the output.
 
 *`native`*:: The default behaviour of {beatname_uc} is to differentiate
 between files using their inodes and device ids.

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -74,6 +74,9 @@ values might change during the lifetime of the file. If this happens
 of the file. To solve this problem you can configure `file_identity` option. Possible
 values besides the default `inode_deviceid` are `path` and `inode_marker`.
 
+WARNING: Changing `file_identity` methods between runs may result in
+duplicated events in the output.
+
 Selecting `path` instructs {beatname_uc} to identify files based on their
 paths. This is a quick way to avoid rereading files if inode and device ids
 might change. However, keep in mind if the files are rotated (renamed), they

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -31,15 +31,13 @@ import (
 // Config stores the options of a file stream.
 type config struct {
 	readerConfig
+	prospectorConfig
 
-	Paths          []string                `config:"paths"`
-	Close          closerConfig            `config:"close"`
-	FileWatcher    *common.ConfigNamespace `config:"prospector"`
-	FileIdentity   *common.ConfigNamespace `config:"file_identity"`
-	CleanInactive  time.Duration           `config:"clean_inactive" validate:"min=0"`
-	CleanRemoved   bool                    `config:"clean_removed"`
-	HarvesterLimit uint32                  `config:"harvester_limit" validate:"min=0"`
-	IgnoreOlder    time.Duration           `config:"ignore_older"`
+	Paths         []string                `config:"paths"`
+	Close         closerConfig            `config:"close"`
+	FileWatcher   *common.ConfigNamespace `config:"prospector"`
+	FileIdentity  *common.ConfigNamespace `config:"file_identity"`
+	CleanInactive time.Duration           `config:"clean_inactive" validate:"min=0"` // TODO
 }
 
 type closerConfig struct {
@@ -72,6 +70,12 @@ type readerConfig struct {
 	Parsers []*common.ConfigNamespace `config:"parsers"` // TODO multiline, json, syslog?
 }
 
+type prospectorConfig struct {
+	CleanRemoved   bool          `config:"clean_removed"`
+	HarvesterLimit uint32        `config:"harvester_limit" validate:"min=0"`
+	IgnoreOlder    time.Duration `config:"ignore_older"`
+}
+
 type backoffConfig struct {
 	Init time.Duration `config:"init" validate:"nonzero"`
 	Max  time.Duration `config:"max" validate:"nonzero"`
@@ -79,28 +83,34 @@ type backoffConfig struct {
 
 func defaultConfig() config {
 	return config{
-		readerConfig:   defaultReaderConfig(),
-		Paths:          []string{},
-		Close:          defaultCloserConfig(),
-		CleanInactive:  0,
-		CleanRemoved:   true,
-		HarvesterLimit: 0,
-		IgnoreOlder:    0,
+		readerConfig:     defaultReaderConfig(),
+		prospectorConfig: defaultProspectorConfig(),
+		Paths:            []string{},
+		Close:            defaultCloserConfig(),
+		CleanInactive:    0,
 	}
 }
 
 func defaultCloserConfig() closerConfig {
 	return closerConfig{
-		OnStateChange: stateChangeCloserConfig{
-			CheckInterval: 5 * time.Second,
-			Removed:       true, // TODO check clean_removed option
-			Inactive:      0 * time.Second,
-			Renamed:       false,
-		},
-		Reader: readerCloserConfig{
-			OnEOF:         false,
-			AfterInterval: 0 * time.Second,
-		},
+		OnStateChange: defaultStateChangeCloserConfig(),
+		Reader:        defaultReaderCloserConfig(),
+	}
+}
+
+func defaultStateChangeCloserConfig() stateChangeCloserConfig {
+	return stateChangeCloserConfig{
+		CheckInterval: 5 * time.Second,
+		Removed:       true,
+		Inactive:      0 * time.Second,
+		Renamed:       false,
+	}
+}
+
+func defaultReaderCloserConfig() readerCloserConfig {
+	return readerCloserConfig{
+		OnEOF:         false,
+		AfterInterval: 0 * time.Second,
 	}
 }
 
@@ -115,6 +125,14 @@ func defaultReaderConfig() readerConfig {
 		MaxBytes:       10 * humanize.MiByte,
 		Tail:           false,
 		Parsers:        nil,
+	}
+}
+
+func defaultProspectorConfig() prospectorConfig {
+	return prospectorConfig{
+		CleanRemoved:   true,
+		HarvesterLimit: 0,
+		IgnoreOlder:    0,
 	}
 }
 

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -211,6 +211,10 @@ func (w *fileWatcher) Event() loginp.FSEvent {
 	return <-w.events
 }
 
+func (w *fileWatcher) GetFiles() map[string]os.FileInfo {
+	return w.scanner.GetFiles()
+}
+
 type fileScannerConfig struct {
 	ExcludedFiles []match.Matcher `config:"exclude_files"`
 	Symlinks      bool            `config:"symlinks"`

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -113,6 +113,11 @@ func (i *inodeDeviceIdentifier) Name() string {
 }
 
 func (i *inodeDeviceIdentifier) Supports(f identifierFeature) bool {
+	switch f {
+	case trackRename:
+		return true
+	default:
+	}
 	return false
 }
 
@@ -145,11 +150,6 @@ func (p *pathIdentifier) Name() string {
 }
 
 func (p *pathIdentifier) Supports(f identifierFeature) bool {
-	switch f {
-	case trackRename:
-		return true
-	default:
-	}
 	return false
 }
 

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -96,7 +96,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                pluginName + identitySep + i.name + identitySep + file.GetOSState(e.Info).String(),
+		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
 }
@@ -124,7 +124,7 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                pluginName + identitySep + p.name + identitySep + path,
+		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}
 }

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -106,3 +106,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 func (i *inodeMarkerIdentifier) Name() string {
 	return i.name
 }
+
+func (i *inodeMarkerIdentifier) Supports(_ identifierFeature) bool {
+	return false
+}

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -107,6 +107,11 @@ func (i *inodeMarkerIdentifier) Name() string {
 	return i.name
 }
 
-func (i *inodeMarkerIdentifier) Supports(_ identifierFeature) bool {
+func (i *inodeMarkerIdentifier) Supports(f identifierFeature) bool {
+	switch f {
+	case trackRename:
+		return true
+	default:
+	}
 	return false
 }

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -98,7 +98,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                fmt.Sprintf("%s%s%s-%s", i.name, identitySep, osstate.InodeString(), i.markerContents()),
+		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}
 }

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -89,7 +89,10 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 
 	prospector, err := newFileProspector(
 		config.Paths,
-		config.IgnoreOlder,
+		common.MustNewConfigFrom(map[string]interface{}{
+			"prospector":   config.prospectorConfig,
+			"state_change": config.Close.OnStateChange,
+		}),
 		config.FileWatcher,
 		config.FileIdentity,
 	)

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -57,6 +57,8 @@ type FSScanner interface {
 
 // FSWatcher returns file events of the monitored files.
 type FSWatcher interface {
+	FSScanner
+
 	// Run is the event loop which watchers for changes
 	// in the file system and returns events based on the data.
 	Run(unison.Canceler)

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -30,11 +30,13 @@ import (
 )
 
 type managedInput struct {
-	locker       resourceLocker
-	store        *store
-	prospector   Prospector
-	harvester    Harvester
-	cleanTimeout time.Duration
+	userID           string
+	locker           resourceLocker
+	sourceIdentifier sourceIder
+	store            *store
+	prospector       Prospector
+	harvester        Harvester
+	cleanTimeout     time.Duration
 }
 
 // Name is required to implement the v2.Input interface
@@ -69,7 +71,11 @@ func (inp *managedInput) Run(
 		tg:           unison.TaskGroup{},
 	}
 
-	inp.prospector.Run(ctx, inp.store, hg)
+	inp.store.Retain()
+	sourceStore := newSourceStore(inp.store, inp.sourceIdentifier)
+	defer inp.store.Release()
+
+	inp.prospector.Run(ctx, sourceStore, hg)
 
 	return nil
 }

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -166,9 +166,10 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 		return nil, errNoInputRunner
 	}
 
+	sourceIdentifier := newSourceIdentifier(cim.Type, settings.ID)
 	prospectorStore := cim.getRetainedStore()
 	defer prospectorStore.Release()
-	err = prospector.Init(prospectorStore)
+	err = prospector.Init(sourceIdentifier.prefix, settings.ID != "", prospectorStore)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 		userID:           settings.ID,
 		prospector:       prospector,
 		harvester:        harvester,
-		sourceIdentifier: newSourceIdentifier(cim.Type, settings.ID),
+		sourceIdentifier: sourceIdentifier,
 		cleanTimeout:     settings.CleanTimeout,
 	}, nil
 }
@@ -194,9 +195,9 @@ type sourceIdentifier struct {
 }
 
 func newSourceIdentifier(pluginName, userID string) *sourceIdentifier {
-	inputPrefix := pluginName + "::"
+	inputPrefix := pluginName
 	if userID != "" {
-		inputPrefix = inputPrefix + "::" + userID
+		inputPrefix = inputPrefix + "-" + userID
 	}
 	return &sourceIdentifier{
 		prefix: inputPrefix,

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -215,5 +215,5 @@ func (i *sourceIdentifier) ID(s Source) string {
 }
 
 func (i *sourceIdentifier) MatchesInput(id string) bool {
-	return strings.Contains(id, i.prefix)
+	return strings.HasPrefix(id, i.prefix)
 }

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -201,7 +201,7 @@ func newSourceIdentifier(pluginName, userID string) *sourceIdentifier {
 	inputPrefix := pluginName
 	configuredUserID := false
 	if userID != "" {
-		inputPrefix = inputPrefix + "-" + userID
+		inputPrefix = inputPrefix + "::" + userID
 		configuredUserID = true
 	}
 	return &sourceIdentifier{

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -205,13 +205,13 @@ func newSourceIdentifier(pluginName, userID string) *sourceIdentifier {
 		configuredUserID = true
 	}
 	return &sourceIdentifier{
-		prefix:           inputPrefix,
+		prefix:           inputPrefix + "::",
 		configuredUserID: configuredUserID,
 	}
 }
 
 func (i *sourceIdentifier) ID(s Source) string {
-	return i.prefix + "::" + s.Name()
+	return i.prefix + s.Name()
 }
 
 func (i *sourceIdentifier) MatchesInput(id string) bool {

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -26,7 +26,7 @@ import (
 // It also updates the statestore with the meta data of the running harvesters.
 type Prospector interface {
 	// Init runs the cleanup processes before starting the prospector.
-	Init(inputPrefix string, userIDConfigured bool, c ProspectorCleaner) error
+	Init(c ProspectorCleaner) error
 	// Run starts the event loop and handles the incoming events
 	// either by starting/stopping a harvester, or updating the statestore.
 	Run(input.Context, StateMetadataUpdater, HarvesterGroup)
@@ -48,11 +48,11 @@ type StateMetadataUpdater interface {
 // ProspectorCleaner cleans the state store before it starts running.
 type ProspectorCleaner interface {
 	// CleanIf removes an entry if the function returns true
-	CleanIf(func(key string, v Value) bool)
+	CleanIf(func(v Value) bool)
 	// UpdateIdentifiers updates ID in the registry.
 	// The function passed to UpdateIdentifiers must return an empty string if the key
 	// remains the same.
-	UpdateIdentifiers(func(key string, v Value) (string, interface{}))
+	UpdateIdentifiers(func(v Value) (string, interface{}))
 }
 
 // Value contains the cursor metadata.

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -35,13 +35,14 @@ type Prospector interface {
 	Test() error
 }
 
+// StateMetadataUpdater updates and removes the state information for a given Source.
 type StateMetadataUpdater interface {
 	// FindCursorMeta retrieves and unpacks a cursor metadata of an entry.
-	FindCursorMeta(key string, v interface{}) error
+	FindCursorMeta(s Source, v interface{}) error
 	// UpdateMetadata updates the source metadata of a registry entry for a given ID.
-	UpdateMetadata(key string, v interface{}) error
+	UpdateMetadata(s Source, v interface{}) error
 	// Remove marks a state for deletion with a given ID.
-	Remove(string) error
+	Remove(s Source) error
 }
 
 // ProspectorCleaner cleans the state store before it starts running.

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -50,7 +50,9 @@ type ProspectorCleaner interface {
 	// CleanIf removes an entry if the function returns true
 	CleanIf(func(key string, v Value) bool)
 	// UpdateIdentifiers updates ID in the registry.
-	UpdateIdentifiers(func(key string, v Value) (bool, string, interface{}))
+	// The function passed to UpdateIdentifiers must return an empty string if the key
+	// remains the same.
+	UpdateIdentifiers(func(key string, v Value) (string, interface{}))
 }
 
 // Value contains the cursor metadata.

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -37,11 +37,11 @@ type Prospector interface {
 
 // StateMetadataUpdater updates and removes the state information for a given Source.
 type StateMetadataUpdater interface {
-	// FindCursorMeta retrieves and unpacks a cursor metadata of an entry.
+	// FindCursorMeta retrieves and unpacks the cursor metadata of an entry of the given Source.
 	FindCursorMeta(s Source, v interface{}) error
-	// UpdateMetadata updates the source metadata of a registry entry for a given ID.
+	// UpdateMetadata updates the source metadata of a registry entry of a given Source.
 	UpdateMetadata(s Source, v interface{}) error
-	// Remove marks a state for deletion with a given ID.
+	// Remove marks a state for deletion of a given Source.
 	Remove(s Source) error
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -26,7 +26,7 @@ import (
 // It also updates the statestore with the meta data of the running harvesters.
 type Prospector interface {
 	// Init runs the cleanup processes before starting the prospector.
-	Init(ProspectorCleaner) error
+	Init(inputPrefix string, userIDConfigured bool, c ProspectorCleaner) error
 	// Run starts the event loop and handles the incoming events
 	// either by starting/stopping a harvester, or updating the statestore.
 	Run(input.Context, StateMetadataUpdater, HarvesterGroup)

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -36,18 +36,24 @@ type Prospector interface {
 }
 
 type StateMetadataUpdater interface {
-	// UpdateID updates the Identifier.
-	UpdateID(oldId, newId string)
-	// Remove deletes a state with a given ID.
+	// FindCursorMeta retrieves and unpacks a cursor metadata of an entry.
+	FindCursorMeta(key string, v interface{}) error
+	// UpdateMetadata updates the source metadata of a registry entry for a given ID.
+	UpdateMetadata(key string, v interface{}) error
+	// Remove marks a state for deletion with a given ID.
 	Remove(string) error
 }
 
+// ProspectorCleaner cleans the state store before it starts running.
 type ProspectorCleaner interface {
-	// CleanIf removes an entry if the cursor is true
-	CleanIf(func(key string, u Unpackable) bool)
-	UpdateIdentifiers(func(key string, u Unpackable) (bool, string))
+	// CleanIf removes an entry if the function returns true
+	CleanIf(func(key string, v Value) bool)
+	// UpdateIdentifiers updates ID in the registry.
+	UpdateIdentifiers(func(key string, v Value) (bool, string, interface{}))
 }
 
-type Unpackable interface {
-	UnpackCursor(to interface{}) error
+// Value contains the cursor metadata.
+type Value interface {
+	// UnpackCursorMeta returns the cursor metadata required by the prospector.
+	UnpackCursorMeta(to interface{}) error
 }

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -231,7 +231,7 @@ func (s *sourceStore) UpdateIdentifiers(getNewID func(v Value) (string, interfac
 
 			r := res.copyWithNewKey(newKey)
 			r.cursorMeta = updatedMeta
-			s.store.ephemeralStore.table[newKey] = r
+			s.store.writeState(r)
 		}
 
 		res.lock.Unlock()

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -403,12 +403,19 @@ func (r *resource) inSyncStateSnapshot() state {
 }
 
 func (r *resource) copyWithNewKey(key string) *resource {
+	internalState := r.internalState
+
+	// This is required to prevent the cleaner from removing the
+	// entry from the registry immediately.
+	// It still might be removed if the output is blocked for a long
+	// time. If removed the whole file is resent to the output when found/updated.
+	internalState.Updated = time.Now()
 	return &resource{
 		key:                    key,
 		stored:                 r.stored,
 		internalInSync:         true,
+		internalState:          internalState,
 		activeCursorOperations: r.activeCursorOperations,
-		internalState:          r.internalState,
 		cursor:                 r.cursor,
 		pendingCursor:          nil,
 		cursorMeta:             r.cursorMeta,

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -231,6 +231,7 @@ func (s *sourceStore) UpdateIdentifiers(getNewID func(v Value) (string, interfac
 
 			r := res.copyWithNewKey(newKey)
 			r.cursorMeta = updatedMeta
+			r.stored = false
 			s.store.writeState(r)
 		}
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -406,11 +406,11 @@ func (r *resource) copyWithNewKey(key string) *resource {
 	return &resource{
 		key:                    key,
 		stored:                 r.stored,
-		internalInSync:         r.internalInSync,
+		internalInSync:         true,
 		activeCursorOperations: r.activeCursorOperations,
 		internalState:          r.internalState,
 		cursor:                 r.cursor,
-		pendingCursor:          r.pendingCursor,
+		pendingCursor:          nil,
 		cursorMeta:             r.cursorMeta,
 	}
 }

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -229,6 +229,11 @@ func (s *sourceStore) UpdateIdentifiers(getNewID func(v Value) (string, interfac
 				continue
 			}
 
+			// Pending updates due to events that have not yet been ACKed
+			// are not included in the copy. Collection on
+			// the copy start from the last known ACKed position.
+			// This might lead to duplicates if configurations are adapted
+			// for inputs with the same ID are changed.
 			r := res.copyWithNewKey(newKey)
 			r.cursorMeta = updatedMeta
 			r.stored = false

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -183,10 +183,6 @@ func (s *sourceStore) Remove(src Source) error {
 
 // CleanIf sets the TTL of a resource if the predicate return true.
 func (s *sourceStore) CleanIf(pred func(v Value) bool) {
-	if !s.identifier.configuredUserID {
-		return
-	}
-
 	s.store.ephemeralStore.mu.Lock()
 	defer s.store.ephemeralStore.mu.Unlock()
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -252,7 +252,7 @@ func (s *store) updateMetadata(key string, meta interface{}) error {
 		TTL:     resource.internalState.TTL,
 		Updated: resource.internalState.Updated,
 		Cursor:  resource.cursor,
-		Meta:    cursorMeta,
+		Meta:    resource.cursorMeta,
 	})
 	if err != nil {
 		s.log.Errorf("Failed to update cursor metadata fields for '%v'", resource.key)

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -206,8 +206,7 @@ func (s *store) UpdateIdentifiers(getNewID func(key string, v Value) (bool, stri
 	for key, res := range s.ephemeralStore.table {
 		update, newKey, updatedMeta := getNewID(key, res)
 		if update && res.internalState.TTL > 0 {
-			r := res.clone()
-			r.key = newKey
+			r := res.copyWithNewKey(newKey)
 			r.cursorMeta = updatedMeta
 			s.ephemeralStore.table[newKey] = r
 			s.UpdateTTL(res, 0)
@@ -337,9 +336,9 @@ func (r *resource) inSyncStateSnapshot() state {
 	}
 }
 
-func (r *resource) clone() *resource {
+func (r *resource) copyWithNewKey(key string) *resource {
 	return &resource{
-		key:                    r.key,
+		key:                    key,
 		stored:                 r.stored,
 		internalInSync:         r.internalInSync,
 		activeCursorOperations: r.activeCursorOperations,

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -246,17 +246,17 @@ func TestStore_UpdateIdentifiers(t *testing.T) {
 		store := testOpenStore(t, "test", backend)
 		defer store.Release()
 
-		store.UpdateIdentifiers(func(key string, v Value) (bool, string, interface{}) {
+		store.UpdateIdentifiers(func(key string, v Value) (string, interface{}) {
 			var m testMeta
 			err := v.UnpackCursorMeta(&m)
 			if err != nil {
 				t.Fatalf("cannot unpack meta: %v", err)
 			}
 			if m.IdentifierName == "method" {
-				return true, key + "::updated", testMeta{IdentifierName: "something"}
+				return key + "::updated", testMeta{IdentifierName: "something"}
 
 			}
-			return false, "", nil
+			return "", nil
 
 		})
 

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -275,13 +275,11 @@ func TestSourceStore_UpdateIdentifiers(t *testing.T) {
 			"test::key1::updated": state{
 				Updated: s.Get("test::key1::updated").internalState.Updated,
 				TTL:     60 * time.Second,
-				Meta:    testMeta{IdentifierName: "something"},
+				Meta:    map[string]interface{}{"identifiername": "something"},
 			},
 		}
 
-		//checkEqualStoreState(t, want, storeMemorySnapshot(s))
-		checkEqualStoreState(t, want, storeInSyncSnapshot(s))
-		//checkEqualStoreState(t, want, backend.snapshot())
+		checkEqualStoreState(t, want, backend.snapshot())
 	})
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -279,8 +279,8 @@ func TestSourceStore_UpdateIdentifiers(t *testing.T) {
 			},
 		}
 
-		checkEqualStoreState(t, want, storeMemorySnapshot(s))
-		//checkEqualStoreState(t, want, storeInSyncSnapshot(s))
+		//checkEqualStoreState(t, want, storeMemorySnapshot(s))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(s))
 		//checkEqualStoreState(t, want, backend.snapshot())
 	})
 }

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -227,6 +227,126 @@ func TestStore_UpdateTTL(t *testing.T) {
 	})
 }
 
+type testMeta struct {
+	IdentifierName string
+}
+
+func TestStore_UpdateIdentifiers(t *testing.T) {
+	t.Run("update identifiers when TTL is bigger than zero", func(t *testing.T) {
+		backend := createSampleStore(t, map[string]state{
+			"test::key1": state{
+				TTL:  60 * time.Second,
+				Meta: testMeta{IdentifierName: "method"},
+			},
+			"test::key2": state{
+				TTL:  0 * time.Second,
+				Meta: testMeta{IdentifierName: "method"},
+			},
+		})
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		store.UpdateIdentifiers(func(key string, v Value) (bool, string, interface{}) {
+			var m testMeta
+			err := v.UnpackCursorMeta(&m)
+			if err != nil {
+				t.Fatalf("cannot unpack meta: %v", err)
+			}
+			if m.IdentifierName == "method" {
+				return true, key + "::updated", testMeta{IdentifierName: "something"}
+
+			}
+			return false, "", nil
+
+		})
+
+		want := map[string]state{
+			"test::key1": state{
+				Updated: store.Get("test::key1").internalState.Updated,
+				TTL:     0 * time.Second,
+				Meta:    map[string]interface{}{"identifiername": "method"},
+			},
+			"test::key2": state{
+				Updated: store.Get("test::key2").internalState.Updated,
+				TTL:     0 * time.Second,
+				Meta:    map[string]interface{}{"identifiername": "method"},
+			},
+			"test::key1::updated": state{
+				Updated: store.Get("test::key1::updated").internalState.Updated,
+				TTL:     60 * time.Second,
+				Meta:    testMeta{IdentifierName: "something"},
+			},
+		}
+
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+}
+
+func TestStore_CleanIf(t *testing.T) {
+	t.Run("entries are cleaned when funtion returns true", func(t *testing.T) {
+		backend := createSampleStore(t, map[string]state{
+			"test::key1": state{
+				TTL: 60 * time.Second,
+			},
+			"test::key2": state{
+				TTL: 0 * time.Second,
+			},
+		})
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		store.CleanIf(func(key string, v Value) bool {
+			return true
+		})
+
+		want := map[string]state{
+			"test::key1": state{
+				Updated: store.Get("test::key1").internalState.Updated,
+				TTL:     0 * time.Second,
+			},
+			"test::key2": state{
+				Updated: store.Get("test::key2").internalState.Updated,
+				TTL:     0 * time.Second,
+			},
+		}
+
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+
+	t.Run("entries are left alone when funtion returns false", func(t *testing.T) {
+		backend := createSampleStore(t, map[string]state{
+			"test::key1": state{
+				TTL: 60 * time.Second,
+			},
+			"test::key2": state{
+				TTL: 0 * time.Second,
+			},
+		})
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		store.CleanIf(func(key string, v Value) bool {
+			return false
+		})
+
+		want := map[string]state{
+			"test::key1": state{
+				Updated: store.Get("test::key1").internalState.Updated,
+				TTL:     60 * time.Second,
+			},
+			"test::key2": state{
+				Updated: store.Get("test::key2").internalState.Updated,
+				TTL:     0 * time.Second,
+			},
+		}
+
+		checkEqualStoreState(t, want, storeMemorySnapshot(store))
+		checkEqualStoreState(t, want, storeInSyncSnapshot(store))
+	})
+}
+
 func closeStoreWith(fn func(s *store)) func() {
 	old := closeStore
 	closeStore = fn

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -261,6 +261,9 @@ func TestSourceStore_UpdateIdentifiers(t *testing.T) {
 
 		})
 
+		var newState state
+		s.persistentStore.Get("test::key1::updated", &newState)
+
 		want := map[string]state{
 			"test::key1": state{
 				Updated: s.Get("test::key1").internalState.Updated,
@@ -273,7 +276,7 @@ func TestSourceStore_UpdateIdentifiers(t *testing.T) {
 				Meta:    map[string]interface{}{"identifiername": "method"},
 			},
 			"test::key1::updated": state{
-				Updated: s.Get("test::key1::updated").internalState.Updated,
+				Updated: newState.Updated,
 				TTL:     60 * time.Second,
 				Meta:    map[string]interface{}{"identifiername": "something"},
 			},

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -18,7 +18,6 @@
 package filestream
 
 import (
-	"os"
 	"time"
 
 	"github.com/urso/sderr"
@@ -46,6 +45,8 @@ type fileProspector struct {
 }
 
 func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
+	files := p.filewatcher.GetFiles()
+
 	if p.cleanRemoved {
 		cleaner.CleanIf(func(v loginp.Value) bool {
 			var fm fileMeta
@@ -55,15 +56,11 @@ func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
 				return true
 			}
 
-			_, err = os.Stat(fm.Source)
-			if err != nil {
-				return true
-			}
-			return false
+			_, ok := files[fm.Source]
+			return !ok
 		})
 	}
 
-	files := p.filewatcher.GetFiles()
 	identifierName := p.identifier.Name()
 	cleaner.UpdateIdentifiers(func(v loginp.Value) (string, interface{}) {
 		var fm fileMeta

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -166,12 +166,17 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 					err := s.FindCursorMeta(src, meta)
 					if err != nil {
 						log.Errorf("Error while getting cursor meta data of entry %s: %v", src.Name(), err)
+
+						meta.IdentifierName = p.identifier.Name()
 					}
 					s.UpdateMetadata(src, fileMeta{Source: src.newPath, IdentifierName: meta.IdentifierName})
 
 					if p.stateChangeCloser.Renamed {
 						log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())
-						hg.Stop(src)
+
+						fe.Op = loginp.OpDelete
+						srcToClose := p.identifier.GetSource(fe)
+						hg.Stop(srcToClose)
 					}
 				}
 

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -19,7 +19,6 @@ package filestream
 
 import (
 	"os"
-	"strings"
 	"time"
 
 	"github.com/urso/sderr"
@@ -46,12 +45,9 @@ type fileProspector struct {
 	stateChangeCloser stateChangeCloserConfig
 }
 
-func (p *fileProspector) Init(inputPrefix string, userIDConfigured bool, cleaner loginp.ProspectorCleaner) error {
-	if p.cleanRemoved && userIDConfigured {
-		cleaner.CleanIf(func(key string, v loginp.Value) bool {
-			if !strings.HasPrefix(key, inputPrefix) {
-				return false
-			}
+func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
+	if p.cleanRemoved {
+		cleaner.CleanIf(func(v loginp.Value) bool {
 			var fm fileMeta
 			err := v.UnpackCursorMeta(&fm)
 			if err != nil {
@@ -68,11 +64,7 @@ func (p *fileProspector) Init(inputPrefix string, userIDConfigured bool, cleaner
 	}
 
 	identifierName := p.identifier.Name()
-	cleaner.UpdateIdentifiers(func(key string, v loginp.Value) (string, interface{}) {
-		if !strings.HasPrefix(key, inputPrefix) {
-			return "", nil
-		}
-
+	cleaner.UpdateIdentifiers(func(v loginp.Value) (string, interface{}) {
 		var fm fileMeta
 		err := v.UnpackCursorMeta(&fm)
 		if err != nil {

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -80,9 +80,9 @@ func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
 
 			_, err = os.Stat(st.Source)
 			if err != nil {
-				return false
+				return true
 			}
-			return true
+			return false
 		})
 	}
 

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -63,6 +63,7 @@ func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
 		})
 	}
 
+	files := p.filewatcher.GetFiles()
 	identifierName := p.identifier.Name()
 	cleaner.UpdateIdentifiers(func(v loginp.Value) (string, interface{}) {
 		var fm fileMeta
@@ -70,16 +71,18 @@ func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
 		if err != nil {
 			return "", nil
 		}
+
+		fi, ok := files[fm.Source]
+		if !ok {
+			return "", fm
+		}
+
 		if fm.IdentifierName != identifierName {
-			fi, err := os.Stat(fm.Source)
-			if err != nil {
-				return "", fm
-			}
 			newKey := p.identifier.GetSource(loginp.FSEvent{NewPath: fm.Source, Info: fi}).Name()
 			fm.IdentifierName = identifierName
 			return newKey, fm
 		}
-		return "", nil
+		return "", fm
 	})
 
 	return nil

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -157,9 +157,8 @@ type testHarvesterGroup struct {
 
 func getTestHarvesterGroup() *testHarvesterGroup { return &testHarvesterGroup{make([]string, 0)} }
 
-func (t *testHarvesterGroup) Start(_ input.Context, s loginp.Source) error {
+func (t *testHarvesterGroup) Start(_ input.Context, s loginp.Source) {
 	t.encounteredNames = append(t.encounteredNames, s.Name())
-	return nil
 }
 
 func (t *testHarvesterGroup) Stop(_ loginp.Source) {
@@ -199,9 +198,13 @@ func (mu *mockMetadataUpdater) has(id string) bool {
 	return ok
 }
 
-func (mu *mockMetadataUpdater) UpdateID(oldID, newID string) {
-	mu.table[newID] = mu.table[oldID]
-	delete(mu.table, oldID)
+func (mu *mockMetadataUpdater) FindCursorMeta(key string, v interface{}) error {
+	return nil
+}
+
+func (mu *mockMetadataUpdater) UpdateMetadata(key string, v interface{}) error {
+	mu.table[key] = v
+	return nil
 }
 
 func (mu *mockMetadataUpdater) Remove(id string) error {

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -19,6 +19,7 @@ package filestream
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -184,6 +185,8 @@ func (m *mockFileWatcher) Event() loginp.FSEvent {
 }
 
 func (m *mockFileWatcher) Run(_ unison.Canceler) { return }
+
+func (m *mockFileWatcher) GetFiles() map[string]os.FileInfo { return nil }
 
 type mockMetadataUpdater struct {
 	table map[string]interface{}


### PR DESCRIPTION
## What does this PR do?

This PR refactors parts of the filestream input.

A new interface is added named `resourceLocker` to let the `HarvesterGroup` lock resources from the store with fewer hops.

Another new interface is added for cleaning up the internal states before a `loginp.Prospector` is started. These cleaner functions can clean entries of removed files and update IDs if the `file_identity` configuration is changed.

The bookkeeping of readers is now threadsafe.

From now on `source.Name()` returns only a suffix of the state ID. The prefix `{input_type}::{user_id}` is added by a new interface `sourceIder` (I am open for better names.).

```golang
// SourceIder generates an ID for a Source.
type sourceIder interface {
    ID(Source) string
}
```

A special store is added as well which accepts `Source` interface as parameters and gets the full ID from a `sourceIder` instance. Only the interface `StateMetadataUpdater` is now accepted by `prospector.Run`. 

```golang
 // StateMetadataUpdater updates and removes the state information for a given Source.
type StateMetadataUpdater interface {
    // FindCursorMeta retrieves and unpacks the cursor metadata of a Source.
    FindCursorMeta(s Source, v interface{}) error
    // UpdateMetadata updates the source metadata of a registry entry for a given Source.
    UpdateMetadata(s Source, v interface{}) error
    // Remove marks a state for deletion with a given Source.
    Remove(s Source) error
}
```

Important difference between `sourceStore` and `store` is that the first one only deals with `Source` parameters. When you use `store`, you need to specify the full ID of an entry in the format of `{input_type::user_id::source_id}`.

## Why is it important?

Cleaner architecture, responsibilities are separated even more.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~