### PR TITLE
Cherry-pick #21282 to 7.x: stop monitoring excluded paths

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -170,6 +170,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
 - auditd: Fix an error condition causing a lot of `audit_send_reply` kernel threads being created. {pull}22673[22673]
 - system/socket: Fixed start failure when run under config reloader. {issue}20851[20851] {pull}21693[21693]
+- file_integrity: stop monitoring excluded paths {issue}21278[21278] {pull}21282[21282]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -39,20 +39,22 @@ type reader struct {
 
 // NewEventReader creates a new EventProducer backed by fsnotify.
 func NewEventReader(c Config) (EventProducer, error) {
-	watcher, err := monitor.New(c.Recursive)
-	if err != nil {
-		return nil, err
-	}
-
 	return &reader{
-		watcher: watcher,
-		config:  c,
-		log:     logp.NewLogger(moduleName),
+		config: c,
+		log:    logp.NewLogger(moduleName),
 	}, nil
 }
 
 func (r *reader) Start(done <-chan struct{}) (<-chan Event, error) {
+	watcher, err := monitor.New(r.config.Recursive, r.config.IsExcludedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	r.watcher = watcher
 	if err := r.watcher.Start(); err != nil {
+		// Ensure that watcher is closed so that we don't leak watchers
+		r.watcher.Close()
 		return nil, errors.Wrap(err, "unable to start watcher")
 	}
 

--- a/auditbeat/module/file_integrity/monitor/monitor.go
+++ b/auditbeat/module/file_integrity/monitor/monitor.go
@@ -37,15 +37,15 @@ type Watcher interface {
 
 // New creates a new Watcher backed by fsnotify with optional recursive
 // logic.
-func New(recursive bool) (Watcher, error) {
-	fsnotify, err := fsnotify.NewWatcher()
+func New(recursive bool, IsExcludedPath func(path string) bool) (Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 	// Use our simulated recursive watches unless the fsnotify implementation
 	// supports OS-provided recursive watches
-	if recursive && fsnotify.SetRecursive() != nil {
-		return newRecursiveWatcher(fsnotify), nil
+	if recursive && watcher.SetRecursive() != nil {
+		return newRecursiveWatcher(watcher, IsExcludedPath), nil
 	}
-	return (*nonRecursiveWatcher)(fsnotify), nil
+	return (*nonRecursiveWatcher)(watcher), nil
 }


### PR DESCRIPTION
Cherry-pick of PR #21282 to 7.x branch. Original message: 

## What does this PR do?

If the files match the excluded pattern, `recursiveWatcher` does not emit events for them, as well as errors if any.

## Why is it important?

This eliminates unnecessary warning logs for file paths that user intends to exclude.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

run test case `TestRecursiveExcludedPaths`

## Related issues

- Closes elastic/beats#21278

