### PR TITLE
Cherry-pick to 7.x: [CI] Add resilience when peak loads (#22674)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,7 +212,7 @@ def generateStages(Map args = [:]) {
 }
 
 def cloud(Map args = [:]) {
-  node(args.label) {
+  withNode(args.label) {
     startCloudTestEnv(name: args.directory, dirs: args.dirs)
   }
   withCloudTestEnv() {
@@ -227,7 +227,7 @@ def cloud(Map args = [:]) {
 def k8sTest(Map args = [:]) {
   def versions = args.versions
   versions.each{ v ->
-    node(args.label) {
+    withNode(args.label) {
       stage("${args.context} ${v}"){
         withEnv(["K8S_VERSION=${v}", "KIND_VERSION=v0.7.0", "KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
           withGithubNotify(context: "${args.context} ${v}") {
@@ -272,7 +272,7 @@ def target(Map args = [:]) {
   def directory = args.get('directory', '')
   def withModule = args.get('withModule', false)
   def isMage = args.get('isMage', false)
-  node(args.label) {
+  withNode(args.label) {
     withGithubNotify(context: "${context}") {
       withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
         dumpVariables()
@@ -283,6 +283,16 @@ def target(Map args = [:]) {
         }
       }
     }
+  }
+}
+
+/**
+* This method wraps the node call with some latency to avoid the known issue with the scalabitity in gobld.
+*/
+def withNode(String label, Closure body) {
+  sleep randomNumber(min: 10, max: 200)
+  node(label) {
+    body()
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Add resilience when peak loads (#22674)