### PR TITLE
Fix section header in traefik docs

### DIFF
--- a/metricbeat/docs/modules/traefik.asciidoc
+++ b/metricbeat/docs/modules/traefik.asciidoc
@@ -8,6 +8,7 @@ This file is generated! See scripts/mage/docs_collector.go
 This module periodically fetches metrics from a https://traefik.io/[Traefik]
 instance. The Traefik instance must be configured to expose it's HTTP API.
 
+[float]
 === Compatibility
 
 The Traefik metricsets were tested with Traefik 1.6.

--- a/metricbeat/module/traefik/_meta/docs.asciidoc
+++ b/metricbeat/module/traefik/_meta/docs.asciidoc
@@ -1,6 +1,7 @@
 This module periodically fetches metrics from a https://traefik.io/[Traefik]
 instance. The Traefik instance must be configured to expose it's HTTP API.
 
+[float]
 === Compatibility
 
 The Traefik metricsets were tested with Traefik 1.6.


### PR DESCRIPTION
Add `[float]` tag to Compatibility section so it is not rendered as a separated page, for consistency with the rest of modules.