### PR TITLE
Cherry-pick #21296 to 7.10: Skip flaky test TestClientPublishEventKerberosAware

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -55,6 +55,8 @@ func TestClientPublishEvent(t *testing.T) {
 }
 
 func TestClientPublishEventKerberosAware(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/21295")
+
 	err := setupRoleMapping(t, eslegtest.GetEsKerberosHost())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Cherry-pick of PR #21296 to 7.10 branch. Original message: 

It is frequently failing, more info here: https://github.com/elastic/beats/issues/21295