### PR TITLE
[Filebeat] Fix dissect pattern for Cisco WebVPN message 716002

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -344,6 +344,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines. {pull}22377[22377]
 - Drop aws.vpcflow.pkt_srcaddr and aws.vpcflow.pkt_dstaddr when equal to "-". {pull}22721[22721] {issue}22716[22716]
 - Fix cisco umbrella module config by adding input variable. {pull}22892[22892]
+- Fix Cisco ASA/FTD module's parsing of WebVPN log message 716002. {pull}22966[22966]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log
@@ -66,4 +66,5 @@ Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 91.240.17.178, IP = 91.240.17.178,
 Apr 27 02:03:03 dev01: %ASA-4-113019: Group = 91.240.17.178, Username = 91.240.17.178, IP = 91.240.17.178, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested
 Apr 27 02:03:03 dev01: %ASA-4-722051: Group some-policy User testuser IP 8.8.8.8 IPv4 Address 8.8.4.4 IPv6 address 2001:4860:4860::8888 assigned to session
 Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.
+Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.
 Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 104.46.88.19/6370 to outside:195.74.114.34/23

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
@@ -3056,6 +3056,7 @@
         "event.kind": "event",
         "event.module": "cisco",
         "event.original": "%ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.",
+        "event.reason": "User Requested.",
         "event.severity": 6,
         "event.timezone": "-02:00",
         "event.type": [
@@ -3103,6 +3104,7 @@
         "event.kind": "event",
         "event.module": "cisco",
         "event.original": "%ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.",
+        "event.reason": "Idle timeout.",
         "event.severity": 6,
         "event.timezone": "-02:00",
         "event.type": [

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
@@ -3093,6 +3093,46 @@
         ]
     },
     {
+        "cisco.asa.message_id": "716002",
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 716002,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info"
+        ],
+        "fileset.name": "asa",
+        "host.hostname": "dev01",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 9810,
+        "observer.hostname": "dev01",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.hosts": [
+            "dev01"
+        ],
+        "related.ip": [
+            "192.168.50.1"
+        ],
+        "service.type": "cisco",
+        "source.address": "192.168.50.1",
+        "source.ip": "192.168.50.1",
+        "source.user.name": "alice",
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "710003",
         "destination.address": "195.74.114.34",
@@ -3126,7 +3166,7 @@
         "host.hostname": "dev01",
         "input.type": "log",
         "log.level": "error",
-        "log.offset": 9810,
+        "log.offset": 9937,
         "network.iana_number": 6,
         "network.transport": "tcp",
         "observer.hostname": "dev01",

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -546,7 +546,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '716002'"
       field: "message"
-      pattern: "Group %{} User %{source.user.name} IP %{source.address} WebVPN session terminated: User Requested."
+      pattern: "Group %{} User %{source.user.name} IP %{source.address} WebVPN session terminated: %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '722051'"
       field: "message"

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -546,7 +546,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '716002'"
       field: "message"
-      pattern: "Group %{} User %{source.user.name} IP %{source.address} WebVPN session terminated: %{}"
+      pattern: "Group %{} User %{source.user.name} IP %{source.address} WebVPN session terminated: %{event.reason}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '722051'"
       field: "message"


### PR DESCRIPTION

## What does this PR do?

The message can contain one of several session termination reasons so don't hardcode "User requested" into the pattern.

Reference: https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs8.html#con_4776918

## Why is it important?

The module was failing to parse some WebVPN log messages.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

