### PR TITLE
Cherry-pick #20150 to 7.x: Log debug message if the Kibana dashboard can not be imported

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -158,6 +158,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix parsing of expired licences. {issue}21112[21112] {pull}22180[22180]
 - Fix duplicated pod events in kubernetes autodiscover for pods with init or ephemeral containers. {pull}22438[22438]
 - Fix index template loading when the new index format is selected. {issue}22482[22482] {pull}22682[22682]
+- Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -241,6 +241,8 @@ func (imp Importer) ImportArchive() error {
 			if err != nil {
 				return err
 			}
+		} else {
+			imp.loader.statusMsg("Skipping import of %s directory. Beat name: %s, base dir name: %s.", dir, imp.cfg.Beat, filepath.Base(dir))
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry-pick of PR #20150 to 7.x branch. Original message: 

This PR is the updated verion of a community contribution which was abandoned in #13387. The original PR description is the following:

As described in #12211, depending on the value of _setup.dashboards.beat_ there is a required directory structure for successful import of the Kibana dashboards from the archive file.

This PR adds additional path in case when no Kibana dashboards can be imported from the archive file, which logs debug message as shown below:

```
2019-08-29T22:40:00.122+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Unzip archive /tmp/tmp263803916
2019-08-29T22:40:00.126+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Importing Kibana from /tmp/tmp263803916/kibana/filebeat
.. 
// this is added 
2019-08-29T22:40:00.126+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Skipping import of /tmp/tmp263803916/kibana/filebeat directory. Beat name: metricbeat, base dir name: filebeat.
// end

2019-08-29T22:40:00.126+0200    INFO    instance/beat.go:776    Kibana dashboards successfully loaded.
```

Implementation of point 2 from #12211  proposal.

There is a table in elastic/beats#12211 that contains test cases for this issue, but I currently don't know how to mock all necessary dependencies and implement unit tests for this without too much changes in libbeat/dashboards/importer.go.

I see that there are some integration tests for loading dashboards in libbeat/tests/system/test_dashboard.py so I'll check those out.

Fixes #12211  
Closes #13387