### PR TITLE
[Filebeat] improve logic for network.direction in sophos xg fileset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -733,6 +733,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve Nats filebeat dashboard. {pull}22726[22726]
 - Add support for UNIX datagram sockets in `unix` input. {issues}18632[18632] {pull}22699[22699]
 - Add new httpjson input features and mark old config ones for deprecation {pull}22320[22320]
+- Add logic for external network.direction in sophos xg fileset {pull}XXXXX[XXXXX]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -733,7 +733,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve Nats filebeat dashboard. {pull}22726[22726]
 - Add support for UNIX datagram sockets in `unix` input. {issues}18632[18632] {pull}22699[22699]
 - Add new httpjson input features and mark old config ones for deprecation {pull}22320[22320]
-- Add logic for external network.direction in sophos xg fileset {pull}XXXXX[XXXXX]
+- Add logic for external network.direction in sophos xg fileset {pull}22973[22973]
 
 *Heartbeat*
 
@@ -913,7 +913,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 ==== Known Issue
 
 *Journalbeat*
-
 
 
 

--- a/x-pack/filebeat/module/sophos/xg/ingest/firewall.yml
+++ b/x-pack/filebeat/module/sophos/xg/ingest/firewall.yml
@@ -390,6 +390,10 @@ processors:
     field: network.direction
     value: internal
     if: "['LAN', 'DMZ', 'VPN', 'WiFi'].contains(ctx?.observer?.ingress?.zone) && ['LAN', 'DMZ', 'VPN', 'WiFi'].contains(ctx?.observer?.egress?.zone)"
+- set:
+    field: network.direction
+    value: external
+    if: "ctx?.observer?.ingress?.zone == 'WAN' && ctx?.observer?.egress?.zone == 'WAN'"
 
 #########################
 ## ECS Related Mapping ##


### PR DESCRIPTION
## What does this PR do?

sets network.direction to "external" when traffic src and dst are in 'WAN' zone

## Why is it important?

data accuracy

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` bash
TESTING_FILEBEAT_MODULES=sophos TESTING_FILEBEAT_FILESETS=xg mage -v pythonIntegTest
```

## Related issues

- Relates #21674