### PR TITLE
Cherry-pick to 7.x: Missing `>` (#22763)

### DIFF
--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -5,7 +5,7 @@
 --
 Learn how to perform common {beatname_uc} configuration tasks.
 
-* <<override-{beatname_lc}-config-settings>
+* <<override-{beatname_lc}-config-settings>>
 * <<{beatname_lc}-template>>
 * <<change-index-name>>
 * <<load-kibana-dashboards>>


### PR DESCRIPTION
Backports the following commits to `7.x`:
 - Missing `>` (#22763)