### PR TITLE
Cherry-pick #21727 to 7.x: Add json body check for sqs message

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -216,6 +216,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix checkpoint module when logs contain time field. {pull}20567[20567]
 - Add field limit check for AWS Cloudtrail flattened fields. {pull}21388[21388] {issue}21382[21382]
 - Fix syslog RFC 5424 parsing in the CheckPoint module. {pull}21854[21854]
+- Add json body check for sqs message. {pull}21727[21727]
 - Fix incorrect connection state mapping in zeek connection pipeline. {pull}22151[22151] {issue}22149[22149]
 - Fix Zeek dashboard reference to `zeek.ssl.server.name` field. {pull}21696[21696]
 - Fix handing missing eventtime and assignip field being set to N/A for fortinet module. {pull}22361[22361]

--- a/x-pack/filebeat/input/s3/collector.go
+++ b/x-pack/filebeat/input/s3/collector.go
@@ -238,10 +238,15 @@ func getRegionFromQueueURL(queueURL string) (string, error) {
 
 // handle message
 func (c *s3Collector) handleSQSMessage(m sqs.Message) ([]s3Info, error) {
-	msg := sqsMessage{}
+	var msg sqsMessage
 	err := json.Unmarshal([]byte(*m.Body), &msg)
 	if err != nil {
-		return nil, fmt.Errorf("json unmarshal sqs message body failed: %w", err)
+		c.logger.Debug("sqs message body = ", *m.Body)
+		if jsonError, ok := err.(*json.SyntaxError); ok {
+			return nil, fmt.Errorf("json unmarshal sqs message body failed at offset %d with syntax error: %w", jsonError.Offset, err)
+		} else {
+			return nil, fmt.Errorf("json unmarshal sqs message body failed: %w", err)
+		}
 	}
 
 	var s3Infos []s3Info


### PR DESCRIPTION
Cherry-pick of PR #21727 to 7.x branch. Original message: 

## What does this PR do?

I suspect sometimes AWS SQS message is not an invalid JSON format. This PR is to add check on it and improving error message for better debugging.

For example:
```
2020-08-26T10:05:10.780Z        ERROR   [s3]    s3/input.go:257 handleSQSMessage failed: json unmarshal sqs message body failed: invalid character 'e' in literal true (expecting 'r')
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Relates https://github.com/elastic/beats/issues/21726