### PR TITLE
Remove quotes

### DIFF
--- a/filebeat/docs/inputs/input-container.asciidoc
+++ b/filebeat/docs/inputs/input-container.asciidoc
@@ -21,7 +21,7 @@ Example configuration:
 {beatname_lc}.inputs:
 - type: container
   paths: <1>
-    - '/var/lib/docker/containers/*/*.log'
+    - /var/lib/docker/containers/*/*.log
 ----
 
 <1> `paths` is required. All other settings are optional.
@@ -51,7 +51,7 @@ all containers under the default Kubernetes logs path:
 - type: container
   stream: stdout
   paths:
-    - "/var/log/containers/*.log"
+    - /var/log/containers/*.log
 ----
 
 include::../inputs/input-common-harvester-options.asciidoc[]


### PR DESCRIPTION
The default for YAML is to not use quotes, so I removed the two different types for consistency from the code blocks.

## Why is it important?

We should have consistent messaging in our documentation, so using the default of no quotes would be best and most consistent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

 ~~- [ ] My code follows the style guidelines of this project ~~
 ~~- [ ] I have commented my code, particularly in hard-to-understand areas ~~
- [Y ] I have made corresponding changes to the documentation
 ~~- [ ] I have made corresponding change to the default configuration files ~~
 ~~- [ ] I have added tests that prove my fix is effective or that my feature works
 ~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`. ~~

## Author's Checklist

- [ ] Verify code works

## How to test this PR locally

N/A

## Related issues

N/A

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A