### PR TITLE
Cherry-pick #22481 to 7.x: [filebeat][panw] Improve panos fileset url parsing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -510,6 +510,7 @@ from being added to events by default. {pull}18159[18159]
 - Added DNS response IP addresses to `related.ip` in Suricata module. {pull}22291[22291]
 - Added TLS JA3 fingerprint, certificate not_before/not_after, certificate SHA1 hash, and certificate subject fields to Zeek SSL dataset. {pull}21696[21696]
 - Added `event.ingested` field to data from the Netflow module. {pull}22412[22412]
+- Improve panw ECS url fields mapping. {pull}22481[22481]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -447,6 +447,47 @@ processors:
      value: "{{panw.panos.ruleset}}"
      ignore_empty_value: true
 
+# Set url and file values
+ - rename:
+     if: 'ctx?.panw?.panos?.sub_type != "url"'
+     field: url.original
+     target_field: file.name
+     ignore_missing: true
+
+ - grok:
+     field: url.original
+     patterns:
+       - '(%{ANY:url.scheme}\:\/\/)?(%{USERNAME:url.username}(\:%{PASSWORD:url.password})?\@)?%{DOMAIN:url.domain}(\:%{POSINT:url.port})?(%{PATH:url.path})?(\?%{QUERY:url.query})?(\#%{ANY:url.fragment})?'
+     ignore_missing: true
+     pattern_definitions:
+       USERNAME: '[^\:]*'
+       PASSWORD: '[^@]*'
+       DOMAIN: '[^\/\?#\:]*'
+       PATH: '[^\?#]*'
+       QUERY: '[^#]*'
+       ANY: '.*'
+     if: 'ctx?.url?.original != null && ctx?.url?.original != "-/" && ctx?.url?.original != ""'
+
+ - grok:
+     field: url.path
+     patterns:
+       - '%{FILENAME}((?:\.%{ANY})*(\.%{ANY:url.extension}))?'
+     ignore_missing: true
+     pattern_definitions:
+       FILENAME: '[^\.]+'
+       ANY: '.*'
+     if: 'ctx?.url?.path != null && ctx?.url?.path != ""'
+
+ - grok:
+     field: file.name
+     patterns:
+       - '%{FILENAME}((?:\.%{ANY})*(\.%{ANY:file.extension}))?'
+     ignore_missing: true
+     pattern_definitions:
+       FILENAME: '[^\.]+'
+       ANY: '.*'
+     if: 'ctx?.file?.name != null && ctx?.file?.name != ""'
+
  - append:
      field: related.user
      value: "{{client.user.name}}"
@@ -468,6 +509,12 @@ processors:
      if: "ctx?.destination?.user?.name != null"
 
  - append:
+     field: related.user
+     value: "{{url.username}}"
+     if: "ctx?.url?.username != null && ctx?.url?.username != ''"
+     allow_duplicates: false
+
+ - append:
      field: related.hash
      value: "{{panw.panos.file.hash}}"
      if: "ctx?.panw?.panos?.file?.hash != null"
@@ -476,6 +523,12 @@ processors:
      field: related.hosts
      value: "{{observer.hostname}}"
      if: "ctx?.observer?.hostname != null && ctx.observer?.hostname != ''"
+     allow_duplicates: false
+
+ - append:
+     field: related.hosts
+     value: "{{url.domain}}"
+     if: "ctx?.url?.domain != null && ctx.url?.domain != ''"
      allow_duplicates: false
 
 # Remove temporary fields.

--- a/x-pack/filebeat/module/panw/panos/test/pan_inc_threat.log-expected.json
+++ b/x-pack/filebeat/module/panw/panos/test/pan_inc_threat.log-expected.json
@@ -69,6 +69,9 @@
         "panw.panos.threat.resource": "lorexx.cn/loader.exe",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lorexx.cn"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -92,7 +95,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lorexx.cn/loader.exe"
