### PR TITLE
Cherry-pick #22676 to 7.x: Increase ES cache size

### DIFF
--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -14,6 +14,10 @@ services:
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=false"
+      - "script.context.template.max_compilations_rate=unlimited"
+      - "script.context.ingest.cache_max_size=2000"
+      - "script.context.processor_conditional.cache_max_size=2000"
+      - "script.context.template.cache_max_size=2000"
 
   logstash:
     image: docker.elastic.co/logstash/logstash:7.9.0

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -14,6 +14,10 @@ services:
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
     - "xpack.security.enabled=false"
+    - "script.context.template.max_compilations_rate=unlimited"
+    - "script.context.ingest.cache_max_size=2000"
+    - "script.context.processor_conditional.cache_max_size=2000"
+    - "script.context.template.cache_max_size=2000"
 
   logstash:
     image: docker.elastic.co/logstash/logstash:7.11.0-SNAPSHOT


### PR DESCRIPTION
Cherry-pick of PR #22676 to 7.x branch. Original message: 

This PR is to increase `cache_max_size` for Elasticsearch in order to fix the issue https://github.com/elastic/beats/issues/22561.