### PR TITLE
Cherry-pick to 7.x: [CI]: run packaging if ^go.mod changes (#22383)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
         dir("${BASE_DIR}"){
           // Skip all the stages except docs for PR's with asciidoc and md changes only
           setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
+          setEnvVar('GO_MOD_CHANGES', isGitRegionMatch(patterns: [ '^go.mod' ], shouldMatchAll: false).toString())
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
@@ -120,6 +121,21 @@ pipeline {
               parallel(mapParallelTasks)
             }
           }
+        }
+      }
+    }
+    stage('Packaging') {
+      agent none
+      options { skipDefaultCheckout() }
+      when {
+        allOf {
+          expression { return env.GO_MOD_CHANGES == "true" }
+          changeRequest()
+        }
+      }
+      steps {
+        withGithubNotify(context: 'Packaging') {
+          build(job: "Beats/packaging/${env.BRANCH_NAME}", propagate: true,  wait: true)
         }
       }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI]: run packaging if ^go.mod changes (#22383)