### PR TITLE
Add documentation for CloudFoundry application metadata persistent cache

### DIFF
--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
@@ -25,6 +25,10 @@ metadata in all events from the firehose since version 2.8. In these cases the
 metadata in the events is used, and `add_cloudfoundry_metadata` processor
 doesn't modify these fields.
 
+For efficient annotation, application metadata retrieved by the Cloud Foundry
+client is stored in a persistent cache on the filesystem under the `path.data`
+directory. For control over this cache, use the `cache_duration` and
+`cache_retry_delay` settings.
 
 [source,yaml]
 -------------------------------------------------------------------------------

--- a/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_cloudfoundry_metadata/docs/add_cloudfoundry_metadata.asciidoc
@@ -27,8 +27,8 @@ doesn't modify these fields.
 
 For efficient annotation, application metadata retrieved by the Cloud Foundry
 client is stored in a persistent cache on the filesystem under the `path.data`
-directory. For control over this cache, use the `cache_duration` and
-`cache_retry_delay` settings.
+directory. This is done so the metadata can persist across restarts of {beatname_uc}.
+For control over this cache, use the `cache_duration` and `cache_retry_delay` settings.
 
 [source,yaml]
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR documents the CloudFoundry application metadata persistent cache feature implemented in #20775.

## Why is it important?

So users of the `add_cloudfoundry_metadata` processors know about the persistent cache.

## Checklist

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues
- Resolves #21560.