### PR TITLE
docs: update docs versions 7.10.1

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.10.0
+:stack-version: 7.10.1
 :doc-branch: 7.10
 :go-version: 1.14.7
 :release-state: unreleased


### PR DESCRIPTION
Updates docs versions to 7.10.1.

Merge before the final Release build.