### PR TITLE
Fixing logic to keep list of unique cluster UUIDs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -441,6 +441,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix failiures caused by custom beat names with more than 15 characters {pull}22550[22550]
 - Stop generating NaN values from Cloud Foundry module to avoid errors in outputs. {pull}22634[22634]
 - Update NATS dashboards to leverage connection and route metricsets {pull}22646[22646]
+- Fix `logstash` module when `xpack.enabled: true` is set from emitting redundant events. {pull}22808[22808]
 
 *Packetbeat*
 

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -57,13 +57,13 @@ type MetricSet struct {
 	XPack bool
 }
 
-type graph struct {
+type Graph struct {
 	Vertices []map[string]interface{} `json:"vertices"`
 	Edges    []map[string]interface{} `json:"edges"`
 }
 
-type graphContainer struct {
-	Graph   *graph `json:"graph,omitempty"`
+type GraphContainer struct {
+	Graph   *Graph `json:"graph,omitempty"`
 	Type    string `json:"type"`
 	Version string `json:"version"`
 	Hash    string `json:"hash"`
@@ -74,8 +74,8 @@ type PipelineState struct {
 	ID             string          `json:"id"`
 	Hash           string          `json:"hash"`
 	EphemeralID    string          `json:"ephemeral_id"`
-	Graph          *graphContainer `json:"graph,omitempty"`
-	Representation *graphContainer `json:"representation"`
+	Graph          *GraphContainer `json:"graph,omitempty"`
+	Representation *GraphContainer `json:"representation"`
 	BatchSize      int             `json:"batch_size"`
 	Workers        int             `json:"workers"`
 }

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -67,20 +67,20 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
 
 	for _, pipeline := range pipelines {
-		clusterUUIDs := make(map[string]struct{}, 0)
+		clusterUUIDs := common.StringSet{}
 		for _, vertex := range pipeline.Graph.Graph.Vertices {
 			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
 			if clusterUUID != "" {
-				clusterUUIDs[clusterUUID] = struct{}{}
+				clusterUUIDs.Add(clusterUUID)
 			}
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one
 		if len(clusterUUIDs) == 0 {
-			clusterUUIDs[""] = struct{}{}
+			clusterUUIDs.Add("")
 		}
 
-		for clusterUUID, _ := range clusterUUIDs {
+		for _, clusterUUID := range clusterUUIDs.ToSlice() {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []logstash.PipelineState{}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -67,20 +67,20 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
 
 	for _, pipeline := range pipelines {
-		var clusterUUIDs []string
+		clusterUUIDs := make(map[string]struct{}, 0)
 		for _, vertex := range pipeline.Graph.Graph.Vertices {
 			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
 			if clusterUUID != "" {
-				clusterUUIDs = append(clusterUUIDs, clusterUUID)
+				clusterUUIDs[clusterUUID] = struct{}{}
 			}
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one
 		if len(clusterUUIDs) == 0 {
-			clusterUUIDs = []string{""}
+			clusterUUIDs[""] = struct{}{}
 		}
 
-		for _, clusterUUID := range clusterUUIDs {
+		for clusterUUID, _ := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []logstash.PipelineState{}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -66,6 +66,11 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 	var clusterToPipelinesMap map[string][]logstash.PipelineState
 	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
 
+	if overrideClusterUUID != "" {
+		clusterToPipelinesMap[overrideClusterUUID] = pipelines
+		return clusterToPipelinesMap
+	}
+
 	for _, pipeline := range pipelines {
 		clusterUUIDs := common.StringSet{}
 		for _, vertex := range pipeline.Graph.Graph.Vertices {

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -85,7 +85,7 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 			clusterUUIDs.Add("")
 		}
 
-		for _, clusterUUID := range clusterUUIDs {
+		for clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []logstash.PipelineState{}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -85,7 +85,7 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState, overrideClust
 			clusterUUIDs.Add("")
 		}
 
-		for _, clusterUUID := range clusterUUIDs.ToSlice() {
+		for _, clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []logstash.PipelineState{}

--- a/metricbeat/module/logstash/node/data_xpack_test.go
+++ b/metricbeat/module/logstash/node/data_xpack_test.go
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/metricbeat/module/logstash"
+)
+
+func TestMakeClusterToPipelinesMap(t *testing.T) {
+	pipelines := []logstash.PipelineState{
+		{
+			ID: "test_pipeline",
+			Graph: &logstash.GraphContainer{
+				Graph: &logstash.Graph{
+					Vertices: []map[string]interface{}{
+						{
+							"id": "vertex_1",
+						},
+						{
+							"id": "vertex_2",
+						},
+						{
+							"id": "vertex_3",
+						},
+					},
+				},
+			},
+		},
+	}
+	m := makeClusterToPipelinesMap(pipelines, "prod_cluster_id")
+	require.Len(t, m, 1)
+	for clusterID, pipelines := range m {
+		require.Equal(t, "prod_cluster_id", clusterID)
+		require.Len(t, pipelines, 1)
+	}
+}

--- a/metricbeat/module/logstash/node/data_xpack_test.go
+++ b/metricbeat/module/logstash/node/data_xpack_test.go
@@ -123,27 +123,6 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						},
 					},
 				},
-				"es_1": {
-					{
-						ID: "test_pipeline",
-						Graph: &logstash.GraphContainer{
-							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
-									{
-										"id":           "vertex_1",
-										"cluster_uuid": "es_1",
-									},
-									{
-										"id": "vertex_2",
-									},
-									{
-										"id": "vertex_3",
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 		"two_pipelines": {
@@ -221,27 +200,6 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 									},
 									{
 										"id": "vertex_2_3",
-									},
-								},
-							},
-						},
-					},
-				},
-				"es_1": {
-					{
-						ID: "test_pipeline_1",
-						Graph: &logstash.GraphContainer{
-							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
-									{
-										"id":           "vertex_1_1",
-										"cluster_uuid": "es_1",
-									},
-									{
-										"id": "vertex_1_2",
-									},
-									{
-										"id": "vertex_1_3",
 									},
 								},
 							},

--- a/metricbeat/module/logstash/node/data_xpack_test.go
+++ b/metricbeat/module/logstash/node/data_xpack_test.go
@@ -28,30 +28,343 @@ import (
 )
 
 func TestMakeClusterToPipelinesMap(t *testing.T) {
-	pipelines := []logstash.PipelineState{
-		{
-			ID: "test_pipeline",
-			Graph: &logstash.GraphContainer{
-				Graph: &logstash.Graph{
-					Vertices: []map[string]interface{}{
-						{
-							"id": "vertex_1",
+	tests := map[string]struct {
+		pipelines           []logstash.PipelineState
+		overrideClusterUUID string
+		expectedMap         map[string][]logstash.PipelineState
+	}{
+		"no_vertex_cluster_id": {
+			pipelines: []logstash.PipelineState{
+				{
+					ID: "test_pipeline",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id": "vertex_1",
+								},
+								{
+									"id": "vertex_2",
+								},
+								{
+									"id": "vertex_3",
+								},
+							},
 						},
-						{
-							"id": "vertex_2",
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]logstash.PipelineState{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id": "vertex_1",
+									},
+									{
+										"id": "vertex_2",
+									},
+									{
+										"id": "vertex_3",
+									},
+								},
+							},
 						},
-						{
-							"id": "vertex_3",
+					},
+				},
+			},
+		},
+		"one_vertex_cluster_id": {
+			pipelines: []logstash.PipelineState{
+				{
+					ID: "test_pipeline",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id":           "vertex_1",
+									"cluster_uuid": "es_1",
+								},
+								{
+									"id": "vertex_2",
+								},
+								{
+									"id": "vertex_3",
+								},
+							},
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]logstash.PipelineState{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id": "vertex_2",
+									},
+									{
+										"id": "vertex_3",
+									},
+								},
+							},
+						},
+					},
+				},
+				"es_1": {
+					{
+						ID: "test_pipeline",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id": "vertex_2",
+									},
+									{
+										"id": "vertex_3",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"two_pipelines": {
+			pipelines: []logstash.PipelineState{
+				{
+					ID: "test_pipeline_1",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id":           "vertex_1_1",
+									"cluster_uuid": "es_1",
+								},
+								{
+									"id": "vertex_1_2",
+								},
+								{
+									"id": "vertex_1_3",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "test_pipeline_2",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id": "vertex_2_1",
+								},
+								{
+									"id": "vertex_2_2",
+								},
+								{
+									"id": "vertex_2_3",
+								},
+							},
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]logstash.PipelineState{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline_1",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id": "vertex_1_2",
+									},
+									{
+										"id": "vertex_1_3",
+									},
+								},
+							},
+						},
+					},
+					{
+						ID: "test_pipeline_2",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id": "vertex_2_1",
+									},
+									{
+										"id": "vertex_2_2",
+									},
+									{
+										"id": "vertex_2_3",
+									},
+								},
+							},
+						},
+					},
+				},
+				"es_1": {
+					{
+						ID: "test_pipeline_1",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id": "vertex_1_2",
+									},
+									{
+										"id": "vertex_1_3",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"no_override_cluster_id": {
+			pipelines: []logstash.PipelineState{
+				{
+					ID: "test_pipeline_1",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id":           "vertex_1_1",
+									"cluster_uuid": "es_1",
+								},
+								{
+									"id":           "vertex_1_2",
+									"cluster_uuid": "es_2",
+								},
+								{
+									"id": "vertex_1_3",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "test_pipeline_2",
+					Graph: &logstash.GraphContainer{
+						Graph: &logstash.Graph{
+							Vertices: []map[string]interface{}{
+								{
+									"id": "vertex_2_1",
+								},
+								{
+									"id": "vertex_2_2",
+								},
+								{
+									"id": "vertex_2_3",
+								},
+							},
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "",
+			expectedMap: map[string][]logstash.PipelineState{
+				"es_1": {
+					{
+						ID: "test_pipeline_1",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id":           "vertex_1_2",
+										"cluster_uuid": "es_2",
+									},
+									{
+										"id": "vertex_1_3",
+									},
+								},
+							},
+						},
+					},
+				},
+				"es_2": {
+					{
+						ID: "test_pipeline_1",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id":           "vertex_1_1",
+										"cluster_uuid": "es_1",
+									},
+									{
+										"id":           "vertex_1_2",
+										"cluster_uuid": "es_2",
+									},
+									{
+										"id": "vertex_1_3",
+									},
+								},
+							},
+						},
+					},
+				},
+				"": {
+					{
+						ID: "test_pipeline_2",
+						Graph: &logstash.GraphContainer{
+							Graph: &logstash.Graph{
+								Vertices: []map[string]interface{}{
+									{
+										"id": "vertex_2_1",
+									},
+									{
+										"id": "vertex_2_2",
+									},
+									{
+										"id": "vertex_2_3",
+									},
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 	}
-	m := makeClusterToPipelinesMap(pipelines, "prod_cluster_id")
-	require.Len(t, m, 1)
-	for clusterID, pipelines := range m {
-		require.Equal(t, "prod_cluster_id", clusterID)
-		require.Len(t, pipelines, 1)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualMap := makeClusterToPipelinesMap(test.pipelines, test.overrideClusterUUID)
+			require.Equal(t, test.expectedMap, actualMap)
+		})
 	}
 }

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -232,7 +232,7 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 			clusterUUIDs.Add("")
 		}
 
