### PR TITLE
Cherry-pick #22640 to 7.x: Make monitoring Namespace thread-safe

### DIFF
--- a/libbeat/monitoring/namespace.go
+++ b/libbeat/monitoring/namespace.go
@@ -23,6 +23,7 @@ var namespaces = NewNamespaces()
 
 // Namespace contains the name of the namespace and it's registry
 type Namespace struct {
+	sync.Mutex
 	name     string
 	registry *Registry
 }
@@ -42,11 +43,15 @@ func GetNamespace(name string) *Namespace {
 
 // SetRegistry sets the registry of the namespace
 func (n *Namespace) SetRegistry(r *Registry) {
+	n.Lock()
+	defer n.Unlock()
 	n.registry = r
 }
 
 // GetRegistry gets the registry of the namespace
 func (n *Namespace) GetRegistry() *Registry {
+	n.Lock()
+	defer n.Unlock()
 	if n.registry == nil {
 		n.registry = NewRegistry()
 	}


### PR DESCRIPTION
Cherry-pick of PR #22640 to 7.x branch. Original message: 


## What does this PR do?

Add a mutex to Namespace to make read/writes thread-safe.

Fixes #22639

## Why is it important?

There was a data race that could possibly lead to incorrect or missing metrics.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

