### PR TITLE
Bump up stack version to 7.10 for testing envs

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -15,11 +15,11 @@ services:
 
   # Used by base tests
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.0}-1
     build:
       context: ./module/elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.9.0}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.0}
     environment:
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
       - "network.host="
@@ -37,11 +37,11 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
     build:
       context: ./module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.9.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.0}
     depends_on:
       - elasticsearch
     ports:
@@ -49,11 +49,11 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.10.0}-1
     build:
       context: ./module/beat/_meta
       args:
-        BEAT_VERSION: ${BEAT_VERSION:-7.9.0}
+        BEAT_VERSION: ${BEAT_VERSION:-7.10.0}
     command: '-e'
     ports:
       - 5066

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-2
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
     build:
       context: ./module/kibana/_meta
       args:

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-2
     build:
       context: ./module/kibana/_meta
       args:

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,5 +1,3 @@
 ARG KIBANA_VERSION
 FROM docker.elastic.co/kibana/kibana:${KIBANA_VERSION}
-RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/share/kibana/jq
-RUN chmod +x jq
-HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD if [ $(curl -s http://myelastic:changeme@localhost:5601/api/status > status && cat status | ./jq ".status.overall.state") == '"green"' ]; then exit 0; else exit 1; fi
+HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD curl -u myelastic:changeme -f http://localhost:5601/api/status | grep -q 'Looking good'

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,4 +1,5 @@
 ARG KIBANA_VERSION
 FROM docker.elastic.co/kibana/kibana:${KIBANA_VERSION}
-HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);'
-
+RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/share/kibana/jq
+RUN chmod +x jq
+HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD if [ $(curl -s http://myelastic:changeme@localhost:5601/api/status > status && cat status | ./jq ".status.overall.state") == '"green"' ]; then exit 0; else exit 1; fi

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,3 +1,3 @@
 ARG KIBANA_VERSION
 FROM docker.elastic.co/kibana/kibana:${KIBANA_VERSION}
-HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD curl -u myelastic:changeme -f http://localhost:5601/api/status | grep -q 'Looking good'
+HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD curl -u myelastic:changeme -f "http://localhost:5601/api/stats?extended=true&legacy=true&exclude_usage=false" | grep '"status":"green"'

--- a/metricbeat/module/logstash/docker-compose.yml
+++ b/metricbeat/module/logstash/docker-compose.yml
@@ -2,22 +2,22 @@ version: '2.3'
 
 services:
   logstash:
-    image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.10.0}-1
     build:
       context: ./_meta
       args:
-        LOGSTASH_VERSION: ${LOGSTASH_VERSION:-7.9.0}
+        LOGSTASH_VERSION: ${LOGSTASH_VERSION:-7.10.0}
     ports:
       - 9600
     depends_on:
       - elasticsearch
 
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.0}-1
     build:
       context: ../elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.9.0}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.0}
     environment:
       - "network.host="
       - "transport.host=127.0.0.1"

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -16,7 +16,7 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.9.0
+    image: docker.elastic.co/logstash/logstash:7.10.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.0
+    image: docker.elastic.co/kibana/kibana:7.10.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -24,11 +24,11 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.9.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.9.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.0}
     depends_on:
       - elasticsearch
     ports:

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-2
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-2
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:


### PR DESCRIPTION
## What does this PR do?
This PR bumps up stack's version for testing environments.

## Why is it important?
So as to be compatible with new versions of dahboards etc. Blocker for https://github.com/elastic/beats/pull/22646