### PR TITLE
[Ingest Manager] Align logging with ECS

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -217,6 +217,14 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 						},
 					},
 				},
+				{
+					"drop_fields": map[string]interface{}{
+						"fields": []string{
+							"ecs.version", //coming from logger, already added by libbeat
+						},
+						"ignore_missing": true,
+					},
+				},
 			},
 		},
 	}
@@ -259,6 +267,14 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 								"version":  o.agentInfo.Version(),
 								"snapshot": o.agentInfo.Snapshot(),
 							},
+						},
+					},
+					{
+						"drop_fields": map[string]interface{}{
+							"fields": []string{
+								"ecs.version", //coming from logger, already added by libbeat
+							},
+							"ignore_missing": true,
 						},
 					},
 				},

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
@@ -114,6 +114,7 @@ func (b *Monitor) EnrichArgs(spec program.Spec, pipelineID string, args []string
 		logFile = fmt.Sprintf("%s-json.log", logFile)
 		appendix = append(appendix,
 			"-E", "logging.json=true",
+			"-E", "logging.ecs=true",
 			"-E", "logging.files.path="+loggingPath,
 			"-E", "logging.files.name="+logFile,
 			"-E", "logging.files.keepfiles=7",


### PR DESCRIPTION
## What does this PR do?

This PR enables ECS loggin back so `log.level` is reported correctly.
On top of that it drops `ecs.version` as `ecs.version` is already added by libbeat (to deal with #21616)

Without drop events contains two ecs version fields one composed another one not e.g
```json
"ecs.version": "1.6.0",
"ecs": {
  "version": "1.6.0",
}
```

## Why is it important?

Fixes: #22858 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
