### PR TITLE
[CI] filter static versus ephemeral workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -687,7 +687,14 @@ def notifyBuildReason() {
 */
 def withNode(def label, Closure body) {
   def uuid = UUID.randomUUID().toString()
-  def labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
+  def labels
+  // There are immutable workers and static ones, so the static ones are only metal, macosx and arm
+  if (label.contains('arm') || label.contains('macosx') || label.contains('metal')) {
+    labels = label
+  } else {
+    // Otherwise use the dynamic UUID for the gobld
+    labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
+  }
   node("${labels}") {
     body()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -683,16 +683,16 @@ def notifyBuildReason() {
 
 /**
 * Guarantee a specific worker can only be used for a specific build. This was not the case
-* with the customise node provisioner that reuses workers when there is peak load.
+* with the customise node provisioner that reuses workers in some cases when there is a peak load.
 */
 def withNode(def label, Closure body) {
-  def uuid = UUID.randomUUID().toString()
   def labels
   // There are immutable workers and static ones, so the static ones are only metal, macosx and arm
   if (label.contains('arm') || label.contains('macosx') || label.contains('metal')) {
     labels = label
   } else {
     // Otherwise use the dynamic UUID for the gobld
+    def uuid = UUID.randomUUID().toString()
     labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
   }
   node("${labels}") {


### PR DESCRIPTION
## What does this PR do?

Detect whether the workers ares ephemeral or static then the new labels are not required for the last one.

## Why is it important?

Avoid builds in the branches that cannot allocate for the resources

## Test

![image](https://user-images.githubusercontent.com/2871786/99377272-eb819480-28bd-11eb-9d25-bddb03c4e2f4.png)
