### PR TITLE
[Filebeat] Disable harvester detailed metrics by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,7 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
-- Disable detailed harvester metrics by default, put it behind a `detailed_metrics` configuration option. {issue}19745[19745] {pull}[]
+- Disable detailed harvester metrics by default, put it behind a `detailed_metrics` configuration option. {issue}19745[19745] {pull}22555[22555]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
+- Disable detailed harvester metrics by default, put it behind a `detailed_metrics` configuration option. {issue}19745[19745] {pull}[]
 
 *Auditbeat*
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -193,6 +193,9 @@ filebeat.inputs:
   # Default is 0 which means unlimited
   #harvester_limit: 0
 
+  # Enable detailed harvester metrics.
+  #detailed_metrics: true
+
   ### Harvester closing options
 
   # Close inactive closes the file handler after the predefined period.

--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -77,10 +77,10 @@ certain criteria or time. Closing the harvester means closing the file handler.
 If a file is updated after the harvester is closed, the file will be picked up
 again after `scan_frequency` has elapsed. However, if the file is moved or
 deleted while the harvester is closed, {beatname_uc} will not be able to pick up
-the file again, and any data that the harvester hasn't read will be lost. 
-The `close_*` settings are applied synchronously when {beatname_uc} attempts 
+the file again, and any data that the harvester hasn't read will be lost.
+The `close_*` settings are applied synchronously when {beatname_uc} attempts
 to read from a file, meaning that if {beatname_uc} is in a blocked state
-due to blocked output, full queue or other issue, a file that would 
+due to blocked output, full queue or other issue, a file that would
 otherwise be closed remains open until {beatname_uc} once again attempts to read from the file.
 
 
@@ -240,7 +240,7 @@ that should be removed based on the `clean_inactive` setting. This happens
 because {beatname_uc} doesn't remove the entries until it opens the registry
 again to read a different file. If you are testing the `clean_inactive` setting,
 make sure {beatname_uc} is configured to read from more than one file, or the
-file state will never be removed from the registry. 
+file state will never be removed from the registry.
 
 [float]
 [id="{beatname_lc}-input-{type}-clean-removed"]
@@ -257,6 +257,13 @@ registry file. In such cases, we recommend that you disable the `clean_removed`
 option.
 
 You must disable this option if you also disable `close_removed`.
+
+[float]
+[id="{beatname_lc}-input-{type}-detailed-metrics"]
+===== `detailed_metrics`
+
+When this option is enabled, {beatname_uc} reports detailed harvester metrics
+for every file it is watching.
 
 [float]
 [id="{beatname_lc}-input-{type}-scan-frequency"]

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -580,6 +580,9 @@ filebeat.inputs:
   # Default is 0 which means unlimited
   #harvester_limit: 0
 
+  # Enable detailed harvester metrics.
+  #detailed_metrics: true
+
   ### Harvester closing options
 
   # Close inactive closes the file handler after the predefined period.

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -45,17 +45,18 @@ type config struct {
 	CleanInactive time.Duration `config:"clean_inactive" validate:"min=0"`
 
 	// Input
-	Enabled        bool                    `config:"enabled"`
-	ExcludeFiles   []match.Matcher         `config:"exclude_files"`
-	IgnoreOlder    time.Duration           `config:"ignore_older"`
-	Paths          []string                `config:"paths"`
-	ScanFrequency  time.Duration           `config:"scan_frequency" validate:"min=0,nonzero"`
-	CleanRemoved   bool                    `config:"clean_removed"`
-	HarvesterLimit uint32                  `config:"harvester_limit" validate:"min=0"`
-	Symlinks       bool                    `config:"symlinks"`
-	TailFiles      bool                    `config:"tail_files"`
-	RecursiveGlob  bool                    `config:"recursive_glob.enabled"`
-	FileIdentity   *common.ConfigNamespace `config:"file_identity"`
+	Enabled         bool                    `config:"enabled"`
+	ExcludeFiles    []match.Matcher         `config:"exclude_files"`
+	IgnoreOlder     time.Duration           `config:"ignore_older"`
+	Paths           []string                `config:"paths"`
+	ScanFrequency   time.Duration           `config:"scan_frequency" validate:"min=0,nonzero"`
+	CleanRemoved    bool                    `config:"clean_removed"`
+	HarvesterLimit  uint32                  `config:"harvester_limit" validate:"min=0"`
+	Symlinks        bool                    `config:"symlinks"`
+	DetailedMetrics bool                    `config:"detailed_metrics"`
+	TailFiles       bool                    `config:"tail_files"`
+	RecursiveGlob   bool                    `config:"recursive_glob.enabled"`
+	FileIdentity    *common.ConfigNamespace `config:"file_identity"`
 
 	// Harvester
 	BufferSize int    `config:"harvester_buffer_size"`

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2016,6 +2016,9 @@ filebeat.inputs:
   # Default is 0 which means unlimited
   #harvester_limit: 0
 
+  # Enable detailed harvester metrics.
+  #detailed_metrics: true
+
   ### Harvester closing options
 
   # Close inactive closes the file handler after the predefined period.


### PR DESCRIPTION
## What does this PR do?

This disables the detailed filebeat harvester metrics added in https://github.com/elastic/beats/pull/13395 by default. In order to enable them, you need to set a `detailed_metrics` configuration option to `true`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #19745