-		for _, clusterUUID := range clusterUUIDs {
+		for clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []PipelineStats{}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -213,6 +213,11 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 	var clusterToPipelinesMap map[string][]PipelineStats
 	clusterToPipelinesMap = make(map[string][]PipelineStats)
 
+	if overrideClusterUUID != "" {
+		clusterToPipelinesMap[overrideClusterUUID] = pipelines
+		return clusterToPipelinesMap
+	}
+
 	for _, pipeline := range pipelines {
 		clusterUUIDs := common.StringSet{}
 		for _, vertex := range pipeline.Vertices {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -213,26 +213,21 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 	var clusterToPipelinesMap map[string][]PipelineStats
 	clusterToPipelinesMap = make(map[string][]PipelineStats)
 
-	if overrideClusterUUID != "" {
-		clusterToPipelinesMap[overrideClusterUUID] = pipelines
-		return clusterToPipelinesMap
-	}
-
 	for _, pipeline := range pipelines {
-		var clusterUUIDs []string
+		clusterUUIDs := make(map[string]struct{}, 0)
 		for _, vertex := range pipeline.Vertices {
 			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
 			if clusterUUID != "" {
-				clusterUUIDs = append(clusterUUIDs, clusterUUID)
+				clusterUUIDs[clusterUUID] = struct{}{}
 			}
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one
 		if len(clusterUUIDs) == 0 {
-			clusterUUIDs = []string{""}
+			clusterUUIDs[""] = struct{}{}
 		}
 
-		for _, clusterUUID := range clusterUUIDs {
+		for clusterUUID, _ := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []PipelineStats{}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -214,20 +214,20 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 	clusterToPipelinesMap = make(map[string][]PipelineStats)
 
 	for _, pipeline := range pipelines {
-		clusterUUIDs := make(map[string]struct{}, 0)
+		clusterUUIDs := common.StringSet{}
 		for _, vertex := range pipeline.Vertices {
 			clusterUUID := logstash.GetVertexClusterUUID(vertex, overrideClusterUUID)
 			if clusterUUID != "" {
-				clusterUUIDs[clusterUUID] = struct{}{}
+				clusterUUIDs.Add(clusterUUID)
 			}
 		}
 
 		// If no cluster UUID was found in this pipeline, assign it a blank one
 		if len(clusterUUIDs) == 0 {
-			clusterUUIDs[""] = struct{}{}
+			clusterUUIDs.Add("")
 		}
 
-		for clusterUUID, _ := range clusterUUIDs {
+		for _, clusterUUID := range clusterUUIDs.ToSlice() {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []PipelineStats{}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -232,7 +232,7 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID st
 			clusterUUIDs.Add("")
 		}
 
-		for _, clusterUUID := range clusterUUIDs.ToSlice() {
+		for _, clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {
 				clusterToPipelinesMap[clusterUUID] = []PipelineStats{}

--- a/metricbeat/module/logstash/node_stats/data_xpack_test.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack_test.go
@@ -105,23 +105,6 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						},
 					},
 				},
-				"es_1": {
-					{
-						ID: "test_pipeline",
-						Vertices: []map[string]interface{}{
-							{
-								"id":           "vertex_1",
-								"cluster_uuid": "es_1",
-							},
-							{
-								"id": "vertex_2",
-							},
-							{
-								"id": "vertex_3",
-							},
-						},
-					},
-				},
 			},
 		},
 		"two_pipelines": {
@@ -189,23 +172,6 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						},
 					},
 				},
-				"es_1": {
-					{
-						ID: "test_pipeline_1",
-						Vertices: []map[string]interface{}{
-							{
-								"id":           "vertex_1_1",
-								"cluster_uuid": "es_1",
-							},
-							{
-								"id": "vertex_1_2",
-							},
-							{
-								"id": "vertex_1_3",
-							},
-						},
-					},
-				},
 			},
 		},
 		"no_override_cluster_id": {
@@ -241,7 +207,6 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					},
 				},
 			},
