### PR TITLE
Cherry-pick #22616 to 7.10: Skip some flaky tests

### DIFF
--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -1,13 +1,15 @@
 # coding=utf-8
 
-from filebeat import BaseTest
-import os
-import codecs
-import time
 import base64
+import codecs
 import io
+import os
+import platform
 import re
+import time
 import unittest
+
+from filebeat import BaseTest
 from parameterized import parameterized
 
 """
@@ -17,6 +19,7 @@ Test Harvesters
 
 class Test(BaseTest):
 
+    @unittest.skipIf(platform.system() == 'Windows', 'Flaky test: https://github.com/elastic/beats/issues/22613')
     def test_close_renamed(self):
         """
         Checks that a file is closed when its renamed / rotated

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1219,6 +1219,7 @@ class Test(BaseTest):
         # Check that offset is set to the end of the file
         assert data[0]["offset"] == os.path.getsize(testfile_path1)
 
+    @unittest.skipIf(platform.system() == 'Darwin', 'Flaky test: https://github.com/elastic/beats/issues/22407')
     def test_ignore_older_state_clean_inactive(self):
         """
         Check that state for ignore_older is not persisted when falling under clean_inactive

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk_integration_test.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk_integration_test.go
@@ -24,9 +24,14 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/mb/testing/flags"
 )
 
 func TestData(t *testing.T) {
+	if !*flags.DataFlag {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/22612")
+	}
+
 	service := compose.EnsureUpWithTimeout(t, 120, "ceph-api")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))

--- a/metricbeat/module/ceph/cluster_health/cluster_health_integration_test.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health_integration_test.go
@@ -24,9 +24,14 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/mb/testing/flags"
 )
 
 func TestData(t *testing.T) {
+	if !*flags.DataFlag {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/22612")
+	}
+
 	service := compose.EnsureUpWithTimeout(t, 120, "ceph-api")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))

--- a/metricbeat/module/ceph/cluster_status/cluster_status_integration_test.go
+++ b/metricbeat/module/ceph/cluster_status/cluster_status_integration_test.go
@@ -24,9 +24,14 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/beats/v7/metricbeat/mb/testing/flags"
 )
 
 func TestData(t *testing.T) {
+	if !*flags.DataFlag {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/22612")
+	}
+
 	service := compose.EnsureUpWithTimeout(t, 120, "ceph-api")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))

--- a/metricbeat/module/windows/service/reader_test.go
+++ b/metricbeat/module/windows/service/reader_test.go
@@ -55,6 +55,8 @@ func TestGetMachineGUID(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/22171")
+
 	reader, err := NewReader()
 	assert.NoError(t, err)
 	result, err := reader.Read()

--- a/metricbeat/module/windows/service/service_status_test.go
+++ b/metricbeat/module/windows/service/service_status_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestGetServiceStates(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/22172")
+
 	handle, err := openSCManager("", "", ScManagerEnumerateService|ScManagerConnect)
 	assert.NoError(t, err)
 	assert.NotEqual(t, handle, InvalidDatabaseHandle)


### PR DESCRIPTION
Cherry-pick of PR #22616 to 7.10 branch. Original message: 

Skip flaky tests reported in these issues:
* https://github.com/elastic/beats/issues/22613
* https://github.com/elastic/beats/issues/22407
* https://github.com/elastic/beats/issues/22612
* https://github.com/elastic/beats/issues/22171
* https://github.com/elastic/beats/issues/22172