### PR TITLE
Cherry-pick #22810 to 7.x: Skip somewhat flaky UDP system test on Windows

### DIFF
--- a/filebeat/tests/system/test_udp.py
+++ b/filebeat/tests/system/test_udp.py
@@ -1,9 +1,12 @@
 from filebeat import BaseTest
+import os
 import socket
+import unittest
 
 
 class Test(BaseTest):
 
+    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/22809')
     def test_udp(self):
 
         host = "127.0.0.1"


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#22810 to 7.x branch. Original message: 

Follow-up issue: https://github.com/elastic/beats/issues/22809