### PR TITLE
Cherry-pick #22787 to 7.x: system/socket: Add ip_local_out alternative

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,6 +171,21 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - auditd: Fix an error condition causing a lot of `audit_send_reply` kernel threads being created. {pull}22673[22673]
 - system/socket: Fixed start failure when run under config reloader. {issue}20851[20851] {pull}21693[21693]
 - file_integrity: stop monitoring excluded paths {issue}21278[21278] {pull}21282[21282]
+- system/socket: Fixed startup error with some 5.x kernels. {issue}18755[18755] {pull}22787[22787]
+
+*Filebeat*
+
+- Fix mapping of fortinet.firewall.mem as integer. {pull}19335[19335]
+- Ensure all zeek timestamps include millisecond precision. {issue}14599[14599] {pull}16766[16766]
+- Fix s3 input hanging with GetObjectRequest API call by adding context_timeout config. {issue}15502[15502] {pull}15590[15590]
+- Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
+- Fix typos in zeek notice fileset config file. {issue}15764[15764] {pull}15765[15765]
+- Fix mapping error when zeek weird logs do not contain IP addresses. {pull}15906[15906]
+- Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
+- Prevent Elasticsearch from spewing log warnings about redundant wildcards when setting up ingest pipelines for the `elasticsearch` module. {issue}15840[15840] {pull}15900[15900]
+- Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
+- Fix a connection error in httpjson input. {pull}16123[16123]
+- Fix integer overflow in S3 offsets when collecting very large files. {pull}22523[22523]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,20 +175,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
-- Fix mapping of fortinet.firewall.mem as integer. {pull}19335[19335]
-- Ensure all zeek timestamps include millisecond precision. {issue}14599[14599] {pull}16766[16766]
-- Fix s3 input hanging with GetObjectRequest API call by adding context_timeout config. {issue}15502[15502] {pull}15590[15590]
-- Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
-- Fix typos in zeek notice fileset config file. {issue}15764[15764] {pull}15765[15765]
-- Fix mapping error when zeek weird logs do not contain IP addresses. {pull}15906[15906]
-- Improve `elasticsearch/audit` fileset to handle timestamps correctly. {pull}15942[15942]
-- Prevent Elasticsearch from spewing log warnings about redundant wildcards when setting up ingest pipelines for the `elasticsearch` module. {issue}15840[15840] {pull}15900[15900]
-- Fix mapping error for cloudtrail additionalEventData field {pull}16088[16088]
-- Fix a connection error in httpjson input. {pull}16123[16123]
-- Fix integer overflow in S3 offsets when collecting very large files. {pull}22523[22523]
-
-*Filebeat*
-
 - cisco/asa fileset: Fix parsing of 302021 message code. {pull}14519[14519]
 - Fix filebeat azure dashboards, event category should be `Alert`. {pull}14668[14668]
 - Fixed dashboard for Cisco ASA Firewall. {issue}15420[15420] {pull}15553[15553]

--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -35,7 +35,7 @@ var baseTemplateVars = common.MapStr{
 // These functions names vary between kernel versions. The first available one
 // will be selected during setup.
 var functionAlternatives = map[string][]string{
-	"IP_LOCAL_OUT":      {"ip_local_out", "ip_local_out_sk"},
+	"IP_LOCAL_OUT":      {"ip_local_out_sk", "__ip_local_out", "ip_local_out"},
 	"RECV_UDP_DATAGRAM": {"__skb_recv_udp", "__skb_recv_datagram", "skb_recv_datagram"},
 	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"SYS_GETTIMEOFDAY":  syscallAlternatives("gettimeofday"),


### PR DESCRIPTION
Cherry-pick of PR #22787 to 7.x branch. Original message: 

## What does this PR do?

This PR adds a new function alternative, `__ip_local_out` for selecting a proper ip_local_out function, and fixes `guess_ip_local_out` logic in order to account for this new function.

The new order of precedence is:
- ip_local_out_sk (kernels before 3.16)
- __ip_local_out (for kernels where ip_local_out calls are inlined)
- ip_local_out (all others).

## Why is it important?

In some systems, the `socket` dataset won't start with an error:
> unable to guess one or more required parameters: guess_ip_local_out failed: timeout while waiting for event

This is caused by Auditbeat expecting a kprobe set to `ip_local_out` to trigger, but it never does. The reason is that calls to this function might have been inlined. In those cases we need to attach the kprobe to `__ip_local_out` instead.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Relates #18755

