### PR TITLE
Add json parsing doc section for Filebeat on Kubernetes

### DIFF
--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -151,7 +151,7 @@ Example log:
 {"type":"log","@timestamp":"2020-11-16T14:30:13+00:00","tags":["warning","plugins","licensing"],"pid":7,"message":"License information could not be obtained from Elasticsearch due to Error: No Living connections error"}
 ```
 
-1. Using `decode_json_fields` processor:
+====== Using `decode_json_fields` processor
 
 [source,yaml]
 ------------------------------------------------
@@ -184,7 +184,7 @@ filebeat.autodiscover:
 ------------------------------------------------
 
 
-2. Using `json.*` options:
+====== Using `json.*` options
 
 [source,yaml]
 ------------------------------------------------
@@ -216,7 +216,7 @@ filebeat.autodiscover:
                       add_error_key: true
 ------------------------------------------------
 
-3. Using `json.*` options with hints:
+====== Using `json.*` options with hints
 
 Key part here is to properly annotate the Pod to only parse logs of the correct container
 as json logs. In this, annotation should be constructed like this:

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -151,8 +151,8 @@ Example log:
 {"type":"log","@timestamp":"2020-11-16T14:30:13+00:00","tags":["warning","plugins","licensing"],"pid":7,"message":"License information could not be obtained from Elasticsearch due to Error: No Living connections error"}
 ```
 
-====== Using `decode_json_fields` processor
-
+. Using `decode_json_fields` processor
++
 [source,yaml]
 ------------------------------------------------
 filebeat.autodiscover:
@@ -184,8 +184,8 @@ filebeat.autodiscover:
 ------------------------------------------------
 
 
-====== Using `json.*` options
-
+. Using `json.*` options
++
 [source,yaml]
 ------------------------------------------------
 filebeat.autodiscover:
@@ -216,15 +216,15 @@ filebeat.autodiscover:
                       add_error_key: true
 ------------------------------------------------
 
-====== Using `json.*` options with hints
-
+. Using `json.*` options with hints
++
 Key part here is to properly annotate the Pod to only parse logs of the correct container
 as json logs. In this, annotation should be constructed like this:
-
++
 `co.elastic.logs.<container_name>/json.keys_under_root: "true"`
-
++
 Autodiscovery configuration:
-
++
 [source,yaml]
 ------------------------------------------------
 filebeat.autodiscover:
@@ -237,9 +237,9 @@ filebeat.autodiscover:
         paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
 ------------------------------------------------
-
++
 Then annotate the pod properly:
-
++
 [source,yaml]
 ------------------------------------------------
 annotations:

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -22,10 +22,10 @@ to ensure there's a running instance on each node of the cluster.
 
 The Docker logs host folder (`/var/lib/docker/containers`) is mounted on the
 {beatname_uc} container. {beatname_uc} starts an input for the files and
-begins harvesting them as soon as they appear in the folder. 
+begins harvesting them as soon as they appear in the folder.
 
 Everything is deployed under the `kube-system` namespace by default. To change
-the namespace, modify the manifest file. 
+the namespace, modify the manifest file.
 
 To download the manifest file, run:
 
@@ -110,7 +110,7 @@ oc patch namespace kube-system -p \
 ----
 +
 This command sets the node selector for the project to an empty string. If you
-don't run this command, the default node selector will skip master nodes.  
+don't run this command, the default node selector will skip master nodes.
 
 
 [float]
@@ -135,3 +135,115 @@ filebeat   32        32        0         32           0           <none>        
 
 Log events should start flowing to Elasticsearch. The events are annotated with
 metadata added by the <<add-kubernetes-metadata>> processor.
