### PR TITLE
Cherry-pick #22448 to 7.x: Refactoring of filestream input backend

### DIFF
--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -358,6 +358,8 @@ instead and let {beatname_uc} pick up the file again.
 Different `file_identity` methods can be configured to suit the
 environment where you are collecting log messages.
 
+WARNING: Changing `file_identity` methods between runs may result in
+duplicated events in the output.
 
 *`native`*:: The default behaviour of {beatname_uc} is to differentiate
 between files using their inodes and device ids.

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -74,6 +74,9 @@ values might change during the lifetime of the file. If this happens
 of the file. To solve this problem you can configure `file_identity` option. Possible
 values besides the default `inode_deviceid` are `path` and `inode_marker`.
 
+WARNING: Changing `file_identity` methods between runs may result in
+duplicated events in the output.
+
 Selecting `path` instructs {beatname_uc} to identify files based on their
 paths. This is a quick way to avoid rereading files if inode and device ids
 might change. However, keep in mind if the files are rotated (renamed), they

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -211,6 +211,10 @@ func (w *fileWatcher) Event() loginp.FSEvent {
 	return <-w.events
 }
 
+func (w *fileWatcher) GetFiles() map[string]os.FileInfo {
+	return w.scanner.GetFiles()
+}
+
 type fileScannerConfig struct {
 	ExcludedFiles []match.Matcher `config:"exclude_files"`
 	Symlinks      bool            `config:"symlinks"`

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -26,7 +26,13 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/file"
 )
 
+type identifierFeature uint8
+
 const (
+	// trackRename is a feature of an identifier which changes
+	// IDs if a source is renamed.
+	trackRename identifierFeature = iota
+
 	nativeName      = "native"
 	pathName        = "path"
 	inodeMarkerName = "inode_marker"
@@ -48,6 +54,7 @@ type identifierFactory func(*common.Config) (fileIdentifier, error)
 type fileIdentifier interface {
 	GetSource(loginp.FSEvent) fileSource
 	Name() string
+	Supports(identifierFeature) bool
 }
 
 // fileSource implements the Source interface
@@ -96,13 +103,22 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                pluginName + identitySep + i.name + identitySep + file.GetOSState(e.Info).String(),
+		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
 }
 
 func (i *inodeDeviceIdentifier) Name() string {
 	return i.name
+}
+
+func (i *inodeDeviceIdentifier) Supports(f identifierFeature) bool {
+	switch f {
+	case trackRename:
+		return true
+	default:
+	}
+	return false
 }
 
 type pathIdentifier struct {
@@ -124,13 +140,17 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                pluginName + identitySep + p.name + identitySep + path,
+		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}
 }
 
 func (p *pathIdentifier) Name() string {
 	return p.name
+}
+
+func (p *pathIdentifier) Supports(f identifierFeature) bool {
+	return false
 }
 
 // mockIdentifier is used for testing
@@ -141,3 +161,5 @@ func (m *MockIdentifier) GetSource(e loginp.FSEvent) fileSource {
 }
 
 func (m *MockIdentifier) Name() string { return "mock" }
+
+func (m *MockIdentifier) Supports(_ identifierFeature) bool { return false }

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -98,11 +98,20 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
-		name:                fmt.Sprintf("%s%s%s-%s", i.name, identitySep, osstate.InodeString(), i.markerContents()),
+		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}
 }
 
 func (i *inodeMarkerIdentifier) Name() string {
 	return i.name
+}
+
+func (i *inodeMarkerIdentifier) Supports(f identifierFeature) bool {
+	switch f {
+	case trackRename:
+		return true
+	default:
+	}
+	return false
 }

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -41,8 +41,11 @@ import (
 const pluginName = "filestream"
 
 type state struct {
+	Offset int64 `json:"offset" struct:"offset"`
+}
+
+type fileMeta struct {
 	Source         string `json:"source" struct:"source"`
-	Offset         int64  `json:"offset" struct:"offset"`
 	IdentifierName string `json:"identifier_name" struct:"identifier_name"`
 }
 
@@ -84,14 +87,14 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 		return nil, nil, err
 	}
 
-	prospector, err := newFileProspector(
-		config.Paths,
-		config.IgnoreOlder,
-		config.FileWatcher,
-		config.FileIdentity,
-	)
+	filewatcher, err := newFileWatcher(config.Paths, config.FileWatcher)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("error while creating filewatcher %v", err)
+	}
+
+	identifier, err := newFileIdentifier(config.FileIdentity)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while creating file identifier: %v", err)
 	}
 
 	encodingFactory, ok := encoding.FindEncoding(config.Encoding)
