### PR TITLE
Cherry-pick #22714 to 7.x: Fix k8s watcher issue when node access to list nodes and ns

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -88,13 +88,13 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 	}
 	nodeWatcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, options, nil)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)
+		logger.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)
 	}
 	namespaceWatcher, err := kubernetes.NewWatcher(client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
 	}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)
+		logger.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)
 	}
 	metaGen := metadata.GetPodMetaGen(cfg, watcher, nodeWatcher, namespaceWatcher, metaConf)
 

--- a/libbeat/common/kubernetes/metadata/metadata.go
+++ b/libbeat/common/kubernetes/metadata/metadata.go
@@ -60,8 +60,13 @@ func GetPodMetaGen(
 	namespaceWatcher kubernetes.Watcher,
 	metaConf *AddResourceMetadataConfig) MetaGen {
 
-	nodeMetaGen := NewNodeMetadataGenerator(metaConf.Node, nodeWatcher.Store())
-	namespaceMetaGen := NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store())
+	var nodeMetaGen, namespaceMetaGen MetaGen
+	if nodeWatcher != nil {
+		nodeMetaGen = NewNodeMetadataGenerator(metaConf.Node, nodeWatcher.Store())
+	}
+	if namespaceWatcher != nil {
+		namespaceMetaGen = NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store())
+	}
 	metaGen := NewPodMetadataGenerator(cfg, podWatcher.Store(), nodeMetaGen, namespaceMetaGen)
 
 	return metaGen

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -220,13 +220,17 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 
 		// NOTE: order is important here since pod meta will include node meta and hence node.Store() should
 		// be populated before trying to generate metadata for Pods.
-		if err := nodeWatcher.Start(); err != nil {
-			k.log.Debugf("add_kubernetes_metadata", "Couldn't start node watcher: %v", err)
-			return
+		if nodeWatcher != nil {
+			if err := nodeWatcher.Start(); err != nil {
+				k.log.Debugf("add_kubernetes_metadata", "Couldn't start node watcher: %v", err)
+				return
+			}
 		}
-		if err := namespaceWatcher.Start(); err != nil {
-			k.log.Debugf("add_kubernetes_metadata", "Couldn't start namespace watcher: %v", err)
-			return
+		if namespaceWatcher != nil {
+			if err := namespaceWatcher.Start(); err != nil {
+				k.log.Debugf("add_kubernetes_metadata", "Couldn't start namespace watcher: %v", err)
+				return
+			}
 		}
 		if err := watcher.Start(); err != nil {
 			k.log.Debugf("add_kubernetes_metadata", "Couldn't start pod watcher: %v", err)


### PR DESCRIPTION
Cherry-pick of PR #22714 to 7.x branch. Original message: 

## What does this PR do?
This PR changes Pod's metadata initialisation process so as not to fatally fail when node's or namespace's objects are not accessible via k8s api. Instead we only log an `ERROR`.

## Why is it important?
So as not to fail when users do not have permission to `watch` nodes and namespaces in a cluster.
Default manifests of Metricbeat provide `watch` access by default: https://github.com/elastic/beats/blob/f5df6407be1832eb7f1ab726861dc4cbb9d01023/deploy/kubernetes/metricbeat-kubernetes.yaml#L241

## Related issues

- Closes https://github.com/elastic/beats/issues/22683

