### PR TITLE
Fix polling node when it is not ready and monitor by hostname

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -536,6 +536,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added Kafka version 2.2 to the list of supported versions. {pull}22328[22328]
 - Add support for ephemeral containers in kubernetes autodiscover and `add_kubernetes_metadata`. {pull}22389[22389] {pull}22439[22439]
 - Added support for wildcard fields and keyword fallback in beats setup commands. {pull}22521[22521]
+- Fix polling node when it is not ready and monitor by hostname {pull}22666[22666]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -168,8 +168,8 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 		return
 	}
 
-	// If the node is not in ready state then dont monitor it
-	if !isNodeReady(node) {
+	// If the node is not in ready state then dont monitor it unless its a stop event
+	if !isNodeReady(node) && flag != "stop" {
 		return
 	}
 

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -168,6 +168,11 @@ func (n *node) emit(node *kubernetes.Node, flag string) {
 		return
 	}
 
+	// If the node is not in ready state then dont monitor it
+	if !isNodeReady(node) {
+		return
+	}
+
 	eventID := fmt.Sprint(node.GetObjectMeta().GetUID())
 	meta := n.metagen.Generate(node)
 
@@ -233,6 +238,12 @@ func getAddress(node *kubernetes.Node) string {
 
 	for _, address := range node.Status.Addresses {
 		if address.Type == v1.NodeInternalIP && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeHostName && address.Address != "" {
 			return address.Address
 		}
 	}

--- a/libbeat/autodiscover/providers/kubernetes/node_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/node_test.go
@@ -156,11 +156,68 @@ func TestEmitEvent_Node(t *testing.T) {
 							Address: "node1",
 						},
 					},
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
 				},
 			},
 			Expected: bus.Event{
 				"start":    true,
 				"host":     "192.168.0.1",
+				"id":       uid,
+				"provider": UUID,
+				"kubernetes": common.MapStr{
+					"node": common.MapStr{
+						"name":     "metricbeat",
+						"uid":      "005f3b90-4b9d-12f8-acf0-31020a840133",
+						"hostname": "node1",
+					},
+					"annotations": common.MapStr{},
+				},
+				"meta": common.MapStr{
+					"kubernetes": common.MapStr{
+						"node": common.MapStr{
+							"name":     "metricbeat",
+							"uid":      "005f3b90-4b9d-12f8-acf0-31020a840133",
+							"hostname": "node1",
+						},
+					},
+				},
+				"config": []*common.Config{},
+			},
+		},
+		{
+			Message: "Test node start with just node name",
+			Flag:    "start",
+			Node: &kubernetes.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					UID:         types.UID(uid),
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				TypeMeta: typeMeta,
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeHostName,
+							Address: "node1",
+						},
+					},
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			Expected: bus.Event{
+				"start":    true,
+				"host":     "node1",
 				"id":       uid,
 				"provider": UUID,
 				"kubernetes": common.MapStr{
@@ -221,7 +278,7 @@ func TestEmitEvent_Node(t *testing.T) {
 			},
 			Expected: bus.Event{
 				"stop":     true,
-				"host":     "",
+				"host":     "node1",
 				"id":       uid,
 				"provider": UUID,
 				"kubernetes": common.MapStr{


### PR DESCRIPTION
Enhancement

## What does this PR do?

This PR ensures that as a last resort we use node's host name to monitor the node in node autodiscover. It also ensures that all events emitted by autodiscover for nodes checks for ready state. 

## Why is it important?

The kube spec leaves it to providers to either define InternalIP, ExternalIp or HostName on the node object. It is upto us to ensure that we monitor any one of them. Currently we dont use HostName if the other two are missing.

By not checking for ready state, we leave `add` events to monitor NotReady nodes which is not right. 

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally


## Related issues
