### PR TITLE
Cherry-pick to 7.9: fix: missing colon in yaml example (#22801)

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -462,7 +462,7 @@ For example, to configure the condition `NOT status = OK`:
 
 [source,yaml]
 ------
-not
+not:
   equals:
     status: OK
 ------


### PR DESCRIPTION
Backports the following commits to 7.9:
 - fix: missing colon in yaml example (#22801)