### PR TITLE
system/socket: Add ip_local_out alternative

### DIFF
--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -35,7 +35,7 @@ var baseTemplateVars = common.MapStr{
 // These functions names vary between kernel versions. The first available one
 // will be selected during setup.
 var functionAlternatives = map[string][]string{
-	"IP_LOCAL_OUT":      {"ip_local_out", "ip_local_out_sk"},
+	"IP_LOCAL_OUT":      {"ip_local_out_sk", "__ip_local_out", "ip_local_out"},
 	"RECV_UDP_DATAGRAM": {"__skb_recv_udp", "__skb_recv_datagram", "skb_recv_datagram"},
 	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"SYS_GETTIMEOFDAY":  syscallAlternatives("gettimeofday"),


### PR DESCRIPTION
## What does this PR do?

This PR adds a new function alternative, `__ip_local_out` for selecting a proper ip_local_out function, and fixes `guess_ip_local_out` logic in order to account for this new function.

The new order of precedence is:
- ip_local_out_sk (kernels before 3.16)
- __ip_local_out (for kernels where ip_local_out calls are inlined)
- ip_local_out (all others).

## Why is it important?

In some systems, the `socket` dataset won't start with an error:
> unable to guess one or more required parameters: guess_ip_local_out failed: timeout while waiting for event

This is caused by Auditbeat expecting a kprobe set to `ip_local_out` to trigger, but it never does. The reason is that calls to this function might have been inlined. In those cases we need to attach the kprobe to `__ip_local_out` instead.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Relates #18755

