### PR TITLE
Cherry-pick #22538 to 7.x: Remove unexpected source URLs from the dependencies report

### DIFF
--- a/dev-tools/notice/dependencies.csv.tmpl
+++ b/dev-tools/notice/dependencies.csv.tmpl
@@ -1,6 +1,6 @@
 {{- define "depInfo" -}}
 {{- range $i, $dep := . }}
-{{ $dep.Name }},{{ $dep.URL }},{{ $dep.Version | canonicalVersion }},{{ $dep.Version | revision }},{{ $dep.LicenceType }},{{ $dep.URL }}
+{{ $dep.Name }},{{ $dep.URL }},{{ $dep.Version | canonicalVersion }},{{ $dep.Version | revision }},{{ $dep.LicenceType }},
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Cherry-pick of PR #22538 to 7.x branch. Original message: 

Source URLs should be specified only for dependencies that we are
re-hosting. Remove them from all the Go dependencies, that are obtained
from mainstream URLs.

Source URLs were added to the dependencies report in #21374.