### PR TITLE
Cherry-pick #22789 to 7.x: Add more Golang tests to filestream input

### DIFF
--- a/filebeat/input/filestream/config_test.go
+++ b/filebeat/input/filestream/config_test.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("paths cannot be empty", func(t *testing.T) {
+		c := config{Paths: []string{}}
+		err := c.Validate()
+		require.Error(t, err)
+	})
+}

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -19,6 +19,7 @@ package filestream
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,12 +33,22 @@ import (
 )
 
 var (
-	excludedFilePath = filepath.Join("testdata", "excluded_file")
-	includedFilePath = filepath.Join("testdata", "included_file")
-	directoryPath    = filepath.Join("testdata", "unharvestable_dir")
+	excludedFileName = "excluded_file"
+	includedFileName = "included_file"
+	directoryPath    = "unharvestable_dir"
 )
 
 func TestFileScanner(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fswatch_test_file_scanner")
+	if err != nil {
+		t.Fatalf("cannot create temporary test dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	setupFilesForScannerTest(t, tmpDir)
+
+	excludedFilePath := filepath.Join(tmpDir, excludedFileName)
+	includedFilePath := filepath.Join(tmpDir, includedFileName)
+
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
@@ -45,29 +56,21 @@ func TestFileScanner(t *testing.T) {
 		expectedFiles []string
 	}{
 		"select all files": {
-			paths: []string{excludedFilePath, includedFilePath},
-			expectedFiles: []string{
-				mustAbsPath(excludedFilePath),
-				mustAbsPath(includedFilePath),
-			},
+			paths:         []string{excludedFilePath, includedFilePath},
+			expectedFiles: []string{excludedFilePath, includedFilePath},
 		},
 		"skip excluded files": {
 			paths: []string{excludedFilePath, includedFilePath},
 			excludedFiles: []match.Matcher{
-				match.MustCompile("excluded_file"),
+				match.MustCompile(excludedFileName),
 			},
-			expectedFiles: []string{
-				mustAbsPath(includedFilePath),
-			},
+			expectedFiles: []string{includedFilePath},
 		},
 		"skip directories": {
-			paths:         []string{directoryPath},
+			paths:         []string{filepath.Join(tmpDir, directoryPath)},
 			expectedFiles: []string{},
 		},
 	}
-
-	setupFilesForScannerTest(t)
-	defer removeFilesOfScannerTest(t)
 
 	for name, test := range testCases {
 		test := test
@@ -92,25 +95,17 @@ func TestFileScanner(t *testing.T) {
 	}
 }
 
-func setupFilesForScannerTest(t *testing.T) {
-	err := os.MkdirAll(directoryPath, 0750)
+func setupFilesForScannerTest(t *testing.T, tmpDir string) {
+	err := os.Mkdir(filepath.Join(tmpDir, directoryPath), 750)
 	if err != nil {
-		t.Fatal(t)
+		t.Fatalf("cannot create non harvestable directory: %v", err)
 	}
-
-	for _, path := range []string{excludedFilePath, includedFilePath} {
-		f, err := os.Create(path)
+	for _, path := range []string{excludedFileName, includedFileName} {
+		f, err := os.Create(filepath.Join(tmpDir, path))
 		if err != nil {
 			t.Fatalf("file %s, error %v", path, err)
 		}
 		f.Close()
-	}
-}
-
-func removeFilesOfScannerTest(t *testing.T) {
-	err := os.RemoveAll("testdata")
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -236,14 +231,6 @@ func (t testFileInfo) Mode() os.FileMode  { return 0 }
 func (t testFileInfo) ModTime() time.Time { return t.time }
 func (t testFileInfo) IsDir() bool        { return false }
 func (t testFileInfo) Sys() interface{}   { return nil }
-
-func mustAbsPath(path string) string {
-	p, err := filepath.Abs(path)
-	if err != nil {
-		panic(err)
-	}
-	return p
-}
 
 func mustDuration(durStr string) time.Duration {
 	dur, err := time.ParseDuration(durStr)

--- a/filebeat/input/filestream/fswatch_test_non_windows.go
+++ b/filebeat/input/filestream/fswatch_test_non_windows.go
@@ -21,6 +21,7 @@ package filestream
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,6 +34,13 @@ import (
 )
 
 func TestFileScannerSymlinks(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fswatch_test_file_scanner")
+	if err != nil {
+		t.Fatalf("cannot create temporary test dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	setupFilesForScannerTest(t, tmpDir)
+
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
@@ -42,29 +50,29 @@ func TestFileScannerSymlinks(t *testing.T) {
 		// covers test_input.py/test_skip_symlinks
 		"skip symlinks": {
 			paths: []string{
-				filepath.Join("testdata", "symlink_to_included_file"),
-				filepath.Join("testdata", "included_file"),
+				filepath.Join(tmpDir, "symlink_to_included_file"),
+				filepath.Join(tmpDir, "included_file"),
 			},
 			symlinks: false,
 			expectedFiles: []string{
-				mustAbsPath(filepath.Join("testdata", "included_file")),
+				mustAbsPath(filepath.Join(tmpDir, "included_file")),
 			},
 		},
 		"return a file once if symlinks are enabled": {
 			paths: []string{
-				filepath.Join("testdata", "symlink_to_included_file"),
-				filepath.Join("testdata", "included_file"),
+				filepath.Join(tmpDir, "symlink_to_included_file"),
+				filepath.Join(tmpDir, "included_file"),
 			},
 			symlinks: true,
 			expectedFiles: []string{
-				mustAbsPath(filepath.Join("testdata", "included_file")),
+				mustAbsPath(filepath.Join(tmpDir, "included_file")),
 			},
 		},
 	}
 
 	err := os.Symlink(
-		mustAbsPath(filepath.Join("testdata", "included_file")),
-		mustAbsPath(filepath.Join("testdata", "symlink_to_included_file")),
+		mustAbsPath(filepath.Join(tmpDir, "included_file")),
+		mustAbsPath(filepath.Join(tmpDir, "symlink_to_included_file")),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/filebeat/input/filestream/identifier_test.go
+++ b/filebeat/input/filestream/identifier_test.go
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/file"
+)
+
+type testFileIdentifierConfig struct {
+	Identifier *common.ConfigNamespace `config:"identifier"`
+}
+
+func TestFileIdentifier(t *testing.T) {
+	t.Run("default file identifier", func(t *testing.T) {
+		identifier, err := newFileIdentifier(nil)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultIdentifierName, identifier.Name())
+
+		tmpFile, err := ioutil.TempFile("", "test_file_identifier_native")
+		if err != nil {
+			t.Fatalf("cannot create temporary file for test: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		fi, err := tmpFile.Stat()
+		if err != nil {
+			t.Fatalf("cannot stat temporary file for test: %v", err)
+		}
+
+		src := identifier.GetSource(loginp.FSEvent{
+			NewPath: tmpFile.Name(),
+			Info:    fi,
+		})
+
+		assert.Equal(t, identifier.Name()+"::"+file.GetOSState(fi).String(), src.Name())
+	})
+
+	t.Run("path identifier", func(t *testing.T) {
+		c := common.MustNewConfigFrom(map[string]interface{}{
+			"identifier": map[string]interface{}{
+				"path": nil,
+			},
+		})
+		var cfg testFileIdentifierConfig
+		err := c.Unpack(&cfg)
+		require.NoError(t, err)
+
+		identifier, err := newFileIdentifier(cfg.Identifier)
+		require.NoError(t, err)
+		assert.Equal(t, pathName, identifier.Name())
+
+		testCases := []struct {
+			newPath     string
+			oldPath     string
+			operation   loginp.Operation
+			expectedSrc string
+		}{
+			{
+				newPath:     "/path/to/file",
+				expectedSrc: "path::/path/to/file",
+			},
+			{
+				newPath:     "/new/path/to/file",
+				oldPath:     "/old/path/to/file",
+				operation:   loginp.OpRename,
+				expectedSrc: "path::/new/path/to/file",
+			},
+			{
+				oldPath:     "/old/path/to/file",
+				operation:   loginp.OpDelete,
+				expectedSrc: "path::/old/path/to/file",
+			},
+		}
+
+		for _, test := range testCases {
+			src := identifier.GetSource(loginp.FSEvent{
+				NewPath: test.newPath,
+				OldPath: test.oldPath,
+				Op:      test.operation,
+			})
+			assert.Equal(t, test.expectedSrc, src.Name())
+		}
+	})
+}

--- a/filebeat/input/filestream/identifier_test_non_windows.go
+++ b/filebeat/input/filestream/identifier_test_non_windows.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !windows
+
+package filestream
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/file"
+)
+
+func TestFileIdentifierInodeMarker(t *testing.T) {
+	t.Run("inode_marker file identifier", func(t *testing.T) {
+		const markerContents = "unique_marker"
+		markerFile, err := ioutil.TempFile("", "test_file_identifier_inode_marker_identifier")
+		if err != nil {
+			t.Fatalf("cannot create marker file for test: %v", err)
+		}
+		defer os.Remove(markerFile.Name())
+
+		_, err = markerFile.Write([]byte(markerContents))
+		if err != nil {
+			t.Fatalf("cannot write marker contents to file: %v", err)
+		}
+		markerFile.Sync()
+
+		c := common.MustNewConfigFrom(map[string]interface{}{
+			"identifier": map[string]interface{}{
+				"inode_marker": map[string]interface{}{
+					"path": markerFile.Name(),
+				},
+			},
+		})
+		var cfg testFileIdentifierConfig
+		err = c.Unpack(&cfg)
+		require.NoError(t, err)
+
+		identifier, err := newFileIdentifier(cfg.Identifier)
+		require.NoError(t, err)
+		assert.Equal(t, inodeMarkerName, identifier.Name())
+
+		tmpFile, err := ioutil.TempFile("", "test_file_identifier_inode_marker")
+		if err != nil {
+			t.Fatalf("cannot create temporary file for test: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		fi, err := tmpFile.Stat()
+		if err != nil {
+			t.Fatalf("cannot stat temporary file for test: %v", err)
+		}
+
+		fsEvent := loginp.FSEvent{
+			NewPath: tmpFile.Name(),
+			Info:    fi,
+		}
+		src := identifier.GetSource(fsEvent)
+
+		osState := file.GetOSState(fi)
+		assert.Equal(t, identifier.Name()+"::"+osState.InodeString()+"-"+markerContents, src.Name())
+
+		const changedMarkerContents = "different_unique_marker"
+		_, err = markerFile.WriteAt([]byte(changedMarkerContents), 0)
+		if err != nil {
+			t.Fatalf("cannot write marker contents to file: %v", err)
+		}
+		markerFile.Sync()
+
+		src = identifier.GetSource(fsEvent)
+
+		assert.Equal(t, identifier.Name()+"::"+osState.InodeString()+"-"+changedMarkerContents, src.Name())
+	})
+}

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -1,0 +1,166 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input_logfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testPluginName = "my_test_plugin"
+
+type testSource struct {
+	name string
+}
+
+func (s *testSource) Name() string {
+	return s.name
+}
+
+func TestSourceIdentifier_ID(t *testing.T) {
+	testCases := map[string]struct {
+		userID            string
+		sources           []*testSource
+		expectedSourceIDs []string
+	}{
+		"plugin with no user configured ID": {
+			sources: []*testSource{
+				&testSource{"unique_name"},
+				&testSource{"another_unique_name"},
+			},
+			expectedSourceIDs: []string{
+				testPluginName + "::.global::unique_name",
+				testPluginName + "::.global::another_unique_name",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier, err := newSourceIdentifier(testPluginName, test.userID)
+			if err != nil {
+				t.Fatalf("cannot create identifier: %v", err)
+			}
+
+			for i, src := range test.sources {
+				t.Run(name+"_with_src: "+src.Name(), func(t *testing.T) {
+					srcID := srcIdentifier.ID(src)
+					assert.Equal(t, test.expectedSourceIDs[i], srcID)
+				})
+			}
+		})
+	}
+}
+
+func TestSourceIdentifier_MachesInput(t *testing.T) {
+	testCases := map[string]struct {
+		userID      string
+		matchingIDs []string
+	}{
+		"plugin with no user configured ID": {
+			matchingIDs: []string{
+				testPluginName + "::.global::my_id",
+				testPluginName + "::.global::path::my_id",
+				testPluginName + "::.global::" + testPluginName + "::my_id",
+			},
+		},
+		"plugin with user configured ID": {
+			userID: "my-id",
+			matchingIDs: []string{
+				testPluginName + "::my-id::my_id",
+				testPluginName + "::my-id::path::my_id",
+				testPluginName + "::my-id::" + testPluginName + "::my_id",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier, err := newSourceIdentifier(testPluginName, test.userID)
+			if err != nil {
+				t.Fatalf("cannot create identifier: %v", err)
+			}
+
+			for _, id := range test.matchingIDs {
+				t.Run(name+"_with_id: "+id, func(t *testing.T) {
+					assert.True(t, srcIdentifier.MatchesInput(id))
+				})
+			}
+		})
+	}
+}
+
+func TestSourceIdentifier_NotMachesInput(t *testing.T) {
+
+	testCases := map[string]struct {
+		userID         string
+		notMatchingIDs []string
+	}{
+		"plugin with no user configured ID": {
+			notMatchingIDs: []string{
+				"::my_id",
+				"::path::my_id::" + testPluginName,
+			},
+		},
+		"plugin with user configured ID": {
+			userID: "my-id",
+			notMatchingIDs: []string{
+				testPluginName + "-other-id::my_id",
+				"my-id::path::my_id",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			srcIdentifier, err := newSourceIdentifier(testPluginName, test.userID)
+			if err != nil {
+				t.Fatalf("cannot create identifier: %v", err)
+			}
+
+			for _, id := range test.notMatchingIDs {
+				t.Run(name+"_with_id: "+id, func(t *testing.T) {
+					assert.False(t, srcIdentifier.MatchesInput(id))
+				})
+			}
+		})
+	}
+}
+
+func TestSourceIdentifierNoAccidentalMatches(t *testing.T) {
+	noIDIdentifier, err := newSourceIdentifier(testPluginName, "")
+	if err != nil {
+		t.Fatalf("cannot create identifier: %v", err)
+	}
+	withIDIdentifier, err := newSourceIdentifier(testPluginName, "id")
+	if err != nil {
+		t.Fatalf("cannot create identifier: %v", err)
+	}
+
+	src := &testSource{"test"}
+	assert.NotEqual(t, noIDIdentifier.ID(src), withIDIdentifier.ID(src))
+	assert.False(t, noIDIdentifier.MatchesInput(withIDIdentifier.ID(src)))
+	assert.False(t, withIDIdentifier.MatchesInput(noIDIdentifier.ID(src)))
+}

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -19,6 +19,8 @@ package filestream
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -27,30 +29,164 @@ import (
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/common/transform/typeconv"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/unison"
 )
+
+func TestProspector_InitCleanIfRemoved(t *testing.T) {
+	testCases := map[string]struct {
+		entries             map[string]loginp.Value
+		filesOnDisk         map[string]os.FileInfo
+		cleanRemoved        bool
+		expectedCleanedKeys []string
+	}{
+		"prospector init with clean_removed enabled with no entries": {
+			entries:             nil,
+			filesOnDisk:         nil,
+			cleanRemoved:        true,
+			expectedCleanedKeys: []string{},
+		},
+		"prospector init with clean_removed disabled with entries": {
+			entries: map[string]loginp.Value{
+				"key1": &mockUnpackValue{
+					fileMeta{
+						Source:         "/no/such/path",
+						IdentifierName: "path",
+					},
+				},
+			},
+			filesOnDisk:         nil,
+			cleanRemoved:        false,
+			expectedCleanedKeys: []string{},
+		},
+		"prospector init with clean_removed enabled with entries": {
+			entries: map[string]loginp.Value{
+				"key1": &mockUnpackValue{
+					fileMeta{
+						Source:         "/no/such/path",
+						IdentifierName: "path",
+					},
+				},
+			},
+			filesOnDisk:         nil,
+			cleanRemoved:        true,
+			expectedCleanedKeys: []string{"key1"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(name, func(t *testing.T) {
+			testStore := newMockProspectorCleaner(testCase.entries)
+			p := fileProspector{
+				identifier:   mustPathIdentifier(false),
+				cleanRemoved: testCase.cleanRemoved,
+				filewatcher:  &mockFileWatcher{filesOnDisk: testCase.filesOnDisk},
+			}
+			p.Init(testStore)
+
+			assert.ElementsMatch(t, testCase.expectedCleanedKeys, testStore.cleanedKeys)
+		})
+	}
+
+}
+
+func TestProspector_InitUpdateIdentifiers(t *testing.T) {
+	f, err := ioutil.TempFile("", "existing_file")
+	if err != nil {
+		t.Fatalf("cannot create temp file")
+	}
+	defer f.Close()
+	tmpFileName := f.Name()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatalf("cannot stat test file: %v", err)
+	}
+
+	testCases := map[string]struct {
+		entries             map[string]loginp.Value
+		filesOnDisk         map[string]os.FileInfo
+		expectedUpdatedKeys map[string]string
+	}{
+		"prospector init does not update keys if there are no entries": {
+			entries:             nil,
+			filesOnDisk:         nil,
+			expectedUpdatedKeys: map[string]string{},
+		},
+		"prospector init does not update keys of not existing files": {
+			entries: map[string]loginp.Value{
+				"not_path::key1": &mockUnpackValue{
+					fileMeta{
+						Source:         "/no/such/path",
+						IdentifierName: "not_path",
+					},
+				},
+			},
+			filesOnDisk:         nil,
+			expectedUpdatedKeys: map[string]string{},
+		},
+		"prospector init updates keys of existing files": {
+			entries: map[string]loginp.Value{
+				"not_path::key1": &mockUnpackValue{
+					fileMeta{
+						Source:         tmpFileName,
+						IdentifierName: "not_path",
+					},
+				},
+			},
+			filesOnDisk: map[string]os.FileInfo{
+				tmpFileName: fi,
+			},
+			expectedUpdatedKeys: map[string]string{"not_path::key1": "path::" + tmpFileName},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(name, func(t *testing.T) {
+			testStore := newMockProspectorCleaner(testCase.entries)
+			p := fileProspector{
+				identifier:  mustPathIdentifier(false),
+				filewatcher: &mockFileWatcher{filesOnDisk: testCase.filesOnDisk},
+			}
+			p.Init(testStore)
+
+			assert.EqualValues(t, testCase.expectedUpdatedKeys, testStore.updatedKeys)
+		})
+	}
+
+}
 
 func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 	minuteAgo := time.Now().Add(-1 * time.Minute)
 
 	testCases := map[string]struct {
-		events          []loginp.FSEvent
-		ignoreOlder     time.Duration
-		expectedSources []string
+		events         []loginp.FSEvent
+		ignoreOlder    time.Duration
+		expectedEvents []harvesterEvent
 	}{
 		"two new files": {
 			events: []loginp.FSEvent{
 				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file"},
 				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/other/file"},
 			},
-			expectedSources: []string{"path::/path/to/file", "path::/path/to/other/file"},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterStart("path::/path/to/other/file"),
+				harvesterGroupStop{},
+			},
 		},
 		"one updated file": {
 			events: []loginp.FSEvent{
 				loginp.FSEvent{Op: loginp.OpWrite, NewPath: "/path/to/file"},
 			},
-			expectedSources: []string{"path::/path/to/file"},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterGroupStop{},
+			},
 		},
 		"old files with ignore older configured": {
 			events: []loginp.FSEvent{
@@ -65,8 +201,10 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo},
 				},
 			},
-			ignoreOlder:     10 * time.Second,
-			expectedSources: []string{},
+			ignoreOlder: 10 * time.Second,
+			expectedEvents: []harvesterEvent{
+				harvesterGroupStop{},
+			},
 		},
 		"newer files with ignore older": {
 			events: []loginp.FSEvent{
@@ -81,8 +219,12 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo},
 				},
 			},
-			ignoreOlder:     5 * time.Minute,
-			expectedSources: []string{"path::/path/to/file", "path::/path/to/other/file"},
+			ignoreOlder: 5 * time.Minute,
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterStart("path::/path/to/other/file"),
+				harvesterGroupStop{},
+			},
 		},
 	}
 
@@ -92,15 +234,15 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := fileProspector{
 				filewatcher: &mockFileWatcher{events: test.events},
-				identifier:  mustPathIdentifier(),
+				identifier:  mustPathIdentifier(false),
 				ignoreOlder: test.ignoreOlder,
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
-			hg := getTestHarvesterGroup()
+			hg := newTestHarvesterGroup()
 
 			p.Run(ctx, newMockMetadataUpdater(), hg)
 
-			assert.ElementsMatch(t, hg.encounteredNames, test.expectedSources)
+			assert.ElementsMatch(t, test.expectedEvents, hg.events)
 		})
 	}
 }
@@ -130,7 +272,7 @@ func TestProspectorDeletedFile(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := fileProspector{
 				filewatcher:  &mockFileWatcher{events: test.events},
-				identifier:   mustPathIdentifier(),
+				identifier:   mustPathIdentifier(false),
 				cleanRemoved: test.cleanRemoved,
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
@@ -138,7 +280,7 @@ func TestProspectorDeletedFile(t *testing.T) {
 			testStore := newMockMetadataUpdater()
 			testStore.set("path::/path/to/file")
 
-			p.Run(ctx, testStore, getTestHarvesterGroup())
+			p.Run(ctx, testStore, newTestHarvesterGroup())
 
 			has := testStore.has("path::/path/to/file")
 
@@ -152,27 +294,126 @@ func TestProspectorDeletedFile(t *testing.T) {
 	}
 }
 
-type testHarvesterGroup struct {
-	encounteredNames []string
+func TestProspectorRenamedFile(t *testing.T) {
+	testCases := map[string]struct {
+		events         []loginp.FSEvent
+		trackRename    bool
+		closeRenamed   bool
+		expectedEvents []harvesterEvent
+	}{
+		"one renamed file without rename tracker": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{
+					Op:      loginp.OpRename,
+					OldPath: "/old/path/to/file",
+					NewPath: "/new/path/to/file",
+				},
+			},
+			expectedEvents: []harvesterEvent{
+				harvesterStop("path::/old/path/to/file"),
+				harvesterStart("path::/new/path/to/file"),
+				harvesterGroupStop{},
+			},
+		},
+		"one renamed file with rename tracker": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{
+					Op:      loginp.OpRename,
+					OldPath: "/old/path/to/file",
+					NewPath: "/new/path/to/file",
+				},
+			},
+			trackRename: true,
+			expectedEvents: []harvesterEvent{
+				harvesterGroupStop{},
+			},
+		},
+		"one renamed file with rename tracker with close renamed": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{
+					Op:      loginp.OpRename,
+					OldPath: "/old/path/to/file",
+					NewPath: "/new/path/to/file",
+				},
+			},
+			trackRename:  true,
+			closeRenamed: true,
+			expectedEvents: []harvesterEvent{
+				harvesterStop("path::/old/path/to/file"),
+				harvesterGroupStop{},
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			p := fileProspector{
+				filewatcher:       &mockFileWatcher{events: test.events},
+				identifier:        mustPathIdentifier(test.trackRename),
+				stateChangeCloser: stateChangeCloserConfig{Renamed: test.closeRenamed},
+			}
+			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+
+			testStore := newMockMetadataUpdater()
+			testStore.set("path::/old/path/to/file")
+
+			hg := newTestHarvesterGroup()
+			p.Run(ctx, testStore, hg)
+
+			has := testStore.has("path::/old/path/to/file")
+			if test.trackRename {
+				assert.True(t, has)
+			} else {
+				assert.False(t, has)
+			}
+
+			assert.Equal(t, test.expectedEvents, hg.events)
+
+		})
+	}
 }
 
-func getTestHarvesterGroup() *testHarvesterGroup { return &testHarvesterGroup{make([]string, 0)} }
+type harvesterEvent interface{ String() string }
+
+type harvesterStart string
+
+func (h harvesterStart) String() string { return string(h) }
+
+type harvesterStop string
+
+func (h harvesterStop) String() string { return string(h) }
+
+type harvesterGroupStop struct{}
+
+func (h harvesterGroupStop) String() string { return "stop" }
+
+type testHarvesterGroup struct {
+	events []harvesterEvent
+}
+
+func newTestHarvesterGroup() *testHarvesterGroup {
+	return &testHarvesterGroup{make([]harvesterEvent, 0)}
+}
 
 func (t *testHarvesterGroup) Start(_ input.Context, s loginp.Source) {
-	t.encounteredNames = append(t.encounteredNames, s.Name())
+	t.events = append(t.events, harvesterStart(s.Name()))
 }
 
-func (t *testHarvesterGroup) Stop(_ loginp.Source) {
-	return
+func (t *testHarvesterGroup) Stop(s loginp.Source) {
+	t.events = append(t.events, harvesterStop(s.Name()))
 }
 
 func (t *testHarvesterGroup) StopGroup() error {
+	t.events = append(t.events, harvesterGroupStop{})
 	return nil
 }
 
 type mockFileWatcher struct {
-	nextIdx int
-	events  []loginp.FSEvent
+	nextIdx     int
+	events      []loginp.FSEvent
+	filesOnDisk map[string]os.FileInfo
 }
 
 func (m *mockFileWatcher) Event() loginp.FSEvent {
@@ -186,7 +427,7 @@ func (m *mockFileWatcher) Event() loginp.FSEvent {
 
 func (m *mockFileWatcher) Run(_ unison.Canceler) { return }
 
-func (m *mockFileWatcher) GetFiles() map[string]os.FileInfo { return nil }
+func (m *mockFileWatcher) GetFiles() map[string]os.FileInfo { return m.filesOnDisk }
 
 type mockMetadataUpdater struct {
 	table map[string]interface{}
@@ -206,6 +447,10 @@ func (mu *mockMetadataUpdater) has(id string) bool {
 }
 
 func (mu *mockMetadataUpdater) FindCursorMeta(s loginp.Source, v interface{}) error {
+	v, ok := mu.table[s.Name()]
+	if !ok {
+		return fmt.Errorf("no such id")
+	}
 	return nil
 }
 
@@ -219,11 +464,59 @@ func (mu *mockMetadataUpdater) Remove(s loginp.Source) error {
 	return nil
 }
 
-func mustPathIdentifier() fileIdentifier {
+type mockUnpackValue struct {
+	fileMeta
+}
+
+func (u *mockUnpackValue) UnpackCursorMeta(to interface{}) error {
+	return typeconv.Convert(to, u.fileMeta)
+}
+
+type mockProspectorCleaner struct {
+	available   map[string]loginp.Value
+	cleanedKeys []string
+	newEntries  map[string]fileMeta
+	updatedKeys map[string]string
+}
+
+func newMockProspectorCleaner(available map[string]loginp.Value) *mockProspectorCleaner {
+	return &mockProspectorCleaner{
+		available:   available,
+		cleanedKeys: make([]string, 0),
+		updatedKeys: make(map[string]string, 0),
+	}
+}
+
+func (c *mockProspectorCleaner) CleanIf(pred func(v loginp.Value) bool) {
+	for key, meta := range c.available {
+		if pred(meta) {
+			c.cleanedKeys = append(c.cleanedKeys, key)
+		}
+	}
+}
+
+func (c *mockProspectorCleaner) UpdateIdentifiers(updater func(v loginp.Value) (string, interface{})) {
+	for key, meta := range c.available {
+		k, _ := updater(meta)
+		if k != "" {
+			c.updatedKeys[key] = k
+		}
+	}
+}
+
+type renamedPathIdentifier struct {
+	fileIdentifier
+}
+
+func (p *renamedPathIdentifier) Supports(_ identifierFeature) bool { return true }
+
+func mustPathIdentifier(renamed bool) fileIdentifier {
 	pathIdentifier, err := newPathIdentifier(nil)
 	if err != nil {
 		panic(err)
 	}
+	if renamed {
+		return &renamedPathIdentifier{pathIdentifier}
+	}
 	return pathIdentifier
-
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#22789 to 7.x branch. Original message: 

## What does this PR do?

Increase the test coverage of `filestream` input.

# Related issues

Requires elastic/beats#22448