### PR TITLE
feat(filebeat): add read_logorotate to container input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
+- Add `read_logrotate` option to Filebeat container/log inputs to avoid miss big partial logs. {pull}22736[22736]
 
 *Auditbeat*
 

--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -77,10 +77,10 @@ certain criteria or time. Closing the harvester means closing the file handler.
 If a file is updated after the harvester is closed, the file will be picked up
 again after `scan_frequency` has elapsed. However, if the file is moved or
 deleted while the harvester is closed, {beatname_uc} will not be able to pick up
-the file again, and any data that the harvester hasn't read will be lost. 
-The `close_*` settings are applied synchronously when {beatname_uc} attempts 
+the file again, and any data that the harvester hasn't read will be lost.
+The `close_*` settings are applied synchronously when {beatname_uc} attempts
 to read from a file, meaning that if {beatname_uc} is in a blocked state
-due to blocked output, full queue or other issue, a file that would 
+due to blocked output, full queue or other issue, a file that would
 otherwise be closed remains open until {beatname_uc} once again attempts to read from the file.
 
 
@@ -240,7 +240,7 @@ that should be removed based on the `clean_inactive` setting. This happens
 because {beatname_uc} doesn't remove the entries until it opens the registry
 again to read a different file. If you are testing the `clean_inactive` setting,
 make sure {beatname_uc} is configured to read from more than one file, or the
-file state will never be removed from the registry. 
+file state will never be removed from the registry.
 
 [float]
 [id="{beatname_lc}-input-{type}-clean-removed"]
@@ -442,3 +442,9 @@ Set the location of the marker file the following way:
 file_identity.inode_marker.path: /logs/.filebeat-marker
 ----
 
+[float]
+===== `read_logrotate`
+
+experimental[]
+
+Use this option for read logrotated files to avoid miss big partial logs. Also, need specify `close_inactive`

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -57,6 +57,8 @@ type config struct {
 	RecursiveGlob  bool                    `config:"recursive_glob.enabled"`
 	FileIdentity   *common.ConfigNamespace `config:"file_identity"`
 
+	ReadLogrotate bool `config:"read_logrotate"`
+
 	// Harvester
 	BufferSize int    `config:"harvester_buffer_size"`
 	Encoding   string `config:"encoding"`
@@ -192,6 +194,14 @@ func (c *config) Validate() error {
 		if _, ok := ValidScanOrder[c.ScanOrder]; !ok {
 			return fmt.Errorf("Invalid scan order: %v", c.ScanOrder)
 		}
+	}
+
+	if c.ReadLogrotate && c.CloseInactive == 0 {
+		return fmt.Errorf("close_inactive must be enabled when read_logrotate is used")
+	}
+
+	if c.ReadLogrotate && (c.CloseRenamed || c.CloseEOF) {
+		return fmt.Errorf("read_logrotate not able work with close_renamed and close_eof")
 	}
 
 	return nil

--- a/filebeat/input/log/config_test.go
+++ b/filebeat/input/log/config_test.go
@@ -70,3 +70,34 @@ func TestCleanOlderIgnoreOlder(t *testing.T) {
 	err := config.Validate()
 	assert.NoError(t, err)
 }
+
+func TestReadLogrotateConfig(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		config := config{
+			ReadLogrotate: true,
+			LogConfig: LogConfig{
+				CloseInactive: time.Second,
+			},
+		}
+
+		assert.NoError(t, config.Validate())
+	})
+
+	t.Run("logrotate without close_inactive", func(t *testing.T) {
+		config := config{
+			ReadLogrotate: true,
+		}
+		assert.EqualError(t, config.Validate(), "close_inactive must be enabled when read_logrotate is used")
+	})
+
+	t.Run("logrotate with close eof", func(t *testing.T) {
+		config := config{
+			ReadLogrotate: true,
+			LogConfig: LogConfig{
+				CloseEOF:      true,
+				CloseInactive: time.Second,
+			},
+		}
+		assert.EqualError(t, config.Validate(), "read_logrotate not able work with close_renamed and close_eof")
+	})
+}

--- a/filebeat/input/stdin/input.go
+++ b/filebeat/input/stdin/input.go
@@ -93,6 +93,7 @@ func (p *Input) createHarvester(state file.State) (*log.Harvester, error) {
 		func() channel.Outleter {
 			return p.outlet
 		},
+		nil,
 	)
 
 	return h, err

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -68,6 +68,7 @@ func NewTimeoutReader(reader reader.Reader, signal error, t time.Duration) *Time
 func (r *TimeoutReader) Next() (reader.Message, error) {
 	if !r.running {
 		r.running = true
+		r.done = make(chan struct{})
 		go func() {
 			for {
 				message, err := r.reader.Next()
@@ -98,7 +99,9 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 }
 
 func (r *TimeoutReader) Close() error {
-	close(r.done)
-
+	if r.running {
+		close(r.done)
+	}
+	r.running = false
 	return r.reader.Close()
 }


### PR DESCRIPTION
## What does this PR do?

Add `read_logrotate` to filebeat's container/log input. This option needs to avoid miss big partial logs in different files. 
If read_logrotate is true, at one-time filebeat reads only one file, after reads file, filebeat will save reader to next harvester.

## Why is it important?

Now, filebeat miss partial logs in different files, this pull request should fix this. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Create docker container which generate logs bigger than 16K. 
Configure filebeat to read log files, example:
```
    - type: container
      paths:
       - '/var/lib/docker/containers/*/*.log*'
...
      read_logrotate: true
      close_inactive: 5s
```
`close_inactive` needs to close harvester and start next harvester with same reader.

## Related issues

- https://github.com/moby/moby/issues/41650

## Use cases

- Read container logs, when these logs possibly partial.
