### PR TITLE
Add more Golang tests to filestream input

### DIFF
--- a/filebeat/input/filestream/config_test.go
+++ b/filebeat/input/filestream/config_test.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("paths cannot be empty", func(t *testing.T) {
+		c := config{Paths: []string{}}
+		err := c.Validate()
+		require.Error(t, err)
+	})
+}

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -62,7 +62,7 @@ func TestFileScanner(t *testing.T) {
 		"skip excluded files": {
 			paths: []string{excludedFilePath, includedFilePath},
 			excludedFiles: []match.Matcher{
-				match.MustCompile(filepath.Join(".*", excludedFileName)),
+				match.MustCompile(excludedFileName),
 			},
 			expectedFiles: []string{includedFilePath},
 		},

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -19,6 +19,7 @@ package filestream
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,53 +33,44 @@ import (
 )
 
 var (
-	excludedFilePath            = filepath.Join("testdata", "excluded_file")
-	includedFilePath            = filepath.Join("testdata", "included_file")
-	unharvestableDir            = filepath.Join("testdata", "unharvestable_dir")
-	includedDir                 = filepath.Join("testdata", "included_dir", "recursively")
-	includedRecursivelyFilePath = filepath.Join("testdata", "included_dir", "recursively", "included_file")
+	excludedFileName = "excluded_file"
+	includedFileName = "included_file"
+	directoryPath    = "unharvestable_dir"
 )
 
 func TestFileScanner(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fswatch_test_file_scanner")
+	if err != nil {
+		t.Fatalf("cannot create temporary test dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	setupFilesForScannerTest(t, tmpDir)
+
+	excludedFilePath := filepath.Join(tmpDir, excludedFileName)
+	includedFilePath := filepath.Join(tmpDir, includedFileName)
+
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
 		symlinks      bool
-		recursiveGlob bool
 		expectedFiles []string
 	}{
 		"select all files": {
-			paths: []string{excludedFilePath, includedFilePath},
-			expectedFiles: []string{
-				mustAbsPath(excludedFilePath),
-				mustAbsPath(includedFilePath),
-			},
+			paths:         []string{excludedFilePath, includedFilePath},
+			expectedFiles: []string{excludedFilePath, includedFilePath},
 		},
 		"skip excluded files": {
 			paths: []string{excludedFilePath, includedFilePath},
 			excludedFiles: []match.Matcher{
-				match.MustCompile("excluded_file"),
+				match.MustCompile(filepath.Join(".*", excludedFileName)),
 			},
-			expectedFiles: []string{
-				mustAbsPath(includedFilePath),
-			},
+			expectedFiles: []string{includedFilePath},
 		},
 		"skip directories": {
-			paths:         []string{unharvestableDir},
+			paths:         []string{filepath.Join(tmpDir, directoryPath)},
 			expectedFiles: []string{},
 		},
-		"select recursively provided file": {
-			paths:         []string{"**/included_file"},
-			recursiveGlob: true,
-			expectedFiles: []string{
-				mustAbsPath(includedFilePath),
-				mustAbsPath(includedRecursivelyFilePath),
-			},
-		},
 	}
-
-	setupFilesForScannerTest(t)
-	defer removeFilesOfScannerTest(t)
 
 	for name, test := range testCases {
 		test := test
@@ -87,7 +79,7 @@ func TestFileScanner(t *testing.T) {
 			cfg := fileScannerConfig{
 				ExcludedFiles: test.excludedFiles,
 				Symlinks:      test.symlinks,
-				RecursiveGlob: test.recursiveGlob,
+				RecursiveGlob: false,
 			}
 			fs, err := newFileScanner(test.paths, cfg)
 			if err != nil {
@@ -103,27 +95,17 @@ func TestFileScanner(t *testing.T) {
 	}
 }
 
-func setupFilesForScannerTest(t *testing.T) {
-	for _, dir := range []string{unharvestableDir, includedDir} {
-		err := os.MkdirAll(dir, 0750)
-		if err != nil {
-			t.Fatal(t)
-		}
+func setupFilesForScannerTest(t *testing.T, tmpDir string) {
+	err := os.Mkdir(filepath.Join(tmpDir, directoryPath), 750)
+	if err != nil {
+		t.Fatalf("cannot create non harvestable directory: %v", err)
 	}
-
-	for _, path := range []string{excludedFilePath, includedFilePath, includedRecursivelyFilePath} {
-		f, err := os.Create(path)
+	for _, path := range []string{excludedFileName, includedFileName} {
+		f, err := os.Create(filepath.Join(tmpDir, path))
 		if err != nil {
 			t.Fatalf("file %s, error %v", path, err)
 		}
 		f.Close()
-	}
-}
-
-func removeFilesOfScannerTest(t *testing.T) {
-	err := os.RemoveAll("testdata")
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -249,14 +231,6 @@ func (t testFileInfo) Mode() os.FileMode  { return 0 }
 func (t testFileInfo) ModTime() time.Time { return t.time }
 func (t testFileInfo) IsDir() bool        { return false }
 func (t testFileInfo) Sys() interface{}   { return nil }
-
-func mustAbsPath(path string) string {
-	p, err := filepath.Abs(path)
-	if err != nil {
-		panic(err)
-	}
-	return p
-}
 
 func mustDuration(durStr string) time.Duration {
 	dur, err := time.ParseDuration(durStr)

--- a/filebeat/input/filestream/fswatch_test_non_windows.go
+++ b/filebeat/input/filestream/fswatch_test_non_windows.go
@@ -21,6 +21,7 @@ package filestream
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,6 +34,13 @@ import (
 )
 
 func TestFileScannerSymlinks(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fswatch_test_file_scanner")
+	if err != nil {
+		t.Fatalf("cannot create temporary test dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	setupFilesForScannerTest(t, tmpDir)
+
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
@@ -42,29 +50,29 @@ func TestFileScannerSymlinks(t *testing.T) {
 		// covers test_input.py/test_skip_symlinks
 		"skip symlinks": {
 			paths: []string{
-				filepath.Join("testdata", "symlink_to_included_file"),
-				filepath.Join("testdata", "included_file"),
+				filepath.Join(tmpDir, "symlink_to_included_file"),
+				filepath.Join(tmpDir, "included_file"),
 			},
 			symlinks: false,
 			expectedFiles: []string{
-				mustAbsPath(filepath.Join("testdata", "included_file")),
+				mustAbsPath(filepath.Join(tmpDir, "included_file")),
 			},
 		},
 		"return a file once if symlinks are enabled": {
 			paths: []string{
-				filepath.Join("testdata", "symlink_to_included_file"),
-				filepath.Join("testdata", "included_file"),
+				filepath.Join(tmpDir, "symlink_to_included_file"),
+				filepath.Join(tmpDir, "included_file"),
 			},
 			symlinks: true,
 			expectedFiles: []string{
-				mustAbsPath(filepath.Join("testdata", "included_file")),
+				mustAbsPath(filepath.Join(tmpDir, "included_file")),
 			},
 		},
 	}
 
 	err := os.Symlink(
-		mustAbsPath(filepath.Join("testdata", "included_file")),
-		mustAbsPath(filepath.Join("testdata", "symlink_to_included_file")),
+		mustAbsPath(filepath.Join(tmpDir, "included_file")),
+		mustAbsPath(filepath.Join(tmpDir, "symlink_to_included_file")),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/filebeat/input/filestream/identifier_test.go
+++ b/filebeat/input/filestream/identifier_test.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+type testFileIdentifierConfig struct {
+	Identifier *common.ConfigNamespace `config:"identifier"`
+}
+
+func TestNewFileIdentifier(t *testing.T) {
+	t.Run("default file identifier", func(t *testing.T) {
+		identifier, err := newFileIdentifier(nil)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultIdentifierName, identifier.Name())
+
+	})
+
+	t.Run("path identifier", func(t *testing.T) {
+		c := common.MustNewConfigFrom(map[string]interface{}{
+			"identifier": map[string]interface{}{
+				"path": nil,
+			},
+		})
+		var cfg testFileIdentifierConfig
+		err := c.Unpack(&cfg)
+		require.NoError(t, err)
+
+		identifier, err := newFileIdentifier(cfg.Identifier)
+		require.NoError(t, err)
+		assert.Equal(t, pathName, identifier.Name())
+
+		testCases := []struct {
+			newPath     string
+			oldPath     string
+			operation   loginp.Operation
+			expectedSrc string
+		}{
+			{
+				newPath:     "/path/to/file",
+				expectedSrc: "path::/path/to/file",
+			},
+			{
+				newPath:     "/new/path/to/file",
+				oldPath:     "/old/path/to/file",
+				operation:   loginp.OpRename,
+				expectedSrc: "path::/new/path/to/file",
+			},
+			{
+				oldPath:     "/old/path/to/file",
+				operation:   loginp.OpDelete,
+				expectedSrc: "path::/old/path/to/file",
+			},
+		}
+
+		for _, test := range testCases {
+			src := identifier.GetSource(loginp.FSEvent{
+				NewPath: test.newPath,
+				OldPath: test.oldPath,
+				Op:      test.operation,
+			})
+			assert.Equal(t, test.expectedSrc, src.Name())
+		}
+	})
+}

--- a/filebeat/input/filestream/identifier_test_non_windows.go
+++ b/filebeat/input/filestream/identifier_test_non_windows.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !windows
+
+package filestream
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/file"
+)
+
+func TestFileIdentifierInodeMarker(t *testing.T) {
+	t.Run("inode_marker file identifier", func(t *testing.T) {
+		const markerContents = "unique_marker"
+		markerFile, err := ioutil.TempFile("", "test_file_identifier_inode_marker_identifier")
+		if err != nil {
+			t.Fatalf("cannot create marker file for test: %v", err)
+		}
+		defer os.Remove(markerFile.Name())
+
+		_, err = markerFile.Write([]byte(markerContents))
+		if err != nil {
+			t.Fatalf("cannot write marker contents to file: %v", err)
+		}
+		markerFile.Sync()
+
+		c := common.MustNewConfigFrom(map[string]interface{}{
+			"identifier": map[string]interface{}{
+				"inode_marker": map[string]interface{}{
+					"path": markerFile.Name(),
+				},
+			},
+		})
+		var cfg testFileIdentifierConfig
+		err = c.Unpack(&cfg)
+		require.NoError(t, err)
+
+		identifier, err := newFileIdentifier(cfg.Identifier)
+		require.NoError(t, err)
+		assert.Equal(t, inodeMarkerName, identifier.Name())
+
+		tmpFile, err := ioutil.TempFile("", "test_file_identifier_inode_marker")
+		if err != nil {
+			t.Fatalf("cannot create temporary file for test: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		fi, err := tmpFile.Stat()
+		if err != nil {
+			t.Fatalf("cannot stat temporary file for test: %v", err)
+		}
+
+		fsEvent := loginp.FSEvent{
+			NewPath: tmpFile.Name(),
+			Info:    fi,
+		}
+		src := identifier.GetSource(fsEvent)
+
+		osState := file.GetOSState(fi)
+		assert.Equal(t, identifier.Name()+"::"+osState.InodeString()+"-"+markerContents, src.Name())
+
+		const changedMarkerContents = "different_unique_marker"
+		_, err = markerFile.WriteAt([]byte(changedMarkerContents), 0)
+		if err != nil {
+			t.Fatalf("cannot write marker contents to file: %v", err)
+		}
+		markerFile.Sync()
+
+		src = identifier.GetSource(fsEvent)
+
+		assert.Equal(t, identifier.Name()+"::"+osState.InodeString()+"-"+changedMarkerContents, src.Name())
+	})
+}

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -1,0 +1,135 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input_logfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testPluginName = "my_test_plugin"
+
+type testSource struct {
+	name string
+}
+
+func (s *testSource) Name() string {
+	return s.name
+}
+
+func TestSourceIdentifier_ID(t *testing.T) {
+	testCases := map[string]struct {
+		userID            string
+		sources           []*testSource
+		expectedSourceIDs []string
+	}{
+		"plugin with no user configured ID": {
+			sources: []*testSource{
+				&testSource{"unique_name"},
+				&testSource{"another_unique_name"},
+			},
+			expectedSourceIDs: []string{
+				testPluginName + "::unique_name",
+				testPluginName + "::another_unique_name",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier := newSourceIdentifier(testPluginName, test.userID)
+
+			for i, src := range test.sources {
+				srcID := srcIdentifier.ID(src)
+				assert.Equal(t, test.expectedSourceIDs[i], srcID)
+			}
+		})
+	}
+}
+
+func TestSourceIdentifier_MachesInput(t *testing.T) {
+	testCases := map[string]struct {
+		userID      string
+		matchingIDs []string
+	}{
+		"plugin with no user configured ID": {
+			matchingIDs: []string{
+				testPluginName + "::my_id",
+				testPluginName + "::path::my_id",
+				testPluginName + "::" + testPluginName + "::my_id",
+			},
+		},
+		"plugin with user configured ID": {
+			userID: "my-id",
+			matchingIDs: []string{
+				testPluginName + "::my-id::my_id",
+				testPluginName + "::my-id::path::my_id",
+				testPluginName + "::my-id::" + testPluginName + "::my_id",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier := newSourceIdentifier(testPluginName, test.userID)
+
+			for _, id := range test.matchingIDs {
+				assert.True(t, srcIdentifier.MatchesInput(id))
+			}
+		})
+	}
+}
+
+func TestSourceIdentifier_NotMachesInput(t *testing.T) {
+
+	testCases := map[string]struct {
+		userID         string
+		notMatchingIDs []string
+	}{
+		"plugin with no user configured ID": {
+			notMatchingIDs: []string{
+				"::my_id",
+				"::path::my_id::" + testPluginName,
+			},
+		},
+		"plugin with user configured ID": {
+			userID: "my-id",
+			notMatchingIDs: []string{
+				testPluginName + "-other-id::my_id",
+				"my-id::path::my_id",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier := newSourceIdentifier(testPluginName, test.userID)
+
+			for _, id := range test.notMatchingIDs {
+				assert.False(t, srcIdentifier.MatchesInput(id))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Increase the test coverage of `filestream` input.

# Related issues

Requires #22448