### PR TITLE
Cherry-pick #22190 to 7.x: [Heartbeat] Add tls fields when connecting through proxy

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -244,6 +244,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misuse. {pull}16397[16397]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
+- Fixed missing `tls` fields when connecting to https via proxy. {issue}15797[15797] {pull}22190[22190]
 
 *Heartbeat*
 

--- a/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta.go
+++ b/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta.go
@@ -33,9 +33,14 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
+// UnknownTLSHandshakeDuration to be used in AddTLSMetadata when the duration of the TLS handshake can't be determined.
+const UnknownTLSHandshakeDuration = time.Duration(-1)
+
 func AddTLSMetadata(fields common.MapStr, connState cryptoTLS.ConnectionState, duration time.Duration) {
 	fields.Put("tls.established", true)
-	fields.Put("tls.rtt.handshake", look.RTT(duration))
+	if duration != UnknownTLSHandshakeDuration {
+		fields.Put("tls.rtt.handshake", look.RTT(duration))
+	}
 	versionDetails := tlscommon.TLSVersion(connState.Version).Details()
 	// The only situation in which versionDetails would be nil is if an unknown TLS version were to be
 	// encountered. Not filling the fields here makes sense, since there's no standard 'unknown' value.

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -275,6 +275,14 @@ func execPing(
 	// Mark the end time as now, since we've finished downloading
 	end = time.Now()
 
+	// Enrich event with TLS information when available. This is useful when connecting to an HTTPS server through
+	// a proxy.
+	if resp.TLS != nil {
+		tlsFields := common.MapStr{}
+		tlsmeta.AddTLSMetadata(tlsFields, *resp.TLS, tlsmeta.UnknownTLSHandshakeDuration)
+		eventext.MergeEventFields(event, tlsFields)
+	}
+
 	// Add total HTTP RTT
 	eventext.MergeEventFields(event, common.MapStr{"http": common.MapStr{
 		"rtt": common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #22190 to 7.x branch. Original message: 

## What does this PR do?

This updates Heartbeat to enrich an event with TLS information when the connection has been established via an HTTP proxy.

## Why is it important?

Because tls fields are missing from events when an HTTPS connection is performed through a proxy.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Tested with tinyproxy (HTTP) and stunnel+tinyproxy (HTTPS)

```diff
diff --git a/heartbeat/heartbeat.yml b/heartbeat/heartbeat.yml
index 19c3f79e96..3ed6e835e1 100644
--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -27,7 +27,9 @@ heartbeat.monitors:
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My Monitor
   # List or urls to query
-  urls: ["http://localhost:9200"]
+  urls: ["https://elastic.co/"]
+  proxy_url: "https://localhost:3333/"
+  ssl.verification_mode: none
   # Configure task schedule
   schedule: '@every 10s'
   # Total test connection and data exchange timeout
```


## Related issues

Closes #15797
