### PR TITLE
Creating failing tests, test cases

### DIFF
--- a/filebeat/placeholder/goroutinepanic/run_test.go
+++ b/filebeat/placeholder/goroutinepanic/run_test.go
@@ -1,0 +1,19 @@
+package goroutinepanic
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWrongPanic(t *testing.T) {
+	t.Run("setup failing go-routine", func(t *testing.T) {
+		go func() {
+			time.Sleep(1 * time.Second)
+			t.Fatal("oops")
+		}()
+	})
+
+	t.Run("false positive failure", func(t *testing.T) {
+		time.Sleep(10 * time.Second)
+	})
+}

--- a/filebeat/placeholder/withassert/run_test.go
+++ b/filebeat/placeholder/withassert/run_test.go
@@ -1,0 +1,51 @@
+package withassert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleAssertFails(t *testing.T) {
+	assert.True(t, false)
+}
+
+func TestSimpleAssertWithMessage(t *testing.T) {
+	assert.True(t, false, "My message")
+}
+
+func TestSimpleAssertWithMessagef(t *testing.T) {
+	assert.True(t, false, "My message with arguments: %v", 42)
+}
+
+func TestSimpleRequireFails(t *testing.T) {
+	require.True(t, false)
+}
+
+func TestSimpleRequireWithMessage(t *testing.T) {
+	require.True(t, false, "My message")
+}
+
+func TestSimpleRequireWithMessagef(t *testing.T) {
+	require.True(t, false, "My message with arguments: %v", 42)
+}
+
+func TestFailEqualMaps(t *testing.T) {
+	want := map[string]interface{}{
+		"a": 1,
+		"b": true,
+		"c": "test",
+		"e": map[string]interface{}{
+			"x": "y",
+		},
+	}
+
+	got := map[string]interface{}{
+		"a": 42,
+		"b": false,
+		"c": "test",
+	}
+
+	assert.Equal(t, want, got)
+}

--- a/filebeat/placeholder/withtestlog/run_test.go
+++ b/filebeat/placeholder/withtestlog/run_test.go
@@ -1,0 +1,28 @@
+package withtestlog
+
+import "testing"
+
+func TestLogIsPrintedOnError(t *testing.T) {
+	t.Log("Log message should be printed")
+	t.Logf("printf style log message: %v", 42)
+	t.Error("Log should fail")
+	t.Errorf("Log should fail with printf style log: %v", 23)
+}
+
+func TestLogIsPrintedOnFatal(t *testing.T) {
+	t.Log("Log message should be printed")
+	t.Logf("printf style log message: %v", 42)
+	t.Fatal("Log should fail")
+}
+
+func TestLogIsPrintedOnFatalf(t *testing.T) {
+	t.Log("Log message should be printed")
+	t.Logf("printf style log message: %v", 42)
+	t.Fatalf("Log should fail with printf style log: %v", 42)
+}
+
+func TestLogsWithNewlines(t *testing.T) {
+	t.Log("Log\nmessage\nshould\nbe\nprinted")
+	t.Logf("printf\nstyle\nlog\nmessage:\n%v", 42)
+	t.Fatalf("Log\nshould\nfail\nwith\nprintf\nstyle\nlog:\n%v", 42)
+}


### PR DESCRIPTION
DO NOT MERGE!!!

This PR adds some failing tests to filebeat, in order to check that CI captures the output correctly.

## Case 1 (goroutinepanic) 

This one might be a little flaky. But it seems that a 'badly' scheduled unmanaged go-routine can bring down and flag unrelated tests. The stack trace in the failed test actually matches the original test that did spawn the go-routine. Let's see if we can reconstruct it with a simple test.

## Case 2 (withassert)

We use the testify package for validation. The package adds a newline before the actual report. Let's see if the failures are correctly reported.

Expected sample output:

```
--- FAIL: TestSimpleAssertFails (0.00s)
    run_test.go:11: 
        	Error Trace:	run_test.go:11
        	Error:      	Should be true
        	Test:       	TestSimpleAssertFails
--- FAIL: TestSimpleAssertWithMessage (0.00s)
    run_test.go:15: 
        	Error Trace:	run_test.go:15
        	Error:      	Should be true
        	Test:       	TestSimpleAssertWithMessage
        	Messages:   	My message
--- FAIL: TestSimpleAssertWithMessagef (0.00s)
    run_test.go:19: 
        	Error Trace:	run_test.go:19
        	Error:      	Should be true
        	Test:       	TestSimpleAssertWithMessagef
        	Messages:   	My message with arguments: 42
--- FAIL: TestSimpleRequireFails (0.00s)
    run_test.go:23: 
        	Error Trace:	run_test.go:23
        	Error:      	Should be true
        	Test:       	TestSimpleRequireFails
--- FAIL: TestSimpleRequireWithMessage (0.00s)
    run_test.go:27: 
        	Error Trace:	run_test.go:27
        	Error:      	Should be true
        	Test:       	TestSimpleRequireWithMessage
        	Messages:   	My message
--- FAIL: TestSimpleRequireWithMessagef (0.00s)
    run_test.go:31: 
        	Error Trace:	run_test.go:31
        	Error:      	Should be true
        	Test:       	TestSimpleRequireWithMessagef
        	Messages:   	My message with arguments: 42
--- FAIL: TestFailEqualMaps (0.00s)
    run_test.go:50: 
        	Error Trace:	run_test.go:50
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"a":1, "b":true, "c":"test", "e":map[string]interface {}{"x":"y"}}
        	            	actual  : map[string]interface {}{"a":42, "b":false, "c":"test"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,8 +1,5 @@
        	            	-(map[string]interface {}) (len=4) {
        	            	- (string) (len=1) "a": (int) 1,
        	            	- (string) (len=1) "b": (bool) true,
        	            	- (string) (len=1) "c": (string) (len=4) "test",
        	            	- (string) (len=1) "e": (map[string]interface {}) (len=1) {
        	            	-  (string) (len=1) "x": (string) (len=1) "y"
        	            	- }
        	            	+(map[string]interface {}) (len=3) {
        	            	+ (string) (len=1) "a": (int) 42,
        	            	+ (string) (len=1) "b": (bool) false,
        	            	+ (string) (len=1) "c": (string) (len=4) "test"
        	            	 }
        	Test:       	TestFailEqualMaps
FAIL
exit status 1
```


## Case 3 (withtestlog)

Use `t.Log`, which normally adds no new line. We want to check if Errorf, Fatalf, and message with newlines are reported correctly:

```
--- FAIL: TestLogIsPrintedOnError (0.00s)
    run_test.go:6: Log message should be printed
    run_test.go:7: printf style log message: 42
    run_test.go:8: Log should fail
    run_test.go:9: Log should fail with printf style log: 23
--- FAIL: TestLogIsPrintedOnFatal (0.00s)
    run_test.go:13: Log message should be printed
    run_test.go:14: printf style log message: 42
    run_test.go:15: Log should fail
--- FAIL: TestLogIsPrintedOnFatalf (0.00s)
    run_test.go:19: Log message should be printed
    run_test.go:20: printf style log message: 42
    run_test.go:21: Log should fail with printf style log: 42
--- FAIL: TestLogsWithNewlines (0.00s)
    run_test.go:25: Log
        message
        should
        be
        printed
    run_test.go:26: printf
        style
        log
        message:
        42
    run_test.go:27: Log
        should
        fail
        with
        printf
        style
        log:
        42
FAIL
exit status 1
```