### PR TITLE
feat: remove verbose output from Docker container logs

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -12,12 +12,23 @@ set -eo pipefail
 # KIBANA_PASSWORD - password for accessing kibana API [changeme]
 # KIBANA_USERNAME - username for accessing kibana API [elastic]
 
+function log(){
+  local msg=$1
+  if [ "${DEBUG}" == "1" ]; then
+    echo $msg
+  fi
+}
+
 function setup(){
-  curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/fleet/setup -H 'kbn-xsrf: true' -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
- curl -X POST  ${KIBANA_HOST:-http://localhost:5601}/api/fleet/agents/setup \
+  echo "Fleet setup"
+  curl -X POST -sS ${KIBANA_HOST:-http://localhost:5601}/api/fleet/setup -H 'kbn-xsrf: true' -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
+  echo ""
+  echo "Agent setup"
+  curl -X POST -sS ${KIBANA_HOST:-http://localhost:5601}/api/fleet/agents/setup \
     -H 'Content-Type: application/json' \
     -H 'kbn-xsrf: true' \
     -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme}
+  echo ""
 }
 
 function enroll(){
@@ -27,23 +38,27 @@ function enroll(){
     if [[ -n "${FLEET_ENROLLMENT_TOKEN}" ]]; then
       apikey="${FLEET_ENROLLMENT_TOKEN}"
     else
-      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys \
+      echo "Enroll Agent API key"
+      enrollResp=$(curl -sS ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys \
         -H 'Content-Type: application/json' \
         -H 'kbn-xsrf: true' \
         -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )
+      echo ""
 
       local exitCode=$?
       if [ $exitCode -ne 0 ]; then
         exit $exitCode
       fi
-      echo $enrollResp
+      log $enrollResp
       local apikeyId=$(echo $enrollResp | jq -r '.list[0].id')
-      echo $apikeyId
+      log $apikeyId
 
-      enrollResp=$(curl ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys/$apikeyId \
+      echo "Enroll Agent"
+      enrollResp=$(curl -sS ${KIBANA_HOST:-http://localhost:5601}/api/fleet/enrollment-api-keys/$apikeyId \
         -H 'Content-Type: application/json' \
         -H 'kbn-xsrf: true' \
         -u ${KIBANA_USERNAME:-elastic}:${KIBANA_PASSWORD:-changeme} )
+      echo ""
 
       exitCode=$?
       if [ $exitCode -ne 0 ]; then
@@ -52,7 +67,7 @@ function enroll(){
 
       apikey=$(echo $enrollResp | jq -r '.item.api_key')
     fi
-    echo $apikey
+    log $apikey
 
     if [[ -n "${FLEET_ENROLL_INSECURE}" ]] && [[ ${FLEET_ENROLL_INSECURE} == 1 ]]; then
       insecure_flag="--insecure"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
* It removes the curl output from the Docker container logs
* It removes API Key and enroll response from Docker container logs, it is possible to set the environment variable `DEBUG=1`to see these messages.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
The curl downloading output is not shown correctly on logs, it does not apport value. The API key and the enroll response is sensible information so we should remove it from the logs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