+
+
+[float]
+==== Parsing json logs
+
+It is common case when collecting logs from workloads running on Kubernetes that these
+applications are logging in json format. In these case, special handling can be applied so as to
+parse these json logs properly and decode them into fields. Bellow there are provided 3 different ways
+of configuring <<configuration-autodiscover, filebeat's autodiscover>> so as to identify and parse json logs.
+We will use an example of one Pod with 2 containers where only one of these logs in json format.
+
+Example log:
+```
+{"type":"log","@timestamp":"2020-11-16T14:30:13+00:00","tags":["warning","plugins","licensing"],"pid":7,"message":"License information could not be obtained from Elasticsearch due to Error: No Living connections error"}
+```
+
+1. Using `decode_json_fields` processor:
+
+[source,yaml]
+------------------------------------------------
+filebeat.autodiscover:
+  providers:
+      - type: kubernetes
+        node: ${NODE_NAME}
+        templates:
+          - condition:
+              contains:
+                kubernetes.container.name: "no-json-logging"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+          - condition:
+              contains:
+                kubernetes.container.name: "json-logging"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+                processors:
+                  - decode_json_fields:
+                      fields:
+                        - message
+                      target: ""
+                      overwrite_keys: true
+                      add_error_key: true
+------------------------------------------------
+
+
+2. Using `json.*` options:
+
+[source,yaml]
+------------------------------------------------
+filebeat.autodiscover:
+  providers:
+      - type: kubernetes
+        node: ${NODE_NAME}
+        templates:
+          - condition:
+              contains:
+                kubernetes.container.name: "no-json-logging"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+          - condition:
+              contains:
+                kubernetes.container.name: "json-logging"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+                processors:
+                  - decode_json_fields:
+                      fields:
+                        - message
+                      target: ""
+                      overwrite_keys: true
+                      add_error_key: true
+------------------------------------------------
+
+3. Using `json.*` options with hints:
+
+Key part here is to properly annotate the Pod to only parse logs of the correct container
+as json logs. In this, annotation should be constructed like this:
+
+`co.elastic.logs.<container_name>/json.keys_under_root: "true"`
+
+Autodiscovery configuration:
+
+[source,yaml]
+------------------------------------------------
+filebeat.autodiscover:
+  providers:
+    - type: kubernetes
+      node: ${NODE_NAME}
+      hints.enabled: true
+      hints.default_config:
+        type: container
+        paths:
+          - /var/log/containers/*${data.kubernetes.container.id}.log
+------------------------------------------------
+
+Then annotate the pod properly:
+
+[source,yaml]
+------------------------------------------------
+annotations:
+    co.elastic.logs.json-logging/json.keys_under_root: "true"
+    co.elastic.logs.json-logging/json.add_error_key: "true"
+    co.elastic.logs.json-logging/json.message_key: "message"
+------------------------------------------------

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -142,7 +142,7 @@ metadata added by the <<add-kubernetes-metadata>> processor.
 
 It is common case when collecting logs from workloads running on Kubernetes that these
 applications are logging in json format. In these case, special handling can be applied so as to
-parse these json logs properly and decode them into fields. Bellow there are provided 3 different ways
+parse these json logs properly and decode them into fields. Bellow there are provided 2 different ways
 of configuring <<configuration-autodiscover, filebeat's autodiscover>> so as to identify and parse json logs.
 We will use an example of one Pod with 2 containers where only one of these logs in json format.
 
@@ -151,7 +151,8 @@ Example log:
 {"type":"log","@timestamp":"2020-11-16T14:30:13+00:00","tags":["warning","plugins","licensing"],"pid":7,"message":"License information could not be obtained from Elasticsearch due to Error: No Living connections error"}
 ```
 
-. Using `decode_json_fields` processor
+
+. Using `json.*` options with templates
 +
 [source,yaml]
 ------------------------------------------------
@@ -174,46 +175,9 @@ filebeat.autodiscover:
               - type: container
                 paths:
                   - "/var/log/containers/*-${data.kubernetes.container.id}.log"
-                processors:
-                  - decode_json_fields:
-                      fields:
-                        - message
-                      target: ""
-                      overwrite_keys: true
-                      add_error_key: true
-------------------------------------------------
-
-
-. Using `json.*` options
-+
-[source,yaml]
-------------------------------------------------
-filebeat.autodiscover:
-  providers:
-      - type: kubernetes
-        node: ${NODE_NAME}
-        templates:
-          - condition:
-              contains:
-                kubernetes.container.name: "no-json-logging"
-            config:
-              - type: container
-                paths:
-                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
-          - condition:
-              contains:
-                kubernetes.container.name: "json-logging"
-            config:
-              - type: container
-                paths:
-                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
-                processors:
-                  - decode_json_fields:
-                      fields:
-                        - message
-                      target: ""
-                      overwrite_keys: true
-                      add_error_key: true
+                json.keys_under_root: true
+                json.add_error_key: true
+                json.message_key: message
 ------------------------------------------------
 
 . Using `json.*` options with hints


### PR DESCRIPTION
Adds documentation section about json parsing for Filebeat on Kubernetes.

Closes https://github.com/elastic/beats/issues/22516


@dedemorton  do you think I should add it in the new docs guide we are preparing?