### PR TITLE
Fix index template loading when the new index is selected

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -215,6 +215,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed documentation for commands in beats dev guide {pull}22194[22194]
 - Fix parsing of expired licences. {issue}21112[21112] {pull}22180[22180]
 - Fix duplicated pod events in kubernetes autodiscover for pods with init or ephemeral containers. {pull}22438[22438]
+- Fix index template loading when the new index format is selected. {issue}22482[22482] {pull}22682[22682]
 
 *Auditbeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -304,8 +304,10 @@ func (t *Template) generateComponent(properties common.MapStr) common.MapStr {
 }
 
 func (t *Template) generateIndex(properties common.MapStr) common.MapStr {
-	tmpl := t.generateLegacy(properties)
+	tmpl := t.generateComponent(properties)
 	tmpl["priority"] = t.priority
+	keyPattern, patterns := buildPatternSettings(t.esVersion, t.GetPattern())
+	tmpl[keyPattern] = patterns
 	delete(tmpl, "order")
 	return tmpl
 }

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -235,9 +235,8 @@ func (t *Template) loadMinimalComponent() common.MapStr {
 }
 
 func (t *Template) loadMinimalIndex() common.MapStr {
-	m := t.loadMinimalLegacy()
+	m := t.loadMinimalComponent()
 	m["priority"] = t.priority
-	delete(m, "order")
 	return m
 }
 
@@ -308,7 +307,6 @@ func (t *Template) generateIndex(properties common.MapStr) common.MapStr {
 	tmpl["priority"] = t.priority
 	keyPattern, patterns := buildPatternSettings(t.esVersion, t.GetPattern())
 	tmpl[keyPattern] = patterns
-	delete(tmpl, "order")
 	return tmpl
 }
 

--- a/libbeat/tests/system/idxmgmt.py
+++ b/libbeat/tests/system/idxmgmt.py
@@ -69,6 +69,15 @@ class IdxMgmt(unittest.TestCase):
                 found = True
         assert found
 
+    def assert_component_template_loaded(self, template):
+        resp = self._client.transport.perform_request('GET', '/_component_template/' + template)
+        found = False
+        print(resp)
+        for index_template in resp['component_templates']:
+            if index_template['name'] == template:
+                found = True
+        assert found
+
     def assert_ilm_template_loaded(self, template, policy, alias):
         resp = self._client.transport.perform_request('GET', '/_template/' + template)
         assert resp[template]["settings"]["index"]["lifecycle"]["name"] == policy

--- a/libbeat/tests/system/idxmgmt.py
+++ b/libbeat/tests/system/idxmgmt.py
@@ -56,10 +56,18 @@ class IdxMgmt(unittest.TestCase):
         with pytest.raises(NotFoundError):
             self._client.transport.perform_request('GET', '/_template/' + template)
 
-    def assert_index_template_loaded(self, template):
+    def assert_legacy_index_template_loaded(self, template):
         resp = self._client.transport.perform_request('GET', '/_template/' + template)
         assert template in resp
         assert "lifecycle" not in resp[template]["settings"]["index"]
+
+    def assert_index_template_loaded(self, template):
+        resp = self._client.transport.perform_request('GET', '/_index_template/' + template)
+        found = False
+        for index_template in resp['index_templates']:
+            if index_template['name'] == template:
+                found = True
+        assert found
 
     def assert_ilm_template_loaded(self, template, policy, alias):
         resp = self._client.transport.perform_request('GET', '/_template/' + template)

--- a/libbeat/tests/system/test_cmd_setup_index_management.py
+++ b/libbeat/tests/system/test_cmd_setup_index_management.py
@@ -110,7 +110,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                               "-E", "setup.ilm.enabled=false"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.index_name)
         self.idxmgmt.assert_alias_not_created(self.alias_name)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
 
@@ -242,7 +242,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                               "-E", "setup.template.pattern=" + self.custom_template + "*"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.custom_template)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.custom_template)
         self.idxmgmt.assert_index_template_index_pattern(self.custom_template, [self.custom_template + "*"])
         self.idxmgmt.assert_alias_not_created(self.alias_name)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
