### PR TITLE
libbeat: override /sys/fs/cgroup paths in Docker

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -218,6 +218,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix FileVersion contained in Windows exe files. {pull}22581[22581]
 - Fix index template loading when the new index format is selected. {issue}22482[22482] {pull}22682[22682]
 - Use PROGRAMDATA environment variable instead of C:\ProgramData for windows install service {pull}22874[22874]
+- Fix reporting of cgroup metrics when running under Docker {pull}22879[22879]
 
 
 *Auditbeat*

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -79,6 +79,11 @@ USER {{ .user }}
 EXPOSE {{ $port }}
 {{- end }}
 
+# When running under Docker, we must ensure libbeat monitoring pulls cgroup
+# metrics from /sys/fs/cgroup/<subsystem>/, ignoring any paths found in
+# /proc/self/cgroup.
+ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
+
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 CMD ["-environment", "container"]

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/elastic/go-txfile v0.0.7
 	github.com/elastic/go-ucfg v0.8.3
 	github.com/elastic/go-windows v1.0.1 // indirect
-	github.com/elastic/gosigar v0.12.0
+	github.com/elastic/gosigar v0.13.0
 	github.com/fatih/color v1.5.0
 	github.com/fsnotify/fsevents v0.1.1
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/elastic/go-ucfg v0.8.3/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+F
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
-github.com/elastic/gosigar v0.12.0 h1:AsdhYCJlTudhfOYQyFNgx+fIVTfrDO0V1ST0vHgiapU=
-github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
+github.com/elastic/gosigar v0.13.0 h1:EIeuQcLPKia759s6mlVztlxUyKiKYHo6y6kOODOLO7A=
+github.com/elastic/gosigar v0.13.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec h1:rAHd7DeHIHjSzvnkl197GKh9TCWGKg/z2BBbbGOEiWI=
 github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec/go.mod h1:X690XXMxlbtN8c7xcpsENKNlbj8VClCZ2hwSOhSyNmE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -21,6 +21,7 @@ package instance
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -35,6 +36,11 @@ var (
 	beatProcessStats *process.Stats
 	systemMetrics    *monitoring.Registry
 )
+
+// libbeatMonitoringCgroupsHierarchyOverride is an undocumented environment variable which
+// overrides the cgroups path under /sys/fs/cgroup, which should be set to "/" when running
+// Beats under Docker.
+const libbeatMonitoringCgroupsHierarchyOverride = "LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE"
 
 func init() {
 	systemMetrics = monitoring.Default.NewRegistry("system")
@@ -277,7 +283,10 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 		return
 	}
 
-	cgroups, err := cgroup.NewReader("", true)
+	cgroups, err := cgroup.NewReaderOptions(cgroup.ReaderOptions{
+		IgnoreRootCgroups:        true,
+		CgroupsHierarchyOverride: os.Getenv(libbeatMonitoringCgroupsHierarchyOverride),
+	})
 	if err != nil {
 		if err == cgroup.ErrCgroupsMissing {
 			logp.Warn("cgroup data collection disabled: %v", err)


### PR DESCRIPTION
## What does this PR do?

This PR adds an undocumented environment variable, `LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE`, which can be used to override where cgroup metrics are found. This follows the approach taken by Elasticsearch (https://github.com/elastic/elasticsearch/pull/22757), Kibana, and Logstash. The environment variable is set (to "/") in the Docker images.

## Why is it important?

Under Docker, the paths in `/proc/<pid>/cgroup` do not have corresponding paths under `/sys/fs/cgroup/<subsystem>`. Instead, we should assume a root cgroup and read directly from the files in the subsystem directories.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Build the Docker image for x-pack/filebeat: `PLATFORMS=linux/amd64 TYPES=docker mage package`)
- Load the Docker image: `docker image load < build/distributions/filebeat-8.0.0-linux-amd64.docker.tar.gz`
- Run a filebeat container under Docker with monitoring enabled, and with a CPU quota defined (I set it to 20000, for example).
- Wait for metrics to be reported, and check that the cgroup metrics are non-zero:

```
GET /.monitoring-beats-7-2020.12.03/_search
{
  "sort": [
    {
      "timestamp": {
        "order": "desc"
      }
    }
  ],
  "_source": "beats_stats.metrics.beat.cgroup"
}
```

```
        "_index" : ".monitoring-beats-7-2020.12.03",
        "_id" : "cz-vJnYBjbWE_R3aj_hz",
        "_score" : null,
        "_source" : {
          "beats_stats" : {
            "metrics" : {
              "beat" : {
                "cgroup" : {
                  "memory" : {
                    "mem" : {
                      "usage" : {
                        "bytes" : 29429760
                      },
                      "limit" : {
                        "bytes" : 9223372036854771712
                      }
                    },
                    "id" : "e62f3fa5f16f05d6edc680e2303ccfb6a323599db6f7dfd2b02640390d1b8319"
                  },
                  "cpu" : {
                    "cfs" : {
                      "period" : {
                        "us" : 100000
                      },
                      "quota" : {
                        "us" : 20000
                      }
                    },
                    "stats" : {
                      "periods" : 254,
                      "throttled" : {
                        "ns" : 9362053609,
                        "periods" : 40
                      }
                    },
                    "id" : "e62f3fa5f16f05d6edc680e2303ccfb6a323599db6f7dfd2b02640390d1b8319"
                  },
                  "cpuacct" : {
                    "total" : {
                      "ns" : 1476308159
                    },
                    "id" : "e62f3fa5f16f05d6edc680e2303ccfb6a323599db6f7dfd2b02640390d1b8319"
                  }
                }
              }
            }
          }
        },
```


## Related issues

Fixes https://github.com/elastic/beats/issues/22844