### PR TITLE
[Ingest Management] Fixed parsing of npipe URI

### DIFF
--- a/libbeat/api/npipe/listener_windows.go
+++ b/libbeat/api/npipe/listener_windows.go
@@ -98,5 +98,14 @@ func DefaultSD(forUser string) (string, error) {
 	// String definition: https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
 	// Give generic read/write access to the specified user.
 	descriptor := "D:P(A;;GA;;;" + u.Uid + ")"
+	if u.Username == "NT AUTHORITY\\SYSTEM" {
+		// running as SYSTEM, include Administrators group so Administrators can talk over
+		// the named pipe to the running Elastic Agent system process
+		admin, err := user.LookupGroup("Administrators")
+		if err != nil {
+			return "", errors.Wrap(err, "failed to lookup Administrators group")
+		}
+		descriptor += "(A;;GA;;;" + admin.Gid + ")"
+	}
 	return descriptor, nil
 }

--- a/metricbeat/mb/parse/url_test.go
+++ b/metricbeat/mb/parse/url_test.go
@@ -121,6 +121,21 @@ func TestParseURL(t *testing.T) {
 		}
 	})
 
+	t.Run("http+npipe short with", func(t *testing.T) {
+		rawURL := "http+npipe:///custom"
+		hostData, err := ParseURL(rawURL, "http", "", "", "apath", "")
+		if assert.NoError(t, err) {
+			transport, ok := hostData.Transport.(*dialer.NpipeDialerBuilder)
+			assert.True(t, ok)
+			assert.Equal(t, `\\.\pipe\custom`, transport.Path)
+			assert.Equal(t, "http://npipe/apath", hostData.URI)
+			assert.Equal(t, "http://npipe/apath", hostData.SanitizedURI)
+			assert.Equal(t, "npipe", hostData.Host)
+			assert.Equal(t, "", hostData.User)
+			assert.Equal(t, "", hostData.Password)
+		}
+	})
+
 	t.Run("npipe", func(t *testing.T) {
 		rawURL := "npipe://./pipe/docker_engine"
 		hostData, err := ParseURL(rawURL, "tcp", "", "", "", "")

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -27,6 +27,7 @@
 - Fix deb/rpm packaging for Elastic Agent {pull}22153[22153]
 - Fix composable input processor promotion to fix duplicates {pull}22344[22344]
 - Fix sysv init files for deb/rpm installation {pull}22543[22543]
+- Fixed parsing of npipe URI {pull}22978[22978]
 
 ==== New features
 


### PR DESCRIPTION
## What does this PR do?

Fixed parsing of `http+npipe` uris used by agent. 

## Why is it important?

Fixes: #22957 
Blocking: #22394

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
