### PR TITLE
Cherry-pick #22733 to 7.x: Collect OneMineRate metrics in Kafka module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -290,6 +290,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix failiures caused by custom beat names with more than 15 characters {pull}22550[22550]
 - Stop generating NaN values from Cloud Foundry module to avoid errors in outputs. {pull}22634[22634]
 - Update NATS dashboards to leverage connection and route metricsets {pull}22646[22646]
+- Fix rate metrics in Kafka broker metricset by using last minute rate instead of mean rate. {pull}22733[22733]
 - Fix `logstash` module when `xpack.enabled: true` is set from emitting redundant events. {pull}22808[22808]
 
 *Packetbeat*

--- a/metricbeat/module/kafka/broker/manifest.yml
+++ b/metricbeat/module/kafka/broker/manifest.yml
@@ -11,81 +11,81 @@ input:
         attributes:
           - attr: Value
             field: request.channel.queue.size
-      - mbean: 'kafka.server:name=FailedProduceRequestsPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: request.produce.failed_per_second
-      - mbean: 'kafka.server:name=FailedFetchRequestsPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: request.fetch.failed_per_second
-      - mbean: 'kafka.server:name=FailedProduceRequestsPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: request.produce.failed
-      - mbean: 'kafka.server:name=FailedFetchRequestsPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: request.fetch.failed
-      - mbean: 'kafka.controller:name=LeaderElectionRateAndTimeMs,type=ControllerStats'
+      - mbean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: replication.leader_elections
       - mbean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: replication.unclean_leader_elections
-      - mbean: 'kafka.server:name=ZooKeeperDisconnectsPerSec,type=SessionExpireListener'
+      - mbean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperDisconnectsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: session.zookeeper.disconnect
-      - mbean: 'kafka.server:name=ZooKeeperExpiresPerSec,type=SessionExpireListener'
+      - mbean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperExpiresPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: session.zookeeper.expire
-      - mbean: 'kafka.server:name=ZooKeeperReadOnlyConnectsPerSec,type=SessionExpireListener'
+      - mbean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperReadOnlyConnectsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: session.zookeeper.readonly
-      - mbean: 'kafka.server:name=ZooKeeperSyncConnectsPerSec,type=SessionExpireListener'
+      - mbean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperSyncConnectsPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: session.zookeeper.sync
       - mbean: 'kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: log.flush_rate
-      - mbean: 'kafka.server:name=BytesRejectedPerSec,topic=*,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=*'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: topic.net.rejected.bytes_per_sec
-      - mbean: 'kafka.server:name=BytesInPerSec,topic=*,type=BrokerTopicMetrics,topic=*'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=*'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: topic.net.in.bytes_per_sec
-      - mbean: 'kafka.server:name=BytesOutPerSec,topic=*,type=BrokerTopicMetrics,topic=*'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=*'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: topic.net.out.bytes_per_sec
-      - mbean: 'kafka.server:type=BrokerTopicMetrics,topic=*,name=MessagesInPerSec,topic=*'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=*'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: topic.messages_in
-      - mbean: 'kafka.server:name=BytesRejectedPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: net.rejected.bytes_per_sec
-      - mbean: 'kafka.server:name=BytesInPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: net.in.bytes_per_sec
-      - mbean: 'kafka.server:name=BytesOutPerSec,type=BrokerTopicMetrics'
+      - mbean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: net.out.bytes_per_sec
       - mbean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec'
         attributes:
-          - attr: MeanRate
+          - attr: OneMinuteRate
             field: messages_in
 
 


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#22733 to 7.x branch. Original message: 

- Bug

## What does this PR do?

Collect OneMinuteRate metrics in Kafka broker metricset instead of MeanRate

## Why is it important?

MeanRate is rate an average rate since Kafka startup.
In short it doesn't mean anything and doesn't shown Kafka current state.

## Checklist

- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Related issues

- Closes elastic/beats#17295 

## Use cases

Kafka monitoring