### PR TITLE
Improve event normalization performance

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -44,6 +44,7 @@ type EventConverter interface {
 type GenericEventConverter struct {
 	log      *logp.Logger
 	keepNull bool
+	keys     []string
 }
 
 // NewGenericEventConverter creates an EventConverter with the given configuration options
@@ -51,6 +52,7 @@ func NewGenericEventConverter(keepNull bool) *GenericEventConverter {
 	return &GenericEventConverter{
 		log:      logp.NewLogger("event"),
 		keepNull: keepNull,
+		keys:     make([]string, 0, 10),
 	}
 }
 
@@ -59,8 +61,7 @@ func NewGenericEventConverter(keepNull bool) *GenericEventConverter {
 // Nil values in maps are dropped during the conversion. Any unsupported types
 // that are found in the MapStr are dropped and warnings are logged.
 func (e *GenericEventConverter) Convert(m MapStr) MapStr {
-	keys := make([]string, 0, 10)
-	event, errs := e.normalizeMap(m, keys...)
+	event, errs := e.normalizeMap(m, e.keys[:0]...)
 	if len(errs) > 0 {
 		e.log.Warnf("Unsuccessful conversion to generic event: %v errors: %v, "+
 			"event=%#v", len(errs), errs, m)

--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -325,6 +325,20 @@ func TestNormalization(t *testing.T) {
 	}
 }
 
+func BenchmarkNormalization(b *testing.B) {
+	s, err := MakeDefaultSupport(true)(beat.Info{}, logp.L(), common.NewConfig())
+	require.NoError(b, err)
+
+	prog, err := s.Create(beat.ProcessingConfig{}, false)
+	require.NoError(b, err)
+
+	fields := common.MapStr{"a": "b"}
+	for i := 0; i < b.N; i++ {
+		f := fields.Clone()
+		_, _ = prog.Run(&beat.Event{Fields: f})
+	}
+}
+
 func TestAlwaysDrop(t *testing.T) {
 	s, err := MakeDefaultSupport(true)(beat.Info{}, logp.L(), common.NewConfig())
 	require.NoError(t, err)

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -44,13 +44,13 @@ type processorFn struct {
 
 func newGeneralizeProcessor(keepNull bool) *processorFn {
 	logger := logp.NewLogger("publisher_processing")
+	g := common.NewGenericEventConverter(keepNull)
 	return newProcessor("generalizeEvent", func(event *beat.Event) (*beat.Event, error) {
 		// Filter out empty events. Empty events are still reported by ACK callbacks.
 		if len(event.Fields) == 0 {
 			return nil, nil
 		}
 
-		g := common.NewGenericEventConverter(keepNull)
 		fields := g.Convert(event.Fields)
 		if fields == nil {
 			logger.Error("fail to convert to generic event")


### PR DESCRIPTION
## What does this PR do?

Improve event normalization performance

## Why is it important?

generalize/normalize is widely used in beats

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

Benchmark 

## Related issues

- 

## Use cases


## Screenshots



## Logs

Before
```
BenchmarkNormalization-8   	 1329153	       920 ns/op	    1176 B/op	      13 allocs/op
```

After
```
BenchmarkNormalization-8   	 2270809	       541 ns/op	     736 B/op	       5 allocs/op
```