-			overrideClusterUUID: "",
 			expectedMap: map[string][]PipelineStats{
 				"es_1": {
 					{

--- a/metricbeat/module/logstash/node_stats/data_xpack_test.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package node_stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeClusterToPipelinesMap(t *testing.T) {
+	pipelines := []PipelineStats{
+		{
+			ID: "test_pipeline",
+			Vertices: []map[string]interface{}{
+				{
+					"id": "vertex_1",
+				},
+				{
+					"id": "vertex_2",
+				},
+				{
+					"id": "vertex_3",
+				},
+			},
+		},
+	}
+
+	m := makeClusterToPipelinesMap(pipelines, "prod_cluster_id")
+	require.Len(t, m, 1)
+	for clusterID, pipelines := range m {
+		require.Equal(t, "prod_cluster_id", clusterID)
+		require.Len(t, pipelines, 1)
+	}
+}

--- a/metricbeat/module/logstash/node_stats/data_xpack_test.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack_test.go
@@ -26,27 +26,283 @@ import (
 )
 
 func TestMakeClusterToPipelinesMap(t *testing.T) {
-	pipelines := []PipelineStats{
-		{
-			ID: "test_pipeline",
-			Vertices: []map[string]interface{}{
+	tests := map[string]struct {
+		pipelines           []PipelineStats
+		overrideClusterUUID string
+		expectedMap         map[string][]PipelineStats
+	}{
+		"no_vertex_cluster_id": {
+			pipelines: []PipelineStats{
 				{
-					"id": "vertex_1",
+					ID: "test_pipeline",
+					Vertices: []map[string]interface{}{
+						{
+							"id": "vertex_1",
+						},
+						{
+							"id": "vertex_2",
+						},
+						{
+							"id": "vertex_3",
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]PipelineStats{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline",
+						Vertices: []map[string]interface{}{
+							{
+								"id": "vertex_1",
+							},
+							{
+								"id": "vertex_2",
+							},
+							{
+								"id": "vertex_3",
+							},
+						},
+					},
+				},
+			},
+		},
+		"one_vertex_cluster_id": {
+			pipelines: []PipelineStats{
+				{
+					ID: "test_pipeline",
+					Vertices: []map[string]interface{}{
+						{
+							"id":           "vertex_1",
+							"cluster_uuid": "es_1",
+						},
+						{
+							"id": "vertex_2",
+						},
+						{
+							"id": "vertex_3",
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]PipelineStats{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id": "vertex_2",
+							},
+							{
+								"id": "vertex_3",
+							},
+						},
+					},
+				},
+				"es_1": {
+					{
+						ID: "test_pipeline",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id": "vertex_2",
+							},
+							{
+								"id": "vertex_3",
+							},
+						},
+					},
+				},
+			},
+		},
+		"two_pipelines": {
+			pipelines: []PipelineStats{
+				{
+					ID: "test_pipeline_1",
+					Vertices: []map[string]interface{}{
+						{
+							"id":           "vertex_1_1",
+							"cluster_uuid": "es_1",
+						},
+						{
+							"id": "vertex_1_2",
+						},
+						{
+							"id": "vertex_1_3",
+						},
+					},
 				},
 				{
-					"id": "vertex_2",
+					ID: "test_pipeline_2",
+					Vertices: []map[string]interface{}{
+						{
+							"id": "vertex_2_1",
+						},
+						{
+							"id": "vertex_2_2",
+						},
+						{
+							"id": "vertex_2_3",
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "prod_cluster_id",
+			expectedMap: map[string][]PipelineStats{
+				"prod_cluster_id": {
+					{
+						ID: "test_pipeline_1",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id": "vertex_1_2",
+							},
+							{
+								"id": "vertex_1_3",
+							},
+						},
+					},
+					{
+						ID: "test_pipeline_2",
+						Vertices: []map[string]interface{}{
+							{
+								"id": "vertex_2_1",
+							},
+							{
+								"id": "vertex_2_2",
+							},
+							{
+								"id": "vertex_2_3",
+							},
+						},
+					},
+				},
+				"es_1": {
+					{
+						ID: "test_pipeline_1",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id": "vertex_1_2",
+							},
+							{
+								"id": "vertex_1_3",
+							},
+						},
+					},
+				},
+			},
+		},
+		"no_override_cluster_id": {
+			pipelines: []PipelineStats{
+				{
+					ID: "test_pipeline_1",
+					Vertices: []map[string]interface{}{
+						{
+							"id":           "vertex_1_1",
+							"cluster_uuid": "es_1",
+						},
+						{
+							"id":           "vertex_1_2",
+							"cluster_uuid": "es_2",
+						},
+						{
+							"id": "vertex_1_3",
+						},
+					},
 				},
 				{
-					"id": "vertex_3",
+					ID: "test_pipeline_2",
+					Vertices: []map[string]interface{}{
+						{
+							"id": "vertex_2_1",
+						},
+						{
+							"id": "vertex_2_2",
+						},
+						{
+							"id": "vertex_2_3",
+						},
+					},
+				},
+			},
+			overrideClusterUUID: "",
+			expectedMap: map[string][]PipelineStats{
+				"es_1": {
+					{
+						ID: "test_pipeline_1",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id":           "vertex_1_2",
+								"cluster_uuid": "es_2",
+							},
+							{
+								"id": "vertex_1_3",
+							},
+						},
+					},
+				},
+				"es_2": {
+					{
+						ID: "test_pipeline_1",
+						Vertices: []map[string]interface{}{
+							{
+								"id":           "vertex_1_1",
+								"cluster_uuid": "es_1",
+							},
+							{
+								"id":           "vertex_1_2",
+								"cluster_uuid": "es_2",
+							},
+							{
+								"id": "vertex_1_3",
+							},
+						},
+					},
+				},
+				"": {
+					{
+						ID: "test_pipeline_2",
+						Vertices: []map[string]interface{}{
+							{
+								"id": "vertex_2_1",
+							},
+							{
+								"id": "vertex_2_2",
+							},
+							{
+								"id": "vertex_2_3",
+							},
+						},
+					},
 				},
 			},
 		},
 	}
 
-	m := makeClusterToPipelinesMap(pipelines, "prod_cluster_id")
-	require.Len(t, m, 1)
-	for clusterID, pipelines := range m {
-		require.Equal(t, "prod_cluster_id", clusterID)
-		require.Len(t, pipelines, 1)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualMap := makeClusterToPipelinesMap(test.pipelines, test.overrideClusterUUID)
+			require.Equal(t, test.expectedMap, actualMap)
+		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a pretty bad bug with the `logstash` module when `xpack.enabled: true` is set. 

The `logstash` module has two metricsets: `node` and `node_stats`. When `xpack.enabled: true` is set, these metricsets emit events for Stack Monitoring with `type: logstash_state` and `type: logstash_stats`, respectively.

The `node` metricset is supposed to emit as many events per `Fetch()` cycle as there are monitored Logstash pipelines x the number of Elasticsearch clusters that each such pipeline talks to. If a Logstash pipeline does not talk to an Elasticsearch cluster, one event for that pipeline must be emitted.

Instead, due to terribly faulty logic in the code, the `node` metricset was emitting as many events per `Fetch()` cycle as there are monitored Logstash pipelines x the number of vertices in each such pipeline!

There was similar faulty logic in the `node_stats` metricset.

This PR fixes this bug in both metricsets.

## Why is it important?

By fixing this bug, we are eliminating a huge source of redundant and unnecessary events being published from the `logstash` module when `xpack.enabled: true` is set. This will not only make the module's behavior correct but also drastically reduce memory consumption in Metricbeat and the number of events sent to Metricbeat's output over the wire.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
