### PR TITLE
[CI] one shot workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -688,13 +688,15 @@ def notifyBuildReason() {
 def withNode(def label, Closure body) {
   def labels
   // There are immutable workers and static ones, so the static ones are only metal, macosx and arm
-  if (label.contains('arm') || label.contains('macosx') || label.contains('metal')) {
+  if (label?.contains('arm') || label?.contains('macosx') || label?.contains('metal')) {
     labels = label
   } else {
     // Otherwise use the dynamic UUID for the gobld
     def uuid = UUID.randomUUID().toString()
+    // Ensure no double quotes are added to the labels.
     labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
   }
+  log(level: 'INFO', text: "Allocating a worker with the labels '${labels}'.")
   node("${labels}") {
     body()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -683,11 +683,18 @@ def notifyBuildReason() {
 
 /**
 * Guarantee a specific worker can only be used for a specific build. This was not the case
-* with the customise node provisioner that reuses workers when there is peak load.
+* with the customise node provisioner that reuses workers in some cases when there is a peak load.
 */
 def withNode(def label, Closure body) {
-  def uuid = UUID.randomUUID().toString()
-  def labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
+  def labels
+  // There are immutable workers and static ones, so the static ones are only metal, macosx and arm
+  if (label.contains('arm') || label.contains('macosx') || label.contains('metal')) {
+    labels = label
+  } else {
+    // Otherwise use the dynamic UUID for the gobld
+    def uuid = UUID.randomUUID().toString()
+    labels = label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}"
+  }
   node("${labels}") {
     body()
   }


### PR DESCRIPTION
## What does this PR do?

Use dynamic labels to assign one shot workers

## Why is it important?

To avoid any environmental issues if any with the provisioner.

## Test


I'll run a few times this PR to validate it works as expected