### PR TITLE
Trim down beat name if it's longer than 15 characters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -434,6 +434,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add interval information to `monitor` metricset in azure. {pull}22152[22152]
 - Change Session ID type from int to string {pull}22359[22359]
 - Fix filesystem types on Windows in filesystem metricset. {pull}22531[22531]
+- Fix failiures caused by custom beat names with more than 15 characters {pull}22550[22550]
 
 *Packetbeat*
 

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -43,6 +43,12 @@ func init() {
 func setupMetrics(name string) error {
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
 
+	//if the beat name is longer than 15 characters, truncate it so we don't fail process checks later on
+	// On *nix, the process name comes from /proc/PID/stat, which uses a comm value of 16 bytes, plus the null byte
+	if len(name) > 15 {
+		name = name[:15]
+	}
+
 	beatProcessStats = &process.Stats{
 		Procs:        []string{name},
 		EnvWhitelist: nil,

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -45,7 +45,7 @@ func setupMetrics(name string) error {
 
 	//if the beat name is longer than 15 characters, truncate it so we don't fail process checks later on
 	// On *nix, the process name comes from /proc/PID/stat, which uses a comm value of 16 bytes, plus the null byte
-	if len(name) > 15 {
+	if (runtime.GOOS == "linux" || runtime.GOOS == "darwin") && len(name) > 15 {
 		name = name[:15]
 	}
 


### PR DESCRIPTION


## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/21297

If a beat name is longer than 15 characters on *nix systems, it won't match the process name found by the libbeat metrics tools, which will cause the beat to bomb out. If the beat name exceeds the name in `/proc/self/comm`, then truncate it.

## Why is it important?

Custom beats with long names can fail.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- create a beat with a name longer than 15 characters
- build, make sure it runs.

## Related issues

-  https://github.com/elastic/beats/issues/21297


