### PR TITLE
Add docs section for ECS EC2 monitoring

### DIFF
--- a/metricbeat/docs/modules/awsfargate.asciidoc
+++ b/metricbeat/docs/modules/awsfargate.asciidoc
@@ -37,11 +37,12 @@ One can monitor these containers by deploying Metricbeat on the corresponding EC
 Metricbeat Docker module enabled.
 
 In order to achieve this one will need:
-
-* to ensure access to these EC2 instances using ssh keys
+--
+. to ensure access to these EC2 instances using ssh keys
 coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
-* to enable shh access for the instances with the
+. to enable shh access for the instances with the
 proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].
+--
 
 * *ECS Fargate*
 

--- a/metricbeat/docs/modules/awsfargate.asciidoc
+++ b/metricbeat/docs/modules/awsfargate.asciidoc
@@ -33,6 +33,16 @@ be managed: ECS EC2 and ECS Fargate.
 ECS EC2 launches containers that run on EC2 instances. Users have to manage EC2
 instances. Pricing depends on the number of EC2 instances running.
 
+One can monitor these containers by deploying Metricbeat on the corresponding EC2 instances with the
+Metricbeat Docker module enabled.
+
+In order to achieve this one will need:
+
+* to ensure access to these EC2 instances using ssh keys
+coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
+* to enable shh access for the instances with the
+proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].
+
 * *ECS Fargate*
 
 ECS Fargate removes the responsibility of provisioning, configuring, and

--- a/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
@@ -27,11 +27,12 @@ One can monitor these containers by deploying Metricbeat on the corresponding EC
 Metricbeat Docker module enabled.
 
 In order to achieve this one will need:
-
-* to ensure access to these EC2 instances using ssh keys
+--
+. to ensure access to these EC2 instances using ssh keys
 coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
-* to enable shh access for the instances with the
+. to enable shh access for the instances with the
 proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].
+--
 
 * *ECS Fargate*
 

--- a/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
@@ -23,6 +23,16 @@ be managed: ECS EC2 and ECS Fargate.
 ECS EC2 launches containers that run on EC2 instances. Users have to manage EC2
 instances. Pricing depends on the number of EC2 instances running.
 
+One can monitor these containers by deploying Metricbeat on the corresponding EC2 instances with the
+Metricbeat Docker module enabled.
+
+In order to achieve this one will need:
+
+. to ensure access to these EC2 instances using ssh keys
+coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
+. to enable shh access for the instances with the
+proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].
+
 * *ECS Fargate*
 
 ECS Fargate removes the responsibility of provisioning, configuring, and
@@ -48,17 +58,3 @@ Currently, we have `task_stats` metricset in `awsfargate` module.
 This metricset collects runtime CPU metrics, disk I/O metrics, memory metrics,
 network metrics and container metadata from both endpoint
 `${ECS_CONTAINER_METADATA_URI_V4}/task/stats` and `${ECS_CONTAINER_METADATA_URI_V4}/task`.
-
-
-[float]
-== How to monitor containers running on ECS EC2
-As it was already mentioned running containers on ECS EC2 launches containers that run on EC2 instances.
-One can monitor these containers by deploying Metricbeat on the corresponding EC2 instances with the
-Metricbeat Docker module enabled.
-
-In order to achieve this one will need:
-
-. to ensure access to these EC2 instances using ssh keys
-coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
-. to enable shh access for the instances with the
-proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].

--- a/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
@@ -48,3 +48,15 @@ Currently, we have `task_stats` metricset in `awsfargate` module.
 This metricset collects runtime CPU metrics, disk I/O metrics, memory metrics,
 network metrics and container metadata from both endpoint
 `${ECS_CONTAINER_METADATA_URI_V4}/task/stats` and `${ECS_CONTAINER_METADATA_URI_V4}/task`.
+
+
+[float]
+== How to monitor containers running on ECS EC2
+As it was already mentioned running containers on ECS EC2 launches containers that run on EC2 instances.
+One can monitor these containers by deploying Metricbeat on the corresponding EC2 instances with the
+Metricbeat Docker module enabled.
+
+In order to achieve this one will need to have access to these EC2 instances using ssh keys
+coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
+and enabling shh access for the instances with the
+proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].

--- a/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
@@ -56,7 +56,9 @@ As it was already mentioned running containers on ECS EC2 launches containers th
 One can monitor these containers by deploying Metricbeat on the corresponding EC2 instances with the
 Metricbeat Docker module enabled.
 
-In order to achieve this one will need to have access to these EC2 instances using ssh keys
+In order to achieve this one will need:
+
+. to ensure access to these EC2 instances using ssh keys
 coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
-and enabling shh access for the instances with the
+. to enable shh access for the instances with the
 proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].

--- a/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/_meta/docs.asciidoc
@@ -28,9 +28,9 @@ Metricbeat Docker module enabled.
 
 In order to achieve this one will need:
 
-. to ensure access to these EC2 instances using ssh keys
+* to ensure access to these EC2 instances using ssh keys
 coupled with EC2 instances (attach ssh keys on cluster creation using `Key pair` option)
-. to enable shh access for the instances with the
+* to enable shh access for the instances with the
 proper https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html[inbound rules].
 
 * *ECS Fargate*


### PR DESCRIPTION
## What does this PR do?
This PR adds docs section for monitoring containers running on ECS EC2.

## Why is it important?
To cover use cases where users running on ECS EC2 instead of ECS fargate.

Closes https://github.com/elastic/beats/issues/22719