### PR TITLE
Fix docs about starting and stopping agent

### DIFF
--- a/x-pack/elastic-agent/docs/elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/elastic-agent.asciidoc
@@ -19,6 +19,7 @@ To learn how to install, configure, and run your {agent}s, see:
 * <<uninstall-elastic-agent>>
 * <<upgrade-elastic-agent>>
 * <<run-elastic-agent-standalone>>
+* <<start-elastic-agent>>
 * <<stop-elastic-agent>>
 * <<unenroll-elastic-agent>>
 * <<elastic-agent-cmd-options>>
@@ -31,6 +32,8 @@ include::uninstall-elastic-agent.asciidoc[leveloffset=+1]
 include::upgrade-elastic-agent.asciidoc[leveloffset=+1]
 
 include::run-elastic-agent-standalone.asciidoc[leveloffset=+1]
+
+include::start-elastic-agent.asciidoc[leveloffset=+1]
 
 include::stop-elastic-agent.asciidoc[leveloffset=+1]
 

--- a/x-pack/elastic-agent/docs/start-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/start-elastic-agent.asciidoc
@@ -1,0 +1,11 @@
+[[start-elastic-agent]]
+[role="xpack"]
+= Start {agent}
+
+If you've stopped the {agent} service and want to restart it, use the commands
+that work with your system:
+
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/start-widget.asciidoc[]
+
+// Add Javascript and CSS for tabbed panels
+include::tab-widgets/code.asciidoc[]

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -3,7 +3,7 @@
 = Stop {agent}
 
 To stop {agent} and its related executables, stop the {agent} service. Use the
-commands that work for your system. 
+commands that work with your system: 
 
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc[]
 

--- a/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
+++ b/x-pack/elastic-agent/docs/stop-elastic-agent.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Stop {agent}
 
-To stop {agent} and its related executables, stop the {agent} process. Use the
+To stop {agent} and its related executables, stop the {agent} service. Use the
 commands that work for your system. 
 
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/stop-widget.asciidoc[]

--- a/x-pack/elastic-agent/docs/tab-widgets/start-widget.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/start-widget.asciidoc
@@ -1,0 +1,94 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="start the agent">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-start"
+            id="mac-start">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start"
+            id="linux-start"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start"
+            id="win-start"
+            tabindex="-1">
+      Windows
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="deb-tab-start"
+            id="deb-start"
+            tabindex="-1">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start"
+            id="rpm-start"
+            tabindex="-1">
+      RPM
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start"
+       aria-labelledby="mac-start">
+++++
+
+include::start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start"
+       aria-labelledby="linux-start"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start"
+       aria-labelledby="win-start"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=win]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start"
+       aria-labelledby="deb-start"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start"
+       aria-labelledby="rpm-start"
+       hidden="">
+++++
+
+include::start.asciidoc[tag=rpm]
+
+++++
+  </div>
+</div>
+++++

--- a/x-pack/elastic-agent/docs/tab-widgets/start.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/start.asciidoc
@@ -1,0 +1,57 @@
+// tag::deb[]
+
+The DEB package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands.
+
+// tag::start-command[]
+Use `systemctl` to start the agent:
+
+[source,shell]
+----
+sudo systemctl start elastic-agent
+----
+
+Otherwise, use:
+
+[source,shell]
+----
+sudo service elastic-agent start
+----
+// end::start-command[]
+
+// end::deb[]
+
+// tag::rpm[]
+The RPM package includes a service unit for Linux systems with systemd. On these
+systems, you can manage {agent} by using the usual systemd commands.
+
+include::start.asciidoc[tag=start-command]
+
+// end::rpm[]
+
+// tag::mac[]
+
+[source,shell]
+----
+sudo launchctl load /Library/LaunchDaemons/co.elastic.elastic-agent.plist
+----
+
+// end::mac[]
+
+// tag::linux[]
+
+[source,shell]
+----
+sudo service elastic-agent start
+----
+
+// end::linux[]
+
+// tag::win[]
+
+[source,shell]
+----
+Start-Service elastic-agent
+----
+
+// end::win[]

--- a/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/stop.asciidoc
@@ -8,7 +8,7 @@ Use `systemctl` to stop the agent:
 
 [source,shell]
 ----
-systemctl stop elastic-agent
+sudo systemctl stop elastic-agent
 ----
 
 Otherwise, use:
@@ -33,35 +33,28 @@ include::stop.asciidoc[tag=stop-command]
 // end::rpm[]
 
 // tag::mac[]
-// tag::kill-process[]
-Get the process ID (PID) of the `elastic-agent` process:
 
 [source,shell]
 ----
-ps | grep elastic-agent <1>
-----
-<1> Make sure you list processes as the root user.
-
-Then kill the process, replacing the PID in this example with the PID from
-the grep command:
-
-[source,shell]
-----
-kill -9 90682
+sudo launchctl unload /Library/LaunchDaemons/co.elastic.elastic-agent.plist
 ----
 
 NOTE: {agent} will restart automatically if the system is rebooted.
 
-// end::kill-process[]
 // end::mac[]
 
 // tag::linux[]
-include::stop.asciidoc[tag=kill-process]
+[source,shell]
+----
+sudo service elastic-agent stop
+----
+
+NOTE: {agent} will restart automatically if the system is rebooted.
+
 // end::linux[]
 
 // tag::win[]
 
-If you installed {agent} as a service, stop the service. 
 [source,shell]
 ----
 Stop-Service elastic-agent

--- a/x-pack/elastic-agent/docs/tab-widgets/uninstall.asciidoc
+++ b/x-pack/elastic-agent/docs/tab-widgets/uninstall.asciidoc
@@ -9,7 +9,7 @@ include::uninstall.asciidoc[tag=uninstall-tip]
 
 [source,shell]
 ----
-elastic-agent uninstall
+sudo elastic-agent uninstall
 ----
 
 // end::mac[]
@@ -20,7 +20,7 @@ include::uninstall.asciidoc[tag=uninstall-tip]
 
 [source,shell]
 ----
-elastic-agent uninstall
+sudo elastic-agent uninstall
 ----
 
 // end::linux[]


### PR DESCRIPTION
Fixes steps for stopping agent now that it's installed as an autostarting service.

Also adds a topic about starting the agent.