### PR TITLE
Add support for reading from UNIX datagram sockets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -728,6 +728,7 @@ from being added to events by default. {pull}18159[18159]
 - Added `event.ingested` field to data from the Netflow module. {pull}22412[22412]
 - Improve panw ECS url fields mapping. {pull}22481[22481]
 - Improve Nats filebeat dashboard. {pull}22726[22726]
+- Add support for UNIX datagram sockets in `unix` input. {issues}18632[18632] {pull}22699[22699]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-common-unix-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-unix-options.asciidoc
@@ -14,7 +14,14 @@ The maximum size of the message received over the socket. The default is `20MiB`
 [id="{beatname_lc}-input-{type}-unix-path"]
 ==== `path`
 
-The path to the Unix socket that will receive event streams.
+The path to the Unix socket that will receive events.
+
+[float]
+[id="{beatname_lc}-input-{type}-unix-socket-type"]
+==== `socket_type`
+
+The type to of the Unix socket that will receive events. Valid values
+are `stream` and `datagram`. The default is `stream`.
 
 [float]
 [id="{beatname_lc}-input-{type}-unix-group"]

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/harvester"
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/filebeat/inputsource"
-	netcommon "github.com/elastic/beats/v7/filebeat/inputsource/common"
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/streaming"
 	"github.com/elastic/beats/v7/filebeat/inputsource/tcp"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -75,13 +75,13 @@ func NewInput(
 		forwarder.Send(event)
 	}
 
-	splitFunc := netcommon.SplitFunc([]byte(config.LineDelimiter))
+	splitFunc := streaming.SplitFunc([]byte(config.LineDelimiter))
 	if splitFunc == nil {
 		return nil, fmt.Errorf("unable to create splitFunc for delimiter %s", config.LineDelimiter)
 	}
 
 	logger := logp.NewLogger("input.tcp").With("address", config.Config.Host)
