### PR TITLE
Cherry-pick #22797 to 7.x: Skip Filebeat test_shutdown on windows 7

### DIFF
--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import platform
 import time
 import unittest
 from filebeat import BaseTest
@@ -11,6 +12,8 @@ Tests that Filebeat shuts down cleanly.
 
 class Test(BaseTest):
 
+    @unittest.skipIf(platform.platform().startswith("Windows-7"),
+                     "Flaky test: https://github.com/elastic/beats/issues/22795")
     def test_shutdown(self):
         """
         Test starting and stopping Filebeat under load.


### PR DESCRIPTION
Cherry-pick of PR #22797 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
Flaky Test

## What does this PR do?

Skip `filebeat.tests.system.test_shutdown.Test.test_shutdown` on Windows-7.

## Why is it important?

The test seems to be unstable on Windows 7 (32  Bit).


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #22795 