### PR TITLE
Minor Typo in Deploying to Kubernetes Docs

### DIFF
--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -203,4 +203,4 @@ Metrics should start flowing to Elasticsearch.
 The size and the number of nodes in a Kubernetes cluster can be fairly large at times, and in such cases
 the Pod that will be collecting cluster level metrics might face performance issues due to
 resources limitations. In this case users might consider to avoid using the leader election strategy
-and instead run a dedicated, standalone Metricbeat instance using a Deployment in addition to the DaemonSet.
+and instead run a dedicated, standalone {beatname_uc} instance using a Deployment in addition to the DaemonSet.

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -203,4 +203,4 @@ Metrics should start flowing to Elasticsearch.
 The size and the number of nodes in a Kubernetes cluster can be fairly large at times, and in such cases
 the Pod that will be collecting cluster level metrics might face performance issues due to
 resources limitations. In this case users might consider to avoid using the leader election strategy
-and instead run a dedicated, standalone Metribceat instance using a Deployment in addition to the DaemonSet.
+and instead run a dedicated, standalone Metricbeat instance using a Deployment in addition to the DaemonSet.


### PR DESCRIPTION
Metribceat -> Metricbeat

Type of change: Docs

## What does this PR do?

Fixed minor typo changing Metribceat to Metricbeat in last paragraph of Metricbeat on Kubernetes Documentation

## Why is it important?

Just makes the documentation look better :)

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

N/A

## How to test this PR locally

N/A

## Related issues

N/A - Did not see an open issue for this at a cursory glance through the currently open issues


## Use cases

N/A

## Screenshots

N/A

## Logs

N/A
