### PR TITLE
ci: split version ID to run beats-tester

### DIFF
--- a/.ci/beats-tester-bc.groovy
+++ b/.ci/beats-tester-bc.groovy
@@ -11,7 +11,7 @@ pipeline {
     BASE_URL = "https://staging.elastic.co/${params.version}/downloads"
     APM_BASE_URL = "${env.BASE_URL}/apm-server"
     BEATS_BASE_URL = "${env.BASE_URL}/beats"
-    VERSION = "${params.version}"
+    VERSION = "${params.version?.split('-')[0]}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
it takes only the Stack version from the BC version.
