### PR TITLE
Cherry-pick #22829 to 7.10: [Heartbeat] Fix exit on disabled monitor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -208,6 +208,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- The `service_name` monitor option is being replaced with `service.name` which is more correct. We will support the old option till 8.0. {pull}20330[20330]
+- Fix exit on monitors with `enabled: false` {pull}22829[22829]
 
 *Journalbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elastic/beats/v7/heartbeat/hbregistry"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/heartbeat/config"
+	"github.com/elastic/beats/v7/heartbeat/hbregistry"
 	"github.com/elastic/beats/v7/heartbeat/monitors"
+	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/scheduler"
 	"github.com/elastic/beats/v7/libbeat/autodiscover"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -128,8 +128,13 @@ func (bt *Heartbeat) RunStaticMonitors(b *beat.Beat) error {
 	for _, cfg := range bt.config.Monitors {
 		created, err := factory.Create(b.Publisher, cfg)
 		if err != nil {
+			if err == stdfields.ErrPluginDisabled {
+				continue // don't stop loading monitors just because they're disabled
+			}
+
 			return errors.Wrap(err, "could not create monitor")
 		}
+
 		created.Start()
 	}
 	return nil

--- a/heartbeat/monitors/stdfields/stdfields.go
+++ b/heartbeat/monitors/stdfields/stdfields.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ErrPluginDisabled is returned when the monitor plugin is marked as disabled.
-var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
+var ErrPluginDisabled = errors.New("monitor not loaded, plugin is disabled")
 
 // StdMonitorFields represents the generic configuration options around a monitor plugin.
 type StdMonitorFields struct {

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -32,6 +32,30 @@ class Test(BaseTest, common_tests.TestExportsMixin):
         self.wait_until(lambda: self.log_contains("heartbeat is running"))
         heartbeat_proc.check_kill_and_wait()
 
+    def test_disabled(self):
+        """
+        Basic test against a disabled monitor
+        """
+
+        config = {
+            "monitors": [
+                {
+                    "type": "http",
+                    "enabled": "false",
+                    "urls": ["http://localhost:9200"],
+                }
+            ]
+        }
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            **config
+        )
+
+        heartbeat_proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("heartbeat is running"))
+        heartbeat_proc.check_kill_and_wait()
+
     def test_fields_under_root(self):
         """
         Basic test with fields and tags in monitor


### PR DESCRIPTION
Cherry-pick of PR #22829 to 7.10 branch. Original message: 

Fixes a bug where when `enabled: false` was set on a monitor heartbeat would refuse to start.

Also fixes capitalization for those those errors.

Fixes https://github.com/elastic/beats/issues/22665

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Simply add `enabled: false` to the default HTTP config in `heartbeat.yml`