@@ -261,7 +261,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                               "-E", "setup.template.settings.index.number_of_shards=2"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.index_name)
 
         # check that settings are overwritten
         resp = self.es.transport.perform_request('GET', '/_template/' + self.index_name)
@@ -284,7 +284,7 @@ class TestCommandSetupIndexManagement(BaseTest):
                                               "-E", "setup.template.name=" + self.custom_alias,
                                               "-E", "setup.template.pattern=" + self.custom_alias + "*"])
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.custom_alias)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.custom_alias)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
 
         # ensure ilm policy is created, triggering overwriting existing template

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -68,7 +68,7 @@ class TestRunILM(BaseTest):
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.index_name)
         self.idxmgmt.assert_alias_not_created(self.alias_name)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
 
@@ -234,7 +234,7 @@ class TestCommandSetupILMPolicy(BaseTest):
                                               "-E", "setup.ilm.enabled=false"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.index_name)
         self.idxmgmt.assert_alias_not_created(self.alias_name)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
 

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -322,6 +322,34 @@ class TestCommandSetupTemplate(BaseTest):
         index = resp[self.custom_alias]["settings"]["index"]
         assert index["number_of_shards"] == "2", index["number_of_shards"]
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @pytest.mark.tag('integration')
+    def test_setup_template_index(self):
+        """
+        Test template setup with config options
+        """
+        self.render_config()
+        exit_code = self.run_beat(logging_args=["-v", "-d", "*"],
+                                  extra_args=["setup", self.setupCmd,
+                                              "-E", "setup.template.type=index"])
+
+        assert exit_code == 0
+        self.idxmgmt.assert_index_template_loaded(self.index_name)
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @pytest.mark.tag('integration')
+    def test_setup_template_component(self):
+        """
+        Test template setup with config options
+        """
+        self.render_config()
+        exit_code = self.run_beat(logging_args=["-v", "-d", "*"],
+                                  extra_args=["setup", self.setupCmd,
+                                              "-E", "setup.template.type=component"])
+
+        assert exit_code == 0
+        self.idxmgmt.assert_index_template_loaded(self.index_name)
+
 
 class TestCommandExportTemplate(BaseTest):
     """

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -267,7 +267,7 @@ class TestCommandSetupTemplate(BaseTest):
                                               "-E", "setup.template.settings.index.number_of_shards=2"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.index_name)
 
         # check that settings are overwritten
         resp = self.es.transport.perform_request('GET', '/_template/' + self.index_name)
@@ -305,7 +305,7 @@ class TestCommandSetupTemplate(BaseTest):
                                               "-E", "setup.template.name=" + self.custom_alias,
                                               "-E", "setup.template.pattern=" + self.custom_alias + "*"])
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.custom_alias)
+        self.idxmgmt.assert_legacy_index_template_loaded(self.custom_alias)
         self.idxmgmt.assert_policy_not_created(self.policy_name)
 
         # ensure ilm policy is created, triggering overwriting existing template

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -326,7 +326,7 @@ class TestCommandSetupTemplate(BaseTest):
     @pytest.mark.tag('integration')
     def test_setup_template_index(self):
         """
-        Test template setup with config options
+        Test template setup of new index templates
         """
         self.render_config()
         exit_code = self.run_beat(logging_args=["-v", "-d", "*"],
@@ -340,7 +340,7 @@ class TestCommandSetupTemplate(BaseTest):
     @pytest.mark.tag('integration')
     def test_setup_template_component(self):
         """
-        Test template setup with config options
+        Test template setup of component index templates
         """
         self.render_config()
         exit_code = self.run_beat(logging_args=["-v", "-d", "*"],

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -348,7 +348,7 @@ class TestCommandSetupTemplate(BaseTest):
                                               "-E", "setup.template.type=component"])
 
         assert exit_code == 0
-        self.idxmgmt.assert_index_template_loaded(self.index_name)
+        self.idxmgmt.assert_component_template_loaded(self.index_name)
 
 
 class TestCommandExportTemplate(BaseTest):


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `setup.template.type` setting. When `index` were selected, Beats based the generated index on the legacy format, not on the component. This prevented Beats from loading the index.

## Why is it important?

`setup.template.type=index` was broken. Now it is fixed.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
./filebeat setup --index-management -E setup.template.type=index
```

## Related issues

Closes #22482