### PR TITLE
Packetbeat agent interface and procs configuration

### DIFF
--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -42,10 +42,30 @@ streams:
     timeout: 10s
     period: 10s
     keep_null: false
+    interface:
+      device: thisisignoredfornow
+      snaplen: 1514
+      type: af_packet
+      buffer_size_mb: 100
+    procs:
+      enabled: true
+      monitored:
+        - process: mysqld
+          cmdline_grep: mysqld
     data_stream:
       dataset: packet.flow
       type: logs
   - type: icmp
+    interface:
+      device: en1
+      snaplen: 1514
+      type: af_packet
+      buffer_size_mb: 100
+    procs:
+      enabled: true
+      monitored:
+        - process: postgresql
+          cmdline_grep: postgresql
     data_stream:
       dataset: packet.icmp
       type: logs
@@ -61,4 +81,6 @@ streams:
 	var protocol map[string]interface{}
 	require.NoError(t, config.ProtocolsList[0].Unpack(&protocol))
 	require.Len(t, protocol["processors"].([]interface{}), 3)
+	require.Equal(t, config.Interfaces.Device, "en1")
+	require.Len(t, config.Procs.Monitored, 2)
 }


### PR DESCRIPTION
## What does this PR do?

This PR acts as a stop-gap to allow for grouped streams to configure a packetbeat sniffer. As discussed in https://github.com/elastic/beats/issues/22227 this currently does the (dumb) thing of just grabbing an interface configuration from any of the streams -- so if you have multiple streams specified, you should make sure they all have the same interface configuration. The next step will be to do some additional lifecycle management changes and spin off new packet sniffers based on configurations that differ, removing the coupling.

I put in a couple of tests to demonstrate the funky, but currently expected, behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Relates #22227

