### PR TITLE
Cherry-pick #21693 to 7.10: Update system/socket dataset to support config reloading

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -131,6 +131,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
+- system/socket: Fixed start failure when run under config reloader. {issue}20851[20851] {pull}21693[21693]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/config.go
+++ b/x-pack/auditbeat/module/system/socket/config.go
@@ -4,7 +4,10 @@
 
 package socket
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 // Config defines this metricset's configuration options.
 type Config struct {
@@ -64,9 +67,25 @@ type Config struct {
 	EnableIPv6 *bool `config:"socket.enable_ipv6"`
 }
 
-// Validate validates the host metricset config.
+// Validate validates the socket metricset config.
 func (c *Config) Validate() error {
 	return nil
+}
+
+// Equals compares two Config objects
+func (c *Config) Equals(other Config) bool {
+	// reflect.DeepEquals() doesn't compare pointed-to values, so strip
+	// all pointers and then compare them manually.
+	simpler := [2]Config{*c, other}
+	for idx := range simpler {
+		simpler[idx].EnableIPv6 = nil
+		simpler[idx].TraceFSPath = nil
+	}
+	return reflect.DeepEqual(simpler[0], simpler[1]) &&
+		(c.EnableIPv6 == nil) == (other.EnableIPv6 == nil) &&
+		(c.EnableIPv6 == nil || *c.EnableIPv6 == *other.EnableIPv6) &&
+		(c.TraceFSPath == nil) == (other.TraceFSPath == nil) &&
+		(c.TraceFSPath == nil || *c.TraceFSPath == *other.TraceFSPath)
 }
 
 var defaultConfig = Config{

--- a/x-pack/auditbeat/module/system/socket/guess/creds.go
+++ b/x-pack/auditbeat/module/system/socket/guess/creds.go
@@ -51,7 +51,7 @@ const (
 )
 
 func init() {
-	if err := Registry.AddGuess(&guessStructCreds{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessStructCreds{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -34,7 +34,7 @@ import (
 */
 
 func init() {
-	if err := Registry.AddGuess(&guessInet6CskXmit{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessInet6CskXmit{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/deref.go
+++ b/x-pack/auditbeat/module/system/socket/guess/deref.go
@@ -28,7 +28,7 @@ import (
 */
 
 func init() {
-	if err := Registry.AddGuess(&guessDeref{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessDeref{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -35,7 +35,7 @@ import (
 // matched the remote address. This is used by guess_inet_sock6.
 
 func init() {
-	if err := Registry.AddGuess(&guessInetSockIPv4{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessInetSockIPv4{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -103,7 +103,7 @@ import (
 const inetSockDumpSize = 8 * 256
 
 func init() {
-	if err := Registry.AddGuess(&guessInetSockIPv6{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessInetSockIPv6{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
@@ -45,7 +45,7 @@ import (
 const inetSockAfDumpSize = 8 * 16
 
 func init() {
-	if err := Registry.AddGuess(&guessInetSockFamily{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessInetSockFamily{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
+++ b/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
@@ -39,7 +39,7 @@ const (
 )
 
 func init() {
-	if err := Registry.AddGuess(&guessIPLocalOut{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessIPLocalOut{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/registry.go
+++ b/x-pack/auditbeat/module/system/socket/guess/registry.go
@@ -8,29 +8,33 @@ package guess
 
 import "fmt"
 
-// Registry serves as a registration point for guesses.
-var Registry = Register{
-	guesses: make(map[string]Guesser),
-}
+// GuesserFactory is a factory function for guesses.
+type GuesserFactory func() Guesser
 
 // Register stores the registered guesses.
 type Register struct {
-	guesses map[string]Guesser
+	factories map[string]GuesserFactory
+}
+
+// Registry serves as a registration point for guesses.
+var Registry = Register{
+	factories: make(map[string]GuesserFactory),
 }
 
 // AddGuess registers a new guess.
-func (r *Register) AddGuess(guess Guesser) error {
-	if _, found := r.guesses[guess.Name()]; found {
+func (r *Register) AddGuess(factory GuesserFactory) error {
+	guess := factory()
+	if _, found := r.factories[guess.Name()]; found {
 		return fmt.Errorf("guess %s is duplicated", guess.Name())
 	}
-	r.guesses[guess.Name()] = guess
+	r.factories[guess.Name()] = factory
 	return nil
 }
 
 // GetList returns a list of registered guesses.
 func (r *Register) GetList() (list []Guesser) {
-	for _, guess := range r.guesses {
-		list = append(list, guess)
+	for _, factory := range r.factories {
+		list = append(list, factory())
 	}
 	return list
 }

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -45,13 +45,13 @@ import (
 const maxSafePayload = 508
 
 func init() {
-	if err := Registry.AddGuess(&guessSkBuffLen{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSkBuffLen{} }); err != nil {
 		panic(err)
 	}
-	if err := Registry.AddGuess(&guessSkBuffProto{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSkBuffProto{} }); err != nil {
 		panic(err)
 	}
-	if err := Registry.AddGuess(&guessSkBuffDataPtr{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSkBuffDataPtr{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
@@ -29,8 +29,7 @@ import (
 */
 
 func init() {
-	if err := Registry.AddGuess(
-		&guessSockaddrIn{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSockaddrIn{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
@@ -29,8 +29,7 @@ import (
 */
 
 func init() {
-	if err := Registry.AddGuess(
-		&guessSockaddrIn6{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSockaddrIn6{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/socketsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/socketsk.go
@@ -29,7 +29,7 @@ import (
 //  "SOCKET_SOCK": 32
 
 func init() {
-	if err := Registry.AddGuess(&guessSocketSock{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessSocketSock{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
@@ -31,8 +31,10 @@ import (
 */
 
 func init() {
-	if err := Registry.AddGuess(&guessSyscallArgs{
-		expected: [2]uintptr{^uintptr(0x11111111), ^uintptr(0x22222222)},
+	if err := Registry.AddGuess(func() Guesser {
+		return &guessSyscallArgs{
+			expected: [2]uintptr{^uintptr(0x11111111), ^uintptr(0x22222222)},
+		}
 	}); err != nil {
 		panic(err)
 	}

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
@@ -24,7 +24,7 @@ import (
 //  TCP_SENDMSG_LEN  : +4(%sp)
 
 func init() {
-	if err := Registry.AddGuess(&guessTCPSendMsg{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessTCPSendMsg{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
@@ -28,7 +28,7 @@ import (
 //  TCP_SENDMSG_SOCK  : %di
 
 func init() {
-	if err := Registry.AddGuess(&guessTcpSendmsgSock{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessTcpSendmsgSock{} }); err != nil {
 		panic(err)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
+++ b/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
@@ -28,7 +28,7 @@ import (
 //  UDP_SENDMSG_MSG: $stack3
 
 func init() {
-	if err := Registry.AddGuess(&guessUDPSendMsg{}); err != nil {
+	if err := Registry.AddGuess(func() Guesser { return &guessUDPSendMsg{} }); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #21693 to 7.10 branch. Original message: 

## What does this PR do?

This updates the `system/socket` dataset so that it behaves correctly when run under config reloader.

When a dataset is run from a static module definition in _auditbeat.yml:_
- Factory method New is called.
- (instance).Run is called.

When the dataset is configured in the context of [configuration reloading:](https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-configuration-reloading.html)
- Factory method New is called to validate that the config is OK. The returned instance is discarded without its context being closed.
- Factory method New is called again.
- (instance).Run is called for the instance returned by the second New. 

Also, if `reload.enable` is `true`, everytime the configuration file changes:
- The metricset context is closed.
- A new instance is created using New.
- (instance).Run is called.

This behavior didn't play well with a dataset with complex initialization (can take up to 20s to start) and that uses global OS resources (kprobes) that need to be released before a new dataset can be instantiated. There's no mechanism for the reloader to wait for a metricset's termination.

This updates the dataset factory method to keep track of an already running instance. Also it checks if the config has changed to prevent initializing two metricsets at startup.

## Why is it important?

Currently Auditbeat will fail with a cryptic error when the socket dataset is started using config reloading. See https://github.com/elastic/beats/issues/20851.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

See the linked issue.

## Related issues

- Closes #20851