-	factory := netcommon.SplitHandlerFactory(netcommon.FamilyTCP, logger, tcp.MetadataCallback, cb, splitFunc)
+	factory := streaming.SplitHandlerFactory(inputsource.FamilyTCP, logger, tcp.MetadataCallback, cb, splitFunc)
 
 	server, err := tcp.New(&config.Config, factory)
 	if err != nil {

--- a/filebeat/inputsource/common/dgram/handler.go
+++ b/filebeat/inputsource/common/dgram/handler.go
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dgram
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/elastic/beats/v7/filebeat/inputsource"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+// HandlerFactory returns a ConnectionHandler func
+type HandlerFactory func(config ListenerConfig) ConnectionHandler
+
+// ConnectionHandler is able to read from incoming connections.
+type ConnectionHandler func(context.Context, net.PacketConn) error
+
+// MetadataFunc defines callback executed when a line is read from the split handler.
+type MetadataFunc func(net.Conn) inputsource.NetworkMetadata
+
+// DatagramReaderFactory allows creation of a handler which can read packets from connections.
+func DatagramReaderFactory(
+	family inputsource.Family,
+	logger *logp.Logger,
+	callback inputsource.NetworkFunc,
+) HandlerFactory {
+	return func(config ListenerConfig) ConnectionHandler {
+		return ConnectionHandler(func(ctx context.Context, conn net.PacketConn) error {
+			for ctx.Err() == nil {
+
+				buffer := make([]byte, config.MaxMessageSize)
+				conn.SetDeadline(time.Now().Add(config.Timeout))
+
+				// If you are using Windows and you are using a fixed buffer and you get a datagram which
+				// is bigger than the specified size of the buffer, it will return an `err` and the buffer will
+				// contains a subset of the data.
+				//
+				// On Unix based system, the buffer will be truncated but no error will be returned.
+				length, addr, err := conn.ReadFrom(buffer)
+				if err != nil {
+					// don't log any deadline events.
+					e, ok := err.(net.Error)
+					if ok && e.Timeout() {
+						continue
+					}
+
+					// Closed network error string will never change in Go 1.X
+					// https://github.com/golang/go/issues/4373
+					opErr, ok := err.(*net.OpError)
+					if ok && strings.Contains(opErr.Err.Error(), "use of closed network connection") {
+						logger.Info("Connection has been closed")
+						return nil
+					}
+
+					logger.Errorf("Error reading from the socket %s", err)
+
+					// On Windows send the current buffer and mark it as truncated.
+					// The buffer will have content but length will return 0, addr will be nil.
+					if family == inputsource.FamilyUDP && isLargerThanBuffer(err) {
+						callback(buffer, inputsource.NetworkMetadata{RemoteAddr: addr, Truncated: true})
+						continue
+					}
+				}
+
+				if length > 0 {
+					callback(buffer[:length], inputsource.NetworkMetadata{RemoteAddr: addr})
+				}
+			}
+			return nil
+		})
+	}
+}
+
+func isLargerThanBuffer(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	return strings.Contains(err.Error(), windowErrBuffer)
+}

--- a/filebeat/inputsource/common/dgram/handler.go
+++ b/filebeat/inputsource/common/dgram/handler.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -49,7 +48,7 @@ func DatagramReaderFactory(
 			for ctx.Err() == nil {
 
 				buffer := make([]byte, config.MaxMessageSize)
-				conn.SetDeadline(time.Now().Add(config.Timeout))
+				//conn.SetDeadline(time.Now().Add(config.Timeout))
 
 				// If you are using Windows and you are using a fixed buffer and you get a datagram which
 				// is bigger than the specified size of the buffer, it will return an `err` and the buffer will

--- a/filebeat/inputsource/common/dgram/handler.go
+++ b/filebeat/inputsource/common/dgram/handler.go
@@ -19,6 +19,7 @@ package dgram
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"runtime"
 	"strings"
@@ -57,6 +58,9 @@ func DatagramReaderFactory(
 				// On Unix based system, the buffer will be truncated but no error will be returned.
 				length, addr, err := conn.ReadFrom(buffer)
 				if err != nil {
+					if family == inputsource.FamilyUnix {
+						fmt.Println("connection handler error", err)
+					}
 					// don't log any deadline events.
 					e, ok := err.(net.Error)
 					if ok && e.Timeout() {
@@ -85,6 +89,7 @@ func DatagramReaderFactory(
 					callback(buffer[:length], inputsource.NetworkMetadata{RemoteAddr: addr})
 				}
 			}
+			fmt.Println("end of connection handling")
 			return nil
 		})
 	}

--- a/filebeat/inputsource/common/dgram/server.go
+++ b/filebeat/inputsource/common/dgram/server.go
@@ -1,0 +1,201 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dgram
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/elastic/go-concert/ctxtool"
+	"github.com/elastic/go-concert/unison"
+
+	"github.com/elastic/beats/v7/filebeat/inputsource"
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+const windowErrBuffer = "A message sent on a datagram socket was larger than the internal message" +
+	" buffer or some other network limit, or the buffer used to receive a datagram into was smaller" +
+	" than the datagram itself."
+
+// HandlerFactory returns a ConnectionHandler func
+type HandlerFactory func(config ListenerConfig) ConnectionHandler
+
+type ConnectionHandler func(context.Context, net.PacketConn) error
+
+type ListenerFactory func() (net.PacketConn, error)
+
+// MetadataFunc defines callback executed when a line is read from the split handler.
+type MetadataFunc func(net.Conn) inputsource.NetworkMetadata
+
+type ListenerConfig struct {
+	Timeout        time.Duration
+	MaxMessageSize cfgtype.ByteSize
+}
+
+type Listener struct {
+	log      *logp.Logger
+	family   inputsource.Family
+	config   *ListenerConfig
+	listener ListenerFactory
+	connect  HandlerFactory
+	tg       unison.TaskGroup
+}
+
+func NewListener(
+	f inputsource.Family,
+	path string,
+	connect HandlerFactory,
+	listenerFactory ListenerFactory,
+	config *ListenerConfig,
+) *Listener {
+	return &Listener{
+		log:      logp.NewLogger(f.String()),
+		family:   f,
+		config:   config,
+		listener: listenerFactory,
+		connect:  connect,
+		tg:       unison.TaskGroup{},
+	}
+}
+
+// DatagramReaderFactory allows creation of a handler that has splitting capabilities.
+func DatagramReaderFactory(
+	family inputsource.Family,
+	logger *logp.Logger,
+	callback inputsource.NetworkFunc,
+) HandlerFactory {
+	return func(config ListenerConfig) ConnectionHandler {
+		return ConnectionHandler(func(ctx context.Context, conn net.PacketConn) error {
+			//metadata := metadataCallback(conn)
+			for ctx.Err() == nil {
+
+				buffer := make([]byte, config.MaxMessageSize)
+				conn.SetDeadline(time.Now().Add(config.Timeout))
+
+				// If you are using Windows and you are using a fixed buffer and you get a datagram which
+				// is bigger than the specified size of the buffer, it will return an `err` and the buffer will
+				// contains a subset of the data.
+				//
+				// On Unix based system, the buffer will be truncated but no error will be returned.
+				length, addr, err := conn.ReadFrom(buffer)
+				if err != nil {
+					// don't log any deadline events.
+					e, ok := err.(net.Error)
+					if ok && e.Timeout() {
+						continue
+					}
+
+					// Closed network error string will never change in Go 1.X
+					// https://github.com/golang/go/issues/4373
+					opErr, ok := err.(*net.OpError)
+					if ok && strings.Contains(opErr.Err.Error(), "use of closed network connection") {
+						logger.Info("Connection has been closed")
+						return nil
+					}
+
+					logger.Errorf("Error reading from the socket %s", err)
+
+					// On Windows send the current buffer and mark it as truncated.
+					// The buffer will have content but length will return 0, addr will be nil.
+					if family == inputsource.FamilyUDP && isLargerThanBuffer(err) {
+						callback(buffer, inputsource.NetworkMetadata{RemoteAddr: addr, Truncated: true})
+						continue
+					}
+				}
+
+				if length > 0 {
+					callback(buffer[:length], inputsource.NetworkMetadata{RemoteAddr: addr})
+				}
+			}
+			return nil
+		})
+	}
+}
+
+func isLargerThanBuffer(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	return strings.Contains(err.Error(), windowErrBuffer)
+}
+
+func (l *Listener) Run(ctx context.Context) error {
+	l.log.Info("Started listening for " + l.family.String() + " connection")
+
+	for ctx.Err() == nil {
+		conn, err := l.listener()
+		if err != nil {
+			l.log.Debugw("Cannot connect", "error", err)
+			continue
+		}
+		connCtx, connCancel := ctxtool.WithFunc(ctx, func() {
+			conn.Close()
+		})
+
+		err = l.run(connCtx, conn)
+		if err != nil {
+			l.log.Debugw("Error while processing input", "error", err)
+			connCancel()
+			continue
+		}
+		connCancel()
+	}
+	return nil
+}
+
+func (l *Listener) Start() error {
+	l.log.Info("Started listening for " + l.family.String() + " connection")
+
+	conn, err := l.listener()
+	if err != nil {
+		return err
+	}
+
+	l.tg.Go(func(ctx unison.Canceler) error {
+		connCtx, connCancel := ctxtool.WithFunc(ctxtool.FromCanceller(ctx), func() {
+			conn.Close()
+		})
+		defer connCancel()
+
+		return l.run(ctxtool.FromCanceller(connCtx), conn)
+	})
+	return nil
+}
+
+func (l *Listener) run(ctx context.Context, conn net.PacketConn) error {
+	handler := l.connect(*l.config)
+	for ctx.Err() == nil {
+		err := handler(ctx, conn)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Listener) Stop() {
+	l.log.Debug("Stopping datagram socket server for " + l.family.String())
+	err := l.tg.Stop()
+	if err != nil {
+		l.log.Errorf("Error while stopping datagram socket server: %v", err)
+	}
+}

--- a/filebeat/inputsource/common/dgram/server.go
+++ b/filebeat/inputsource/common/dgram/server.go
@@ -20,8 +20,6 @@ package dgram
 import (
 	"context"
 	"net"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/elastic/go-concert/ctxtool"
@@ -36,15 +34,8 @@ const windowErrBuffer = "A message sent on a datagram socket was larger than the
 	" buffer or some other network limit, or the buffer used to receive a datagram into was smaller" +
 	" than the datagram itself."
 
-// HandlerFactory returns a ConnectionHandler func
-type HandlerFactory func(config ListenerConfig) ConnectionHandler
-
-type ConnectionHandler func(context.Context, net.PacketConn) error
-
+// ListenerFactory is used to craete connections based on the configuration.
 type ListenerFactory func() (net.PacketConn, error)
-
-// MetadataFunc defines callback executed when a line is read from the split handler.
-type MetadataFunc func(net.Conn) inputsource.NetworkMetadata
 
 type ListenerConfig struct {
 	Timeout        time.Duration
@@ -75,67 +66,6 @@ func NewListener(
 		connect:  connect,
 		tg:       unison.TaskGroup{},
 	}
-}
-
-// DatagramReaderFactory allows creation of a handler that has splitting capabilities.
-func DatagramReaderFactory(
-	family inputsource.Family,
-	logger *logp.Logger,
-	callback inputsource.NetworkFunc,
-) HandlerFactory {
-	return func(config ListenerConfig) ConnectionHandler {
-		return ConnectionHandler(func(ctx context.Context, conn net.PacketConn) error {
-			//metadata := metadataCallback(conn)
-			for ctx.Err() == nil {
-
-				buffer := make([]byte, config.MaxMessageSize)
-				conn.SetDeadline(time.Now().Add(config.Timeout))
-
-				// If you are using Windows and you are using a fixed buffer and you get a datagram which
-				// is bigger than the specified size of the buffer, it will return an `err` and the buffer will
-				// contains a subset of the data.
-				//
-				// On Unix based system, the buffer will be truncated but no error will be returned.
-				length, addr, err := conn.ReadFrom(buffer)
-				if err != nil {
-					// don't log any deadline events.
-					e, ok := err.(net.Error)
-					if ok && e.Timeout() {
-						continue
-					}
-
-					// Closed network error string will never change in Go 1.X
-					// https://github.com/golang/go/issues/4373
-					opErr, ok := err.(*net.OpError)
-					if ok && strings.Contains(opErr.Err.Error(), "use of closed network connection") {
-						logger.Info("Connection has been closed")
-						return nil
-					}
-
-					logger.Errorf("Error reading from the socket %s", err)
-
-					// On Windows send the current buffer and mark it as truncated.
-					// The buffer will have content but length will return 0, addr will be nil.
-					if family == inputsource.FamilyUDP && isLargerThanBuffer(err) {
-						callback(buffer, inputsource.NetworkMetadata{RemoteAddr: addr, Truncated: true})
-						continue
-					}
-				}
-
-				if length > 0 {
-					callback(buffer[:length], inputsource.NetworkMetadata{RemoteAddr: addr})
-				}
-			}
-			return nil
-		})
-	}
-}
-
-func isLargerThanBuffer(err error) bool {
-	if runtime.GOOS != "windows" {
-		return false
-	}
-	return strings.Contains(err.Error(), windowErrBuffer)
 }
 
 func (l *Listener) Run(ctx context.Context) error {

--- a/filebeat/inputsource/common/streaming/config.go
+++ b/filebeat/inputsource/common/streaming/config.go
@@ -15,27 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package unix
+package streaming
 
 import (
 	"time"
 
-	"github.com/dustin/go-humanize"
-
-	"github.com/elastic/beats/v7/filebeat/inputsource/unix"
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 )
 
-type config struct {
-	unix.Config `config:",inline"`
-}
-
-func defaultConfig() config {
-	return config{
-		Config: unix.Config{
-			Timeout:        time.Minute * 5,
-			MaxMessageSize: 20 * humanize.MiByte,
-			SocketType:     unix.StreamSocket,
-			LineDelimiter:  "\n",
-		},
-	}
+// ListenerConfig exposes the shared listener configuration.
+type ListenerConfig struct {
+	Timeout        time.Duration
+	MaxMessageSize cfgtype.ByteSize
+	MaxConnections int
 }

--- a/filebeat/inputsource/common/streaming/conn.go
+++ b/filebeat/inputsource/common/streaming/conn.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"io"

--- a/filebeat/inputsource/common/streaming/conn_test.go
+++ b/filebeat/inputsource/common/streaming/conn_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"math/rand"

--- a/filebeat/inputsource/common/streaming/handler.go
+++ b/filebeat/inputsource/common/streaming/handler.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"bufio"
@@ -38,14 +38,14 @@ type ConnectionHandler func(context.Context, net.Conn) error
 type MetadataFunc func(net.Conn) inputsource.NetworkMetadata
 
 // SplitHandlerFactory allows creation of a handler that has splitting capabilities.
-func SplitHandlerFactory(family Family, logger *logp.Logger, metadataCallback MetadataFunc, callback inputsource.NetworkFunc, splitFunc bufio.SplitFunc) HandlerFactory {
+func SplitHandlerFactory(family inputsource.Family, logger *logp.Logger, metadataCallback MetadataFunc, callback inputsource.NetworkFunc, splitFunc bufio.SplitFunc) HandlerFactory {
 	return func(config ListenerConfig) ConnectionHandler {
 		return ConnectionHandler(func(ctx context.Context, conn net.Conn) error {
 			metadata := metadataCallback(conn)
 			maxMessageSize := uint64(config.MaxMessageSize)
 
 			var log *logp.Logger
-			if family == FamilyUnix {
+			if family == inputsource.FamilyUnix {
 				// unix sockets have an empty `RemoteAddr` value, so no need to capture it
 				log = logger.With("handler", "split_client")
 			} else {

--- a/filebeat/inputsource/common/streaming/listener.go
+++ b/filebeat/inputsource/common/streaming/listener.go
@@ -170,6 +170,10 @@ func (l *Listener) unregisterHandler() {
 
 // SplitFunc allows to create a `bufio.SplitFunc` based on a delimiter provided.
 func SplitFunc(lineDelimiter []byte) bufio.SplitFunc {
+	if len(lineDelimiter) == 0 {
+		return nil
+	}
+
 	ld := []byte(lineDelimiter)
 	if bytes.Equal(ld, []byte("\n")) {
 		// This will work for most usecases and will also strip \r if present.

--- a/filebeat/inputsource/common/streaming/listener.go
+++ b/filebeat/inputsource/common/streaming/listener.go
@@ -15,34 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"bufio"
 	"bytes"
 	"context"
 	"net"
-	"strings"
 	"sync"
 
+	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/ctxtool"
 )
-
-// Family represents the type of connection we're handling
-type Family string
-
-const (
-	// FamilyUnix represents a unix socket listener
-	FamilyUnix Family = "unix"
-	// FamilyTCP represents a tcp socket listener
-	FamilyTCP Family = "tcp"
-)
-
-func (f Family) String() string {
-	return strings.ToUpper(string(f))
-}
 
 // ListenerFactory returns a net.Listener
 type ListenerFactory func() (net.Listener, error)
@@ -51,7 +37,7 @@ type ListenerFactory func() (net.Listener, error)
 type Listener struct {
 	Listener        net.Listener
 	config          *ListenerConfig
-	family          Family
+	family          inputsource.Family
 	wg              sync.WaitGroup
 	log             *logp.Logger
 	ctx             context.Context
@@ -62,7 +48,7 @@ type Listener struct {
 }
 
 // NewListener creates a new Listener
-func NewListener(family Family, location string, handlerFactory HandlerFactory, listenerFactory ListenerFactory, config *ListenerConfig) *Listener {
+func NewListener(family inputsource.Family, location string, handlerFactory HandlerFactory, listenerFactory ListenerFactory, config *ListenerConfig) *Listener {
 	return &Listener{
 		config:          config,
 		family:          family,
@@ -141,7 +127,7 @@ func (l *Listener) run() {
 			l.registerHandler()
 			defer l.unregisterHandler()
 
-			if l.family == FamilyUnix {
+			if l.family == inputsource.FamilyUnix {
 				// unix sockets have an empty `RemoteAddr` value, so no need to capture it
 				l.log.Debugw("New client", "total", l.clientsCount.Load())
 			} else {
@@ -155,7 +141,7 @@ func (l *Listener) run() {
 			}
 
 			defer func() {
-				if l.family == FamilyUnix {
+				if l.family == inputsource.FamilyUnix {
 					// unix sockets have an empty `RemoteAddr` value, so no need to capture it
 					l.log.Debugw("client disconnected", "total", l.clientsCount.Load())
 				} else {

--- a/filebeat/inputsource/common/streaming/scan.go
+++ b/filebeat/inputsource/common/streaming/scan.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"bufio"

--- a/filebeat/inputsource/common/streaming/scan_test.go
+++ b/filebeat/inputsource/common/streaming/scan_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package streaming
 
 import (
 	"bufio"

--- a/filebeat/inputsource/family.go
+++ b/filebeat/inputsource/family.go
@@ -15,17 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package inputsource
 
-import (
-	"time"
+import "strings"
 
-	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
+// Family represents the type of connection we're handling
+type Family string
+
+const (
+	// FamilyUnix represents a unix socket listener
+	FamilyUnix Family = "unix"
+	// FamilyTCP represents a tcp socket listener
+	FamilyTCP Family = "tcp"
+	// FamilyUDP represents a udp socket listener
+	FamilyUDP Family = "udp"
 )
 
-// ListenerConfig exposes the shared listener configuration.
-type ListenerConfig struct {
-	Timeout        time.Duration
-	MaxMessageSize cfgtype.ByteSize
-	MaxConnections int
+func (f Family) String() string {
+	return strings.ToUpper(string(f))
 }

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -24,13 +24,14 @@ import (
 
 	"golang.org/x/net/netutil"
 
-	"github.com/elastic/beats/v7/filebeat/inputsource/common"
+	"github.com/elastic/beats/v7/filebeat/inputsource"
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/streaming"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
 // Server represent a TCP server
 type Server struct {
-	*common.Listener
+	*streaming.Listener
 
 	config    *Config
 	tlsConfig *tlscommon.TLSConfig
@@ -39,7 +40,7 @@ type Server struct {
 // New creates a new tcp server
 func New(
 	config *Config,
-	factory common.HandlerFactory,
+	factory streaming.HandlerFactory,
 ) (*Server, error) {
 	tlsConfig, err := tlscommon.LoadTLSServerConfig(config.TLS)
 	if err != nil {
@@ -54,7 +55,7 @@ func New(
 		config:    config,
 		tlsConfig: tlsConfig,
 	}
-	server.Listener = common.NewListener(common.FamilyTCP, config.Host, factory, server.createServer, &common.ListenerConfig{
+	server.Listener = streaming.NewListener(inputsource.FamilyTCP, config.Host, factory, server.createServer, &streaming.ListenerConfig{
 		Timeout:        config.Timeout,
 		MaxMessageSize: config.MaxMessageSize,
 		MaxConnections: config.MaxConnections,

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/filebeat/inputsource"
-	netcommon "github.com/elastic/beats/v7/filebeat/inputsource/common"
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/streaming"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -69,76 +69,76 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 		{
 			name:             "NewLine",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("\n")),
+			splitFunc:        streaming.SplitFunc([]byte("\n")),
 			expectedMessages: expectedMessages,
 			messageSent:      strings.Join(expectedMessages, "\n"),
 		},
 		{
 			name:             "NewLineWithCR",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("\r\n")),
+			splitFunc:        streaming.SplitFunc([]byte("\r\n")),
 			expectedMessages: expectedMessages,
 			messageSent:      strings.Join(expectedMessages, "\r\n"),
 		},
 		{
 			name:             "CustomDelimiter",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte(";")),
+			splitFunc:        streaming.SplitFunc([]byte(";")),
 			expectedMessages: expectedMessages,
 			messageSent:      strings.Join(expectedMessages, ";"),
 		},
 		{
 			name:             "MultipleCharsCustomDelimiter",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("<END>")),
+			splitFunc:        streaming.SplitFunc([]byte("<END>")),
 			expectedMessages: expectedMessages,
 			messageSent:      strings.Join(expectedMessages, "<END>"),
 		},
 		{
 			name:             "SingleCharCustomDelimiterMessageWithoutBoundaries",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte(";")),
+			splitFunc:        streaming.SplitFunc([]byte(";")),
 			expectedMessages: []string{"hello"},
 			messageSent:      "hello",
 		},
 		{
 			name:             "MultipleCharCustomDelimiterMessageWithoutBoundaries",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("<END>")),
+			splitFunc:        streaming.SplitFunc([]byte("<END>")),
 			expectedMessages: []string{"hello"},
 			messageSent:      "hello",
 		},
 		{
 			name:             "NewLineMessageWithoutBoundaries",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("\n")),
+			splitFunc:        streaming.SplitFunc([]byte("\n")),
 			expectedMessages: []string{"hello"},
 			messageSent:      "hello",
 		},
 		{
 			name:             "NewLineLargeMessagePayload",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("\n")),
+			splitFunc:        streaming.SplitFunc([]byte("\n")),
 			expectedMessages: largeMessages,
 			messageSent:      strings.Join(largeMessages, "\n"),
 		},
 		{
 			name:             "CustomLargeMessagePayload",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte(";")),
+			splitFunc:        streaming.SplitFunc([]byte(";")),
 			expectedMessages: largeMessages,
 			messageSent:      strings.Join(largeMessages, ";"),
 		},
 		{
 			name:             "ReadRandomLargePayload",
 			cfg:              map[string]interface{}{},
-			splitFunc:        netcommon.SplitFunc([]byte("\n")),
+			splitFunc:        streaming.SplitFunc([]byte("\n")),
 			expectedMessages: []string{randomGeneratedText},
 			messageSent:      randomGeneratedText,
 		},
 		{
 			name:      "MaxReadBufferReachedUserConfigured",
-			splitFunc: netcommon.SplitFunc([]byte("\n")),
+			splitFunc: streaming.SplitFunc([]byte("\n")),
 			cfg: map[string]interface{}{
 				"max_message_size": 50000,
 			},
@@ -147,7 +147,7 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 		},
 		{
 			name:      "MaxBufferSizeSet",
-			splitFunc: netcommon.SplitFunc([]byte("\n")),
+			splitFunc: streaming.SplitFunc([]byte("\n")),
 			cfg: map[string]interface{}{
 				"max_message_size": 66 * 1024,
 			},
@@ -171,7 +171,7 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 				return
 			}
 
-			factory := netcommon.SplitHandlerFactory(netcommon.FamilyTCP, logp.NewLogger("test"), MetadataCallback, to, test.splitFunc)
+			factory := streaming.SplitHandlerFactory(inputsource.FamilyTCP, logp.NewLogger("test"), MetadataCallback, to, test.splitFunc)
 			server, err := New(&config, factory)
 			if !assert.NoError(t, err) {
 				return
@@ -223,7 +223,7 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 		return
 	}
 
-	factory := netcommon.SplitHandlerFactory(netcommon.FamilyTCP, logp.NewLogger("test"), MetadataCallback, to, bufio.ScanLines)
+	factory := streaming.SplitHandlerFactory(inputsource.FamilyTCP, logp.NewLogger("test"), MetadataCallback, to, bufio.ScanLines)
 
 	server, err := New(&config, factory)
 	if !assert.NoError(t, err) {

--- a/filebeat/inputsource/udp/server.go
+++ b/filebeat/inputsource/udp/server.go
@@ -19,134 +19,55 @@ package udp
 
 import (
 	"net"
-	"runtime"
-	"strings"
-	"sync"
-	"time"
 
 	"github.com/dustin/go-humanize"
 
 	"github.com/elastic/beats/v7/filebeat/inputsource"
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/dgram"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // Name is the human readable name and identifier.
 const Name = "udp"
 
-const windowErrBuffer = "A message sent on a datagram socket was larger than the internal message" +
-	" buffer or some other network limit, or the buffer used to receive a datagram into was smaller" +
-	" than the datagram itself."
-
 // Server creates a simple UDP Server and listen to a specific host:port and will send any
 // event received to the callback method.
 type Server struct {
-	config   *Config
-	callback inputsource.NetworkFunc
-	Listener *net.UDPConn
-	log      *logp.Logger
-	wg       sync.WaitGroup
-	done     chan struct{}
+	*dgram.Listener
+	config *Config
+
+	localaddress string
 }
 
 // New returns a new UDPServer instance.
 func New(config *Config, callback inputsource.NetworkFunc) *Server {
-	return &Server{
-		config:   config,
-		callback: callback,
-		log:      logp.NewLogger("udp").With("address", config.Host),
-		done:     make(chan struct{}),
-	}
+	server := &Server{config: config}
+	log := logp.NewLogger("udp").With("address", config.Host)
+	factory := dgram.DatagramReaderFactory(inputsource.FamilyUDP, log, callback)
+	server.Listener = dgram.NewListener(inputsource.FamilyUDP, config.Host, factory, server.createConn, &dgram.ListenerConfig{
+		Timeout:        config.Timeout,
+		MaxMessageSize: config.MaxMessageSize,
+	})
+	return server
 }
 
-// Start starts the UDP Server and listen to incoming events.
-func (u *Server) Start() error {
+func (u *Server) createConn() (net.PacketConn, error) {
 	var err error
 	udpAdddr, err := net.ResolveUDPAddr("udp", u.config.Host)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	u.Listener, err = net.ListenUDP("udp", udpAdddr)
+	listener, err := net.ListenUDP("udp", udpAdddr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	socketSize := int(u.config.ReadBuffer) * humanize.KiByte
 	if socketSize != 0 {
-		if err := u.Listener.SetReadBuffer(int(u.config.ReadBuffer)); err != nil {
-			return err
+		if err := listener.SetReadBuffer(int(u.config.ReadBuffer)); err != nil {
+			return nil, err
 		}
 	}
-	if err != nil {
-		return err
-	}
-	u.log.Info("Started listening for UDP connection")
-	u.wg.Add(1)
-	go func() {
-		defer u.wg.Done()
-		u.run()
-	}()
-	return nil
-}
+	u.localaddress = listener.LocalAddr().String()
 
-func (u *Server) run() {
-	for {
-		select {
-		case <-u.done:
-			return
-		default:
-		}
-
-		buffer := make([]byte, u.config.MaxMessageSize)
-		u.Listener.SetDeadline(time.Now().Add(u.config.Timeout))
-
-		// If you are using Windows and you are using a fixed buffer and you get a datagram which
-		// is bigger than the specified size of the buffer, it will return an `err` and the buffer will
-		// contains a subset of the data.
-		//
-		// On Unix based system, the buffer will be truncated but no error will be returned.
-		length, addr, err := u.Listener.ReadFrom(buffer)
-		if err != nil {
-			// don't log any deadline events.
-			e, ok := err.(net.Error)
-			if ok && e.Timeout() {
-				continue
-			}
-
-			// Closed network error string will never change in Go 1.X
-			// https://github.com/golang/go/issues/4373
-			opErr, ok := err.(*net.OpError)
-			if ok && strings.Contains(opErr.Err.Error(), "use of closed network connection") {
-				u.log.Info("Connection has been closed")
-				return
-			}
-
-			u.log.Errorf("Error reading from the socket %s", err)
-
-			// On Windows send the current buffer and mark it as truncated.
-			// The buffer will have content but length will return 0, addr will be nil.
-			if isLargerThanBuffer(err) {
-				u.callback(buffer, inputsource.NetworkMetadata{RemoteAddr: addr, Truncated: true})
-				continue
-			}
-		}
-
-		if length > 0 {
-			u.callback(buffer[:length], inputsource.NetworkMetadata{RemoteAddr: addr})
-		}
-	}
-}
-
-// Stop stops the current udp server.
-func (u *Server) Stop() {
-	u.log.Info("Stopping UDP server")
-	close(u.done)
-	u.Listener.Close()
-	u.wg.Wait()
-	u.log.Info("UDP server stopped")
-}
-
-func isLargerThanBuffer(err error) bool {
-	if runtime.GOOS != "windows" {
-		return false
-	}
-	return strings.Contains(err.Error(), windowErrBuffer)
+	return listener, err
 }

--- a/filebeat/inputsource/udp/server_test.go
+++ b/filebeat/inputsource/udp/server_test.go
@@ -75,7 +75,7 @@ func TestReceiveEventFromUDP(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			conn, err := net.Dial("udp", s.Listener.LocalAddr().String())
+			conn, err := net.Dial("udp", s.localaddress)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/filebeat/inputsource/unix/config.go
+++ b/filebeat/inputsource/unix/config.go
@@ -60,7 +60,12 @@ func (c *Config) Validate() error {
 	if len(c.Path) == 0 {
 		return fmt.Errorf("need to specify the path to the unix socket")
 	}
+
+	if c.SocketType == StreamSocket && c.LineDelimiter == "" {
+		return fmt.Errorf("line_delimiter cannot be empty when using stream socket")
+	}
 	return nil
+
 }
 
 func (s *SocketType) Unpack(value string) error {

--- a/filebeat/inputsource/unix/config.go
+++ b/filebeat/inputsource/unix/config.go
@@ -24,8 +24,24 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 )
 
-// Name is the human readable name and identifier.
-const Name = "unix"
+type SocketType uint8
+
+const (
+	// StreamSocket is used when reading from a Unix stream socket.
+	StreamSocket SocketType = iota
+	// DatagramSocket is used when reading from a Unix datagram socket.
+	DatagramSocket
+)
+
+const (
+	// Name is the human readable name and identifier.
+	Name = "unix"
+)
+
+var socketTypes = map[string]SocketType{
+	"stream":   StreamSocket,
+	"datagram": DatagramSocket,
+}
 
 // Config exposes the unix configuration.
 type Config struct {
@@ -35,6 +51,8 @@ type Config struct {
 	Timeout        time.Duration    `config:"timeout" validate:"nonzero,positive"`
 	MaxMessageSize cfgtype.ByteSize `config:"max_message_size" validate:"nonzero,positive"`
 	MaxConnections int              `config:"max_connections"`
+	LineDelimiter  string           `config:"line_delimiter"`
+	SocketType     SocketType       `config:"socket_type"`
 }
 
 // Validate validates the Config option for the unix input.
@@ -42,5 +60,21 @@ func (c *Config) Validate() error {
 	if len(c.Path) == 0 {
 		return fmt.Errorf("need to specify the path to the unix socket")
 	}
+	return nil
+}
+
+func (s *SocketType) Unpack(value string) error {
+	setting, ok := socketTypes[value]
+	if !ok {
+		availableTypes := make([]string, len(socketTypes))
+		i := 0
+		for t := range socketTypes {
+			availableTypes[i] = t
+			i++
+		}
+		return fmt.Errorf("unknown socket type: %s, supported types: %v", value, availableTypes)
+	}
+
+	*s = setting
 	return nil
 }

--- a/filebeat/inputsource/unix/config_test.go
+++ b/filebeat/inputsource/unix/config_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package unix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestErrorMissingPath(t *testing.T) {
+	c := common.MustNewConfigFrom(map[string]interface{}{
+		"timeout":          1,
+		"max_message_size": 1,
+	})
+	var config Config
+	err := c.Unpack(&config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "need to specify the path to the unix socket")
+}
+
+func TestErrorOnEmptyLineDelimiterWhenStreamSocket(t *testing.T) {
+	c := common.MustNewConfigFrom(map[string]interface{}{
+		"timeout":          1,
+		"max_message_size": 1,
+		"path":             "my-path",
+		"socket_type":      "stream",
+	})
+	var config Config
+	err := c.Unpack(&config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "line_delimiter cannot be empty when using stream socket")
+}
+
+func TestInvalidSocketType(t *testing.T) {
+	c := common.MustNewConfigFrom(map[string]interface{}{
+		"timeout":          1,
+		"max_message_size": 1,
+		"path":             "my-path",
+		"socket_type":      "invalid_type",
+	})
+	var config Config
+	err := c.Unpack(&config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown socket type")
+}

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -336,6 +336,9 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 				return
 			}
 
+			if socketType == "datagram" {
+				config.Timeout = 0
+			}
 			server, err := New(logp.L(), &config, to)
 			if !assert.NoError(t, err) {
 				return

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -383,15 +383,13 @@ func sendOverUnixStream(t *testing.T, ctx context.Context, path string, samples 
 	if !assert.NoError(t, err) {
 		return
 	}
+	defer conn.Close()
+
 	for _, sample := range samples {
 		fmt.Fprintln(conn, sample)
 	}
 
-	select {
-	case <-ctx.Done():
-		conn.Close()
-	}
-
+	<-ctx.Done()
 }
 
 func sendOverUnixDatagram(t *testing.T, ctx context.Context, path string, samples []string) {
@@ -399,14 +397,13 @@ func sendOverUnixDatagram(t *testing.T, ctx context.Context, path string, sample
 	if !assert.NoError(t, err) {
 		return
 	}
+	defer conn.Close()
 	for _, sample := range samples {
 		fmt.Fprintln(conn, sample)
 	}
 
-	select {
-	case <-ctx.Done():
-		conn.Close()
-	}
+	<-ctx.Done()
+	fmt.Println("closing UNIX DGRAM connection")
 }
 
 func randomString(l int) string {

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -393,7 +393,7 @@ func sendOverUnixStream(t *testing.T, ctx context.Context, path string, samples 
 }
 
 func sendOverUnixDatagram(t *testing.T, ctx context.Context, path string, samples []string) {
-	conn, err := net.Dial("unixgram", path)
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{path, "unixgram"})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -53,11 +53,20 @@ type info struct {
 	mt      inputsource.NetworkMetadata
 }
 
-func TestErrorOnEmptyLineDelimiterWhenStreamSocket(t *testing.T) {
-	c := common.NewConfig()
-	config := defaultConfig()
-	config.Path = "my-random-path"
-	err := c.Unpack(&config)
+func TestErrorOnInvalidSocketType(t *testing.T) {
+	config := &Config{
+		SocketType: SocketType(7),
+	}
+	_, err := New(logp.L(), config, nil)
+	assert.Error(t, err)
+}
+
+func TestErrorOnEmptyLineDelimiter(t *testing.T) {
+	config := &Config{
+		SocketType:    StreamSocket,
+		LineDelimiter: "",
+	}
+	_, err := New(logp.L(), config, nil)
 	assert.Error(t, err)
 }
 
@@ -312,9 +321,10 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 				ch <- &info{message: string(message), mt: mt}
 			}
 			cfg, err := common.NewConfigFrom(map[string]interface{}{
-				"path":           path,
-				"line_delimiter": "\n",
-				"socket_type":    socketType,
+				"path":            path,
+				"line_delimiter":  "\n",
+				"socket_type":     socketType,
+				"max_connections": 2,
 			})
 			if !assert.NoError(t, err) {
 				return

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -393,7 +393,7 @@ func sendOverUnixStream(t *testing.T, ctx context.Context, path string, samples 
 }
 
 func sendOverUnixDatagram(t *testing.T, ctx context.Context, path string, samples []string) {
-	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{path, "unixgram"})
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: path, Net: "unixgram"})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -312,7 +312,7 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 		}
 
 		t.Run("socket_type "+socketType, func(t *testing.T) {
-			workers := 4
+			workers := 1
 			eventsCount := 100
 			path := filepath.Join(os.TempDir(), "test.sock")
 			ch := make(chan *info, eventsCount*workers)

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -380,7 +380,10 @@ func sendOverUnixStream(t *testing.T, path string, samples []string) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	defer conn.Close()
+	defer func() {
+		fmt.Println("Closing stream connection")
+		conn.Close()
+	}()
 	for _, sample := range samples {
 		fmt.Fprintln(conn, sample)
 	}
@@ -392,7 +395,10 @@ func sendOverUnixDatagram(t *testing.T, path string, samples []string) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	defer conn.Close()
+	defer func() {
+		fmt.Println("Closing datagram connection")
+		conn.Close()
+	}()
 	for _, sample := range samples {
 		fmt.Fprintln(conn, sample)
 	}

--- a/filebeat/inputsource/unix/server_test.go
+++ b/filebeat/inputsource/unix/server_test.go
@@ -355,9 +355,18 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 			}
 
 			var events []*info
+			prevId := -1
 			for len(events) < eventsCount*workers {
 				select {
 				case event := <-ch:
+					parts := strings.Split(event.message, "-")
+					id, _ := strconv.Atoi(strings.TrimSuffix(parts[1], "\n"))
+					if id <= prevId {
+						fmt.Println("current ID is not bigger than prev ID, prev:", prevId, "current:", id)
+					} else {
+						fmt.Println("difference between two IDs:", strconv.Itoa(id-prevId), id, prevId)
+					}
+					prevId = id
 					events = append(events, event)
 				default:
 				}
@@ -402,7 +411,7 @@ func randomString(l int) string {
 func generateMessages(c int, l int) []string {
 	messages := make([]string, c)
 	for i := range messages {
-		messages[i] = randomString(l)
+		messages[i] = randomString(l) + "-" + strconv.Itoa(i)
 	}
 	return messages
 }

--- a/filebeat/inputsource/unix/socket.go
+++ b/filebeat/inputsource/unix/socket.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unix
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func cleanupStaleSocket(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		// If the file does not exist, then the cleanup can be considered successful.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "cannot lstat unix socket file at location %s", path)
+	}
+
+	if runtime.GOOS != "windows" {
+		// see https://github.com/golang/go/issues/33357 for context on Windows socket file attributes bug
+		if info.Mode()&os.ModeSocket == 0 {
+			return fmt.Errorf("refusing to remove file at location %s, it is not a socket", path)
+		}
+	}
+
+	if err := os.Remove(path); err != nil {
+		return errors.Wrapf(err, "cannot remove existing unix socket file at location %s", path)
+	}
+
+	return nil
+}
+
+func setSocketOwnership(path string, group *string) error {
+	if group != nil {
+		if runtime.GOOS == "windows" {
+			logp.NewLogger("unix").Warn("windows does not support the 'group' configuration option, ignoring")
+			return nil
+		}
+		g, err := user.LookupGroup(*group)
+		if err != nil {
+			return err
+		}
+		gid, err := strconv.Atoi(g.Gid)
+		if err != nil {
+			return err
+		}
+		return os.Chown(path, -1, gid)
+	}
+	return nil
+}
+
+func setSocketMode(path string, mode *string) error {
+	if mode != nil {
+		m, err := parseFileMode(*mode)
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, m)
+	}
+	return nil
+}
+
+func parseFileMode(mode string) (os.FileMode, error) {
+	parsed, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return 0, err
+	}
+	if parsed > 0777 {
+		return 0, errors.New("invalid file mode")
+	}
+	return os.FileMode(parsed), nil
+}

--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -127,6 +127,8 @@ class Test(BaseTest):
 
         filebeat.check_kill_and_wait()
 
+        sock.close()
+
         output = self.read_output()
 
         assert len(output) == 2
@@ -281,8 +283,6 @@ def send_stream_socket(path, message):
 
 def send_datagram_socket(path, message):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-
-    sock.connect(path)
 
     for n in range(0, 2):
         message = message.format(n)

--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -135,13 +135,28 @@ class Test(BaseTest):
     # AF_UNIX support in python isn't available until
     # Python 3.9, see https://bugs.python.org/issue33408
     @unittest.skipIf(not hasattr(socket, 'AF_UNIX'), "No Windows AF_UNIX support before Python 3.9")
-    def test_syslog_with_unix(self):
+    def test_syslog_with_unix_stream(self):
         """
-        Test syslog input with events from UNIX.
+        Test syslog input with events from UNIX stream.
         """
+
+        self.run_filebeat_and_send_using_socket("stream", send_stream_socket)
+
+    # AF_UNIX support in python isn't available until
+    # Python 3.9, see https://bugs.python.org/issue33408
+    @unittest.skipIf(not hasattr(socket, 'AF_UNIX'), "No Windows AF_UNIX support before Python 3.9")
+    def test_syslog_with_unix_datagram(self):
+        """
+        Test syslog input with events from UNIX stream.
+        """
+
+        self.run_filebeat_and_send_using_socket("datagram", send_datagram_socket)
+
+    def run_filebeat_and_send_using_socket(self, socket_type, send_over_socket):
         # we create the socket in a temporary directory because
         # go will fail to create a unix socket if the path length
         # is longer than 108 characters. See https://github.com/golang/go/issues/6895
+
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "filebeat.sock")
             input_raw = """
@@ -149,9 +164,10 @@ class Test(BaseTest):
   protocol:
     unix:
         path: {}
+        socket_type: {}
 """
 
-            input_raw = input_raw.format(path)
+            input_raw = input_raw.format(path, socket_type)
             self.render_config_template(
                 input_raw=input_raw,
                 inputs=False,
@@ -161,15 +177,9 @@ class Test(BaseTest):
 
             self.wait_until(lambda: self.log_contains("Started listening for UNIX connection"))
 
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # UNIX
-
-            sock.connect(path)
-
-            for n in range(0, 2):
-                m = "<13>Oct 11 22:14:15 wopr.mymachine.co postfix/smtpd[2000]:" \
-                    " 'su root' failed for lonvick on /dev/pts/8 {}\n"
-                m = m.format(n)
-                sock.send(m.encode("utf-8"))
+            sock = send_over_socket(path,
+                                    "<13>Oct 11 22:14:15 wopr.mymachine.co postfix/smtpd[2000]:"
+                                    " 'su root' failed for lonvick on /dev/pts/8 {}\n")
 
             self.wait_until(lambda: self.output_count(lambda x: x >= 2))
 
@@ -180,13 +190,30 @@ class Test(BaseTest):
             assert len(output) == 2
             self.assert_syslog(output[0], False)
 
+            sock.close()
+
     # AF_UNIX support in python isn't available until
     # Python 3.9, see https://bugs.python.org/issue33408
+
     @unittest.skipIf(not hasattr(socket, 'AF_UNIX'), "No Windows AF_UNIX support before Python 3.9")
-    def test_syslog_with_unix_invalid_message(self):
+    def test_syslog_with_unix_stream_invalid_message(self):
         """
         Test syslog input with invalid events from UNIX.
         """
+
+        self.run_filebeat_and_send_invalid_message_using_socket("stream", send_stream_socket)
+
+    # AF_UNIX support in python isn't available until
+    # Python 3.9, see https://bugs.python.org/issue33408
+    @unittest.skipIf(not hasattr(socket, 'AF_UNIX'), "No Windows AF_UNIX support before Python 3.9")
+    def test_syslog_with_unix_datagram_invalid_message(self):
+        """
+        Test syslog input with invalid events from UNIX.
+        """
+
+        self.run_filebeat_and_send_invalid_message_using_socket("datagram", send_datagram_socket)
+
+    def run_filebeat_and_send_invalid_message_using_socket(self, socket_type, send_over_socket):
         # we create the socket in a temporary directory because
         # go will fail to create a unix socket if the path length
         # is longer than 108 characters. See https://github.com/golang/go/issues/6895
@@ -197,9 +224,10 @@ class Test(BaseTest):
   protocol:
     unix:
         path: {}
+        socket_type: {}
 """
 
-            input_raw = input_raw.format(path)
+            input_raw = input_raw.format(path, socket_type)
             self.render_config_template(
                 input_raw=input_raw,
                 inputs=False,
@@ -209,11 +237,7 @@ class Test(BaseTest):
 
             self.wait_until(lambda: self.log_contains("Started listening for UNIX connection"))
 
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # UNIX
-
-            sock.connect(path)
-            for n in range(0, 2):
-                sock.send("invalid\n".encode("utf-8"))
+            sock = send_over_socket(path, "invalid\n")
 
             self.wait_until(lambda: self.output_count(lambda x: x >= 2))
 
@@ -222,7 +246,10 @@ class Test(BaseTest):
             output = self.read_output()
 
             assert len(output) == 2
-            assert output[0]["message"] == "invalid"
+            expected_message = "invalid"
+            if socket_type == "datagram":
+                expected_message += "\n"
+            assert output[0]["message"] == expected_message
             sock.close()
 
     def assert_syslog(self, syslog, has_address=True):
@@ -238,3 +265,27 @@ class Test(BaseTest):
         assert syslog["syslog.facility_label"] == "user-level"
         if has_address:
             assert len(syslog["log.source.address"]) > 0
+
+
+def send_stream_socket(path, message):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    sock.connect(path)
+
+    for n in range(0, 2):
+        message = message.format(n)
+        sock.send(message.encode("utf-8"))
+
+    return sock
+
+
+def send_datagram_socket(path, message):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+
+    sock.connect(path)
+
+    for n in range(0, 2):
+        message = message.format(n)
+        sock.sendto(message.encode("utf-8"), path)
+
+    return sock

--- a/filebeat/tests/system/test_unix.py
+++ b/filebeat/tests/system/test_unix.py
@@ -61,11 +61,7 @@ class Test(BaseTest):
 
             self.wait_until(lambda: self.log_contains("Started listening for UNIX connection"))
 
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # UNIX
-            sock.connect(path)
-
-            for n in range(0, 2):
-                sock.send(bytes("Hello World: " + str(n) + delimiter, "utf-8"))
+            sock = send_stream_socket(path, delimiter)
 
             self.wait_until(lambda: self.output_count(lambda x: x >= 2))
 
@@ -77,3 +73,61 @@ class Test(BaseTest):
             assert output[0]["input.type"] == "unix"
 
             sock.close()
+
+    def test_unix_datagram_socket(self):
+        # we create the socket in a temporary directory because
+        # go will fail to create a unix socket if the path length
+        # is longer than 108 characters. See https://github.com/golang/go/issues/6895
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = os.path.join(tempdir, "filebeat.sock")
+            input_raw = """
+- type: unix
+  path: {}
+  enabled: true
+  socket_type: datagram
+"""
+
+            input_raw = input_raw.format(path)
+
+            self.render_config_template(
+                input_raw=input_raw,
+                inputs=False,
+            )
+
+            filebeat = self.start_beat()
+
+            self.wait_until(lambda: self.log_contains("Started listening for UNIX connection"))
+
+            sock = send_datagram_socket(path)
+
+            self.wait_until(lambda: self.output_count(lambda x: x >= 2))
+
+            filebeat.check_kill_and_wait()
+
+            output = self.read_output()
+
+            assert len(output) == 2
+            assert output[0]["message"] == "Hello World: 0;"
+            assert output[0]["input.type"] == "unix"
+
+            sock.close()
+
+
+def send_stream_socket(path, delimiter):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(path)
+
+    for n in range(0, 2):
+        sock.send(bytes("Hello World: " + str(n) + delimiter, "utf-8"))
+
+    return sock
+
+
+def send_datagram_socket(path):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.connect(path)
+
+    for n in range(0, 2):
+        sock.sendto(bytes("Hello World: " + str(n) + ";", "utf-8"), path)
+
+    return sock


### PR DESCRIPTION
## What does this PR do?

This PR adds support for reading from UNIX datagram sockets both from the `unix` input and the `syslog` input. A new option is added to select the type of the socket named `socket_type`. Available options are: `stream` and `datagram`.

## Why is it important?

A few applications which send logs over Unix sockets, use datagrams not streams. From now on, Filebeat can accept input from these applications as well.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #18632

