### PR TITLE
[Winlogbeat] protect against accessing undefined variable in security module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -460,6 +460,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fields from Winlogbeat modules were not being included in index templates and patterns. {pull}18983[18983]
 - Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
+- Protect against accessing an undefined variable in Security module.
 
 *Functionbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -460,7 +460,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fields from Winlogbeat modules were not being included in index templates and patterns. {pull}18983[18983]
 - Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
-- Protect against accessing an undefined variable in Security module.
+- Protect against accessing an undefined variable in Security module. {pull}22937[22937]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -1519,11 +1519,13 @@ var security = (function () {
         })
         .Add(function(evt) {
             var user = evt.Get("winlog.event_data.TargetUserName");
-            if (/.@*/.test(user)) {
-                user = user.split('@')[0];
-                evt.Put('user.name', user);
+            if (user) {
+                if (/.@*/.test(user)) {
+                    user = user.split('@')[0];
+                    evt.Put('user.name', user);
+                }
+                evt.AppendTo('related.user', user);
             }
-            evt.AppendTo('related.user', user);
         })
         .Build();
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This pull request protects against trying to use string functions against a variable which is undefined. This has already been done for two other variables, but not this one:

logonSuccess 

https://github.com/elastic/beats/blob/8369eff1c4d75fd164a8b171f1f2481c1a13932b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js#L1689-L1704


event4648 

https://github.com/elastic/beats/blob/8369eff1c4d75fd164a8b171f1f2481c1a13932b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js#L1707-L1721


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

In some environments, as much as 99% of some events are showing this error (particularly with event id 4625)

```
TypeError: Cannot read property 'split' of undefined at c:\Program Files\winlogbeat-7.10.0/module/security/config/winlogbeat-security.js:1522:24(16)
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
 ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
 ~~[ ] I have made corresponding changes to the documentation~~
 ~~[ ] I have made corresponding change to the default configuration files~~
 ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```
go test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

Similar work was recently done for the Sysmon module: https://github.com/elastic/beats/pull/22236 https://github.com/elastic/beats/issues/22219 



## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