+        "url.domain": "lorexx.cn",
+        "url.extension": "exe",
+        "url.original": "lorexx.cn/loader.exe",
+        "url.path": "/loader.exe"
     },
     {
         "@timestamp": "2012-04-10T04:39:56.000-02:00",
@@ -164,6 +170,9 @@
         "panw.panos.threat.resource": "lsiu.info/evo/count.php?o=2",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lsiu.info"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -187,7 +196,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lsiu.info/evo/count.php?o=2"
+        "url.domain": "lsiu.info",
+        "url.extension": "php",
+        "url.original": "lsiu.info/evo/count.php?o=2",
+        "url.path": "/evo/count.php",
+        "url.query": "o=2"
     },
     {
         "@timestamp": "2012-04-10T04:39:56.000-02:00",
@@ -259,6 +272,9 @@
         "panw.panos.threat.resource": "lsiu.info/evo/count.php?o=5",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lsiu.info"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -282,7 +298,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lsiu.info/evo/count.php?o=5"
+        "url.domain": "lsiu.info",
+        "url.extension": "php",
+        "url.original": "lsiu.info/evo/count.php?o=5",
+        "url.path": "/evo/count.php",
+        "url.query": "o=5"
     },
     {
         "@timestamp": "2012-04-10T04:39:57.000-02:00",
@@ -354,6 +374,9 @@
         "panw.panos.threat.resource": "lsiu.info/evo/count.php?o=7",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lsiu.info"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -377,7 +400,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lsiu.info/evo/count.php?o=7"
+        "url.domain": "lsiu.info",
+        "url.extension": "php",
+        "url.original": "lsiu.info/evo/count.php?o=7",
+        "url.path": "/evo/count.php",
+        "url.query": "o=7"
     },
     {
         "@timestamp": "2012-04-10T04:39:57.000-02:00",
@@ -449,6 +476,9 @@
         "panw.panos.threat.resource": "lsiu.info/evo/exploits/x18.php?o=2&t=1241403746&i=1365814122",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lsiu.info"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -472,7 +502,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lsiu.info/evo/exploits/x18.php?o=2&t=1241403746&i=1365814122"
+        "url.domain": "lsiu.info",
+        "url.extension": "php",
+        "url.original": "lsiu.info/evo/exploits/x18.php?o=2&t=1241403746&i=1365814122",
+        "url.path": "/evo/exploits/x18.php",
+        "url.query": "o=2&t=1241403746&i=1365814122"
     },
     {
         "@timestamp": "2012-04-10T04:39:57.000-02:00",
@@ -544,6 +578,9 @@
         "panw.panos.threat.resource": "lsiu.info/evo/exploits/x19.php?o=2&t=1241403746&i=1365814122",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lsiu.info"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -567,7 +604,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lsiu.info/evo/exploits/x19.php?o=2&t=1241403746&i=1365814122"
+        "url.domain": "lsiu.info",
+        "url.extension": "php",
+        "url.original": "lsiu.info/evo/exploits/x19.php?o=2&t=1241403746&i=1365814122",
+        "url.path": "/evo/exploits/x19.php",
+        "url.query": "o=2&t=1241403746&i=1365814122"
     },
     {
         "@timestamp": "2012-04-10T04:39:54.000-02:00",
@@ -639,6 +680,9 @@
         "panw.panos.threat.resource": "liteautobestguide.cn/load.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "liteautobestguide.cn"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -662,7 +706,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "liteautobestguide.cn/load.php"
+        "url.domain": "liteautobestguide.cn",
+        "url.extension": "php",
+        "url.original": "liteautobestguide.cn/load.php",
+        "url.path": "/load.php"
     },
     {
         "@timestamp": "2012-04-10T04:39:54.000-02:00",
@@ -734,6 +781,9 @@
         "panw.panos.threat.resource": "liteautobestguide.cn/index.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "liteautobestguide.cn"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -757,7 +807,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "liteautobestguide.cn/index.php"
+        "url.domain": "liteautobestguide.cn",
+        "url.extension": "php",
+        "url.original": "liteautobestguide.cn/index.php",
+        "url.path": "/index.php"
     },
     {
         "@timestamp": "2012-04-10T04:39:55.000-02:00",
@@ -829,6 +882,9 @@
         "panw.panos.threat.resource": "litetopdetect.cn/index.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "litetopdetect.cn"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -852,7 +908,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "litetopdetect.cn/index.php"
+        "url.domain": "litetopdetect.cn",
+        "url.extension": "php",
+        "url.original": "litetopdetect.cn/index.php",
+        "url.path": "/index.php"
     },
     {
         "@timestamp": "2012-04-10T04:39:55.000-02:00",
@@ -924,6 +983,9 @@
         "panw.panos.threat.resource": "lkmpmlm.com/fff9999.php?aid=0&uid=6cbbc5081e7548e276611ff5059df6ed30c8f8f1&os=513",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "lkmpmlm.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -947,7 +1009,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "lkmpmlm.com/fff9999.php?aid=0&uid=6cbbc5081e7548e276611ff5059df6ed30c8f8f1&os=513"
+        "url.domain": "lkmpmlm.com",
+        "url.extension": "php",
+        "url.original": "lkmpmlm.com/fff9999.php?aid=0&uid=6cbbc5081e7548e276611ff5059df6ed30c8f8f1&os=513",
+        "url.path": "/fff9999.php",
+        "url.query": "aid=0&uid=6cbbc5081e7548e276611ff5059df6ed30c8f8f1&os=513"
     },
     {
         "@timestamp": "2012-04-10T04:39:52.000-02:00",
@@ -1019,6 +1085,9 @@
         "panw.panos.threat.resource": "girlteenxxxfreemov.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "girlteenxxxfreemov.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1042,7 +1111,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "girlteenxxxfreemov.com/"
+        "url.domain": "girlteenxxxfreemov.com",
+        "url.original": "girlteenxxxfreemov.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:39:53.000-02:00",
@@ -1114,6 +1185,9 @@
         "panw.panos.threat.resource": "imagesrepository.com/resolution.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "imagesrepository.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1137,7 +1211,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "imagesrepository.com/resolution.php"
+        "url.domain": "imagesrepository.com",
+        "url.extension": "php",
+        "url.original": "imagesrepository.com/resolution.php",
+        "url.path": "/resolution.php"
     },
     {
         "@timestamp": "2012-04-10T04:39:53.000-02:00",
@@ -1209,6 +1286,9 @@
         "panw.panos.threat.resource": "hottestfiles.com/search/search.php?q=xxx",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "search-engines",
+        "related.hosts": [
+            "hottestfiles.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1232,7 +1312,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "hottestfiles.com/search/search.php?q=xxx"
+        "url.domain": "hottestfiles.com",
+        "url.extension": "php",
+        "url.original": "hottestfiles.com/search/search.php?q=xxx",
+        "url.path": "/search/search.php",
+        "url.query": "q=xxx"
     },
     {
         "@timestamp": "2012-04-10T04:39:54.000-02:00",
@@ -1303,6 +1387,9 @@
         "panw.panos.threat.resource": "infodist1.com/in.cgi?11&parameter=404",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "infodist1.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1326,7 +1413,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "infodist1.com/in.cgi?11&parameter=404"
+        "url.domain": "infodist1.com",
+        "url.extension": "cgi",
+        "url.original": "infodist1.com/in.cgi?11&parameter=404",
+        "url.path": "/in.cgi",
+        "url.query": "11&parameter=404"
     },
     {
         "@timestamp": "2012-04-10T04:39:51.000-02:00",
@@ -1398,6 +1489,9 @@
         "panw.panos.threat.resource": "cls-softwares.com/suc.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "cls-softwares.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1421,7 +1515,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "cls-softwares.com/suc.php"
+        "url.domain": "cls-softwares.com",
+        "url.extension": "php",
+        "url.original": "cls-softwares.com/suc.php",
+        "url.path": "/suc.php"
     },
     {
         "@timestamp": "2012-04-10T04:39:51.000-02:00",
@@ -1493,6 +1590,9 @@
         "panw.panos.threat.resource": "cls-softwares.com/softwarefortubeview.40013.exe",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "cls-softwares.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1516,7 +1616,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "cls-softwares.com/softwarefortubeview.40013.exe"
+        "url.domain": "cls-softwares.com",
+        "url.extension": "exe",
+        "url.original": "cls-softwares.com/softwarefortubeview.40013.exe",
+        "url.path": "/softwarefortubeview.40013.exe"
     },
     {
         "@timestamp": "2012-04-10T04:39:52.000-02:00",
@@ -1584,6 +1687,9 @@
         "panw.panos.threat.resource": "findmorepill.com/klik/search.php?q=xxx",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "online-gambling",
+        "related.hosts": [
+            "findmorepill.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "78.159.99.224",
@@ -1607,7 +1713,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "findmorepill.com/klik/search.php?q=xxx"
+        "url.domain": "findmorepill.com",
+        "url.extension": "php",
+        "url.original": "findmorepill.com/klik/search.php?q=xxx",
+        "url.path": "/klik/search.php",
+        "url.query": "q=xxx"
     },
     {
         "@timestamp": "2012-04-10T04:39:48.000-02:00",
@@ -1679,6 +1789,9 @@
         "panw.panos.threat.resource": "allowedwebsurfing.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "allowedwebsurfing.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1702,7 +1815,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "allowedwebsurfing.com/"
+        "url.domain": "allowedwebsurfing.com",
+        "url.original": "allowedwebsurfing.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:39:49.000-02:00",
@@ -1774,6 +1889,9 @@
         "panw.panos.threat.resource": "antivirus-remote.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "antivirus-remote.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1797,7 +1915,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "antivirus-remote.com/"
+        "url.domain": "antivirus-remote.com",
+        "url.original": "antivirus-remote.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:39:49.000-02:00",
@@ -1869,6 +1989,9 @@
         "panw.panos.threat.resource": "bklinkov.ru/hi/start.cfg",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "bklinkov.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1892,7 +2015,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "bklinkov.ru/hi/start.cfg"
+        "url.domain": "bklinkov.ru",
+        "url.extension": "cfg",
+        "url.original": "bklinkov.ru/hi/start.cfg",
+        "url.path": "/hi/start.cfg"
     },
     {
         "@timestamp": "2012-04-10T04:39:50.000-02:00",
@@ -1964,6 +2090,9 @@
         "panw.panos.threat.resource": "blogsexnakedgirlxxx.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "blogsexnakedgirlxxx.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -1987,7 +2116,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "blogsexnakedgirlxxx.com/"
+        "url.domain": "blogsexnakedgirlxxx.com",
+        "url.original": "blogsexnakedgirlxxx.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:39:50.000-02:00",
@@ -2059,6 +2190,9 @@
         "panw.panos.threat.resource": "bklinkov.ru/hi/start.exe",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "not-resolved",
+        "related.hosts": [
+            "bklinkov.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -2082,7 +2216,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "bklinkov.ru/hi/start.exe"
+        "url.domain": "bklinkov.ru",
+        "url.extension": "exe",
+        "url.original": "bklinkov.ru/hi/start.exe",
+        "url.path": "/hi/start.exe"
     },
     {
         "@timestamp": "2012-04-10T04:39:47.000-02:00",
@@ -3195,6 +3332,9 @@
         "panw.panos.threat.resource": "wantfinest.com/tds/in.cgi?default",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "unknown",
+        "related.hosts": [
+            "wantfinest.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "69.43.161.167",
@@ -3218,7 +3358,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "wantfinest.com/tds/in.cgi?default"
+        "url.domain": "wantfinest.com",
+        "url.extension": "cgi",
+        "url.original": "wantfinest.com/tds/in.cgi?default",
+        "url.path": "/tds/in.cgi",
+        "url.query": "default"
     },
     {
         "@timestamp": "2012-04-10T04:39:38.000-02:00",
@@ -3286,6 +3430,9 @@
         "panw.panos.threat.resource": "sameshitasiteverwas.com/traf/tds/in.cgi?2",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "sameshitasiteverwas.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "202.31.187.154",
@@ -3309,7 +3456,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "sameshitasiteverwas.com/traf/tds/in.cgi?2"
+        "url.domain": "sameshitasiteverwas.com",
+        "url.extension": "cgi",
+        "url.original": "sameshitasiteverwas.com/traf/tds/in.cgi?2",
+        "url.path": "/traf/tds/in.cgi",
+        "url.query": "2"
     },
     {
         "@timestamp": "2012-04-10T04:39:39.000-02:00",
@@ -3377,6 +3528,9 @@
         "panw.panos.threat.resource": "svarkon.ru/update.exe",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "svarkon.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "89.111.176.67",
@@ -3400,7 +3554,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "svarkon.ru/update.exe"
+        "url.domain": "svarkon.ru",
+        "url.extension": "exe",
+        "url.original": "svarkon.ru/update.exe",
+        "url.path": "/update.exe"
     },
     {
         "@timestamp": "2012-04-10T04:39:36.000-02:00",
@@ -3471,6 +3628,9 @@
         "panw.panos.threat.resource": "onlinescanxpp.com/land/eurl/1.php?code=",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "onlinescanxpp.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -3494,7 +3654,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "onlinescanxpp.com/land/eurl/1.php?code="
+        "url.domain": "onlinescanxpp.com",
+        "url.extension": "php",
+        "url.original": "onlinescanxpp.com/land/eurl/1.php?code=",
+        "url.path": "/land/eurl/1.php",
+        "url.query": "code="
     },
     {
         "@timestamp": "2012-04-10T04:39:34.000-02:00",
@@ -3562,6 +3726,9 @@
         "panw.panos.threat.resource": "nolagtime.com/conn/?JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "nolagtime.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "208.73.210.29",
@@ -3585,7 +3752,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "nolagtime.com/conn/?JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6"
+        "url.domain": "nolagtime.com",
+        "url.original": "nolagtime.com/conn/?JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6",
+        "url.path": "/conn/",
+        "url.query": "JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6"
     },
     {
         "@timestamp": "2012-04-10T04:39:35.000-02:00",
@@ -3653,6 +3823,9 @@
         "panw.panos.threat.resource": "nolagtime.com/gwc.txt",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "nolagtime.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "208.73.210.29",
@@ -3676,7 +3849,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "nolagtime.com/gwc.txt"
+        "url.domain": "nolagtime.com",
+        "url.extension": "txt",
+        "url.original": "nolagtime.com/gwc.txt",
+        "url.path": "/gwc.txt"
     },
     {
         "@timestamp": "2012-04-10T04:38:19.000-02:00",
@@ -3747,6 +3923,9 @@
         "panw.panos.threat.resource": "karavan.us/bon/index.php",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "unknown",
+        "related.hosts": [
+            "karavan.us"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -3770,7 +3949,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "karavan.us/bon/index.php"
+        "url.domain": "karavan.us",
+        "url.extension": "php",
+        "url.original": "karavan.us/bon/index.php",
+        "url.path": "/bon/index.php"
     },
     {
         "@timestamp": "2012-04-10T04:38:14.000-02:00",
@@ -3838,6 +4020,9 @@
         "panw.panos.threat.resource": "findnolimits.com/go.php?sid=1",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "dead-sites",
+        "related.hosts": [
+            "findnolimits.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "208.73.210.29",
@@ -3861,7 +4046,11 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "findnolimits.com/go.php?sid=1"
+        "url.domain": "findnolimits.com",
+        "url.extension": "php",
+        "url.original": "findnolimits.com/go.php?sid=1",
+        "url.path": "/go.php",
+        "url.query": "sid=1"
     },
     {
         "@timestamp": "2012-04-10T04:38:12.000-02:00",
@@ -3929,6 +4118,9 @@
         "panw.panos.threat.resource": "bizoplata.ru/moun.html",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "parked-domains",
+        "related.hosts": [
+            "bizoplata.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "89.108.64.156",
@@ -3952,7 +4144,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "bizoplata.ru/moun.html"
+        "url.domain": "bizoplata.ru",
+        "url.extension": "html",
+        "url.original": "bizoplata.ru/moun.html",
+        "url.path": "/moun.html"
     },
     {
         "@timestamp": "2012-04-10T04:38:12.000-02:00",
@@ -4020,6 +4215,9 @@
         "panw.panos.threat.resource": "bizoplata.ru/palast.html",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "parked-domains",
+        "related.hosts": [
+            "bizoplata.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "89.108.64.156",
@@ -4043,7 +4241,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "bizoplata.ru/palast.html"
+        "url.domain": "bizoplata.ru",
+        "url.extension": "html",
+        "url.original": "bizoplata.ru/palast.html",
+        "url.path": "/palast.html"
     },
     {
         "@timestamp": "2012-04-10T04:37:28.000-02:00",
@@ -4066,6 +4267,8 @@
         "event.outcome": "success",
         "event.severity": 1,
         "event.timezone": "-02:00",
+        "file.extension": "php",
+        "file.name": "controller.php",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -4133,8 +4336,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "controller.php"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:37:32.000-02:00",
@@ -4205,6 +4407,9 @@
         "panw.panos.threat.resource": "www.15min.it/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "www.15min.it"
+        ],
         "related.ip": [
             "192.168.0.2",
             "216.8.179.25",
@@ -4228,7 +4433,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "www.15min.it/"
+        "url.domain": "www.15min.it",
+        "url.original": "www.15min.it/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:37:27.000-02:00",
@@ -4296,6 +4503,9 @@
         "panw.panos.threat.resource": "tubemov.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "adult-and-pornography",
+        "related.hosts": [
+            "tubemov.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "69.43.161.154",
@@ -4319,7 +4529,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "tubemov.com/"
+        "url.domain": "tubemov.com",
+        "url.original": "tubemov.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:37:25.000-02:00",
@@ -4387,6 +4599,9 @@
         "panw.panos.threat.resource": "pagesinxt.com/?dn=teenstube.us&flrdr=yes&nxte=js",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "pagesinxt.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "208.91.196.252",
@@ -4410,7 +4625,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "pagesinxt.com/?dn=teenstube.us&flrdr=yes&nxte=js"
+        "url.domain": "pagesinxt.com",
+        "url.original": "pagesinxt.com/?dn=teenstube.us&flrdr=yes&nxte=js",
+        "url.path": "/",
+        "url.query": "dn=teenstube.us&flrdr=yes&nxte=js"
     },
     {
         "@timestamp": "2012-04-10T04:37:05.000-02:00",
@@ -4478,6 +4696,9 @@
         "panw.panos.threat.resource": "movfree.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "spyware-and-adware",
+        "related.hosts": [
+            "movfree.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "208.73.210.29",
@@ -4501,7 +4722,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "movfree.com/"
+        "url.domain": "movfree.com",
+        "url.original": "movfree.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:36:51.000-02:00",
@@ -4572,6 +4795,9 @@
         "panw.panos.threat.resource": "gometascan.com/",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "gometascan.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -4595,7 +4821,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "gometascan.com/"
+        "url.domain": "gometascan.com",
+        "url.original": "gometascan.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2012-04-10T04:36:39.000-02:00",
@@ -4666,6 +4894,9 @@
         "panw.panos.threat.resource": "antivirus-powerful-scannerv2.com/download/Install_11-1.exe",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "antivirus-powerful-scannerv2.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -4689,7 +4920,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "antivirus-powerful-scannerv2.com/download/Install_11-1.exe"
+        "url.domain": "antivirus-powerful-scannerv2.com",
+        "url.extension": "exe",
+        "url.original": "antivirus-powerful-scannerv2.com/download/Install_11-1.exe",
+        "url.path": "/download/Install_11-1.exe"
     },
     {
         "@timestamp": "2012-04-10T04:36:38.000-02:00",
@@ -4760,6 +4994,9 @@
         "panw.panos.threat.resource": "antivirus-powerful-scannerv2.com/1/?id=11-1&back==TQzyDTyMUQNMI=N",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "antivirus-powerful-scannerv2.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -4783,7 +5020,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "antivirus-powerful-scannerv2.com/1/?id=11-1&back==TQzyDTyMUQNMI=N"
+        "url.domain": "antivirus-powerful-scannerv2.com",
+        "url.original": "antivirus-powerful-scannerv2.com/1/?id=11-1&back==TQzyDTyMUQNMI=N",
+        "url.path": "/1/",
+        "url.query": "id=11-1&back==TQzyDTyMUQNMI=N"
     },
     {
         "@timestamp": "2012-04-10T04:36:27.000-02:00",
@@ -4854,6 +5094,9 @@
         "panw.panos.threat.resource": "basdzsdas.com/poker/config.bin",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "basdzsdas.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -4877,7 +5120,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "basdzsdas.com/poker/config.bin"
+        "url.domain": "basdzsdas.com",
+        "url.extension": "bin",
+        "url.original": "basdzsdas.com/poker/config.bin",
+        "url.path": "/poker/config.bin"
     },
     {
         "@timestamp": "2012-04-10T04:36:27.000-02:00",
@@ -4948,6 +5194,9 @@
         "panw.panos.threat.resource": "basdzsdas.com/poker/config.bin",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "basdzsdas.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -4971,7 +5220,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "basdzsdas.com/poker/config.bin"
+        "url.domain": "basdzsdas.com",
+        "url.extension": "bin",
+        "url.original": "basdzsdas.com/poker/config.bin",
+        "url.path": "/poker/config.bin"
     },
     {
         "@timestamp": "2012-04-10T04:19:59.000-02:00",
@@ -4997,6 +5249,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "uLLGRaXP.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5064,8 +5318,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "uLLGRaXP.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:36:27.000-02:00",
@@ -5136,6 +5389,9 @@
         "panw.panos.threat.resource": "basdzsdas.com/poker/config.bin",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "basdzsdas.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -5159,7 +5415,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "basdzsdas.com/poker/config.bin"
+        "url.domain": "basdzsdas.com",
+        "url.extension": "bin",
+        "url.original": "basdzsdas.com/poker/config.bin",
+        "url.path": "/poker/config.bin"
     },
     {
         "@timestamp": "2012-04-10T04:51:29.000-02:00",
@@ -5185,6 +5444,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "FunkyEmoticons_setup.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5252,8 +5513,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "FunkyEmoticons_setup.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:54:33.000-02:00",
@@ -5279,6 +5539,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "52hxw.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5345,8 +5607,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "52hxw.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T05:01:00.000-02:00",
@@ -5417,6 +5678,9 @@
         "panw.panos.threat.resource": "softsellfast.com/test/config.bin",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "softsellfast.com"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -5440,7 +5704,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "softsellfast.com/test/config.bin"
+        "url.domain": "softsellfast.com",
+        "url.extension": "bin",
+        "url.original": "softsellfast.com/test/config.bin",
+        "url.path": "/test/config.bin"
     },
     {
         "@timestamp": "2012-04-10T04:45:17.000-02:00",
@@ -5466,6 +5733,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "setup.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5530,8 +5799,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "setup.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:46:16.000-02:00",
@@ -5557,6 +5825,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "Live-Player_setup.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5624,8 +5894,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "Live-Player_setup.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:42:39.000-02:00",
@@ -5693,6 +5962,9 @@
         "panw.panos.threat.resource": "boialex.narod.ru/config.txt",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "boialex.narod.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "213.180.199.61",
@@ -5716,7 +5988,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "boialex.narod.ru/config.txt"
+        "url.domain": "boialex.narod.ru",
+        "url.extension": "txt",
+        "url.original": "boialex.narod.ru/config.txt",
+        "url.path": "/config.txt"
     },
     {
         "@timestamp": "2012-04-10T04:42:42.000-02:00",
@@ -5784,6 +6059,9 @@
         "panw.panos.threat.resource": "edw-melon.narod.ru/config.txt",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "edw-melon.narod.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "213.180.199.61",
@@ -5807,7 +6085,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "edw-melon.narod.ru/config.txt"
+        "url.domain": "edw-melon.narod.ru",
+        "url.extension": "txt",
+        "url.original": "edw-melon.narod.ru/config.txt",
+        "url.path": "/config.txt"
     },
     {
         "@timestamp": "2012-04-10T04:42:51.000-02:00",
@@ -5875,6 +6156,9 @@
         "panw.panos.threat.resource": "maximtushin.narod.ru/config.txt",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "malware-sites",
+        "related.hosts": [
+            "maximtushin.narod.ru"
+        ],
         "related.ip": [
             "192.168.0.2",
             "213.180.199.61",
@@ -5898,7 +6182,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "maximtushin.narod.ru/config.txt"
+        "url.domain": "maximtushin.narod.ru",
+        "url.extension": "txt",
+        "url.original": "maximtushin.narod.ru/config.txt",
+        "url.path": "/config.txt"
     },
     {
         "@timestamp": "2012-04-10T04:19:59.000-02:00",
@@ -5924,6 +6211,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "uLLGRaXP.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -5991,8 +6280,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "uLLGRaXP.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-10T04:09:01.000-02:00",
@@ -6063,6 +6351,9 @@
         "panw.panos.threat.resource": "marketingsoluchion.biz/fkn/config.bin",
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "unknown",
+        "related.hosts": [
+            "marketingsoluchion.biz"
+        ],
         "related.ip": [
             "192.168.0.2",
             "204.232.231.46",
@@ -6086,7 +6377,10 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "marketingsoluchion.biz/fkn/config.bin"
+        "url.domain": "marketingsoluchion.biz",
+        "url.extension": "bin",
+        "url.original": "marketingsoluchion.biz/fkn/config.bin",
+        "url.path": "/fkn/config.bin"
     },
     {
         "@timestamp": "2012-04-09T08:18:27.000-02:00",
@@ -6122,6 +6416,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "aspx",
+        "file.name": "default.aspx",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6179,8 +6475,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "default.aspx"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:18:29.000-02:00",
@@ -6206,6 +6501,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "aspx",
+        "file.name": "sck.aspx",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6273,8 +6570,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "sck.aspx"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:18:32.000-02:00",
@@ -6300,6 +6596,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "dll",
+        "file.name": "ADSAdClient31.dll",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6367,8 +6665,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "ADSAdClient31.dll"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:18:33.000-02:00",
@@ -6404,6 +6701,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "gif",
+        "file.name": "c.gif",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6461,8 +6760,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "c.gif"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:18:37.000-02:00",
@@ -6488,6 +6786,7 @@
         "event.type": [
             "allowed"
         ],
+        "file.name": "csi",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6552,8 +6851,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "csi"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:50:12.000-02:00",
@@ -6586,6 +6884,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "com",
+        "file.name": "internal-tuner.pandora.com",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6643,8 +6943,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "internal-tuner.pandora.com"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:58:18.000-02:00",
@@ -6670,6 +6969,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6734,8 +7034,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:22:27.000-02:00",
@@ -6761,6 +7060,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "exe",
+        "file.name": "about.exe",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6828,8 +7129,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "about.exe"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:11:43.000-02:00",
@@ -6855,6 +7155,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -6919,8 +7220,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:14:02.000-02:00",
@@ -6946,6 +7246,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7010,8 +7311,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:14:39.000-02:00",
@@ -7037,6 +7337,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7101,8 +7402,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:16:03.000-02:00",
@@ -7128,6 +7428,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7192,8 +7493,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:18:14.000-02:00",
@@ -7226,6 +7526,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "gif",
+        "file.name": "__utm.gif",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7283,8 +7585,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "__utm.gif"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:25:04.000-02:00",
@@ -7310,6 +7611,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7374,8 +7676,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T07:36:04.000-02:00",
@@ -7401,6 +7702,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "png",
+        "file.name": "nav_logo107.png",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7465,8 +7768,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "nav_logo107.png"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:08:08.000-02:00",
@@ -7492,6 +7794,7 @@
         "event.type": [
             "allowed"
         ],
+        "file.name": "Eadweard_Muybridge",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7556,8 +7859,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "Eadweard_Muybridge"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:08:44.000-02:00",
@@ -7583,6 +7885,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "php",
+        "file.name": "load.php",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7647,8 +7951,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "load.php"
+        ]
     },
     {
         "@timestamp": "2012-04-09T08:16:57.000-02:00",
@@ -7674,6 +7977,8 @@
         "event.type": [
             "denied"
         ],
+        "file.extension": "css",
+        "file.name": "8fe44cb728c0f40750c64ee906eb72.css",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7741,8 +8046,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "8fe44cb728c0f40750c64ee906eb72.css"
+        ]
     },
     {
         "@timestamp": "2012-04-09T04:06:41.000-02:00",
@@ -7768,6 +8072,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7832,8 +8137,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T04:12:52.000-02:00",
@@ -7859,6 +8163,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -7923,8 +8228,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:07:49.000-02:00",
@@ -7950,6 +8254,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "xml",
+        "file.name": "appcast.xml",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8017,8 +8323,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "appcast.xml"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:48:44.000-02:00",
@@ -8044,6 +8349,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8108,8 +8414,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:48:59.000-02:00",
@@ -8135,6 +8440,7 @@
         "event.type": [
             "allowed"
         ],
+        "file.name": "csi",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8199,8 +8505,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "csi"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:50:14.000-02:00",
@@ -8226,6 +8531,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "php",
+        "file.name": "index.php",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8293,8 +8600,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "index.php"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:51:34.000-02:00",
@@ -8320,6 +8626,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8384,8 +8691,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:53:41.000-02:00",
@@ -8418,6 +8724,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "gif",
+        "file.name": "__utm.gif",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8475,8 +8783,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "__utm.gif"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:54:35.000-02:00",
@@ -8502,6 +8809,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8566,8 +8874,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T06:54:55.000-02:00",
@@ -8593,6 +8900,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8657,8 +8965,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:44:49.000-02:00",
@@ -8691,6 +8998,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "com",
+        "file.name": "internal-tuner.pandora.com",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8748,8 +9057,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "internal-tuner.pandora.com"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:45:45.000-02:00",
@@ -8775,6 +9083,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8839,8 +9148,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:49:17.000-02:00",
@@ -8866,6 +9174,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -8930,8 +9239,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:53:41.000-02:00",
@@ -8957,6 +9265,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -9021,8 +9330,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:55:23.000-02:00",
@@ -9048,6 +9356,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -9112,8 +9421,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T03:55:52.000-02:00",
@@ -9139,6 +9447,8 @@
         "event.type": [
             "allowed"
         ],
+        "file.extension": "js",
+        "file.name": "ga.js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -9203,8 +9513,7 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "ga.js"
+        ]
     },
     {
         "@timestamp": "2012-04-09T04:03:55.000-02:00",
@@ -9230,6 +9539,7 @@
         "event.type": [
             "denied"
         ],
+        "file.name": "js",
         "fileset.name": "panos",
         "input.type": "log",
         "labels.captive_portal": true,
@@ -9294,7 +9604,6 @@
         "tags": [
             "pan-os",
             "forwarded"
-        ],
-        "url.original": "js"
+        ]
     }
 ]

--- a/x-pack/filebeat/module/panw/panos/test/threat.log-expected.json
+++ b/x-pack/filebeat/module/panw/panos/test/threat.log-expected.json
@@ -75,7 +75,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -99,7 +100,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -177,7 +180,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -201,7 +205,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -279,7 +285,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -303,7 +310,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -381,7 +390,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -405,7 +415,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -483,7 +495,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -507,7 +520,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -585,7 +600,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -609,7 +625,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -687,7 +705,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -711,7 +730,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -789,7 +810,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -813,7 +835,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -891,7 +915,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -915,7 +940,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -993,7 +1020,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1017,7 +1045,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -1095,7 +1125,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1119,7 +1150,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -1197,7 +1230,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1221,7 +1255,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -1299,7 +1335,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1323,7 +1360,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -1401,7 +1440,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1425,7 +1465,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:36.000-02:00",
@@ -1503,7 +1545,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1527,7 +1570,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:37.000-02:00",
@@ -1605,7 +1650,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1629,7 +1675,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:37.000-02:00",
@@ -1707,7 +1755,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1731,7 +1780,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:37.000-02:00",
@@ -1809,7 +1860,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1833,7 +1885,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:37.000-02:00",
@@ -1911,7 +1965,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -1935,7 +1990,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:38.000-02:00",
@@ -2013,7 +2070,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2037,7 +2095,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:38.000-02:00",
@@ -2115,7 +2175,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "b.scorecardresearch.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2139,7 +2200,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "b.scorecardresearch.com/"
+        "url.domain": "b.scorecardresearch.com",
+        "url.original": "b.scorecardresearch.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:38.000-02:00",
@@ -2217,7 +2280,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2241,7 +2305,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2319,7 +2385,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2343,7 +2410,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2421,7 +2490,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2445,7 +2515,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2523,7 +2595,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2547,7 +2620,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2625,7 +2700,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2649,7 +2725,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2727,7 +2805,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2751,7 +2830,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2829,7 +2910,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2853,7 +2935,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -2931,7 +3015,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -2955,7 +3040,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3033,7 +3120,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3057,7 +3145,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3135,7 +3225,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3159,7 +3250,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3237,7 +3330,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3261,7 +3355,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3339,7 +3435,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3363,7 +3460,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3441,7 +3540,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3465,7 +3565,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:46.000-02:00",
@@ -3543,7 +3645,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "consent.cmp.oath.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3567,7 +3670,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "consent.cmp.oath.com/"
+        "url.domain": "consent.cmp.oath.com",
+        "url.original": "consent.cmp.oath.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:53.000-02:00",
@@ -3645,7 +3750,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "cdn.taboola.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3669,7 +3775,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "cdn.taboola.com/"
+        "url.domain": "cdn.taboola.com",
+        "url.original": "cdn.taboola.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:54.000-02:00",
@@ -3750,7 +3858,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "rules.quantcount.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3774,7 +3883,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "rules.quantcount.com/"
+        "url.domain": "rules.quantcount.com",
+        "url.original": "rules.quantcount.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:58.000-02:00",
@@ -3855,7 +3966,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3879,7 +3991,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:58.000-02:00",
@@ -3960,7 +4074,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -3984,7 +4099,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:58.000-02:00",
@@ -4065,7 +4182,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4089,7 +4207,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:58.000-02:00",
@@ -4170,7 +4290,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4194,7 +4315,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:59.000-02:00",
@@ -4275,7 +4398,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4299,7 +4423,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:59.000-02:00",
@@ -4380,7 +4506,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4404,7 +4531,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:44:59.000-02:00",
@@ -4485,7 +4614,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4509,7 +4639,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:00.000-02:00",
@@ -4590,7 +4722,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4614,7 +4747,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:00.000-02:00",
@@ -4695,7 +4830,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4719,7 +4855,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:00.000-02:00",
@@ -4800,7 +4938,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4824,7 +4963,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:00.000-02:00",
@@ -4905,7 +5046,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -4929,7 +5071,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:00.000-02:00",
@@ -5010,7 +5154,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "srv-2018-11-30-22.config.parsely.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5034,7 +5179,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "srv-2018-11-30-22.config.parsely.com/"
+        "url.domain": "srv-2018-11-30-22.config.parsely.com",
+        "url.original": "srv-2018-11-30-22.config.parsely.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:13.000-02:00",
@@ -5115,7 +5262,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "www.googleadservices.com"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5139,7 +5287,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "www.googleadservices.com/"
+        "url.domain": "www.googleadservices.com",
+        "url.original": "www.googleadservices.com/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:15.000-02:00",
@@ -5217,7 +5367,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5241,7 +5392,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:15.000-02:00",
@@ -5319,7 +5472,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5343,7 +5497,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:15.000-02:00",
@@ -5421,7 +5577,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5445,7 +5602,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:15.000-02:00",
@@ -5523,7 +5682,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5547,7 +5707,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -5625,7 +5787,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5649,7 +5812,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -5727,7 +5892,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5751,7 +5917,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -5829,7 +5997,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5853,7 +6022,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -5931,7 +6102,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -5955,7 +6127,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -6033,7 +6207,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6057,7 +6232,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:16.000-02:00",
@@ -6135,7 +6312,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "service.maxymiser.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6159,7 +6337,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "service.maxymiser.net/"
+        "url.domain": "service.maxymiser.net",
+        "url.original": "service.maxymiser.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:26.000-02:00",
@@ -6240,7 +6420,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6264,7 +6445,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:26.000-02:00",
@@ -6345,7 +6528,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6369,7 +6553,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:26.000-02:00",
@@ -6450,7 +6636,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6474,7 +6661,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:26.000-02:00",
@@ -6555,7 +6744,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6579,7 +6769,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:26.000-02:00",
@@ -6660,7 +6852,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6684,7 +6877,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -6765,7 +6960,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6789,7 +6985,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -6870,7 +7068,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6894,7 +7093,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -6975,7 +7176,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -6999,7 +7201,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -7080,7 +7284,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7104,7 +7309,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -7185,7 +7392,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7209,7 +7417,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -7290,7 +7500,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7314,7 +7525,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:27.000-02:00",
@@ -7395,7 +7608,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7419,7 +7633,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:28.000-02:00",
@@ -7500,7 +7716,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7524,7 +7741,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:28.000-02:00",
@@ -7605,7 +7824,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7629,7 +7849,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:28.000-02:00",
@@ -7710,7 +7932,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7734,7 +7957,9 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     },
     {
         "@timestamp": "2018-11-30T16:45:29.000-02:00",
@@ -7815,7 +8040,8 @@
         "panw.panos.type": "THREAT",
         "panw.panos.url.category": "business-and-economy",
         "related.hosts": [
-            "PA-220"
+            "PA-220",
+            "segment-data.zqtk.net"
         ],
         "related.ip": [
             "192.168.15.224",
@@ -7839,6 +8065,8 @@
             "pan-os",
             "forwarded"
         ],
-        "url.original": "segment-data.zqtk.net/"
+        "url.domain": "segment-data.zqtk.net",
+        "url.original": "segment-data.zqtk.net/",
+        "url.path": "/"
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #22481 to 7.x branch. Original message: 

## What does this PR do?

Parse panos url field to extract useful ecs fields.

## Why is it important?

To improve ECS support in our modules.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

