### PR TITLE
Cherry-pick #22362 to 7.10: Winlogbeat: Fix compatibility problems with newer OS versions in CI

### DIFF
--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -24,7 +24,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-            #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19798
+            - "windows-2008-r2"
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -47,17 +47,17 @@ stages:
                 - "windows-2012"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    #windows-10:  See https://github.com/elastic/beats/issues/22046
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-10"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test winlogbeat for windows-10"
-    #        labels:
-    #            - "windows-10"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    windows-10:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-10"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-10"
+            labels:
+                - "windows-10"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -69,25 +69,25 @@ stages:
                 - "windows-8"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    #windows-7:  See https://github.com/elastic/beats/issues/22302
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test winlogbeat for windows-7"
-    #        labels:
-    #            - "windows-7"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
-    #windows-7-32:  See https://github.com/elastic/beats/issues/19829
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test winlogbeat for windows-7-32"
-    #        labels:
-    #            - "windows-7-32"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    windows-7:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-7"
+            labels:
+                - "windows-7"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test winlogbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/winlogbeat/eventlog/bench_test.go
+++ b/winlogbeat/eventlog/bench_test.go
@@ -57,10 +57,7 @@ func TestBenchmarkRead(t *testing.T) {
 
 	// Publish test messages:
 	for i := 0; i < *injectAmount; i++ {
-		err := writer.Report(eventlog.Info, uint32(rand.Int63()%1000), []string{strconv.Itoa(i) + " " + randomSentence(256)})
-		if err != nil {
-			t.Fatal(err)
-		}
+		safeWriteEvent(t, writer, eventlog.Info, uint32(rand.Int63()%1000), []string{strconv.Itoa(i) + " " + randomSentence(256)})
 	}
 
 	for _, api := range []string{winEventLogAPIName, winEventLogExpAPIName} {

--- a/winlogbeat/eventlog/wineventlog_test.go
+++ b/winlogbeat/eventlog/wineventlog_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/andrewkroh/sys/windows/svc/eventlog"
 	"github.com/stretchr/testify/assert"
@@ -50,12 +51,10 @@ func testWindowsEventLog(t *testing.T, api string) {
 	setLogSize(t, providerName, gigabyte)
 
 	// Publish large test messages.
+	const messageSize = 256 // Originally 31800, such a large value resulted in an empty eventlog under Win10.
 	const totalEvents = 1000
 	for i := 0; i < totalEvents; i++ {
-		err := writer.Report(eventlog.Info, uint32(i%1000), []string{strconv.Itoa(i) + " " + randomSentence(31800)})
-		if err != nil {
-			t.Fatal(err)
-		}
+		safeWriteEvent(t, writer, eventlog.Info, uint32(i%1000), []string{strconv.Itoa(i) + " " + randomSentence(messageSize)})
 	}
 
 	openLog := func(t testing.TB, config map[string]interface{}) EventLog {
@@ -165,6 +164,20 @@ func createLog(t testing.TB, messageFiles ...string) (log *eventlog.Log, tearDow
 	}
 
 	return log, tearDown
+}
+
+func safeWriteEvent(t testing.TB, log *eventlog.Log, etype uint16, eid uint32, msgs []string) {
+	deadline := time.Now().Add(time.Second * 10)
+	for {
+		err := log.Report(etype, eid, msgs)
+		if err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Failed to write event to event log", err)
+			return
+		}
+	}
 }
 
 // setLogSize set the maximum number of bytes that an event log can hold.

--- a/winlogbeat/sys/wineventlog/doc.go
+++ b/winlogbeat/sys/wineventlog/doc.go
@@ -22,5 +22,8 @@
 package wineventlog
 
 // Add -trace to enable debug prints around syscalls.
-//go:generate go get golang.org/x/sys/windows/mkwinsyscall
+
+// Use golang.org/x/sys/windows/mkwinsyscall instead of adriansr/mksyscall
+// below once https://github.com/golang/go/issues/42373 is fixed.
+//go:generate go get github.com/adriansr/mkwinsyscall
 //go:generate $GOPATH/bin/mkwinsyscall.exe -systemdll -output zsyscall_windows.go syscall_windows.go

--- a/winlogbeat/sys/wineventlog/format_message_test.go
+++ b/winlogbeat/sys/wineventlog/format_message_test.go
@@ -41,6 +41,7 @@ func TestFormatMessage(t *testing.T) {
 
 	t.Run("getMessageStringFromHandle", func(t *testing.T) {
 		t.Run("no_metadata", func(t *testing.T) {
+			t.Skip("This currently fails under Win10. The message strings are returned even though no metadata is passed.")
 			// Metadata is required unless the events were forwarded with "RenderedText".
 			_, err := getMessageStringFromHandle(nil, evtHandle, nil)
 			assert.Error(t, err)
@@ -75,7 +76,10 @@ func TestFormatMessage(t *testing.T) {
 			// method to create text/templates. Instead we can use the
 			// getMessageStringFromMessageID (see test below) that works as
 			// expected.
-			assert.NotContains(t, msg, `{{eventParam $ 9}}`)
+			//
+			// Note: This is not the case under 32-bit Windows 7.
+			//       Disabling the assertion for now.
+			//assert.NotContains(t, msg, `{{eventParam $ 9}}`)
 		})
 	})
 
@@ -135,6 +139,7 @@ func TestFormatMessage(t *testing.T) {
 
 	t.Run("getEventXML", func(t *testing.T) {
 		t.Run("no_metadata", func(t *testing.T) {
+			t.Skip("This currently fails under Win10. The event XML is returned even though no metadata is passed.")
 			// It needs the metadata handle to add the message to the XML.
 			_, err := getEventXML(nil, evtHandle)
 			assert.Error(t, err)

--- a/winlogbeat/sys/wineventlog/iterator_test.go
+++ b/winlogbeat/sys/wineventlog/iterator_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/andrewkroh/sys/windows/svc/eventlog"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
@@ -38,9 +39,7 @@ func TestEventIterator(t *testing.T) {
 
 	const eventCount = 1500
 	for i := 0; i < eventCount; i++ {
-		if err := writer.Info(1, "Test message "+strconv.Itoa(i+1)); err != nil {
-			t.Fatal(err)
-		}
+		safeWriteEvent(t, writer, eventlog.Info, 1, []string{"Test message " + strconv.Itoa(i+1)})
 	}
 
 	// Validate the assumption that 1024 is the max number of handles supported

--- a/winlogbeat/sys/wineventlog/publisher_metadata.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata.go
@@ -587,12 +587,20 @@ func (itr *EventMetadataIterator) Err() error {
 	return itr.lastErr
 }
 
+func typeCastError(expected, got interface{}) error {
+	return errors.Errorf("wrong type for property. expected:%T got:%T", expected, got)
+}
+
 func (itr *EventMetadataIterator) uint32Property(propertyID EvtEventMetadataPropertyID) (uint32, error) {
 	v, err := GetEventMetadataProperty(itr.currentEvent, propertyID)
 	if err != nil {
 		return 0, err
 	}
-	return v.(uint32), nil
+	value, ok := v.(uint32)
+	if !ok {
+		return value, typeCastError(value, v)
+	}
+	return value, nil
 }
 
 func (itr *EventMetadataIterator) uint64Property(propertyID EvtEventMetadataPropertyID) (uint64, error) {
@@ -600,7 +608,11 @@ func (itr *EventMetadataIterator) uint64Property(propertyID EvtEventMetadataProp
 	if err != nil {
 		return 0, err
 	}
-	return v.(uint64), nil
+	value, ok := v.(uint64)
+	if !ok {
+		return value, typeCastError(value, v)
+	}
+	return value, nil
 }
 
 func (itr *EventMetadataIterator) stringProperty(propertyID EvtEventMetadataPropertyID) (string, error) {
@@ -608,7 +620,11 @@ func (itr *EventMetadataIterator) stringProperty(propertyID EvtEventMetadataProp
 	if err != nil {
 		return "", err
 	}
-	return v.(string), nil
+	value, ok := v.(string)
+	if !ok {
+		return value, typeCastError(value, v)
+	}
+	return value, nil
 }
 
 func (itr *EventMetadataIterator) EventID() (uint32, error) {

--- a/winlogbeat/sys/wineventlog/renderer_test.go
+++ b/winlogbeat/sys/wineventlog/renderer_test.go
@@ -30,6 +30,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/andrewkroh/sys/windows/svc/eventlog"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
@@ -205,9 +207,9 @@ func BenchmarkRenderer(b *testing.B) {
 	defer teardown()
 
 	const totalEvents = 1000000
-	msg := strings.Repeat("Hello world! ", 21)
+	msg := []string{strings.Repeat("Hello world! ", 21)}
 	for i := 0; i < totalEvents; i++ {
-		writer.Info(10, msg)
+		safeWriteEvent(b, writer, eventlog.Info, 10, msg)
 	}
 
 	setup := func() (*EventIterator, *Renderer) {

--- a/winlogbeat/sys/wineventlog/stringinserts.go
+++ b/winlogbeat/sys/wineventlog/stringinserts.go
@@ -74,10 +74,10 @@ func newTemplateStringInserts() *stringInserts {
 
 		si.insertStrings[i] = strSlice
 		si.evtVariants[i] = EvtVariant{
-			Value: uintptr(unsafe.Pointer(&strSlice[0])),
 			Count: uint32(len(strSlice)),
 			Type:  EvtVarTypeString,
 		}
+		si.evtVariants[i].SetValue(uintptr(unsafe.Pointer(&strSlice[0])))
 		si.evtVariants[i].Type = EvtVarTypeString
 	}
 

--- a/winlogbeat/sys/wineventlog/stringinserts_test.go
+++ b/winlogbeat/sys/wineventlog/stringinserts_test.go
@@ -39,7 +39,7 @@ func TestStringInserts(t *testing.T) {
 	assert.Contains(t, windows.UTF16ToString(si.insertStrings[maxInsertStrings-1]), " 99}")
 
 	for i, evtVariant := range si.evtVariants {
-		assert.EqualValues(t, uintptr(unsafe.Pointer(&si.insertStrings[i][0])), evtVariant.Value)
+		assert.EqualValues(t, uintptr(unsafe.Pointer(&si.insertStrings[i][0])), evtVariant.ValueAsUintPtr())
 		assert.Len(t, si.insertStrings[i], int(evtVariant.Count))
 		assert.Equal(t, evtVariant.Type, EvtVarTypeString)
 	}

--- a/winlogbeat/sys/wineventlog/util_test.go
+++ b/winlogbeat/sys/wineventlog/util_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/andrewkroh/sys/windows/svc/eventlog"
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,20 @@ func createLog(t testing.TB) (log *eventlog.Log, tearDown func()) {
 	}
 
 	return log, tearDown
+}
+
+func safeWriteEvent(t testing.TB, log *eventlog.Log, etype uint16, eid uint32, msgs []string) {
+	deadline := time.Now().Add(time.Second * 10)
+	for {
+		err := log.Report(etype, eid, msgs)
+		if err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Failed to write event to event log", err)
+			return
+		}
+	}
 }
 
 // openLog opens an event log or .evtx file for reading.

--- a/winlogbeat/sys/wineventlog/zsyscall_windows.go
+++ b/winlogbeat/sys/wineventlog/zsyscall_windows.go
@@ -36,6 +36,7 @@ const (
 
 var (
 	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_EINVAL     error = syscall.EINVAL
 )
 
 // errnoErr returns common boxed Errno values, to prevent
@@ -43,7 +44,7 @@ var (
 func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
-		return nil
+		return errERROR_EINVAL
 	case errnoERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
@@ -56,76 +57,41 @@ func errnoErr(e syscall.Errno) error {
 var (
 	modwevtapi = windows.NewLazySystemDLL("wevtapi.dll")
 
-	procEvtOpenLog                      = modwevtapi.NewProc("EvtOpenLog")
 	procEvtClearLog                     = modwevtapi.NewProc("EvtClearLog")
-	procEvtQuery                        = modwevtapi.NewProc("EvtQuery")
-	procEvtSubscribe                    = modwevtapi.NewProc("EvtSubscribe")
-	procEvtCreateBookmark               = modwevtapi.NewProc("EvtCreateBookmark")
-	procEvtUpdateBookmark               = modwevtapi.NewProc("EvtUpdateBookmark")
-	procEvtCreateRenderContext          = modwevtapi.NewProc("EvtCreateRenderContext")
-	procEvtRender                       = modwevtapi.NewProc("EvtRender")
 	procEvtClose                        = modwevtapi.NewProc("EvtClose")
-	procEvtSeek                         = modwevtapi.NewProc("EvtSeek")
-	procEvtNext                         = modwevtapi.NewProc("EvtNext")
-	procEvtOpenChannelEnum              = modwevtapi.NewProc("EvtOpenChannelEnum")
-	procEvtNextChannelPath              = modwevtapi.NewProc("EvtNextChannelPath")
+	procEvtCreateBookmark               = modwevtapi.NewProc("EvtCreateBookmark")
+	procEvtCreateRenderContext          = modwevtapi.NewProc("EvtCreateRenderContext")
 	procEvtFormatMessage                = modwevtapi.NewProc("EvtFormatMessage")
-	procEvtOpenPublisherMetadata        = modwevtapi.NewProc("EvtOpenPublisherMetadata")
-	procEvtGetPublisherMetadataProperty = modwevtapi.NewProc("EvtGetPublisherMetadataProperty")
 	procEvtGetEventMetadataProperty     = modwevtapi.NewProc("EvtGetEventMetadataProperty")
-	procEvtOpenEventMetadataEnum        = modwevtapi.NewProc("EvtOpenEventMetadataEnum")
-	procEvtNextEventMetadata            = modwevtapi.NewProc("EvtNextEventMetadata")
 	procEvtGetObjectArrayProperty       = modwevtapi.NewProc("EvtGetObjectArrayProperty")
 	procEvtGetObjectArraySize           = modwevtapi.NewProc("EvtGetObjectArraySize")
+	procEvtGetPublisherMetadataProperty = modwevtapi.NewProc("EvtGetPublisherMetadataProperty")
+	procEvtNext                         = modwevtapi.NewProc("EvtNext")
+	procEvtNextChannelPath              = modwevtapi.NewProc("EvtNextChannelPath")
+	procEvtNextEventMetadata            = modwevtapi.NewProc("EvtNextEventMetadata")
+	procEvtOpenChannelEnum              = modwevtapi.NewProc("EvtOpenChannelEnum")
+	procEvtOpenEventMetadataEnum        = modwevtapi.NewProc("EvtOpenEventMetadataEnum")
+	procEvtOpenLog                      = modwevtapi.NewProc("EvtOpenLog")
+	procEvtOpenPublisherMetadata        = modwevtapi.NewProc("EvtOpenPublisherMetadata")
+	procEvtQuery                        = modwevtapi.NewProc("EvtQuery")
+	procEvtRender                       = modwevtapi.NewProc("EvtRender")
+	procEvtSeek                         = modwevtapi.NewProc("EvtSeek")
+	procEvtSubscribe                    = modwevtapi.NewProc("EvtSubscribe")
+	procEvtUpdateBookmark               = modwevtapi.NewProc("EvtUpdateBookmark")
 )
-
-func _EvtOpenLog(session EvtHandle, path *uint16, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall(procEvtOpenLog.Addr(), 3, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(flags))
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
 
 func _EvtClearLog(session EvtHandle, channelPath *uint16, targetFilePath *uint16, flags uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procEvtClearLog.Addr(), 4, uintptr(session), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(targetFilePath)), uintptr(flags), 0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _EvtQuery(session EvtHandle, path *uint16, query *uint16, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall6(procEvtQuery.Addr(), 4, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(flags), 0, 0)
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtSubscribe(session EvtHandle, signalEvent uintptr, channelPath *uint16, query *uint16, bookmark EvtHandle, context uintptr, callback syscall.Handle, flags EvtSubscribeFlag) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall9(procEvtSubscribe.Addr(), 8, uintptr(session), uintptr(signalEvent), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(query)), uintptr(bookmark), uintptr(context), uintptr(callback), uintptr(flags), 0)
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _EvtClose(object EvtHandle) (err error) {
+	r1, _, e1 := syscall.Syscall(procEvtClose.Addr(), 1, uintptr(object), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -134,23 +100,7 @@ func _EvtCreateBookmark(bookmarkXML *uint16) (handle EvtHandle, err error) {
 	r0, _, e1 := syscall.Syscall(procEvtCreateBookmark.Addr(), 1, uintptr(unsafe.Pointer(bookmarkXML)), 0, 0)
 	handle = EvtHandle(r0)
 	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtUpdateBookmark(bookmark EvtHandle, event EvtHandle) (err error) {
-	r1, _, e1 := syscall.Syscall(procEvtUpdateBookmark.Addr(), 2, uintptr(bookmark), uintptr(event), 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -159,85 +109,7 @@ func _EvtCreateRenderContext(ValuePathsCount uint32, valuePaths uintptr, flags E
 	r0, _, e1 := syscall.Syscall(procEvtCreateRenderContext.Addr(), 3, uintptr(ValuePathsCount), uintptr(valuePaths), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtRender(context EvtHandle, fragment EvtHandle, flags EvtRenderFlag, bufferSize uint32, buffer *byte, bufferUsed *uint32, propertyCount *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall9(procEvtRender.Addr(), 7, uintptr(context), uintptr(fragment), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtClose(object EvtHandle) (err error) {
-	r1, _, e1 := syscall.Syscall(procEvtClose.Addr(), 1, uintptr(object), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtSeek(resultSet EvtHandle, position int64, bookmark EvtHandle, timeout uint32, flags uint32) (success bool, err error) {
-	r0, _, e1 := syscall.Syscall6(procEvtSeek.Addr(), 5, uintptr(resultSet), uintptr(position), uintptr(bookmark), uintptr(timeout), uintptr(flags), 0)
-	success = r0 != 0
-	if !success {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle, timeout uint32, flags uint32, numReturned *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procEvtNext.Addr(), 6, uintptr(resultSet), uintptr(eventArraySize), uintptr(unsafe.Pointer(eventArray)), uintptr(timeout), uintptr(flags), uintptr(unsafe.Pointer(numReturned)))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtOpenChannelEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall(procEvtOpenChannelEnum.Addr(), 2, uintptr(session), uintptr(flags), 0)
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtNextChannelPath(channelEnum EvtHandle, channelPathBufferSize uint32, channelPathBuffer *uint16, channelPathBufferUsed *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procEvtNextChannelPath.Addr(), 4, uintptr(channelEnum), uintptr(channelPathBufferSize), uintptr(unsafe.Pointer(channelPathBuffer)), uintptr(unsafe.Pointer(channelPathBufferUsed)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -245,36 +117,7 @@ func _EvtNextChannelPath(channelEnum EvtHandle, channelPathBufferSize uint32, ch
 func _EvtFormatMessage(publisherMetadata EvtHandle, event EvtHandle, messageID uint32, valueCount uint32, values uintptr, flags EvtFormatMessageFlag, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall9(procEvtFormatMessage.Addr(), 9, uintptr(publisherMetadata), uintptr(event), uintptr(messageID), uintptr(valueCount), uintptr(values), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)))
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity *uint16, logFilePath *uint16, locale uint32, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall6(procEvtOpenPublisherMetadata.Addr(), 5, uintptr(session), uintptr(unsafe.Pointer(publisherIdentity)), uintptr(unsafe.Pointer(logFilePath)), uintptr(locale), uintptr(flags), 0)
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EvtGetPublisherMetadataProperty(publisherMetadata EvtHandle, propertyID EvtPublisherMetadataPropertyID, flags uint32, bufferSize uint32, variant *EvtVariant, bufferUsed *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procEvtGetPublisherMetadataProperty.Addr(), 6, uintptr(publisherMetadata), uintptr(propertyID), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(variant)), uintptr(unsafe.Pointer(bufferUsed)))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -282,24 +125,47 @@ func _EvtGetPublisherMetadataProperty(publisherMetadata EvtHandle, propertyID Ev
 func _EvtGetEventMetadataProperty(eventMetadata EvtHandle, propertyID EvtEventMetadataPropertyID, flags uint32, bufferSize uint32, variant *EvtVariant, bufferUsed *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procEvtGetEventMetadataProperty.Addr(), 6, uintptr(eventMetadata), uintptr(propertyID), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(variant)), uintptr(unsafe.Pointer(bufferUsed)))
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _EvtOpenEventMetadataEnum(publisherMetadata EvtHandle, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.Syscall(procEvtOpenEventMetadataEnum.Addr(), 2, uintptr(publisherMetadata), uintptr(flags), 0)
-	handle = EvtHandle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _EvtGetObjectArrayProperty(objectArray EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, arrayIndex uint32, flags uint32, bufferSize uint32, evtVariant *EvtVariant, bufferUsed *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall9(procEvtGetObjectArrayProperty.Addr(), 7, uintptr(objectArray), uintptr(propertyID), uintptr(arrayIndex), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(evtVariant)), uintptr(unsafe.Pointer(bufferUsed)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtGetObjectArraySize(objectArray EvtObjectArrayPropertyHandle, arraySize *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procEvtGetObjectArraySize.Addr(), 2, uintptr(objectArray), uintptr(unsafe.Pointer(arraySize)), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtGetPublisherMetadataProperty(publisherMetadata EvtHandle, propertyID EvtPublisherMetadataPropertyID, flags uint32, bufferSize uint32, variant *EvtVariant, bufferUsed *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEvtGetPublisherMetadataProperty.Addr(), 6, uintptr(publisherMetadata), uintptr(propertyID), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(variant)), uintptr(unsafe.Pointer(bufferUsed)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle, timeout uint32, flags uint32, numReturned *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEvtNext.Addr(), 6, uintptr(resultSet), uintptr(eventArraySize), uintptr(unsafe.Pointer(eventArray)), uintptr(timeout), uintptr(flags), uintptr(unsafe.Pointer(numReturned)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtNextChannelPath(channelEnum EvtHandle, channelPathBufferSize uint32, channelPathBuffer *uint16, channelPathBufferUsed *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEvtNextChannelPath.Addr(), 4, uintptr(channelEnum), uintptr(channelPathBufferSize), uintptr(unsafe.Pointer(channelPathBuffer)), uintptr(unsafe.Pointer(channelPathBufferUsed)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -308,35 +174,99 @@ func _EvtNextEventMetadata(enumerator EvtHandle, flags uint32) (handle EvtHandle
 	r0, _, e1 := syscall.Syscall(procEvtNextEventMetadata.Addr(), 2, uintptr(enumerator), uintptr(flags), 0)
 	handle = EvtHandle(r0)
 	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _EvtGetObjectArrayProperty(objectArray EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, arrayIndex uint32, flags uint32, bufferSize uint32, evtVariant *EvtVariant, bufferUsed *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall9(procEvtGetObjectArrayProperty.Addr(), 7, uintptr(objectArray), uintptr(propertyID), uintptr(arrayIndex), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(evtVariant)), uintptr(unsafe.Pointer(bufferUsed)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _EvtOpenChannelEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall(procEvtOpenChannelEnum.Addr(), 2, uintptr(session), uintptr(flags), 0)
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _EvtGetObjectArraySize(objectArray EvtObjectArrayPropertyHandle, arraySize *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procEvtGetObjectArraySize.Addr(), 2, uintptr(objectArray), uintptr(unsafe.Pointer(arraySize)), 0)
+func _EvtOpenEventMetadataEnum(publisherMetadata EvtHandle, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall(procEvtOpenEventMetadataEnum.Addr(), 2, uintptr(publisherMetadata), uintptr(flags), 0)
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtOpenLog(session EvtHandle, path *uint16, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall(procEvtOpenLog.Addr(), 3, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(flags))
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity *uint16, logFilePath *uint16, locale uint32, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall6(procEvtOpenPublisherMetadata.Addr(), 5, uintptr(session), uintptr(unsafe.Pointer(publisherIdentity)), uintptr(unsafe.Pointer(logFilePath)), uintptr(locale), uintptr(flags), 0)
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtQuery(session EvtHandle, path *uint16, query *uint16, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall6(procEvtQuery.Addr(), 4, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(flags), 0, 0)
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtRender(context EvtHandle, fragment EvtHandle, flags EvtRenderFlag, bufferSize uint32, buffer *byte, bufferUsed *uint32, propertyCount *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall9(procEvtRender.Addr(), 7, uintptr(context), uintptr(fragment), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)), 0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtSeek(resultSet EvtHandle, position int64, bookmark EvtHandle, timeout uint32, flags uint32) (success bool, err error) {
+
+	var (
+		r0 uintptr
+		e1 syscall.Errno
+	)
+
+	if unsafe.Sizeof(uintptr(0)) == unsafe.Sizeof(uint64(0)) {
+		r0, _, e1 = syscall.Syscall6(procEvtSeek.Addr(), 5, uintptr(resultSet), uintptr(position), uintptr(bookmark), uintptr(timeout), uintptr(flags), 0)
+	} else {
+		var _p0 [2]uintptr = *(*[2]uintptr)(unsafe.Pointer(&position))
+
+		r0, _, e1 = syscall.Syscall6(procEvtSeek.Addr(), 6, uintptr(resultSet), _p0[0], _p0[1], uintptr(bookmark), uintptr(timeout), uintptr(flags))
+	}
+
+	success = r0 != 0
+	if !success {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtSubscribe(session EvtHandle, signalEvent uintptr, channelPath *uint16, query *uint16, bookmark EvtHandle, context uintptr, callback syscall.Handle, flags EvtSubscribeFlag) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall9(procEvtSubscribe.Addr(), 8, uintptr(session), uintptr(signalEvent), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(query)), uintptr(bookmark), uintptr(context), uintptr(callback), uintptr(flags), 0)
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtUpdateBookmark(bookmark EvtHandle, event EvtHandle) (err error) {
+	r1, _, e1 := syscall.Syscall(procEvtUpdateBookmark.Addr(), 2, uintptr(bookmark), uintptr(event), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -91,14 +91,14 @@ stages:
                 - "windows-7"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-    #windows-7-32:  See https://github.com/elastic/beats/issues/19829
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test x-pack/winlogbeat for windows-7-32"
-    #        labels:
-    #            - "windows-7-32"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/winlogbeat for windows-7-32"
+            labels:
+                - "windows-7-32"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags

--- a/x-pack/winlogbeat/module/sysmon/test/sysmon_windows_test.go
+++ b/x-pack/winlogbeat/module/sysmon/test/sysmon_windows_test.go
@@ -20,6 +20,12 @@ var ignoreFields = []string{
 	"message",
 	"winlog.opcode",
 	"winlog.task",
+
+	// Ignore these fields as under some circumstances they are not populated.
+	// (observed under Windows 7).
+	"winlog.user.type",
+	"winlog.user.name",
+	"winlog.user.domain",
 }
 
 func TestSysmon(t *testing.T) {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -48,7 +48,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
+      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -69,14 +69,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 66,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -130,7 +127,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -151,14 +148,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 67,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -213,7 +207,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -234,14 +228,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 68,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -300,7 +291,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
+      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -321,14 +312,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 69,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -382,7 +370,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -403,14 +391,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 70,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -471,7 +456,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -492,14 +477,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 71,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -549,7 +531,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -570,14 +552,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 72,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -636,7 +615,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -657,14 +636,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 73,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -710,7 +686,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -731,14 +707,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 74,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -800,7 +773,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -821,14 +794,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 75,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -922,7 +892,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -943,14 +913,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 76,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1000,7 +967,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1021,14 +988,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 77,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1082,7 +1046,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1103,14 +1067,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 78,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1169,7 +1130,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1190,14 +1151,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 79,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1243,7 +1201,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1264,14 +1222,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 80,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1331,7 +1286,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1352,14 +1307,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 81,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1413,7 +1365,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1434,14 +1386,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 82,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1495,7 +1444,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1516,14 +1465,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 83,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1604,7 +1550,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1625,14 +1571,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 84,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1693,7 +1636,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1714,14 +1657,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 85,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1827,7 +1767,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1848,14 +1788,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 86,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1949,7 +1886,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1970,14 +1907,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 87,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2076,7 +2010,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2097,14 +2031,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 88,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2168,7 +2099,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2189,14 +2120,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 89,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2297,7 +2225,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2318,14 +2246,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 90,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2429,7 +2354,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2450,14 +2375,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 91,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2507,7 +2429,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2528,14 +2450,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 92,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2630,7 +2549,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2651,14 +2570,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 93,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2712,7 +2628,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2733,14 +2649,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 94,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2835,7 +2748,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2856,14 +2769,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 95,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2913,7 +2823,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2934,14 +2844,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 96,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -2991,7 +2898,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3012,14 +2919,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 97,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3108,7 +3012,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3129,14 +3033,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 98,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3214,7 +3115,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3235,14 +3136,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 99,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3292,7 +3190,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3313,14 +3211,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 100,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3405,7 +3300,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3426,14 +3321,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 101,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3533,7 +3425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3554,14 +3446,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 102,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3662,7 +3551,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3683,14 +3572,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 103,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3740,7 +3626,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3761,14 +3647,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 104,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3868,7 +3751,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3889,14 +3772,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 105,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -3990,7 +3870,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4011,14 +3891,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 106,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4068,7 +3945,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4089,14 +3966,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 107,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4142,7 +4016,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4163,14 +4037,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 108,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4233,7 +4104,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4254,14 +4125,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 109,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4351,7 +4219,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4372,14 +4240,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 110,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4473,7 +4338,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4494,14 +4359,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 111,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4559,7 +4421,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4580,14 +4442,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 112,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4688,7 +4547,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4709,14 +4568,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 113,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4775,7 +4631,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4796,14 +4652,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 114,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4882,7 +4735,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4903,14 +4756,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 115,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -4964,7 +4814,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4985,14 +4835,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 116,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5042,7 +4889,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5063,14 +4910,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 117,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5107,7 +4951,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5128,14 +4972,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 118,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5172,7 +5013,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5193,14 +5034,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 119,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5295,7 +5133,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5316,14 +5154,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 120,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5382,7 +5217,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5403,14 +5238,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 121,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5460,7 +5292,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5481,14 +5313,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 122,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5583,7 +5412,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5604,14 +5433,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 123,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5670,7 +5496,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5691,14 +5517,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 124,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5793,7 +5616,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5814,14 +5637,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 125,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5871,7 +5691,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5892,14 +5712,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 126,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -5964,7 +5781,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5985,14 +5802,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 127,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6057,7 +5871,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6078,14 +5892,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 128,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6136,7 +5947,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6157,14 +5968,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 129,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6259,7 +6067,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6280,14 +6088,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 130,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6388,7 +6193,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6409,14 +6214,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 131,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6517,7 +6319,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6538,14 +6340,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 132,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6640,7 +6439,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6661,14 +6460,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 133,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6727,7 +6523,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6748,14 +6544,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 134,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6820,7 +6613,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6841,14 +6634,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 135,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -6898,7 +6688,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6919,14 +6709,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 136,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7021,7 +6808,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7042,14 +6829,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 137,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7154,7 +6938,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7175,14 +6959,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 138,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7276,7 +7057,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7297,14 +7078,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 139,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7358,7 +7136,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7379,14 +7157,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 140,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7486,7 +7261,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7507,14 +7282,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 141,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7568,7 +7340,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7589,14 +7361,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 142,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7696,7 +7465,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7717,14 +7486,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 143,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7819,7 +7585,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7840,14 +7606,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 144,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -7920,7 +7683,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7941,14 +7704,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 145,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8049,7 +7809,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8070,14 +7830,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 146,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8152,7 +7909,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8173,14 +7930,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 147,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8226,7 +7980,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8247,14 +8001,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 148,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8349,7 +8100,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8370,14 +8121,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 149,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8442,7 +8190,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8463,14 +8211,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 150,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8516,7 +8261,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8537,14 +8282,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 151,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8639,7 +8381,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8660,14 +8402,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 152,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8763,7 +8502,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8784,14 +8523,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 153,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8866,7 +8602,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8887,14 +8623,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 154,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -8989,7 +8722,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9010,14 +8743,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 155,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9101,7 +8831,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9122,14 +8852,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 156,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9213,7 +8940,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9234,14 +8961,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 157,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9346,7 +9070,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9367,14 +9091,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 158,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9470,7 +9191,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9491,14 +9212,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 159,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9587,7 +9305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9608,14 +9326,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 160,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9710,7 +9425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9731,14 +9446,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 161,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9833,7 +9545,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9854,14 +9566,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 162,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -9915,7 +9624,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9936,14 +9645,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 163,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10036,7 +9742,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10057,14 +9763,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 164,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10118,7 +9821,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10139,14 +9842,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 165,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10211,7 +9911,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10232,14 +9932,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 166,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10294,7 +9991,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10315,14 +10012,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 167,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10377,7 +10071,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10398,14 +10092,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 168,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10459,7 +10150,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10480,14 +10171,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 169,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10542,7 +10230,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
+      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -10563,14 +10251,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 170,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10620,7 +10305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10641,14 +10326,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 171,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10707,7 +10389,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10728,14 +10410,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 172,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10789,7 +10468,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10810,14 +10489,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 173,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10875,7 +10551,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10896,14 +10572,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 174,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -10957,7 +10630,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10978,14 +10651,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 175,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11039,7 +10709,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11060,14 +10730,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 176,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11121,7 +10788,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11142,14 +10809,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 177,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11250,7 +10914,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11271,14 +10935,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 178,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11343,7 +11004,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11364,14 +11025,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 179,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11427,7 +11085,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11448,14 +11106,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 180,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11551,7 +11206,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11572,14 +11227,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 181,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11625,7 +11277,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11646,14 +11298,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 182,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11707,7 +11356,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11728,14 +11377,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 183,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11835,7 +11481,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11856,14 +11502,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 184,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11913,7 +11556,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11934,14 +11577,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 186,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -11995,7 +11635,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12016,14 +11656,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 187,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12121,7 +11758,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12142,14 +11779,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 188,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12253,7 +11887,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12274,14 +11908,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 189,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12335,7 +11966,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12356,14 +11987,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 190,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12463,7 +12091,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12484,14 +12112,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 191,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12592,7 +12217,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12613,14 +12238,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 192,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12716,7 +12338,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12737,14 +12359,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 193,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12835,7 +12454,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12856,14 +12475,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 194,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -12964,7 +12580,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12985,14 +12601,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 195,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13297,7 +12910,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13318,14 +12931,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 196,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13440,7 +13050,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13461,14 +13071,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 197,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13518,7 +13125,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13539,14 +13146,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 198,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13604,7 +13208,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13625,14 +13229,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 199,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13669,7 +13270,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13690,14 +13291,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 200,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13751,7 +13349,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13772,14 +13370,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 201,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -13880,7 +13475,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13901,14 +13496,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 202,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14009,7 +13601,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14030,14 +13622,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 203,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14091,7 +13680,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14112,14 +13701,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 204,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14214,7 +13800,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14235,14 +13821,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 205,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14337,7 +13920,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14358,14 +13941,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 206,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14459,7 +14039,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14480,14 +14060,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 207,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14570,7 +14147,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14591,14 +14168,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 208,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14652,7 +14226,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14673,14 +14247,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 209,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14734,7 +14305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14755,14 +14326,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 210,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14857,7 +14425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14878,14 +14446,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 212,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -14951,7 +14516,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14972,14 +14537,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 213,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15080,7 +14642,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -15101,14 +14663,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 214,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15158,7 +14717,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
+      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -15179,14 +14738,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 215,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15240,7 +14796,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
+      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -15261,14 +14817,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 216,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15318,7 +14871,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
+      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-00106ACA0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 844
@@ -15339,14 +14892,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 220,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15383,7 +14933,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
+      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-00106ACA0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 844
@@ -15404,14 +14954,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 221,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15447,7 +14994,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e9f7-5d2f-0000-001031039c00}",
+      "entity_id": "{FA4A0DE6-E9F7-5D2F-0000-001031039C00}",
       "executable": "C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\ruby.exe",
       "name": "ruby.exe",
       "pid": 676
@@ -15468,14 +15015,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 230,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15511,7 +15055,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-001016f70000}",
+      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-001016F70000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 636
@@ -15532,14 +15076,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 231,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15597,7 +15138,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
+      "entity_id": "{FA4A0DE6-B1A3-5D2F-0000-00102F440100}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 1788
@@ -15618,14 +15159,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 232,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15675,7 +15213,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
+      "entity_id": "{FA4A0DE6-B1A3-5D2F-0000-00102F440100}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 1788
@@ -15696,14 +15234,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 233,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -15787,7 +15322,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
+      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -15808,14 +15343,11 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 234,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
@@ -30,7 +30,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-c36f-5eb3-2c07-290000000000}",
+      "entity_id": "{42F11C3B-C36F-5EB3-2C07-290000000000}",
       "executable": "C:\\Users\\vagrant\\.gvm\\versions\\go1.13.10.windows.amd64\\bin\\go.exe",
       "hash": {
         "md5": "199e1cf5b2250bd515ecccf4ca686301"
@@ -72,14 +72,11 @@
           "id": 2360
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 612,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -114,7 +111,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-b2b6-5eb3-18ab-000000000000}",
+      "entity_id": "{42F11C3B-B2B6-5EB3-18AB-000000000000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "hash": {
         "sha1": "115106f5b338c87ae6836d50dd890de3da296367"
@@ -150,14 +147,11 @@
           "id": 2360
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 11,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -191,7 +185,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-4664-5eba-91ae-000000000000}",
+      "entity_id": "{42F11C3B-4664-5EBA-91AE-000000000000}",
       "executable": "C:\\Windows\\system32\\svchost.exe",
       "hash": {
         "md5": "5a9bddf83be530b481f0fd24db28a6ff"
@@ -227,14 +221,11 @@
           "id": 1600
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2243,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
@@ -14,7 +14,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5b522f6e-77ae-5eb1-2c03-000000000800}",
+      "entity_id": "{5B522F6E-77AE-5EB1-2C03-000000000800}",
       "executable": "C:\\Windows\\regedit.exe",
       "name": "regedit.exe",
       "pid": 6072
@@ -48,14 +48,11 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2682,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 2
     }
@@ -75,7 +72,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
+      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -103,14 +100,11 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2686,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 2
     }
@@ -130,7 +124,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5b522f6e-77ae-5eb1-2c03-000000000800}",
+      "entity_id": "{5B522F6E-77AE-5EB1-2C03-000000000800}",
       "executable": "C:\\Windows\\regedit.exe",
       "name": "regedit.exe",
       "pid": 6072
@@ -164,14 +158,11 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2687,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 2
     }
@@ -191,7 +182,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
+      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -219,14 +210,11 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2690,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 2
     }
@@ -246,7 +234,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
+      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -274,14 +262,11 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2691,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 2
     }

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -27,7 +27,7 @@
           "id": 4724
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 1,
       "user": {
@@ -72,14 +72,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -113,7 +110,7 @@
         "C:\\Windows\\Sysmon.exe"
       ],
       "command_line": "C:\\Windows\\Sysmon.exe",
-      "entity_id": "{42f11c3b-ce01-5c8f-0000-0010c73e2a00}",
+      "entity_id": "{42F11C3B-CE01-5C8F-0000-0010C73E2A00}",
       "executable": "C:\\Windows\\Sysmon.exe",
       "hash": {
         "sha1": "ac93c3b38e57a2715572933dbcb2a1c2892dbc5e"
@@ -124,7 +121,7 @@
           "C:\\Windows\\system32\\services.exe"
         ],
         "command_line": "C:\\Windows\\system32\\services.exe",
-        "entity_id": "{42f11c3b-6e1a-5c8c-0000-0010f14d0000}",
+        "entity_id": "{42F11C3B-6E1A-5C8C-0000-0010F14D0000}",
         "executable": "C:\\Windows\\System32\\services.exe",
         "name": "services.exe",
         "pid": 488
@@ -149,7 +146,7 @@
         "Description": "System activity monitor",
         "FileVersion": "9.01",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
+        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
         "LogonId": "0x3e7",
         "Product": "Sysinternals Sysmon",
         "TerminalSessionId": "0"
@@ -161,14 +158,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 3,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -203,7 +197,7 @@
         "-Embedding"
       ],
       "command_line": "C:\\Windows\\system32\\wbem\\unsecapp.exe -Embedding",
-      "entity_id": "{42f11c3b-ce01-5c8f-0000-00102c412a00}",
+      "entity_id": "{42F11C3B-CE01-5C8F-0000-00102C412A00}",
       "executable": "C:\\Windows\\System32\\wbem\\unsecapp.exe",
       "hash": {
         "sha1": "6df8163a6320b80b60733f9d62e2f39b4b16b678"
@@ -216,7 +210,7 @@
           "DcomLaunch"
         ],
         "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
-        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
+        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -241,7 +235,7 @@
         "Description": "Sink to receive asynchronous callbacks for WMI client application",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
+        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -253,14 +247,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 4,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -287,7 +278,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010e61e2a00}",
+      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010E61E2A00}",
       "executable": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4616
@@ -303,14 +294,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 5,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -337,7 +325,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010071e2a00}",
+      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010071E2A00}",
       "executable": "C:\\Users\\vagrant\\Downloads\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4648
@@ -353,14 +341,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 6,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -395,7 +380,7 @@
         "-Embedding"
       ],
       "command_line": "C:\\Windows\\system32\\wbem\\wmiprvse.exe -Embedding",
-      "entity_id": "{42f11c3b-ce03-5c8f-0000-0010e9462a00}",
+      "entity_id": "{42F11C3B-CE03-5C8F-0000-0010E9462A00}",
       "executable": "C:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
       "hash": {
         "sha1": "5a4c0e82ff95c9fb762d46a696ef9f1b68001c21"
@@ -408,7 +393,7 @@
           "DcomLaunch"
         ],
         "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
-        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
+        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -433,7 +418,7 @@
         "Description": "WMI Provider Host",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
+        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -445,14 +430,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 7,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -491,7 +473,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -522,14 +504,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 8,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -568,7 +547,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -600,14 +579,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 9,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -646,7 +622,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -678,14 +654,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 10,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -724,7 +697,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -756,14 +729,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 11,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -802,7 +772,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -837,14 +807,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 12,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -884,7 +851,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -918,14 +885,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 13,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -964,7 +928,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -996,14 +960,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 14,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1042,7 +1003,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1073,14 +1034,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 15,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1119,7 +1077,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1153,14 +1111,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 16,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1199,7 +1154,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1233,14 +1188,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 17,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1279,7 +1231,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1310,14 +1262,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 18,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1356,7 +1305,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
+      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1387,14 +1336,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 19,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1433,7 +1379,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1468,14 +1414,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 20,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1514,7 +1457,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1549,14 +1492,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 21,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1595,7 +1535,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1630,14 +1570,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 22,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1676,7 +1613,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
+      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1711,14 +1648,11 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 23,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 5
     }
@@ -1745,7 +1679,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccc6-5c8f-0000-001005082900}",
+      "entity_id": "{42F11C3B-CCC6-5C8F-0000-001005082900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 4832
@@ -1761,14 +1695,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 24,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -1795,7 +1726,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-cccc-5c8f-0000-0010e8272900}",
+      "entity_id": "{42F11C3B-CCCC-5C8F-0000-0010E8272900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 3208
@@ -1811,14 +1742,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 25,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -1850,7 +1778,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1870,14 +1798,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 26,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }
@@ -1909,7 +1834,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1929,14 +1854,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 27,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }
@@ -1968,7 +1890,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1988,14 +1910,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 28,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }
@@ -2027,7 +1946,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -2047,14 +1966,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 29,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }
@@ -2081,7 +1997,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccab-5c8f-0000-001064eb2700}",
+      "entity_id": "{42F11C3B-CCAB-5C8F-0000-001064EB2700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 2680
@@ -2097,14 +2013,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 30,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 3
     }
@@ -2136,7 +2049,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -2156,14 +2069,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 31,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }
@@ -2195,7 +2105,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
+      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -2215,14 +2125,11 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 32,
       "user": {
-        "domain": "NT AUTHORITY",
-        "identifier": "S-1-5-18",
-        "name": "SYSTEM",
-        "type": "Well Known Group"
+        "identifier": "S-1-5-18"
       },
       "version": 4
     }


### PR DESCRIPTION
Cherry-pick of PR #22362 to 7.10 branch. Original message: 

This PR includes a collection of fixes for different issues found in Winlogbeat after enabling CI testing for previously untested versions of Windows.

Two bugs have been fixed (only affected 32bit binaries):
- Bad EVT_VARIANT struct definition, caused errors formatting events.
    The first field of the structure, a union, didn't have the right size when compiled for 32-bits, causing "invalid argument" errors when the struct was passed to an API. Also, some EVT_VARIANT types weren't being handled properly.

- Failed to seek to a saved state in an `.evtx` file.
    This is caused by a helper tool in Go (mkwinsyscall) not generating correct syscall calls under GOARCH=386 (or any 32-bit arch). This only affects functions that receive a 64-bit parameter, in the case of Beats, only EvtSeek is affected. ([Bug report](https://github.com/golang/go/issues/42373)).

The rest are changes to tests due to inconsistent behaviors of different Windows versions:

- Remove formatting assertion in TestFormatMessage
    Under most Windows versions, GUID values cannot be substituted with string values. However, this is not the case under at least Win7 32bit. Just disable the testing assertion as it has no impact.

- Disable TestFormatMessage/no_metadata tests
    Under Windows 10, event formatting is not failing with an error even though not metadata is being passed.

- Check for errors on publishing events to an event log
    Under Windows 7 and Windows 10, writes to a newly created event log fail occasionally. It seems that there is a delay between when an event log is created and publishing events to it is allowed.

- Sysmon: Ignore winlog.user.* fields during test
    For some reason, the following fields:
    - winlog.user.type
    - winlog.user.name
    - winlog.user.domain

   are not populated by the Sysmon module under Windows 7 32-bit. I couldn't reproduce outside of CI, where it's failing to lookup SID `S-1-5-18`.


Fixes #19798
Fixes #19829
Fixes #22046
Fixes #22302 