### PR TITLE
ci: job to launch beat-tester only with the version

### DIFF
--- a/.ci/beats-tester-bc.groovy
+++ b/.ci/beats-tester-bc.groovy
@@ -34,7 +34,7 @@ pipeline {
         }
       }
       steps {
-        build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false,
+        build(job: env.BEATS_TESTER_JOB, propagate: true, wait: true,
           parameters: [
             string(name: 'APM_URL_BASE', value: "${APM_BASE_URL}"),
             string(name: 'BEATS_URL_BASE', value: "${BEATS_BASE_URL}"),

--- a/.ci/beats-tester-bc.groovy
+++ b/.ci/beats-tester-bc.groovy
@@ -1,0 +1,46 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    BASE_DIR = 'src/github.com/elastic/beats'
+    PIPELINE_LOG_LEVEL = "INFO"
+    BEATS_TESTER_JOB = 'Beats/beats-tester-mbp/master'
+    BASE_URL = "https://staging.elastic.co/${params.version}/downloads"
+    APM_BASE_URL = "${env.BASE_URL}/apm-server"
+    BEATS_BASE_URL = "${env.BASE_URL}/beats"
+    VERSION = "${params.version}"
+  }
+  options {
+    timeout(time: 2, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    disableConcurrentBuilds()
+  }
+  parameters {
+    stringParam(name: 'version', defaultValue: '', description: 'Id of the Build Candidate (7.10.0-b55684ff).')
+  }
+  stages {
+    stage('Run Beat Tester') {
+      options { skipDefaultCheckout() }
+      when {
+        expression {
+          return '' != "${VERSION}"
+        }
+      }
+      steps {
+        build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false,
+          parameters: [
+            string(name: 'APM_URL_BASE', value: "${APM_BASE_URL}"),
+            string(name: 'BEATS_URL_BASE', value: "${BEATS_BASE_URL}"),
+            string(name: 'VERSION', value: "${VERSION}")
+        ])
+      }
+    }
+  }
+}

--- a/.ci/jobs/beats-tester-bc.yml
+++ b/.ci/jobs/beats-tester-bc.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: Beats/beats-tester-bc
+    display-name: Beats Tester orchestrator for Build Candidates
+    description: Launch the beat-tester suit on Build Candidates easily
+    view: Beats
+    disabled: false
+    project-type: pipeline
+    script-path: .ci/beats-tester-bc.groovy
+    parameters:
+      - string:
+          name: BRANCH_REFERENCE
+          default: master
+          description: the Git branch specifier
+    pipeline-scm:
+      script-path: .ci/build-docker-images.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/beats.git
+            refspec: +refs/heads/*:refs/remotes/origin/*
+            wipe-workspace: true
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/beats.git
+            branches:
+              - $BRANCH_REFERENCE


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
it adds a job to launch beats tester with BCs only using the version name,

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
run the job from the MBP requires to copy & paste the BC URL and remove stuff for two URLs, it is error-prone and you have to remember how to do it, launch the beats tester only with the version is a better user experience