### PR TITLE
Cherry-pick #22892 to 7.x: [Filebeat][Cisco] Fix umbrella config: add input var

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -238,6 +238,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix handing missing eventtime and assignip field being set to N/A for fortinet module. {pull}22361[22361]
 - Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines. {pull}22377[22377]
 - Drop aws.vpcflow.pkt_srcaddr and aws.vpcflow.pkt_dstaddr when equal to "-". {pull}22721[22721] {issue}22716[22716]
+- Fix cisco umbrella module config by adding input variable. {pull}22892[22892]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/umbrella/manifest.yml
+++ b/x-pack/filebeat/module/cisco/umbrella/manifest.yml
@@ -7,6 +7,8 @@ var:
     default: 300
   - name: api_timeout
     default: 120
+  - name: input
+    default: s3
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml


### PR DESCRIPTION
Cherry-pick of PR #22892 to 7.x branch. Original message: 

## What does this PR do?

Adds input var to cisco umbrella config

## Why is it important?

Config expects `input` variable to be either `s3` or `file` but none is provided, breaking the default config.

The error we get is:
`Exiting: Error getting config for fileset cisco/umbrella: Error interpreting the template of the input: template: text:1:9: executing "text" at <.input>: map has no entry for key "input"`

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

