### PR TITLE
Cherry-pick #22865 to 7.x: Increase the number of reruns of test_reload_same_config

### DIFF
--- a/filebeat/tests/system/test_reload_inputs.py
+++ b/filebeat/tests/system/test_reload_inputs.py
@@ -251,7 +251,7 @@ class Test(BaseTest):
         assert output[1]["message"] == second_line
 
     # 1/20 build fails https://github.com/elastic/beats/issues/21307
-    @pytest.mark.flaky(reruns=1, reruns_delay=10)
+    @pytest.mark.flaky(reruns=2, reruns_delay=10)
     def test_reload_same_config(self):
         """
         Test reload same config with same file but different config. Makes sure reloading also works on conflicts.


### PR DESCRIPTION
Cherry-pick of PR #22865 to 7.x branch. Original message: 

The test `test_reload_same_config` is already marked flaky. Now it seems that the number of current reruns is not enough. So I am increasing it now to 2. If this does not help, we should skip the test on Windows.

The test issue tracked here: https://github.com/elastic/beats/issues/21307