### PR TITLE
Cherry-pick #22690 to 7.x: Log level reloadable from fleet 

### DIFF
--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -79,7 +79,7 @@ func ConfigureWithOutputs(cfg Config, outputs ...zapcore.Core) error {
 
 	// Build a single output (stderr has priority if more than one are enabled).
 	if cfg.toObserver {
-		sink, observedLogs = observer.New(cfg.Level.zapLevel())
+		sink, observedLogs = observer.New(cfg.Level.ZapLevel())
 	} else {
 		sink, err = createLogOutput(cfg)
 	}
@@ -201,16 +201,16 @@ func makeOptions(cfg Config) []zap.Option {
 
 func makeStderrOutput(cfg Config) (zapcore.Core, error) {
 	stderr := zapcore.Lock(os.Stderr)
-	return newCore(cfg, buildEncoder(cfg), stderr, cfg.Level.zapLevel()), nil
+	return newCore(cfg, buildEncoder(cfg), stderr, cfg.Level.ZapLevel()), nil
 }
 
 func makeDiscardOutput(cfg Config) (zapcore.Core, error) {
 	discard := zapcore.AddSync(ioutil.Discard)
-	return newCore(cfg, buildEncoder(cfg), discard, cfg.Level.zapLevel()), nil
+	return newCore(cfg, buildEncoder(cfg), discard, cfg.Level.ZapLevel()), nil
 }
 
 func makeSyslogOutput(cfg Config) (zapcore.Core, error) {
-	core, err := newSyslog(buildEncoder(cfg), cfg.Level.zapLevel())
+	core, err := newSyslog(buildEncoder(cfg), cfg.Level.ZapLevel())
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func makeSyslogOutput(cfg Config) (zapcore.Core, error) {
 }
 
 func makeEventLogOutput(cfg Config) (zapcore.Core, error) {
-	core, err := newEventLog(cfg.Beat, buildEncoder(cfg), cfg.Level.zapLevel())
+	core, err := newEventLog(cfg.Beat, buildEncoder(cfg), cfg.Level.ZapLevel())
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func makeFileOutput(cfg Config) (zapcore.Core, error) {
 		return nil, errors.Wrap(err, "failed to create file rotator")
 	}
 
-	return newCore(cfg, buildEncoder(cfg), rotator, cfg.Level.zapLevel()), nil
+	return newCore(cfg, buildEncoder(cfg), rotator, cfg.Level.ZapLevel()), nil
 }
 
 func newCore(cfg Config, enc zapcore.Encoder, ws zapcore.WriteSyncer, enab zapcore.LevelEnabler) zapcore.Core {

--- a/libbeat/logp/level.go
+++ b/libbeat/logp/level.go
@@ -101,7 +101,8 @@ func (l Level) MarshalJSON() ([]byte, error) {
 	return nil, errors.Errorf("invalid level '%d'", l)
 }
 
-func (l Level) zapLevel() zapcore.Level {
+// ZapLevel returns zap alternative to logp.Level.
+func (l Level) ZapLevel() zapcore.Level {
 	z, found := zapLevels[l]
 	if found {
 		return z

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -51,3 +51,4 @@
 - Removed `install-service.ps1` and `uninstall-service.ps1` from Windows .zip packaging {pull}21694[21694]
 - Add `priority` to `AddOrUpdate` on dynamic composable input providers communication channel {pull}22352[22352]
 - Ship `endpoint-security` logs to elasticsearch {pull}22526[22526]
+- Log level reloadable from fleet {pull}22690[22690]

--- a/x-pack/elastic-agent/pkg/agent/application/config_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/config_test.go
@@ -70,7 +70,7 @@ func testMgmtMode(t *testing.T) {
 		err := c.Unpack(&m)
 		require.NoError(t, err)
 		assert.Equal(t, false, m.Fleet.Enabled)
-		assert.Equal(t, true, isStandalone(m.Fleet))
+		assert.Equal(t, true, IsStandalone(m.Fleet))
 
 	})
 
@@ -80,7 +80,7 @@ func testMgmtMode(t *testing.T) {
 		err := c.Unpack(&m)
 		require.NoError(t, err)
 		assert.Equal(t, true, m.Fleet.Enabled)
-		assert.Equal(t, false, isStandalone(m.Fleet))
+		assert.Equal(t, false, IsStandalone(m.Fleet))
 	})
 }
 

--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_settings.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_settings.go
@@ -1,0 +1,52 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
+)
+
+// handlerSettings handles settings change coming from fleet and updates log level.
+type handlerSettings struct {
+	log       *logger.Logger
+	reexec    reexecManager
+	agentInfo *info.AgentInfo
+}
+
+// Handle handles SETTINGS action.
+func (h *handlerSettings) Handle(ctx context.Context, a action, acker fleetAcker) error {
+	h.log.Debugf("handlerUpgrade: action '%+v' received", a)
+	action, ok := a.(*fleetapi.ActionSettings)
+	if !ok {
+		return fmt.Errorf("invalid type, expected ActionSettings and received %T", a)
+	}
+
+	if !isSupportedLogLevel(action.LogLevel) {
+		return fmt.Errorf("invalid log level, expected debug|info|warning|error and received '%s'", action.LogLevel)
+	}
+
+	if err := h.agentInfo.LogLevel(action.LogLevel); err != nil {
+		return errors.New("failed to update log level", err)
+	}
+
+	if err := acker.Ack(ctx, a); err != nil {
+		h.log.Errorf("failed to acknowledge SETTINGS action with id '%s'", action.ActionID)
+	} else if err := acker.Commit(ctx); err != nil {
+		h.log.Errorf("failed to commit acker after acknowledging action with id '%s'", action.ActionID)
+	}
+
+	h.reexec.ReExec()
+	return nil
+}
+
+func isSupportedLogLevel(level string) bool {
+	return level == "error" || level == "debug" || level == "info" || level == "warning"
+}

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
@@ -4,11 +4,32 @@
 
 package info
 
-import "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
 
 // AgentInfo is a collection of information about agent.
 type AgentInfo struct {
-	agentID string
+	agentID  string
+	logLevel string
+}
+
+// NewAgentInfoWithLog creates a new agent information.
+// In case when agent ID was already created it returns,
+// this created ID otherwise it generates
+// new unique identifier for agent.
+// If agent config file does not exist it gets created.
+// Initiates log level to predefined value.
+func NewAgentInfoWithLog(level string) (*AgentInfo, error) {
+	agentInfo, err := loadAgentInfo(false, level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AgentInfo{
+		agentID:  agentInfo.ID,
+		logLevel: agentInfo.LogLevel,
+	}, nil
 }
 
 // NewAgentInfo creates a new agent information.
@@ -17,29 +38,17 @@ type AgentInfo struct {
 // new unique identifier for agent.
 // If agent config file does not exist it gets created.
 func NewAgentInfo() (*AgentInfo, error) {
-	agentInfo, err := loadAgentInfo(false)
-	if err != nil {
-		return nil, err
-	}
-
-	return &AgentInfo{
-		agentID: agentInfo.ID,
-	}, nil
+	return NewAgentInfoWithLog(defaultLogLevel)
 }
 
-// ForceNewAgentInfo creates a new agent information.
-// Generates new unique identifier for agent regardless
-// of any existing ID.
-// If agent config file does not exist it gets created.
-func ForceNewAgentInfo() (*AgentInfo, error) {
-	agentInfo, err := loadAgentInfo(true)
-	if err != nil {
-		return nil, err
+// LogLevel updates log level of agent.
+func (i *AgentInfo) LogLevel(level string) error {
+	if err := updateLogLevel(level); err != nil {
+		return err
 	}
 
-	return &AgentInfo{
-		agentID: agentInfo.ID,
-	}, nil
+	i.logLevel = level
+	return nil
 }
 
 // AgentID returns an agent identifier.

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_metadata.go
@@ -40,6 +40,9 @@ type AgentECSMeta struct {
 	BuildOriginal string `json:"build.original"`
 	// Upgradeable is a flag specifying if it is possible for agent to be upgraded.
 	Upgradeable bool `json:"upgradeable"`
+	// LogLevel describes currently set log level.
+	// Possible values: "debug"|"info"|"warning"|"error"
+	LogLevel string `json:"log_level"`
 }
 
 // SystemECSMeta is a collection of operating system metadata in ECS compliant object form.
@@ -140,6 +143,7 @@ func (i *AgentInfo) ECSMetadata() (*ECSMeta, error) {
 				// only upgradeable if running from Agent installer and running under the
 				// control of the system supervisor (or built specifically with upgrading enabled)
 				Upgradeable: release.Upgradeable() || (install.RunningInstalled() && install.RunningUnderSupervisor()),
+				LogLevel:    i.logLevel,
 			},
 		},
 		Host: &HostECSMeta{

--- a/x-pack/elastic-agent/pkg/agent/application/inspect_config_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/inspect_config_cmd.go
@@ -46,7 +46,7 @@ func (c *InspectConfigCmd) inspectConfig() error {
 		return err
 	}
 
-	if isStandalone(cfg.Fleet) {
+	if IsStandalone(cfg.Fleet) {
 		return printConfig(rawConfig)
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/inspect_output_cmd.go
@@ -66,7 +66,7 @@ func (c *InspectOutputCmd) inspectOutputs(agentInfo *info.AgentInfo) error {
 		return err
 	}
 
-	if isStandalone(cfg.Fleet) {
+	if IsStandalone(cfg.Fleet) {
 		return listOutputsFromConfig(l, agentInfo, rawConfig)
 	}
 
@@ -119,7 +119,7 @@ func (c *InspectOutputCmd) inspectOutput(agentInfo *info.AgentInfo) error {
 		return err
 	}
 
-	if isStandalone(cfg.Fleet) {
+	if IsStandalone(cfg.Fleet) {
 		return printOutputFromConfig(l, agentInfo, c.output, c.program, rawConfig)
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -63,6 +63,7 @@ func newLocal(
 	rawConfig *config.Config,
 	reexec reexecManager,
 	uc upgraderControl,
+	agentInfo *info.AgentInfo,
 ) (*Local, error) {
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
@@ -74,10 +75,6 @@ func newLocal(
 		if err != nil {
 			return nil, err
 		}
-	}
-	agentInfo, err := info.NewAgentInfo()
-	if err != nil {
-		return nil, err
 	}
 
 	logR := logreporter.NewReporter(log)

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -66,12 +66,8 @@ func newManaged(
 	log *logger.Logger,
 	rawConfig *config.Config,
 	reexec reexecManager,
+	agentInfo *info.AgentInfo,
 ) (*Managed, error) {
-	agentInfo, err := info.NewAgentInfo()
-	if err != nil {
-		return nil, err
-	}
-
 	path := info.AgentConfigFile()
 
 	store := storage.NewDiskStore(path)
@@ -242,6 +238,15 @@ func newManaged(
 		&handlerUpgrade{
 			upgrader: managedApplication.upgrader,
 			log:      log,
+		},
+	)
+
+	actionDispatcher.MustRegister(
+		&fleetapi.ActionSettings{},
+		&handlerSettings{
+			log:       log,
+			reexec:    reexec,
+			agentInfo: agentInfo,
 		},
 	)
 

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -54,7 +54,7 @@ func new(name string, cfg *Config) (*Logger, error) {
 	if err != nil {
 		return nil, err
 	}
-	internal, err := makeInternalFileOutput()
+	internal, err := makeInternalFileOutput(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func toCommonConfig(cfg *Config) (*common.Config, error) {
 func DefaultLoggingConfig() *Config {
 	cfg := logp.DefaultConfig(logp.DefaultEnvironment)
 	cfg.Beat = agentName
-	cfg.Level = logp.DebugLevel
+	cfg.Level = logp.InfoLevel
 	cfg.Files.Path = paths.Logs()
 	cfg.Files.Name = fmt.Sprintf("%s.log", agentName)
 
@@ -96,7 +96,7 @@ func DefaultLoggingConfig() *Config {
 // makeInternalFileOutput creates a zapcore.Core logger that cannot be changed with configuration.
 //
 // This is the logger that the spawned filebeat expects to read the log file from and ship to ES.
-func makeInternalFileOutput() (zapcore.Core, error) {
+func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 	// defaultCfg is used to set the defaults for the file rotation of the internal logging
 	// these settings cannot be changed by a user configuration
 	defaultCfg := logp.DefaultConfig(logp.DefaultEnvironment)
@@ -115,5 +115,5 @@ func makeInternalFileOutput() (zapcore.Core, error) {
 	}
 
 	encoder := zapcore.NewJSONEncoder(ecszap.ECSCompatibleEncoderConfig(logp.JSONEncoderConfig()))
-	return ecszap.WrapCore(zapcore.NewCore(encoder, rotator, zapcore.DebugLevel)), nil
+	return ecszap.WrapCore(zapcore.NewCore(encoder, rotator, cfg.Level.ZapLevel())), nil
 }

--- a/x-pack/elastic-agent/pkg/fleetapi/action.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/action.go
@@ -19,6 +19,8 @@ const (
 	ActionTypeUnenroll = "UNENROLL"
 	// ActionTypePolicyChange specifies policy change action.
 	ActionTypePolicyChange = "POLICY_CHANGE"
+	// ActionTypeSettings specifies change of agent settings.
+	ActionTypeSettings = "SETTINGS"
 )
 
 // Action base interface for all the implemented action from the fleet API.
@@ -145,6 +147,34 @@ func (a *ActionUnenroll) ID() string {
 	return a.ActionID
 }
 
+// ActionSettings is a request to change agent settings.
+type ActionSettings struct {
+	ActionID   string
+	ActionType string
+	LogLevel   string `json:"log_level"`
+}
+
+func (a *ActionSettings) String() string {
+	var s strings.Builder
+	s.WriteString("action_id: ")
+	s.WriteString(a.ActionID)
+	s.WriteString(", type: ")
+	s.WriteString(a.ActionType)
+	s.WriteString(", log_level: ")
+	s.WriteString(a.LogLevel)
+	return s.String()
+}
+
+// Type returns the type of the Action.
+func (a *ActionSettings) Type() string {
+	return a.ActionType
+}
+
+// ID returns the ID of the Action.
+func (a *ActionSettings) ID() string {
+	return a.ActionID
+}
+
 // Actions is a list of Actions to executes and allow to unmarshal heterogenous action type.
 type Actions []Action
 
@@ -193,6 +223,17 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(response.Data, action); err != nil {
 				return errors.New(err,
 					"fail to decode UPGRADE_ACTION action",
+					errors.TypeConfig)
+			}
+		case ActionTypeSettings:
+			action = &ActionSettings{
+				ActionID:   response.ActionID,
+				ActionType: response.ActionType,
+			}
+
+			if err := json.Unmarshal(response.Data, action); err != nil {
+				return errors.New(err,
+					"fail to decode SETTINGS_ACTION action",
 					errors.TypeConfig)
 			}
 		default:


### PR DESCRIPTION
Cherry-pick of PR #22690 to 7.x branch. Original message:

## What does this PR do?

This PR introduces log level reloading initiated by SETTINGS action coming from fleet introduced in this PR: https://github.com/elastic/kibana/pull/83707

This strategy reexecs agent on log level change.

## Why is it important?

#20756

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
