### PR TITLE
Cherry-pick #22815 to 7.x:  Push log level downstream 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -52,3 +52,4 @@
 - Add `priority` to `AddOrUpdate` on dynamic composable input providers communication channel {pull}22352[22352]
 - Ship `endpoint-security` logs to elasticsearch {pull}22526[22526]
 - Log level reloadable from fleet {pull}22690[22690]
+- Push log level downstream {pull}22815[22815]

--- a/x-pack/elastic-agent/pkg/agent/application/fleet_decorator.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_decorator.go
@@ -9,13 +9,20 @@ import (
 
 	"github.com/elastic/go-sysinfo/types"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/transpiler"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
-func injectFleet(cfg *config.Config, hostInfo types.HostInfo) func(*logger.Logger, *transpiler.AST) error {
+func injectFleet(cfg *config.Config, hostInfo types.HostInfo, agentInfo *info.AgentInfo) func(*logger.Logger, *transpiler.AST) error {
 	return func(logger *logger.Logger, rootAst *transpiler.AST) error {
+		ecsMeta, err := agentInfo.ECSMetadata()
+		if err != nil {
+			return err
+		}
+		logLevel := ecsMeta.Elastic.Agent.LogLevel
+
 		config, err := cfg.ToMapStr()
 		if err != nil {
 			return err
@@ -37,6 +44,10 @@ func injectFleet(cfg *config.Config, hostInfo types.HostInfo) func(*logger.Logge
 		agent, ok := transpiler.Lookup(ast, "agent")
 		if !ok {
 			return fmt.Errorf("failed to get agent key from fleet config")
+		}
+
+		if _, found := transpiler.Lookup(ast, "agent.logging.level"); !found {
+			transpiler.Insert(ast, transpiler.NewKey("level", transpiler.NewStrVal(logLevel)), "agent.logging")
 		}
 
 		host := transpiler.NewKey("host", transpiler.NewDict([]transpiler.Node{

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -173,7 +173,7 @@ func newManaged(
 		router,
 		&configModifiers{
 			Decorators: []decoratorFunc{injectMonitoring},
-			Filters:    []filterFunc{filters.StreamChecker, injectFleet(config, sysInfo.Info())},
+			Filters:    []filterFunc{filters.StreamChecker, injectFleet(config, sysInfo.Info(), agentInfo)},
 		},
 		monitor,
 	)


### PR DESCRIPTION
Cherry-pick of PR #22815 to 7.x branch. Original message:

## What does this PR do?

This PR injects log level settings into fleet section of config as discussed in linked issue. 
resulting config will look like this
```
fleet:
  agent:
    id: {agent_id}
    logging:
      level: warning
  api:
    access_api_key: {agent_api_key}
    kibana:
      host: {host_uri}:443
      hosts:
      - {host_uri}
      protocol: https
      timeout: 5m0s
  host:
    id: {host_id}
inputs:
- artifact_manifest:
    artifacts:
      endpoint-exceptionlist-macos-v1:
...so on
```

## Why is it important?

#20756

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @ph @ferullo 