### PR TITLE
Cherry-pick #22543 to 7.x: [Elastic Agent] Fix sysv init files for deb/rpm installation

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -59,7 +59,7 @@ shared:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl'
         mode: 0644
       /etc/init.d/{{.BeatServiceName}}:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl'
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/elastic-agent.sh.tmpl'
         mode: 0755
       /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}

--- a/dev-tools/packaging/templates/deb/elastic-agent.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/elastic-agent.sh.tmpl
@@ -1,0 +1,161 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          {{.ServiceName}}
+# Required-Start:    $local_fs $network $syslog
+# Required-Stop:     $local_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: {{.Description}}
+# Description:       {{.BeatName | title}} is a shipper part of the Elastic Beats
+#                    family. Please see: https://www.elastic.co/products/beats
+### END INIT INFO
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="{{.Description}}"
+NAME="{{.BeatName}}"
+DAEMON=/usr/share/${NAME}/bin/${NAME}
+DAEMON_ARGS="-c /etc/${NAME}/${NAME}.yml --path.home /usr/share/${NAME} --path.config /etc/${NAME} --path.logs /var/log/${NAME}"
+PIDFILE=/var/run/{{.ServiceName}}.pid
+WRAPPER="/usr/share/${NAME}/bin/${NAME}-god"
+BEAT_USER="{{.BeatUser}}"
+WRAPPER_ARGS="-r / -n -p $PIDFILE"
+SCRIPTNAME=/etc/init.d/{{.ServiceName}}
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/{{.ServiceName}} ] && . /etc/default/{{.ServiceName}}
+
+[ "$BEAT_USER" != "root" ] && WRAPPER_ARGS="$WRAPPER_ARGS -u $BEAT_USER"
+USER_WRAPPER="su"
+USER_WRAPPER_ARGS="$BEAT_USER -c"
+
+if command -v runuser >/dev/null 2>&1; then
+    USER_WRAPPER="runuser"
+fi
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start \
+                --pidfile $PIDFILE  \
+		--exec $WRAPPER -- $WRAPPER_ARGS -- $DAEMON $DAEMON_ARGS \
+		|| return 2
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --pidfile $PIDFILE --exec $WRAPPER
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --exec $DAEMON
+	return 0
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc "$WRAPPER" "$NAME" && exit 0 || exit $?
+       ;;
+  #reload|force-reload)
+	#
+	# If do_reload() is not implemented then leave this commented out
+	# and leave 'force-reload' as an alias for 'restart'.
+	#
+	#log_daemon_msg "Reloading $DESC" "$NAME"
+	#do_reload
+	#log_end_msg $?
+	#;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/dev-tools/packaging/templates/rpm/elastic-agent.sh.tmpl
+++ b/dev-tools/packaging/templates/rpm/elastic-agent.sh.tmpl
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# {{.ServiceName}}          {{.BeatName}} shipper
+#
+# chkconfig: 2345 98 02
+# description: Starts and stops a single {{.BeatName}} instance on this system
+#
+
+### BEGIN INIT INFO
+# Provides:          {{.ServiceName}}
+# Required-Start:    $local_fs $network $syslog
+# Required-Stop:     $local_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: {{.Description}}
+# Description:       {{.BeatName | title}} is a shipper part of the Elastic Beats
+#                    family. Please see: https://www.elastic.co/products/beats
+### END INIT INFO
+
+
+
+PATH=/usr/bin:/sbin:/bin:/usr/sbin
+export PATH
+
+[ -f /etc/sysconfig/{{.ServiceName}} ] && . /etc/sysconfig/{{.ServiceName}}
+pidfile=${PIDFILE-/var/run/{{.ServiceName}}.pid}
+agent=${BEATS_AGENT-/usr/share/{{.BeatName}}/bin/{{.BeatName}}}
+args="-c /etc/{{.BeatName}}/{{.BeatName}}.yml --path.home /usr/share/{{.BeatName}} --path.config /etc/{{.BeatName}} --path.logs /var/log/{{.BeatName}}"
+beat_user="${BEAT_USER:-{{.BeatUser}}}"
+wrapper="/usr/share/{{.BeatName}}/bin/{{.BeatName}}-god"
+wrapperopts="-r / -n -p $pidfile"
+user_wrapper="su"
+user_wrapperopts="$beat_user -c"
+RETVAL=0
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Determine if we can use the -p option to daemon, killproc, and status.
+# RHEL < 5 can't.
+if status | grep -q -- '-p' 2>/dev/null; then
+    daemonopts="--pidfile $pidfile"
+    pidopts="-p $pidfile"
+fi
+
+if command -v runuser >/dev/null 2>&1; then
+    user_wrapper="runuser"
+fi
+
+[ "$beat_user" != "root" ] && wrapperopts="$wrapperopts -u $beat_user"
+
+start() {
+    echo -n $"Starting {{.BeatName}}: "
+	if [ $? -ne 0 ]; then
+		echo
+		exit 1
+	fi
+    daemon $daemonopts $wrapper $wrapperopts -- $agent $args
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping {{.BeatName}}: "
+    killproc $pidopts $wrapper
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${pidfile}
+}
+
+restart() {
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+    stop
+    start
+}
+
+rh_status() {
+    status $pidopts $wrapper
+    RETVAL=$?
+    return $RETVAL
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    restart)
+        restart
+    ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+    ;;
+    status)
+        rh_status
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -26,6 +26,7 @@
 - Ensure shell wrapper path exists before writing wrapper on install {pull}22144[22144]
 - Fix deb/rpm packaging for Elastic Agent {pull}22153[22153]
 - Fix composable input processor promotion to fix duplicates {pull}22344[22344]
+- Fix sysv init files for deb/rpm installation {pull}22543[22543]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #22543 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the sysv init files so it works on deb/rpm systems that use sysv and not systemd.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So deb/rpm work on sysv init systems.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #22360
- Closes #22485
