### PR TITLE
Fix export dashboard command from Elastic Cloud

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -57,6 +57,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 
 - Stop using `mage:import` in community beats. This was ignoring the vendorized beats directory for some mage targets, using the code available in GOPATH, this causes inconsistencies and compilation problems if the version of the code in the GOPATH is different to the vendored one. Use of `mage:import` will continue to be unsupported in custom beats till beats is migrated to go modules, or mage supports vendored dependencies. {issue}13998[13998] {pull}14162[14162]
 - Metricbeat module builders call host parser only once when instantiating light modules. {pull}20149[20149]
+- Fix export dashboard command when running against Elastic Cloud hosted Kibana. {pull}22746[22746]
 
 ==== Added
 

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -49,7 +49,16 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 				b.Config.Kibana = common.NewConfig()
 			}
 
-			client, err := kibana.NewKibanaClient(b.Config.Kibana)
+			// Initialize kibana config. If username and password is set in
+			// elasticsearch output config but not in kibana, initKibanaConfig
+			// will attach the username and password into kibana config as a
+			// part of the initialization.
+			initConfig, err := instance.InitKibanaConfig(b.Config)
+			if err != nil {
+				fatalf("error InitKibanaConfig: %v", err)
+			}
+
+			client, err := kibana.NewKibanaClient(initConfig)
 			if err != nil {
 				fatalf("Error creating Kibana client: %+v.\n", err)
 			}

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -53,10 +53,7 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 			// elasticsearch output config but not in kibana, initKibanaConfig
 			// will attach the username and password into kibana config as a
 			// part of the initialization.
-			initConfig, err := instance.InitKibanaConfig(b.Config)
-			if err != nil {
-				fatalf("error InitKibanaConfig: %v", err)
-			}
+			initConfig := instance.InitKibanaConfig(b.Config)
 
 			client, err := kibana.NewKibanaClient(initConfig)
 			if err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -774,10 +774,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 
 		// Initialize kibana config. If username and password is set in elasticsearch output config but not in kibana,
 		// initKibanaConfig will attach the username and password into kibana config as a part of the initialization.
-		kibanaConfig, err := InitKibanaConfig(b.Config)
-		if err != nil {
-			return fmt.Errorf("error InitKibanaConfig: %v", err)
-		}
+		kibanaConfig := InitKibanaConfig(b.Config)
 
 		client, err := kibana.NewKibanaClient(kibanaConfig)
 		if err != nil {
@@ -1041,7 +1038,7 @@ func LoadKeystore(cfg *common.Config, name string) (keystore.Keystore, error) {
 	return keystore.Factory(keystoreCfg, defaultPathConfig)
 }
 
-func InitKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
+func InitKibanaConfig(beatConfig beatConfig) *common.Config {
 	var esConfig *common.Config
 	if beatConfig.Output.Name() == "elasticsearch" {
 		esConfig = beatConfig.Output.Config()
@@ -1064,7 +1061,7 @@ func InitKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
 			kibanaConfig.SetString("password", -1, password)
 		}
 	}
-	return kibanaConfig, nil
+	return kibanaConfig
 }
 
 func initPaths(cfg *common.Config) error {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -774,9 +774,9 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 
 		// Initialize kibana config. If username and password is set in elasticsearch output config but not in kibana,
 		// initKibanaConfig will attach the username and password into kibana config as a part of the initialization.
-		kibanaConfig, err := initKibanaConfig(b.Config)
+		kibanaConfig, err := InitKibanaConfig(b.Config)
 		if err != nil {
-			return fmt.Errorf("error initKibanaConfig: %v", err)
+			return fmt.Errorf("error InitKibanaConfig: %v", err)
 		}
 
 		client, err := kibana.NewKibanaClient(kibanaConfig)
@@ -1041,7 +1041,7 @@ func LoadKeystore(cfg *common.Config, name string) (keystore.Keystore, error) {
 	return keystore.Factory(keystoreCfg, defaultPathConfig)
 }
 
-func initKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
+func InitKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
 	var esConfig *common.Config
 	if beatConfig.Output.Name() == "elasticsearch" {
 		esConfig = beatConfig.Output.Config()

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -82,8 +82,7 @@ func TestInitKibanaConfig(t *testing.T) {
 	err = cfg.Unpack(&b.Config)
 	assert.NoError(t, err)
 
-	kibanaConfig, err := InitKibanaConfig(b.Config)
-	assert.NoError(t, err)
+	kibanaConfig := InitKibanaConfig(b.Config)
 	username, err := kibanaConfig.String("username", -1)
 	password, err := kibanaConfig.String("password", -1)
 	protocol, err := kibanaConfig.String("protocol", -1)

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -82,7 +82,7 @@ func TestInitKibanaConfig(t *testing.T) {
 	err = cfg.Unpack(&b.Config)
 	assert.NoError(t, err)
 
-	kibanaConfig, err := initKibanaConfig(b.Config)
+	kibanaConfig, err := InitKibanaConfig(b.Config)
 	assert.NoError(t, err)
 	username, err := kibanaConfig.String("username", -1)
 	password, err := kibanaConfig.String("password", -1)


### PR DESCRIPTION
## What does this PR do?

This PR is to fix `./metricbeat export dashboard -E cloud.id=<cloud-id> -E cloud.auth=<cloud-auth> --id=<dashboard-id>` command that points a Kibana hosted in Elastic Cloud by updating kibana config to include username and password.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This is already tested with https://github.com/elastic/beats/pull/22745.
