### PR TITLE
Cherry-pick #22352 to 7.x: [Elastic Agent] Add priority to dynamic input provider mappings

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -48,3 +48,4 @@
 - Update `install` command to perform enroll before starting Elastic Agent {pull}21772[21772]
 - Update `fleet.kibana.path` from a POLICY_CHANGE {pull}21804[21804]
 - Removed `install-service.ps1` and `uninstall-service.ps1` from Windows .zip packaging {pull}21694[21694]
+- Add `priority` to `AddOrUpdate` on dynamic composable input providers communication channel {pull}22352[22352]

--- a/x-pack/elastic-agent/pkg/composable/controller.go
+++ b/x-pack/elastic-agent/pkg/composable/controller.go
@@ -214,6 +214,7 @@ func (c *contextProviderState) Current() map[string]interface{} {
 }
 
 type dynamicProviderMapping struct {
+	priority   int
 	mapping    map[string]interface{}
 	processors transpiler.Processors
 }
@@ -228,7 +229,11 @@ type dynamicProviderState struct {
 }
 
 // AddOrUpdate adds or updates the current mapping for the dynamic provider.
-func (c *dynamicProviderState) AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error {
+//
+// `priority` ensures that order is maintained when adding the mapping to the current state
+// for the processor. Lower priority mappings will always be sorted before higher priority mappings
+// to ensure that matching of variables occurs on the lower priority mappings first.
+func (c *dynamicProviderState) AddOrUpdate(id string, priority int, mapping map[string]interface{}, processors []map[string]interface{}) error {
 	var err error
 	mapping, err = cloneMap(mapping)
 	if err != nil {
@@ -252,6 +257,7 @@ func (c *dynamicProviderState) AddOrUpdate(id string, mapping map[string]interfa
 		return nil
 	}
 	c.mappings[id] = dynamicProviderMapping{
+		priority:   priority,
 		mapping:    mapping,
 		processors: processors,
 	}
@@ -276,14 +282,24 @@ func (c *dynamicProviderState) Mappings() []dynamicProviderMapping {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
+	// add the mappings sorted by (priority,id)
 	mappings := make([]dynamicProviderMapping, 0)
-	ids := make([]string, 0)
-	for name := range c.mappings {
-		ids = append(ids, name)
+	priorities := make([]int, 0)
+	for _, mapping := range c.mappings {
+		priorities = addToSet(priorities, mapping.priority)
 	}
-	sort.Strings(ids)
-	for _, name := range ids {
-		mappings = append(mappings, c.mappings[name])
+	sort.Ints(priorities)
+	for _, priority := range priorities {
+		ids := make([]string, 0)
+		for name, mapping := range c.mappings {
+			if mapping.priority == priority {
+				ids = append(ids, name)
+			}
+		}
+		sort.Strings(ids)
+		for _, name := range ids {
+			mappings = append(mappings, c.mappings[name])
+		}
 	}
 	return mappings
 }
@@ -318,4 +334,13 @@ func cloneMapArray(source []map[string]interface{}) ([]map[string]interface{}, e
 		return nil, fmt.Errorf("failed to clone: %s", err)
 	}
 	return dest, nil
+}
+
+func addToSet(set []int, i int) []int {
+	for _, j := range set {
+		if j == i {
+			return set
+		}
+	}
+	return append(set, i)
 }

--- a/x-pack/elastic-agent/pkg/composable/dynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/dynamic.go
@@ -18,7 +18,11 @@ type DynamicProviderComm interface {
 	context.Context
 
 	// AddOrUpdate updates a mapping with given ID with latest mapping and processors.
-	AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error
+	//
+	// `priority` ensures that order is maintained when adding the mapping to the current state
+	// for the processor. Lower priority mappings will always be sorted before higher priority mappings
+	// to ensure that matching of variables occurs on the lower priority mappings first.
+	AddOrUpdate(id string, priority int, mapping map[string]interface{}, processors []map[string]interface{}) error
 	// Remove removes a mapping by given ID.
 	Remove(id string)
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/docker/docker.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/docker/docker.go
@@ -18,6 +18,9 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
+// ContainerPriority is the priority that container mappings are added to the provider.
+const ContainerPriority = 0
+
 func init() {
 	composable.Providers.AddDynamicProvider("docker", DynamicProviderBuilder)
 }
@@ -76,7 +79,7 @@ func (c *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
 					delete(stoppers, data.container.ID)
 					return
 				}
-				comm.AddOrUpdate(data.container.ID, data.mapping, data.processors)
+				comm.AddOrUpdate(data.container.ID, ContainerPriority, data.mapping, data.processors)
 			case event := <-stopListener.Events():
 				data, err := generateData(event)
 				if err != nil {

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -28,4 +28,5 @@ type Config struct {
 func (c *Config) InitDefaults() {
 	c.SyncPeriod = 10 * time.Minute
 	c.CleanupTimeout = 60 * time.Second
+	c.Scope = "node"
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic.go
@@ -14,6 +14,9 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
+// ItemPriority is the priority that item mappings are added to the provider.
+const ItemPriority = 0
+
 func init() {
 	composable.Providers.AddDynamicProvider("local_dynamic", DynamicProviderBuilder)
 }
@@ -30,7 +33,7 @@ type dynamicProvider struct {
 // Run runs the environment context provider.
 func (c *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
 	for i, item := range c.Items {
-		if err := comm.AddOrUpdate(strconv.Itoa(i), item.Mapping, item.Processors); err != nil {
+		if err := comm.AddOrUpdate(strconv.Itoa(i), ItemPriority, item.Mapping, item.Processors); err != nil {
 			return errors.New(err, fmt.Sprintf("failed to add mapping for index %d", i), errors.TypeUnexpected)
 		}
 	}

--- a/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/localdynamic/localdynamic_test.go
@@ -69,11 +69,13 @@ func TestContextProvider(t *testing.T) {
 
 	curr1, ok1 := comm.Current("0")
 	assert.True(t, ok1)
+	assert.Equal(t, ItemPriority, curr1.Priority)
 	assert.Equal(t, mapping1, curr1.Mapping)
 	assert.Equal(t, processors1, curr1.Processors)
 
 	curr2, ok2 := comm.Current("1")
 	assert.True(t, ok2)
+	assert.Equal(t, ItemPriority, curr2.Priority)
 	assert.Equal(t, mapping2, curr2.Mapping)
 	assert.Equal(t, processors2, curr2.Processors)
 }

--- a/x-pack/elastic-agent/pkg/composable/testing/dynamic.go
+++ b/x-pack/elastic-agent/pkg/composable/testing/dynamic.go
@@ -11,6 +11,7 @@ import (
 
 // DynamicState is the state of the dynamic mapping.
 type DynamicState struct {
+	Priority   int
 	Mapping    map[string]interface{}
 	Processors []map[string]interface{}
 }
@@ -34,7 +35,7 @@ func NewDynamicComm(ctx context.Context) *DynamicComm {
 }
 
 // AddOrUpdate adds or updates a current mapping.
-func (t *DynamicComm) AddOrUpdate(id string, mapping map[string]interface{}, processors []map[string]interface{}) error {
+func (t *DynamicComm) AddOrUpdate(id string, priority int, mapping map[string]interface{}, processors []map[string]interface{}) error {
 	var err error
 	mapping, err = CloneMap(mapping)
 	if err != nil {
@@ -53,6 +54,7 @@ func (t *DynamicComm) AddOrUpdate(id string, mapping map[string]interface{}, pro
 		t.previous[id] = prev
 	}
 	t.current[id] = DynamicState{
+		Priority:   priority,
 		Mapping:    mapping,
 		Processors: processors,
 	}


### PR DESCRIPTION
Cherry-pick of PR #22352 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a priority to the `AddOrUpdate` function on the communication channel for a dynamic composable input provider.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is used by the composable inputs controller to sort the mappings of a provider by priority before parsing them for the generated AST configuration for the running Elastic Agent. This ensures that matching of variables in the configuration happens based on the priority so lower priority processors are used over the higher priority processors. (lower wins)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #21844

