### PR TITLE
Cherry-pick to 7.x: Remove what's new and add breaking changes (#22475)

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -20,7 +20,7 @@ include::{libbeat-dir}/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::./release-notes/whats-new.asciidoc[]
+include::./release-notes/redirects.asciidoc[]
 
 include::./communitybeats.asciidoc[]
 

--- a/libbeat/docs/release-notes/breaking/breaking-7.10.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.10.asciidoc
@@ -1,0 +1,17 @@
+[[breaking-changes-7.10]]
+
+=== Breaking changes in 7.10
+++++
+<titleabbrev>7.10</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+No breaking changes.
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.
+

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.10>>
+
 * <<breaking-changes-7.9>>
 
 * <<breaking-changes-7.8>>
@@ -30,6 +32,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.10.asciidoc[]
 
 include::breaking-7.9.asciidoc[]
 

--- a/libbeat/docs/release-notes/redirects.asciidoc
+++ b/libbeat/docs/release-notes/redirects.asciidoc
@@ -1,0 +1,5 @@
+[role="exclude",id="whats-new"]
+== What's new in {beats} {minor-version}
+
+This page has moved. Please see {observability-guide}/whats-new.html[What's new
+in Observability {minor-version}].


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove what's new and add breaking changes (#22475)