@@ -99,7 +102,15 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 		return nil, nil, fmt.Errorf("unknown encoding('%v')", config.Encoding)
 	}
 
-	return prospector, &filestream{
+	prospector := &fileProspector{
+		filewatcher:       filewatcher,
+		identifier:        identifier,
+		ignoreOlder:       config.IgnoreOlder,
+		cleanRemoved:      config.CleanRemoved,
+		stateChangeCloser: config.Close.OnStateChange,
+	}
+
+	filestream := &filestream{
 		readerConfig:    config.readerConfig,
 		bufferSize:      config.BufferSize,
 		encodingFactory: encodingFactory,
@@ -108,13 +119,20 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 		includeLines:    config.IncludeLines,
 		maxBytes:        config.MaxBytes,
 		closerConfig:    config.Close,
-	}, nil
+	}
+
+	return prospector, filestream, nil
 }
 
 func (inp *filestream) Name() string { return pluginName }
 
 func (inp *filestream) Test(src loginp.Source, ctx input.TestContext) error {
-	reader, err := inp.open(ctx.Logger, ctx.Cancelation, state{})
+	fs, ok := src.(fileSource)
+	if !ok {
+		return fmt.Errorf("not file source")
+	}
+
+	reader, err := inp.open(ctx.Logger, ctx.Cancelation, fs.newPath, 0)
 	if err != nil {
 		return err
 	}
@@ -135,7 +153,7 @@ func (inp *filestream) Run(
 	log := ctx.Logger.With("path", fs.newPath).With("state-id", src.Name())
 	state := initState(log, cursor, fs)
 
-	r, err := inp.open(log, ctx.Cancelation, state)
+	r, err := inp.open(log, ctx.Cancelation, fs.newPath, state.Offset)
 	if err != nil {
 		log.Errorf("File could not be opened for reading: %v", err)
 		return err
@@ -154,7 +172,7 @@ func (inp *filestream) Run(
 }
 
 func initState(log *logp.Logger, c loginp.Cursor, s fileSource) state {
-	state := state{Source: s.newPath, IdentifierName: s.identifierGenerator}
+	var state state
 	if c.IsNew() {
 		return state
 	}
@@ -167,8 +185,8 @@ func initState(log *logp.Logger, c loginp.Cursor, s fileSource) state {
 	return state
 }
 
-func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, s state) (reader.Reader, error) {
-	f, err := inp.openFile(s.Source, s.Offset)
+func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path string, offset int64) (reader.Reader, error) {
+	f, err := inp.openFile(path, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -57,6 +57,8 @@ type FSScanner interface {
 
 // FSWatcher returns file events of the monitored files.
 type FSWatcher interface {
+	FSScanner
+
 	// Run is the event loop which watchers for changes
 	// in the file system and returns events based on the data.
 	Run(unison.Canceler)

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -21,10 +21,13 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/ctxtool"
 	"github.com/elastic/go-concert/unison"
 )
@@ -41,15 +44,63 @@ type Harvester interface {
 	Run(input.Context, Source, Cursor, Publisher) error
 }
 
+type readerGroup struct {
+	mu    sync.Mutex
+	table map[string]context.CancelFunc
+}
+
+func newReaderGroup() *readerGroup {
+	return &readerGroup{
+		table: make(map[string]context.CancelFunc),
+	}
+}
+
+// newContext createas a new context, cancel function and associates it with the given id within
+// the reader group. Using the cancel function does not remvoe the association.
+// An error is returned if the id is already associated with a context. The cancel
+// function is nil in that case and must not be called.
+//
+// The context will be automatically cancelled once the ID is removed from the group. Calling `cancel` is optional.
+func (r *readerGroup) newContext(id string, cancelation v2.Canceler) (context.Context, context.CancelFunc, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.table[id]; ok {
+		return nil, nil, fmt.Errorf("harvester is already running for file")
+	}
+
+	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(cancelation))
+
+	r.table[id] = cancel
+	return ctx, cancel, nil
+}
+
+func (r *readerGroup) remove(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cancel, ok := r.table[id]
+	if !ok {
+		return
+	}
+
+	cancel()
+	delete(r.table, id)
+}
+
 // HarvesterGroup is responsible for running the
 // Harvesters started by the Prospector.
 type HarvesterGroup interface {
-	Run(input.Context, Source) error
+	// Start starts a Harvester and adds it to the readers list.
+	Start(input.Context, Source)
+	// Stop cancels the reader of a given Source.
+	Stop(Source)
+	// StopGroup cancels all running Harvesters.
+	StopGroup() error
 }
 
 type defaultHarvesterGroup struct {
-	manager      *InputManager
-	readers      map[string]context.CancelFunc
+	readers      *readerGroup
 	pipeline     beat.PipelineConnector
 	harvester    Harvester
 	cleanTimeout time.Duration
@@ -57,70 +108,92 @@ type defaultHarvesterGroup struct {
 	tg           unison.TaskGroup
 }
 
-// Run starts the Harvester for a Source.
-func (hg *defaultHarvesterGroup) Run(ctx input.Context, s Source) error {
-	log := ctx.Logger.With("source", s.Name())
-	log.Debug("Starting harvester for file")
+// Start starts the Harvester for a Source. It does not block.
+func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
+	sourceName := s.Name()
 
-	harvesterCtx, cancelHarvester := context.WithCancel(ctxtool.FromCanceller(ctx.Cancelation))
-	ctx.Cancelation = harvesterCtx
+	ctx.Logger = ctx.Logger.With("source", sourceName)
+	ctx.Logger.Debug("Starting harvester for file")
 
-	resource, err := hg.manager.lock(ctx, s.Name())
-	if err != nil {
-		cancelHarvester()
-		return err
-	}
-
-	if _, ok := hg.readers[s.Name()]; ok {
-		cancelHarvester()
-		log.Debug("A harvester is already running for file")
-		return nil
-	}
-	hg.readers[s.Name()] = cancelHarvester
-
-	hg.store.UpdateTTL(resource, hg.cleanTimeout)
-
-	client, err := hg.pipeline.ConnectWith(beat.ClientConfig{
-		CloseRef:   ctx.Cancelation,
-		ACKHandler: newInputACKHandler(ctx.Logger),
-	})
-	if err != nil {
-		cancelHarvester()
-		return err
-	}
-
-	cursor := makeCursor(hg.store, resource)
-	publisher := &cursorPublisher{canceler: ctx.Cancelation, client: client, cursor: &cursor}
-
-	go func(cancel context.CancelFunc) {
-		defer client.Close()
-		defer log.Debug("Stopped harvester for file")
-		defer cancel()
-		defer releaseResource(resource)
-		defer delete(hg.readers, s.Name())
-
+	hg.tg.Go(func(canceler unison.Canceler) error {
 		defer func() {
 			if v := recover(); v != nil {
 				err := fmt.Errorf("harvester panic with: %+v\n%s", v, debug.Stack())
 				ctx.Logger.Errorf("Harvester crashed with: %+v", err)
 			}
 		}()
+		defer ctx.Logger.Debug("Stopped harvester for file")
 
-		err := hg.harvester.Run(ctx, s, cursor, publisher)
+		harvesterCtx, cancelHarvester, err := hg.readers.newContext(sourceName, canceler)
 		if err != nil {
-			log.Errorf("Harvester stopped: %v", err)
+			return fmt.Errorf("error while adding new reader to the bookkeeper %v", err)
 		}
-	}(cancelHarvester)
-	return nil
+		ctx.Cancelation = harvesterCtx
+		defer cancelHarvester()
+		defer hg.readers.remove(sourceName)
+
+		resource, err := lock(ctx, hg.store, sourceName)
+		if err != nil {
+			return fmt.Errorf("error while locking resource: %v", err)
+		}
+		defer releaseResource(resource)
+
+		client, err := hg.pipeline.ConnectWith(beat.ClientConfig{
+			CloseRef:   ctx.Cancelation,
+			ACKHandler: newInputACKHandler(ctx.Logger),
+		})
+		if err != nil {
+			return fmt.Errorf("error while connecting to output with pipeline: %v", err)
+		}
+		defer client.Close()
+
+		hg.store.UpdateTTL(resource, hg.cleanTimeout)
+		cursor := makeCursor(hg.store, resource)
+		publisher := &cursorPublisher{canceler: ctx.Cancelation, client: client, cursor: &cursor}
+
+		err = hg.harvester.Run(ctx, s, cursor, publisher)
+		if err != nil && err != context.Canceled {
+			return fmt.Errorf("error while running harvester: %v", err)
+		}
+		return nil
+	})
 }
 
-// Cancel stops the running Harvester for a given Source.
-func (hg *defaultHarvesterGroup) Cancel(s Source) error {
-	if cancel, ok := hg.readers[s.Name()]; ok {
-		cancel()
+// Stop stops the running Harvester for a given Source.
+func (hg *defaultHarvesterGroup) Stop(s Source) {
+	hg.tg.Go(func(_ unison.Canceler) error {
+		hg.readers.remove(s.Name())
 		return nil
+	})
+}
+
+// StopGroup stops all running Harvesters.
+func (hg *defaultHarvesterGroup) StopGroup() error {
+	return hg.tg.Stop()
+}
+
+// Lock locks a key for exclusive access and returns an resource that can be used to modify
+// the cursor state and unlock the key.
+func lock(ctx input.Context, store *store, key string) (*resource, error) {
+	resource := store.Get(key)
+	err := lockResource(ctx.Logger, resource, ctx.Cancelation)
+	if err != nil {
+		resource.Release()
+		return nil, err
 	}
-	return fmt.Errorf("no such harvester %s", s.Name())
+	return resource, nil
+}
+
+func lockResource(log *logp.Logger, resource *resource, canceler input.Canceler) error {
+	if !resource.lock.TryLock() {
+		log.Infof("Resource '%v' currently in use, waiting...", resource.key)
+		err := resource.lock.LockContext(canceler)
+		if err != nil {
+			log.Infof("Input for resource '%v' has been stopped while waiting", resource.key)
+			return err
+		}
+	}
+	return nil
 }
 
 func releaseResource(resource *resource) {

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -30,10 +30,12 @@ import (
 )
 
 type managedInput struct {
-	manager      *InputManager
-	prospector   Prospector
-	harvester    Harvester
-	cleanTimeout time.Duration
+	userID           string
+	manager          *InputManager
+	sourceIdentifier *sourceIdentifier
+	prospector       Prospector
+	harvester        Harvester
+	cleanTimeout     time.Duration
 }
 
 // Name is required to implement the v2.Input interface
@@ -49,33 +51,29 @@ func (inp *managedInput) Run(
 	ctx input.Context,
 	pipeline beat.PipelineConnector,
 ) (err error) {
+	groupStore := inp.manager.getRetainedStore()
+	defer groupStore.Release()
+
 	// Setup cancellation using a custom cancel context. All workers will be
 	// stopped if one failed badly by returning an error.
 	cancelCtx, cancel := context.WithCancel(ctxtool.FromCanceller(ctx.Cancelation))
 	defer cancel()
 	ctx.Cancelation = cancelCtx
 
-	store := inp.manager.store
-	store.Retain()
-	defer store.Release()
-
 	hg := &defaultHarvesterGroup{
 		pipeline:     pipeline,
-		readers:      make(map[string]context.CancelFunc),
-		manager:      inp.manager,
+		readers:      newReaderGroup(),
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
-		store:        store,
+		store:        groupStore,
 		tg:           unison.TaskGroup{},
 	}
 
-	stateStore, err := inp.manager.StateStore.Access()
-	if err != nil {
-		return err
-	}
-	defer stateStore.Close()
+	prospectorStore := inp.manager.getRetainedStore()
+	defer prospectorStore.Release()
+	sourceStore := newSourceStore(prospectorStore, inp.sourceIdentifier)
 
-	inp.prospector.Run(ctx, stateStore, hg)
+	inp.prospector.Run(ctx, sourceStore, hg)
 
 	return nil
 }

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -18,17 +18,13 @@
 package filestream
 
 import (
-	"os"
-	"strings"
 	"time"
 
 	"github.com/urso/sderr"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/go-concert/unison"
 )
 
@@ -41,47 +37,61 @@ const (
 // The FS events then trigger either new Harvester runs or updates
 // the statestore.
 type fileProspector struct {
-	filewatcher  loginp.FSWatcher
-	identifier   fileIdentifier
-	ignoreOlder  time.Duration
-	cleanRemoved bool
+	filewatcher       loginp.FSWatcher
+	identifier        fileIdentifier
+	ignoreOlder       time.Duration
+	cleanRemoved      bool
+	stateChangeCloser stateChangeCloserConfig
 }
 
-func newFileProspector(
-	paths []string,
-	ignoreOlder time.Duration,
-	fileWatcherNs, identifierNs *common.ConfigNamespace,
-) (loginp.Prospector, error) {
+func (p *fileProspector) Init(cleaner loginp.ProspectorCleaner) error {
+	files := p.filewatcher.GetFiles()
 
-	filewatcher, err := newFileWatcher(paths, fileWatcherNs)
-	if err != nil {
-		return nil, err
+	if p.cleanRemoved {
+		cleaner.CleanIf(func(v loginp.Value) bool {
+			var fm fileMeta
+			err := v.UnpackCursorMeta(&fm)
+			if err != nil {
+				// remove faulty entries
+				return true
+			}
+
+			_, ok := files[fm.Source]
+			return !ok
+		})
 	}
 
-	identifier, err := newFileIdentifier(identifierNs)
-	if err != nil {
-		return nil, err
-	}
+	identifierName := p.identifier.Name()
+	cleaner.UpdateIdentifiers(func(v loginp.Value) (string, interface{}) {
+		var fm fileMeta
+		err := v.UnpackCursorMeta(&fm)
+		if err != nil {
+			return "", nil
+		}
 
-	return &fileProspector{
-		filewatcher:  filewatcher,
-		identifier:   identifier,
-		ignoreOlder:  ignoreOlder,
-		cleanRemoved: true,
-	}, nil
+		fi, ok := files[fm.Source]
+		if !ok {
+			return "", fm
+		}
+
+		if fm.IdentifierName != identifierName {
+			newKey := p.identifier.GetSource(loginp.FSEvent{NewPath: fm.Source, Info: fi}).Name()
+			fm.IdentifierName = identifierName
+			return newKey, fm
+		}
+		return "", fm
+	})
+
+	return nil
 }
 
 // Run starts the fileProspector which accepts FS events from a file watcher.
-func (p *fileProspector) Run(ctx input.Context, s *statestore.Store, hg loginp.HarvesterGroup) {
+func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, hg loginp.HarvesterGroup) {
 	log := ctx.Logger.With("prospector", prospectorDebugKey)
 	log.Debug("Starting prospector")
 	defer log.Debug("Prospector has stopped")
 
-	if p.cleanRemoved {
-		p.cleanRemovedBetweenRuns(log, s)
-	}
-
-	p.updateIdentifiersBetweenRuns(log, s)
+	defer p.stopHarvesterGroup(log, hg)
 
 	var tg unison.MultiErrGroup
 
@@ -115,15 +125,20 @@ func (p *fileProspector) Run(ctx input.Context, s *statestore.Store, hg loginp.H
 					}
 				}
 
-				hg.Run(ctx, src)
+				hg.Start(ctx, src)
 
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)
 
+				if p.stateChangeCloser.Removed {
+					log.Debugf("Stopping harvester as file %s has been removed and close.on_state_change.removed is enabled.", src.Name())
+					hg.Stop(src)
+				}
+
 				if p.cleanRemoved {
 					log.Debugf("Remove state for file as file removed: %s", fe.OldPath)
 
-					err := s.Remove(src.Name())
+					err := s.Remove(src)
 					if err != nil {
 						log.Errorf("Error while removing state from statestore: %v", err)
 					}
@@ -131,7 +146,39 @@ func (p *fileProspector) Run(ctx input.Context, s *statestore.Store, hg loginp.H
 
 			case loginp.OpRename:
 				log.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)
-				// TODO update state information in the store
+
+				// if file_identity is based on path, the current reader has to be cancelled
+				// and a new one has to start.
+				if !p.identifier.Supports(trackRename) {
+					prevSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: fe.OldPath})
+					hg.Stop(prevSrc)
+
+					log.Debugf("Remove state for file as file renamed and path file_identity is configured: %s", fe.OldPath)
+					err := s.Remove(prevSrc)
+					if err != nil {
+						log.Errorf("Error while removing old state of renamed file (%s): %v", fe.OldPath, err)
+					}
+
+					hg.Start(ctx, src)
+				} else {
+					// update file metadata as the path has changed
+					var meta fileMeta
+					err := s.FindCursorMeta(src, meta)
+					if err != nil {
+						log.Errorf("Error while getting cursor meta data of entry %s: %v", src.Name(), err)
+
+						meta.IdentifierName = p.identifier.Name()
+					}
+					s.UpdateMetadata(src, fileMeta{Source: src.newPath, IdentifierName: meta.IdentifierName})
+
+					if p.stateChangeCloser.Renamed {
+						log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())
+
+						fe.Op = loginp.OpDelete
+						srcToClose := p.identifier.GetSource(fe)
+						hg.Stop(srcToClose)
+					}
+				}
 
 			default:
 				log.Error("Unkown return value %v", fe.Op)
@@ -146,62 +193,11 @@ func (p *fileProspector) Run(ctx input.Context, s *statestore.Store, hg loginp.H
 	}
 }
 
-func (p *fileProspector) cleanRemovedBetweenRuns(log *logp.Logger, s *statestore.Store) {
-	keyPrefix := pluginName + "::"
-	s.Each(func(key string, dec statestore.ValueDecoder) (bool, error) {
-		if !strings.HasPrefix(string(key), keyPrefix) {
-			return true, nil
-		}
-
-		var st state
-		if err := dec.Decode(&st); err != nil {
-			log.Errorf("Failed to read regisry state for '%v', cursor state will be ignored. Error was: %+v",
-				key, err)
-			return true, nil
-		}
-
-		_, err := os.Stat(st.Source)
-		if err != nil {
-			s.Remove(key)
-		}
-
-		return true, nil
-	})
-}
-
-func (p *fileProspector) updateIdentifiersBetweenRuns(log *logp.Logger, s *statestore.Store) {
-	keyPrefix := pluginName + "::"
-	s.Each(func(key string, dec statestore.ValueDecoder) (bool, error) {
-		if !strings.HasPrefix(string(key), keyPrefix) {
-			return true, nil
-		}
-
-		var st state
-		if err := dec.Decode(&st); err != nil {
-			log.Errorf("Failed to read regisry state for '%v', cursor state will be ignored. Error was: %+v", key, err)
-			return true, nil
-		}
-
-		if st.IdentifierName == p.identifier.Name() {
-			return true, nil
-		}
-
-		fi, err := os.Stat(st.Source)
-		if err != nil {
-			return true, nil
-		}
-		newKey := p.identifier.GetSource(loginp.FSEvent{NewPath: st.Source, Info: fi}).Name()
-		st.IdentifierName = p.identifier.Name()
-
-		err = s.Set(newKey, st)
-		if err != nil {
-			log.Errorf("Failed to add updated state for '%v', cursor state will be ignored. Error was: %+v", key, err)
-			return true, nil
-		}
-		s.Remove(key)
-
-		return true, nil
-	})
+func (p *fileProspector) stopHarvesterGroup(log *logp.Logger, hg loginp.HarvesterGroup) {
+	err := hg.StopGroup()
+	if err != nil {
+		log.Errorf("Error while stopping harverster group: %v", err)
+	}
 }
 
 func (p *fileProspector) Test() error {


### PR DESCRIPTION
Cherry-pick of PR #22448 to 7.x branch. Original message: 

## What does this PR do?

This PR refactors parts of the filestream input.

A new interface is added named `resourceLocker` to let the `HarvesterGroup` lock resources from the store with fewer hops.

Another new interface is added for cleaning up the internal states before a `loginp.Prospector` is started. These cleaner functions can clean entries of removed files and update IDs if the `file_identity` configuration is changed.

The bookkeeping of readers is now threadsafe.

From now on `source.Name()` returns only a suffix of the state ID. The prefix `{input_type}::{user_id}` is added by a new interface `sourceIder` (I am open for better names.).

```golang
// SourceIder generates an ID for a Source.
type sourceIder interface {
    ID(Source) string
}
```

A special store is added as well which accepts `Source` interface as parameters and gets the full ID from a `sourceIder` instance. Only the interface `StateMetadataUpdater` is now accepted by `prospector.Run`. 

```golang
 // StateMetadataUpdater updates and removes the state information for a given Source.
type StateMetadataUpdater interface {
    // FindCursorMeta retrieves and unpacks the cursor metadata of a Source.
    FindCursorMeta(s Source, v interface{}) error
    // UpdateMetadata updates the source metadata of a registry entry for a given Source.
    UpdateMetadata(s Source, v interface{}) error
    // Remove marks a state for deletion with a given Source.
    Remove(s Source) error
}
```

Important difference between `sourceStore` and `store` is that the first one only deals with `Source` parameters. When you use `store`, you need to specify the full ID of an entry in the format of `{input_type::user_id::source_id}`.

## Why is it important?

Cleaner architecture, responsibilities are separated even more.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~