### PR TITLE
fix: align default metrics_path with the sample appplication

### DIFF
--- a/metricbeat/docs/modules/dropwizard.asciidoc
+++ b/metricbeat/docs/modules/dropwizard.asciidoc
@@ -26,7 +26,7 @@ metricbeat.modules:
   metricsets: ["collector"]
   period: 10s
   hosts: ["localhost:8080"]
-  metrics_path: /metrics/metrics
+  metrics_path: /test/metrics
   namespace: example
   enabled: true
 ----

--- a/metricbeat/module/dropwizard/_meta/config.reference.yml
+++ b/metricbeat/module/dropwizard/_meta/config.reference.yml
@@ -2,6 +2,6 @@
   metricsets: ["collector"]
   period: 10s
   hosts: ["localhost:8080"]
-  metrics_path: /metrics/metrics
+  metrics_path: /test/metrics
   namespace: example
   enabled: true

--- a/metricbeat/module/dropwizard/_meta/config.yml
+++ b/metricbeat/module/dropwizard/_meta/config.yml
@@ -3,7 +3,7 @@
   #  - collector
   period: 10s
   hosts: ["localhost:8080"]
-  metrics_path: /metrics/metrics
+  metrics_path: /test/metrics
   namespace: example
   #username: "user"
   #password: "secret"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
It aligns the configuration for dropwizard, updating the metrics_path using test appplication's web context path.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Running integrations-ci/dropwizard and a default metricbeat configured following config.yml/cconfig.reference.yml, it fails with HTTP 404 because the /metrics endpoint is not found. With this change, the configuration and the application path is aligned.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing elastic/e2e-testing#507



<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->