### PR TITLE
[Winlogbeat] Add configuration category and more security events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -888,7 +888,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add new winlogbeat security dashboard {pull}18775[18775]
 - Add `event.outcome` to events based on the audit success and audit failure keywords. {pull}20564[20564]
 - Add file.pe and process.pe fields to ProcessCreate & LoadImage events in Sysmon module. {issue}17335[17335] {pull}22217[22217]
-- Add additional event categorization for security and sysmon modules. {pull}
+- Add additional event categorization for security and sysmon modules. {pull}22988[22988]
 
 *Elastic Log Driver*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -888,6 +888,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add new winlogbeat security dashboard {pull}18775[18775]
 - Add `event.outcome` to events based on the audit success and audit failure keywords. {pull}20564[20564]
 - Add file.pe and process.pe fields to ProcessCreate & LoadImage events in Sysmon module. {issue}17335[17335] {pull}22217[22217]
+- Add additional event categorization for security and sysmon modules. {pull}
 
 *Elastic Log Driver*
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -259,8 +259,8 @@ var security = (function () {
         "5024": [["process"], ["start"], "windows-firewall-service-started"],
         "5025": [["process"], ["end"], "windows-firewall-service-stopped"],
         "5033": [["driver"], ["start"], "windows-firewall-driver-started"],
-        "5034": [["driver"], ["end"], "windows-firewall-service-stopped"],
-        "5037": [["driver"], ["end"], "windows-firewall-service-error"],
+        "5034": [["driver"], ["end"], "windows-firewall-driver-stopped"],
+        "5037": [["driver"], ["end"], "windows-firewall-driver-error"],
     };
 
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -164,82 +164,103 @@ var security = (function () {
 
     // event.category, event.type, event.action
     var eventActionTypes = {
-        "1100": ["process","end","logging-service-shutdown"],
-        "1102": ["iam", "admin", "audit-log-cleared"],
-        "1104": ["iam","admin","logging-full"],
-        "1105": ["iam","admin","auditlog-archieved"],
-        "1108": ["iam","admin","logging-processing-error"],
-        "4624": ["authentication","start","logged-in"],
-        "4625": ["authentication","start","logon-failed"],
-        "4634": ["authentication","end","logged-out"],
-        "4647": ["authentication","end","logged-out"],
-        "4648": ["authentication","start","logged-in-explicit"],
-        "4672": ["iam","admin","logged-in-special"],
-        "4673": ["iam","admin","privileged-service-called"],
-        "4674": ["iam","admin","privileged-operation"],
-        "4688": ["process","start","created-process"],
-        "4689": ["process", "end", "exited-process"],
-        "4697": ["iam","admin","service-installed"],
-        "4698": ["iam","creation","scheduled-task-created"],
-        "4699": ["iam","deletion","scheduled-task-deleted"],
-        "4700": ["iam","change","scheduled-task-enabled"],
-        "4701": ["iam","change","scheduled-task-disabled"],
-        "4702": ["iam","change","scheduled-task-updated"],
-        "4719": ["iam","admin","changed-audit-config"],
-        "4720": ["iam","creation","added-user-account"],
-        "4722": ["iam","creation","enabled-user-account"],
-        "4723": ["iam","change","changed-password"],
-        "4724": ["iam","change","reset-password"],
-        "4725": ["iam","deletion","disabled-user-account"],
-        "4726": ["iam","deletion","deleted-user-account"],
-        "4727": ["iam","creation","added-group-account"],
-        "4728": ["iam","change","added-member-to-group"],
-        "4729": ["iam","change","removed-member-from-group"],
-        "4730": ["iam","deletion","deleted-group-account"],
-        "4731": ["iam","creation","added-group-account"],
-        "4732": ["iam","change","added-member-to-group"],
-        "4733": ["iam","change","removed-member-from-group"],
-        "4734": ["iam","deletion","deleted-group-account"],
-        "4735": ["iam","change","modified-group-account"],
-        "4737": ["iam","change","modified-group-account"],
-        "4738": ["iam","change","modified-user-account"],
-        "4740": ["iam","change","locked-out-user-account"],
-        "4741": ["iam","creation","added-computer-account"],
-        "4742": ["iam","change","changed-computer-account"],
-        "4743": ["iam","deletion","deleted-computer-account"],
-        "4744": ["iam","creation","added-distribution-group-account"],
-        "4745": ["iam","change","changed-distribution-group-account"],
-        "4746": ["iam","change","added-member-to-distribution-group"],
-        "4747": ["iam","change","removed-member-from-distribution-group"],
-        "4748": ["iam","deletion","deleted-distribution-group-account"],
-        "4749": ["iam","creation","added-distribution-group-account"],
-        "4750": ["iam","change","changed-distribution-group-account"],
-        "4751": ["iam","change","added-member-to-distribution-group"],
-        "4752": ["iam","change","removed-member-from-distribution-group"],
-        "4753": ["iam","deletion","deleted-distribution-group-account"],
-        "4754": ["iam","creation","added-group-account"],
-        "4755": ["iam","change","modified-group-account"],
-        "4756": ["iam","change","added-member-to-group"],
-        "4757": ["iam","change","removed-member-from-group"],
-        "4758": ["iam","deletion","deleted-group-account"],
-        "4759": ["iam","creation","added-distribution-group-account"],
-        "4760": ["iam","change","changed-distribution-group-account"],
-        "4761": ["iam","change","added-member-to-distribution-group"],
-        "4762": ["iam","change","removed-member-from-distribution-group"],
-        "4763": ["iam","deletion","deleted-distribution-group-account"],
-        "4764": ["iam","change","type-changed-group-account"],
-        "4767": ["iam","change","unlocked-user-account"],
-        "4768": ["authentication","start","kerberos-authentication-ticket-requested"],
-        "4769": ["authentication","start","kerberos-service-ticket-requested"],
-        "4770": ["authentication","start","kerberos-service-ticket-renewed"],
-        "4771": ["authentication","start","kerberos-preauth-failed"],
-        "4776": ["authentication","start","credential-validated"],
-        "4778": ["authentication","start","session-reconnected"],
-        "4779": ["authentication","end","session-disconnected"],
-        "4781": ["iam","change","renamed-user-account","dummy"],
-        "4798": ["iam","info","group-membership-enumerated"],
-        "4799": ["iam","info","user-member-enumerated","dummy"],
-        "4964": ["iam","admin","logged-in-special"],
+        "1100": [["process"], ["end"], "logging-service-shutdown"],
+        "1102": [["iam"], ["admin", "change"], "audit-log-cleared"], // need to recategorize
+        "1104": [["iam"], ["admin"],"logging-full"],
+        "1105": [["iam"], ["admin"],"auditlog-archieved"],
+        "1108": [["iam"], ["admin"],"logging-processing-error"],
+        "4610": [["configuration"], ["access"], "authentication-package-loaded"],
+        "4611": [["configuration"], ["change"], "trusted-logon-process-registered"],
+        "4614": [["configuration"], ["access"], "notification-package-loaded"],
+        "4616": [["configuration"], ["change"], "system-time-changed"],
+        "4622": [["configuration"], ["access"], "security-package-loaded"],
+        "4624": [["authentication"], ["start"], "logged-in"],
+        "4625": [["authentication"], ["start"], "logon-failed"],
+        "4634": [["authentication"], ["end"], "logged-out"],
+        "4647": [["authentication"], ["end"], "logged-out"],
+        "4648": [["authentication"], ["start"], "logged-in-explicit"],
+        "4657": [["configuration"], ["change"], "registry-value-modified"],
+        "4672": [["iam"], ["admin"], "logged-in-special"],
+        "4673": [["iam"], ["admin"], "privileged-service-called"],
+        "4674": [["iam"], ["admin"], "privileged-operation"],
+        "4688": [["process"], ["start"], "created-process"],
+        "4689": [["process"], ["end"], "exited-process"],
+        "4697": [["iam", "configuration"], ["admin", "change"],"service-installed"], // remove iam and admin
+        "4698": [["iam", "configuration"], ["creation", "admin"], "scheduled-task-created"], // remove iam and admin
+        "4699": [["iam", "configuration"], ["deletion", "admin"], "scheduled-task-deleted"], // remove iam and admin
+        "4700": [["iam", "configuration"], ["change", "admin"], "scheduled-task-enabled"], // remove iam and admin
+        "4701": [["iam", "configuration"], ["change", "admin"], "scheduled-task-disabled"], // remove iam and admin
+        "4702": [["iam", "configuration"], ["change", "admin"], "scheduled-task-updated"], // remove iam and admin
+        "4706": [["configuration"], ["creation"], "domain-trust-added"],
+        "4707": [["configuration"], ["deletion"], "domain-trust-removed"],
+        "4713": [["configuration"], ["change"], "kerberos-policy-changed"],
+        "4714": [["configuration"], ["change"], "encrypted-data-recovery-policy-changed"],
+        "4715": [["configuration"], ["change"], "object-audit-policy-changed"],
+        "4716": [["configuration"], ["change"], "trusted-domain-information-changed"],
+        "4719": [["iam", "configuration"], ["admin", "change"], "changed-audit-config"], // remove iam and admin
+        "4720": [["iam"], ["user", "creation"], "added-user-account"],
+        "4722": [["iam"], ["user", "change"], "enabled-user-account"],
+        "4723": [["iam"], ["user", "change"], "changed-password"],
+        "4724": [["iam"], ["user", "change"], "reset-password"],
+        "4725": [["iam"], ["user", "deletion"], "disabled-user-account"],
+        "4726": [["iam"], ["user", "deletion"], "deleted-user-account"],
+        "4727": [["iam"], ["group", "creation"], "added-group-account"],
+        "4728": [["iam"], ["group", "change"], "added-member-to-group"],
+        "4729": [["iam"], ["group", "change"], "removed-member-from-group"],
+        "4730": [["iam"], ["group", "deletion"], "deleted-group-account"],
+        "4731": [["iam"], ["group", "creation"], "added-group-account"],
+        "4732": [["iam"], ["group", "change"], "added-member-to-group"],
+        "4733": [["iam"], ["group", "change"], "removed-member-from-group"],
+        "4734": [["iam"], ["group", "deletion"], "deleted-group-account"],
+        "4735": [["iam"], ["group", "change"], "modified-group-account"],
+        "4737": [["iam"], ["group", "change"], "modified-group-account"],
+        "4738": [["iam"], ["user", "change"], "modified-user-account"],
+        "4739": [["configuration"], ["change"], "domain-policy-changed"],
+        "4740": [["iam"], ["user", "change"], "locked-out-user-account"],
+        "4741": [["iam"], ["creation", "admin"], "added-computer-account"], // remove admin
+        "4742": [["iam"], ["change", "admin"], "changed-computer-account"], // remove admin
+        "4743": [["iam"], ["deletion", "admin"], "deleted-computer-account"], // remove admin
+        "4744": [["iam"], ["group", "creation"], "added-distribution-group-account"],
+        "4745": [["iam"], ["group", "change"], "changed-distribution-group-account"],
+        "4746": [["iam"], ["group", "change"], "added-member-to-distribution-group"],
+        "4747": [["iam"], ["group", "change"], "removed-member-from-distribution-group"],
+        "4748": [["iam"], ["group", "deletion"], "deleted-distribution-group-account"],
+        "4749": [["iam"], ["group", "creation"], "added-distribution-group-account"],
+        "4750": [["iam"], ["group", "change"], "changed-distribution-group-account"],
+        "4751": [["iam"], ["group", "change"], "added-member-to-distribution-group"],
+        "4752": [["iam"], ["group", "change"], "removed-member-from-distribution-group"],
+        "4753": [["iam"], ["group", "deletion"], "deleted-distribution-group-account"],
+        "4754": [["iam"], ["group", "creation"], "added-group-account"],
+        "4755": [["iam"], ["group", "change"], "modified-group-account"],
+        "4756": [["iam"], ["group", "change"], "added-member-to-group"],
+        "4757": [["iam"], ["group", "change"], "removed-member-from-group"],
+        "4758": [["iam"], ["group", "deletion"], "deleted-group-account"],
+        "4759": [["iam"], ["group", "creation"], "added-distribution-group-account"],
+        "4760": [["iam"], ["group", "change"], "changed-distribution-group-account"],
+        "4761": [["iam"], ["group", "change"], "added-member-to-distribution-group"],
+        "4762": [["iam"], ["group", "change"], "removed-member-from-distribution-group"],
+        "4763": [["iam"], ["group", "deletion"], "deleted-distribution-group-account"],
+        "4764": [["iam"], ["group", "change"], "type-changed-group-account"],
+        "4767": [["iam"], ["user", "change"], "unlocked-user-account"],
+        "4768": [["authentication"], ["start"], "kerberos-authentication-ticket-requested"],
+        "4769": [["authentication"], ["start"], "kerberos-service-ticket-requested"],
+        "4770": [["authentication"], ["start"], "kerberos-service-ticket-renewed"],
+        "4771": [["authentication"], ["start"], "kerberos-preauth-failed"],
+        "4776": [["authentication"], ["start"], "credential-validated"],
+        "4778": [["authentication"], ["start"], "session-reconnected"],
+        "4779": [["authentication"], ["end"], "session-disconnected"],
+        "4781": [["iam"], ["user", "change"], "renamed-user-account"],
+        "4798": [["iam"], ["user", "info"], "group-membership-enumerated"], // process enumerates the local groups to which the specified user belongs
+        "4799": [["iam"], ["group", "info"], "user-member-enumerated"], // a process enumerates the members of the specified local group
+        "4912": [["configuration"], ["change"], "per-user-audit-policy-changed"],
+        "4950": [["configuration"], ["change"], "windows-firewall-setting-changed"],
+        "4954": [["configuration"], ["change"], "windows-firewall-group-policy-changed"],
+        "4964": [["iam"], ["admin", "group"], "logged-in-special"],
+        "5024": [["process"], ["start"], "windows-firewall-service-started"],
+        "5025": [["process"], ["end"], "windows-firewall-service-stopped"],
+        "5033": [["driver"], ["start"], "windows-firewall-driver-started"],
+        "5034": [["driver"], ["end"], "windows-firewall-service-stopped"],
+        "5037": [["driver"], ["end"], "windows-firewall-service-error"],
     };
 
 
@@ -1348,8 +1369,8 @@ var security = (function () {
         }
         var eventActionDescription = eventActionTypes[code][2];
         if (eventActionDescription) {
-            evt.AppendTo("event.category", eventActionTypes[code][0]);
-            evt.AppendTo("event.type", eventActionTypes[code][1]);
+            evt.Put("event.category", eventActionTypes[code][0]);
+            evt.Put("event.type", eventActionTypes[code][1]);
             evt.Put("event.action", eventActionTypes[code][2]);
         }
     };
@@ -1771,9 +1792,6 @@ var security = (function () {
         .Add(renameCommonAuthFields)
         .Add(addServiceFields)
         .Add(addEventFields)
-        .Add(function(evt) {
-            evt.AppendTo("event.type", "change");
-        })
         .Build();
 
     var userMgmtEvts = new processor.Chain()
@@ -1785,7 +1803,6 @@ var security = (function () {
         .Add(function(evt) {
             var user = evt.Get("winlog.event_data.TargetUserName");
             evt.AppendTo('related.user', user);
-            evt.AppendTo("event.type", "user");
         })
         .Build();
 
@@ -1798,7 +1815,6 @@ var security = (function () {
             evt.AppendTo('related.user', userNew);
             var userOld = evt.Get("winlog.event_data.OldTargetUserName");
             evt.AppendTo('related.user', userOld);
-            evt.AppendTo("event.type", "user");
         })
         .Build();
 
@@ -1809,7 +1825,6 @@ var security = (function () {
         .Add(renameCommonAuthFields)
         .Add(addEventFields)
         .Add(function(evt) {
-            evt.AppendTo("event.type", "group");
             var member = evt.Get("winlog.event_data.MemberName");
             if (!member) {
                 return;
@@ -1824,9 +1839,6 @@ var security = (function () {
         .Add(copySubjectUserLogonIdFromUserData)
         .Add(renameCommonAuthFields)
         .Add(addEventFields)
-        .Add(function(evt) {
-            evt.AppendTo("event.type", "change");
-        })
         .Build();
 
     var auditChanged = new processor.Chain()
@@ -1835,9 +1847,6 @@ var security = (function () {
         .Add(renameCommonAuthFields)
         .Add(addAuditInfo)
         .Add(addEventFields)
-        .Add(function(evt) {
-            evt.AppendTo("event.type", "change");
-        })
         .Build();
 
     var auditLogMgmt = new processor.Chain()
@@ -1858,7 +1867,6 @@ var security = (function () {
                 return;
             }
             evt.Put("winlog.event_data.PrivilegeList", privs.split(/\s+/));
-            evt.AppendTo("event.type", "admin");
         })
         .Build();
 
@@ -1871,9 +1879,6 @@ var security = (function () {
         .Add(copyTargetUser)
         .Add(copyTargetUserLogonId)
         .Add(addEventFields)
-        .Add(function(evt) {
-            evt.AppendTo("event.type", "group");
-        })
         .Build();
 
     var kerberosTktEvts = new processor.Chain()
@@ -1901,9 +1906,6 @@ var security = (function () {
         .Add(copySubjectUser)
         .Add(copySubjectUserLogonId)
         .Add(addEventFields)
-        .Add(function(evt) {
-            evt.AppendTo("event.type", "admin");
-        })
         .Build();
 
     var sensitivePrivilege = new processor.Chain()

--- a/x-pack/winlogbeat/module/security/test/testdata/1100.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1100.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-11-07T10:37:04.2260925Z",
     "event": {
       "action": "logging-service-shutdown",
-      "category": "process",
+      "category": [
+        "process"
+      ],
       "code": 1100,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Eventlog",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "WIN-41OB2LO92CR.wlbeat.local"

--- a/x-pack/winlogbeat/module/security/test/testdata/1102.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1102.evtx.golden.json
@@ -3,7 +3,9 @@
     "@timestamp": "2019-11-07T10:34:29.0559196Z",
     "event": {
       "action": "audit-log-cleared",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 1102,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/1104.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1104.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-11-08T07:56:17.3217049Z",
     "event": {
       "action": "logging-full",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 1104,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Eventlog",
-      "type": "admin"
+      "type": [
+        "admin"
+      ]
     },
     "host": {
       "name": "WIN-41OB2LO92CR.wlbeat.local"

--- a/x-pack/winlogbeat/module/security/test/testdata/1105.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1105.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-11-07T16:22:14.8425353Z",
     "event": {
       "action": "auditlog-archieved",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 1105,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Eventlog",
-      "type": "admin"
+      "type": [
+        "admin"
+      ]
     },
     "host": {
       "name": "WIN-41OB2LO92CR.wlbeat.local"

--- a/x-pack/winlogbeat/module/security/test/testdata/4719.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4719.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2019-11-07T15:22:57.6553291Z",
     "event": {
       "action": "changed-audit-config",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4719,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/4741.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4741.evtx.golden.json
@@ -3,7 +3,9 @@
     "@timestamp": "2019-12-18T16:22:12.3112534Z",
     "event": {
       "action": "added-computer-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4741,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/4742.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4742.evtx.golden.json
@@ -3,7 +3,9 @@
     "@timestamp": "2019-12-18T16:22:12.3425087Z",
     "event": {
       "action": "changed-computer-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4742,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/4743.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4743.evtx.golden.json
@@ -3,7 +3,9 @@
     "@timestamp": "2019-12-18T16:25:21.5781833Z",
     "event": {
       "action": "deleted-computer-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4743,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/4744.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4744.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-18T16:26:46.8744233Z",
     "event": {
       "action": "added-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4744,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4745.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4745.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-18T16:29:05.0175739Z",
     "event": {
       "action": "changed-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4745,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4746.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4746.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-18T16:31:01.6117458Z",
     "event": {
       "action": "added-member-to-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4746,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4747.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4747.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-18T16:35:16.6816525Z",
     "event": {
       "action": "removed-member-from-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4747,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4748.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4748.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:01:45.9824133Z",
     "event": {
       "action": "deleted-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4748,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4749.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4749.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:03:42.7234679Z",
     "event": {
       "action": "added-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4749,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4750.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4750.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:10:57.4737631Z",
     "event": {
       "action": "changed-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4750,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4751.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4751.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:20:29.0889568Z",
     "event": {
       "action": "added-member-to-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4751,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4752.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4752.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:21:23.6444225Z",
     "event": {
       "action": "removed-member-from-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4752,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4753.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4753.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:24:36.5952761Z",
     "event": {
       "action": "deleted-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4753,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4759.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4759.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:26:26.1432582Z",
     "event": {
       "action": "added-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4759,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4760.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4760.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:28:21.0305977Z",
     "event": {
       "action": "changed-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4760,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4761.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4761.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:29:38.4487328Z",
     "event": {
       "action": "added-member-to-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4761,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4762.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4762.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:33:25.9678735Z",
     "event": {
       "action": "removed-member-from-distribution-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4762,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/4763.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4763.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-12-19T08:34:23.1623432Z",
     "event": {
       "action": "deleted-distribution-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4763,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4673.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4673.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-06T06:39:04.5491199Z",
     "event": {
       "action": "privileged-service-called",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4673,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "admin"
+      "type": [
+        "admin"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4674.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4674.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-06T06:38:31.1087891Z",
     "event": {
       "action": "privileged-operation",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4674,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "admin"
+      "type": [
+        "admin"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4697.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4697.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-02T14:34:08.8896056Z",
     "event": {
       "action": "service-installed",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4697,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4698.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4698.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-01T14:34:34.6061085Z",
     "event": {
       "action": "scheduled-task-created",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4698,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4699.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4699.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-01T14:35:47.822282Z",
     "event": {
       "action": "scheduled-task-deleted",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4699,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4700.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4700.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-01T14:35:14.8732455Z",
     "event": {
       "action": "scheduled-task-enabled",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4700,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4701.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4701.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-01T14:35:04.7030004Z",
     "event": {
       "action": "scheduled-task-disabled",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4701,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4702.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4702.evtx.golden.json
@@ -3,7 +3,10 @@
     "@timestamp": "2020-04-01T14:35:36.2637108Z",
     "event": {
       "action": "scheduled-task-updated",
-      "category": "iam",
+      "category": [
+        "iam",
+        "configuration"
+      ],
       "code": 4702,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-01T08:45:44.1717416Z",
     "event": {
       "action": "kerberos-authentication-ticket-requested",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4768,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-01T08:45:44.1717416Z",
     "event": {
       "action": "kerberos-service-ticket-requested",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4769,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-01T07:32:55.0104462Z",
     "event": {
       "action": "kerberos-service-ticket-renewed",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4770,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4771.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4771.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-03-31T07:50:27.1681182Z",
     "event": {
       "action": "kerberos-preauth-failed",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4771,
       "kind": "event",
       "module": "security",
       "outcome": "failure",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4776.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4776.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-01T08:45:42.1873153Z",
     "event": {
       "action": "credential-validated",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4776,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4778.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4778.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-05T16:33:32.3888253Z",
     "event": {
       "action": "session-reconnected",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4778,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2020-04-03T10:18:01.8822336Z",
     "event": {
       "action": "session-disconnected",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4779,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "DC_TEST2k12.TEST.SAAS"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-03-29T21:10:39.7868321Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -83,13 +87,17 @@
     "@timestamp": "2019-03-29T21:10:40.2555609Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -163,13 +171,17 @@
     "@timestamp": "2019-03-29T21:10:40.3805426Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -246,13 +258,17 @@
     "@timestamp": "2019-03-29T21:10:40.5055514Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -326,13 +342,17 @@
     "@timestamp": "2019-03-29T21:10:40.6305447Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -403,13 +423,17 @@
     "@timestamp": "2019-03-29T21:10:53.6617957Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -480,13 +504,17 @@
     "@timestamp": "2019-03-29T21:10:54.6618303Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -557,13 +585,17 @@
     "@timestamp": "2019-03-29T21:10:55.4587259Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -634,13 +666,17 @@
     "@timestamp": "2019-03-29T21:13:17.3025591Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -714,13 +750,17 @@
     "@timestamp": "2019-03-29T21:13:17.5213056Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -794,13 +834,17 @@
     "@timestamp": "2019-03-29T21:13:17.6149946Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -877,13 +921,17 @@
     "@timestamp": "2019-03-29T21:13:18.7869259Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -957,13 +1005,17 @@
     "@timestamp": "2019-03-29T21:20:48.7402309Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1037,13 +1089,17 @@
     "@timestamp": "2019-03-29T21:20:48.7402309Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1117,13 +1173,17 @@
     "@timestamp": "2019-03-29T21:20:50.5840151Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1197,13 +1257,17 @@
     "@timestamp": "2019-03-29T21:23:42.5201798Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1277,13 +1341,17 @@
     "@timestamp": "2019-03-29T21:26:24.1764267Z",
     "event": {
       "action": "logged-in",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4624,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -1357,13 +1425,17 @@
     "@timestamp": "2019-03-29T21:45:35.177054Z",
     "event": {
       "action": "logon-failed",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4625,
       "kind": "event",
       "module": "security",
       "outcome": "failure",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2018-05-18T23:09:03.2086661Z",
     "event": {
       "action": "logged-in-special",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4672,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "admin"
+      "type": [
+        "admin"
+      ]
     },
     "host": {
       "name": "vagrant-2016"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-05-17T11:06:58.210768Z",
     "event": {
       "action": "logged-out",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4634,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "WIN-41OB2LO92CR"
@@ -61,13 +65,17 @@
     "@timestamp": "2019-05-19T16:15:38.542273Z",
     "event": {
       "action": "logged-out",
-      "category": "authentication",
+      "category": [
+        "authentication"
+      ],
       "code": 4634,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "WIN-41OB2LO92CR"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:24:39.2933111Z",
     "event": {
       "action": "added-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4720,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "user"
+        "user",
+        "creation"
       ]
     },
     "host": {
@@ -96,15 +98,17 @@
     "@timestamp": "2019-09-06T13:25:21.8672707Z",
     "event": {
       "action": "added-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4720,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "user"
+        "user",
+        "creation"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:28:46.1631928Z",
     "event": {
       "action": "enabled-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4722,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {
@@ -69,15 +71,17 @@
     "@timestamp": "2019-09-06T13:29:08.5737904Z",
     "event": {
       "action": "enabled-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4722,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:32:13.8554125Z",
     "event": {
       "action": "changed-password",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4723,
       "kind": "event",
       "module": "security",
       "outcome": "failure",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {
@@ -67,15 +69,17 @@
     "@timestamp": "2019-09-06T13:32:23.8855201Z",
     "event": {
       "action": "changed-password",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4723,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:24:39.339071Z",
     "event": {
       "action": "reset-password",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4724,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {
@@ -69,15 +71,17 @@
     "@timestamp": "2019-09-06T13:25:21.9005914Z",
     "event": {
       "action": "reset-password",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4724,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:28:40.0015275Z",
     "event": {
       "action": "disabled-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4725,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "user"
+        "user",
+        "deletion"
       ]
     },
     "host": {
@@ -69,15 +71,17 @@
     "@timestamp": "2019-09-06T13:28:55.2644212Z",
     "event": {
       "action": "disabled-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4725,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "user"
+        "user",
+        "deletion"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:35:25.5153959Z",
     "event": {
       "action": "deleted-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4726,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "user"
+        "user",
+        "deletion"
       ]
     },
     "host": {
@@ -70,15 +72,17 @@
     "@timestamp": "2019-09-06T13:35:29.6900555Z",
     "event": {
       "action": "deleted-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4726,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "user"
+        "user",
+        "deletion"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4727.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4727.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:26:12.4955445Z",
     "event": {
       "action": "added-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4727,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4728.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4728.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:33:26.8613751Z",
     "event": {
       "action": "added-member-to-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4728,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4729.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4729.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:33:45.5433159Z",
     "event": {
       "action": "removed-member-from-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4729,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4730.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4730.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:34:01.6107262Z",
     "event": {
       "action": "deleted-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4730,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4731.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4731.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:29:49.3586766Z",
     "event": {
       "action": "added-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4731,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4732.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4732.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:31:58.0398598Z",
     "event": {
       "action": "added-member-to-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4732,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4733.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4733.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:32:14.8941288Z",
     "event": {
       "action": "removed-member-from-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4733,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4734.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4734.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:32:35.1274042Z",
     "event": {
       "action": "deleted-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4734,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4735.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4735.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:32:30.425487Z",
     "event": {
       "action": "modified-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4735,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4737.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4737.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:33:57.2710608Z",
     "event": {
       "action": "modified-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4737,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:36:17.5667652Z",
     "event": {
       "action": "modified-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4738,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {
@@ -95,15 +97,17 @@
     "@timestamp": "2019-09-06T13:36:36.3634107Z",
     "event": {
       "action": "modified-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4738,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:39:43.0856521Z",
     "event": {
       "action": "locked-out-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4740,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4754.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4754.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:34:33.783048Z",
     "event": {
       "action": "added-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4754,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "creation",
-        "group"
+        "group",
+        "creation"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4755.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4755.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:35:09.0701134Z",
     "event": {
       "action": "modified-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4755,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4756.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4756.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:34:58.4130288Z",
     "event": {
       "action": "added-member-to-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4756,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4757.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4757.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:35:09.0701919Z",
     "event": {
       "action": "removed-member-from-group",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4757,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4758.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4758.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:35:13.5502867Z",
     "event": {
       "action": "deleted-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4758,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "deletion",
-        "group"
+        "group",
+        "deletion"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4764.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4764.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-22T11:33:57.271141Z",
     "event": {
       "action": "type-changed-group-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4764,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "group"
+        "group",
+        "change"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:40:52.3149485Z",
     "event": {
       "action": "unlocked-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4767,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-09-06T13:38:17.5566269Z",
     "event": {
       "action": "renamed-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4781,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {
@@ -72,15 +74,17 @@
     "@timestamp": "2019-09-06T13:38:23.5161066Z",
     "event": {
       "action": "renamed-user-account",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4781,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "change",
-        "user"
+        "user",
+        "change"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4798.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4798.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-08T10:20:34.0535453Z",
     "event": {
       "action": "group-membership-enumerated",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4798,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "info",
-        "user"
+        "user",
+        "info"
       ]
     },
     "host": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4799.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4799.evtx.golden.json
@@ -3,15 +3,17 @@
     "@timestamp": "2019-10-08T10:20:44.4724208Z",
     "event": {
       "action": "user-member-enumerated",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4799,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
       "type": [
-        "info",
-        "group"
+        "group",
+        "info"
       ]
     },
     "group": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4964.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4964.evtx.golden.json
@@ -3,7 +3,9 @@
     "@timestamp": "2020-03-21T23:50:34.347458Z",
     "event": {
       "action": "logged-in-special",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4964,
       "kind": "event",
       "module": "security",
@@ -70,7 +72,9 @@
     "@timestamp": "2020-03-24T16:36:59.5703294Z",
     "event": {
       "action": "logged-in-special",
-      "category": "iam",
+      "category": [
+        "iam"
+      ],
       "code": 4964,
       "kind": "event",
       "module": "security",

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-11-14T17:10:15.1515514Z",
     "event": {
       "action": "created-process",
-      "category": "process",
+      "category": [
+        "process"
+      ],
       "code": 4688,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "start"
+      "type": [
+        "start"
+      ]
     },
     "host": {
       "name": "vagrant"

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
@@ -3,13 +3,17 @@
     "@timestamp": "2019-11-14T21:26:49.4961966Z",
     "event": {
       "action": "exited-process",
-      "category": "process",
+      "category": [
+        "process"
+      ],
       "code": 4689,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -65,13 +69,17 @@
     "@timestamp": "2019-11-14T21:27:46.9609089Z",
     "event": {
       "action": "exited-process",
-      "category": "process",
+      "category": [
+        "process"
+      ],
       "code": 4689,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -127,13 +135,17 @@
     "@timestamp": "2019-11-14T21:28:18.4605129Z",
     "event": {
       "action": "exited-process",
-      "category": "process",
+      "category": [
+        "process"
+      ],
       "code": 4689,
       "kind": "event",
       "module": "security",
       "outcome": "success",
       "provider": "Microsoft-Windows-Security-Auditing",
-      "type": "end"
+      "type": [
+        "end"
+      ]
     },
     "host": {
       "name": "vagrant"

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -1190,6 +1190,13 @@ var sysmon = (function () {
     // Event ID 12 - Registry object added or deleted.
     var event12 = new processor.Chain()
         .Add(parseUtcTime)
+        .AddFields({
+            fields: {
+                category: ["configuration"],
+                type: ["change"],
+            },
+            target: "event",
+        })
         .Convert({
             fields: [{
                     from: "winlog.event_data.UtcTime",
@@ -1222,6 +1229,13 @@ var sysmon = (function () {
     // Event ID 13 - Registry value set.
     var event13 = new processor.Chain()
         .Add(parseUtcTime)
+        .AddFields({
+            fields: {
+                category: ["configuration"],
+                type: ["change"],
+            },
+            target: "event",
+        })
         .Convert({
             fields: [{
                     from: "winlog.event_data.UtcTime",
@@ -1254,6 +1268,13 @@ var sysmon = (function () {
     // Event ID 14 - Registry object renamed.
     var event14 = new processor.Chain()
         .Add(parseUtcTime)
+        .AddFields({
+            fields: {
+                category: ["configuration"],
+                type: ["change"],
+            },
+            target: "event",
+        })
         .Convert({
             fields: [{
                     from: "winlog.event_data.UtcTime",
@@ -1330,6 +1351,13 @@ var sysmon = (function () {
     // Event ID 16 - Sysmon config state changed.
     var event16 = new processor.Chain()
         .Add(parseUtcTime)
+        .AddFields({
+            fields: {
+                category: ["configuration"],
+                type: ["change"],
+            },
+            target: "event",
+        })
         .Convert({
             fields: [{
                 from: "winlog.event_data.UtcTime",

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -48,7 +48,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
+      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -69,7 +69,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 66,
       "user": {
@@ -127,7 +127,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -148,7 +148,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 67,
       "user": {
@@ -207,7 +207,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -228,7 +228,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 68,
       "user": {
@@ -291,7 +291,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
+      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -312,7 +312,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 69,
       "user": {
@@ -370,7 +370,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -391,7 +391,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 70,
       "user": {
@@ -456,7 +456,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -477,7 +477,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 71,
       "user": {
@@ -531,7 +531,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -552,7 +552,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 72,
       "user": {
@@ -615,7 +615,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -636,7 +636,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 73,
       "user": {
@@ -686,7 +686,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -707,7 +707,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 74,
       "user": {
@@ -773,7 +773,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -794,7 +794,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 75,
       "user": {
@@ -892,7 +892,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -913,7 +913,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 76,
       "user": {
@@ -967,7 +967,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -988,7 +988,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 77,
       "user": {
@@ -1046,7 +1046,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1067,7 +1067,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 78,
       "user": {
@@ -1130,7 +1130,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1151,7 +1151,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 79,
       "user": {
@@ -1201,7 +1201,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1222,7 +1222,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 80,
       "user": {
@@ -1286,7 +1286,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1307,7 +1307,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 81,
       "user": {
@@ -1365,7 +1365,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1386,7 +1386,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 82,
       "user": {
@@ -1444,7 +1444,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1465,7 +1465,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 83,
       "user": {
@@ -1550,7 +1550,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1571,7 +1571,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 84,
       "user": {
@@ -1636,7 +1636,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1657,7 +1657,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 85,
       "user": {
@@ -1767,7 +1767,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1788,7 +1788,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 86,
       "user": {
@@ -1886,7 +1886,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -1907,7 +1907,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 87,
       "user": {
@@ -2010,7 +2010,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2031,7 +2031,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 88,
       "user": {
@@ -2099,7 +2099,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2120,7 +2120,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 89,
       "user": {
@@ -2225,7 +2225,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2246,7 +2246,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 90,
       "user": {
@@ -2354,7 +2354,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2375,7 +2375,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 91,
       "user": {
@@ -2429,7 +2429,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2450,7 +2450,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 92,
       "user": {
@@ -2549,7 +2549,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2570,7 +2570,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 93,
       "user": {
@@ -2628,7 +2628,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2649,7 +2649,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 94,
       "user": {
@@ -2748,7 +2748,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2769,7 +2769,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 95,
       "user": {
@@ -2823,7 +2823,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2844,7 +2844,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 96,
       "user": {
@@ -2898,7 +2898,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -2919,7 +2919,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 97,
       "user": {
@@ -3012,7 +3012,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3033,7 +3033,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 98,
       "user": {
@@ -3115,7 +3115,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3136,7 +3136,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 99,
       "user": {
@@ -3190,7 +3190,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3211,7 +3211,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 100,
       "user": {
@@ -3300,7 +3300,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3321,7 +3321,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 101,
       "user": {
@@ -3425,7 +3425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3446,7 +3446,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 102,
       "user": {
@@ -3551,7 +3551,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3572,7 +3572,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 103,
       "user": {
@@ -3626,7 +3626,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3647,7 +3647,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 104,
       "user": {
@@ -3751,7 +3751,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3772,7 +3772,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 105,
       "user": {
@@ -3870,7 +3870,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3891,7 +3891,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 106,
       "user": {
@@ -3945,7 +3945,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -3966,7 +3966,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 107,
       "user": {
@@ -4016,7 +4016,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4037,7 +4037,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 108,
       "user": {
@@ -4104,7 +4104,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4125,7 +4125,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 109,
       "user": {
@@ -4219,7 +4219,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4240,7 +4240,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 110,
       "user": {
@@ -4338,7 +4338,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4359,7 +4359,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 111,
       "user": {
@@ -4421,7 +4421,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4442,7 +4442,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 112,
       "user": {
@@ -4547,7 +4547,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4568,7 +4568,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 113,
       "user": {
@@ -4631,7 +4631,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4652,7 +4652,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 114,
       "user": {
@@ -4735,7 +4735,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4756,7 +4756,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 115,
       "user": {
@@ -4814,7 +4814,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4835,7 +4835,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 116,
       "user": {
@@ -4889,7 +4889,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4910,7 +4910,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 117,
       "user": {
@@ -4951,7 +4951,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -4972,7 +4972,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 118,
       "user": {
@@ -5013,7 +5013,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5034,7 +5034,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 119,
       "user": {
@@ -5133,7 +5133,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5154,7 +5154,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 120,
       "user": {
@@ -5217,7 +5217,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5238,7 +5238,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 121,
       "user": {
@@ -5292,7 +5292,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5313,7 +5313,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 122,
       "user": {
@@ -5412,7 +5412,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5433,7 +5433,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 123,
       "user": {
@@ -5496,7 +5496,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5517,7 +5517,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 124,
       "user": {
@@ -5616,7 +5616,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5637,7 +5637,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 125,
       "user": {
@@ -5691,7 +5691,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5712,7 +5712,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 126,
       "user": {
@@ -5781,7 +5781,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5802,7 +5802,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 127,
       "user": {
@@ -5871,7 +5871,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5892,7 +5892,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 128,
       "user": {
@@ -5947,7 +5947,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -5968,7 +5968,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 129,
       "user": {
@@ -6067,7 +6067,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6088,7 +6088,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 130,
       "user": {
@@ -6193,7 +6193,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6214,7 +6214,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 131,
       "user": {
@@ -6319,7 +6319,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6340,7 +6340,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 132,
       "user": {
@@ -6439,7 +6439,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6460,7 +6460,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 133,
       "user": {
@@ -6523,7 +6523,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6544,7 +6544,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 134,
       "user": {
@@ -6613,7 +6613,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6634,7 +6634,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 135,
       "user": {
@@ -6688,7 +6688,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6709,7 +6709,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 136,
       "user": {
@@ -6808,7 +6808,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6829,7 +6829,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 137,
       "user": {
@@ -6938,7 +6938,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -6959,7 +6959,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 138,
       "user": {
@@ -7057,7 +7057,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7078,7 +7078,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 139,
       "user": {
@@ -7136,7 +7136,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7157,7 +7157,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 140,
       "user": {
@@ -7261,7 +7261,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7282,7 +7282,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 141,
       "user": {
@@ -7340,7 +7340,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7361,7 +7361,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 142,
       "user": {
@@ -7465,7 +7465,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7486,7 +7486,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 143,
       "user": {
@@ -7585,7 +7585,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7606,7 +7606,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 144,
       "user": {
@@ -7683,7 +7683,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7704,7 +7704,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 145,
       "user": {
@@ -7809,7 +7809,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7830,7 +7830,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 146,
       "user": {
@@ -7909,7 +7909,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -7930,7 +7930,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 147,
       "user": {
@@ -7980,7 +7980,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8001,7 +8001,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 148,
       "user": {
@@ -8100,7 +8100,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8121,7 +8121,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 149,
       "user": {
@@ -8190,7 +8190,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8211,7 +8211,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 150,
       "user": {
@@ -8261,7 +8261,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8282,7 +8282,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 151,
       "user": {
@@ -8381,7 +8381,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8402,7 +8402,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 152,
       "user": {
@@ -8502,7 +8502,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8523,7 +8523,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 153,
       "user": {
@@ -8602,7 +8602,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8623,7 +8623,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 154,
       "user": {
@@ -8722,7 +8722,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8743,7 +8743,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 155,
       "user": {
@@ -8831,7 +8831,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8852,7 +8852,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 156,
       "user": {
@@ -8940,7 +8940,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -8961,7 +8961,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 157,
       "user": {
@@ -9070,7 +9070,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9091,7 +9091,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 158,
       "user": {
@@ -9191,7 +9191,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9212,7 +9212,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 159,
       "user": {
@@ -9305,7 +9305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9326,7 +9326,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 160,
       "user": {
@@ -9425,7 +9425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9446,7 +9446,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 161,
       "user": {
@@ -9545,7 +9545,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9566,7 +9566,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 162,
       "user": {
@@ -9624,7 +9624,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9645,7 +9645,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 163,
       "user": {
@@ -9742,7 +9742,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9763,7 +9763,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 164,
       "user": {
@@ -9821,7 +9821,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9842,7 +9842,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 165,
       "user": {
@@ -9911,7 +9911,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -9932,7 +9932,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 166,
       "user": {
@@ -9991,7 +9991,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10012,7 +10012,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 167,
       "user": {
@@ -10071,7 +10071,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10092,7 +10092,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 168,
       "user": {
@@ -10150,7 +10150,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10171,7 +10171,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 169,
       "user": {
@@ -10230,7 +10230,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
+      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -10251,7 +10251,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 170,
       "user": {
@@ -10305,7 +10305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10326,7 +10326,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 171,
       "user": {
@@ -10389,7 +10389,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10410,7 +10410,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 172,
       "user": {
@@ -10468,7 +10468,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10489,7 +10489,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 173,
       "user": {
@@ -10551,7 +10551,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10572,7 +10572,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 174,
       "user": {
@@ -10630,7 +10630,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10651,7 +10651,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 175,
       "user": {
@@ -10709,7 +10709,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10730,7 +10730,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 176,
       "user": {
@@ -10788,7 +10788,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10809,7 +10809,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 177,
       "user": {
@@ -10914,7 +10914,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -10935,7 +10935,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 178,
       "user": {
@@ -11004,7 +11004,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11025,7 +11025,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 179,
       "user": {
@@ -11085,7 +11085,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11106,7 +11106,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 180,
       "user": {
@@ -11206,7 +11206,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11227,7 +11227,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 181,
       "user": {
@@ -11277,7 +11277,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11298,7 +11298,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 182,
       "user": {
@@ -11356,7 +11356,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11377,7 +11377,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 183,
       "user": {
@@ -11481,7 +11481,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11502,7 +11502,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 184,
       "user": {
@@ -11556,7 +11556,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11577,7 +11577,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 186,
       "user": {
@@ -11635,7 +11635,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11656,7 +11656,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 187,
       "user": {
@@ -11758,7 +11758,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11779,7 +11779,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 188,
       "user": {
@@ -11887,7 +11887,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11908,7 +11908,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 189,
       "user": {
@@ -11966,7 +11966,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -11987,7 +11987,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 190,
       "user": {
@@ -12091,7 +12091,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12112,7 +12112,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 191,
       "user": {
@@ -12217,7 +12217,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12238,7 +12238,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 192,
       "user": {
@@ -12338,7 +12338,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12359,7 +12359,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 193,
       "user": {
@@ -12454,7 +12454,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12475,7 +12475,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 194,
       "user": {
@@ -12580,7 +12580,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12601,7 +12601,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 195,
       "user": {
@@ -12910,7 +12910,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -12931,7 +12931,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 196,
       "user": {
@@ -13050,7 +13050,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13071,7 +13071,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 197,
       "user": {
@@ -13125,7 +13125,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13146,7 +13146,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 198,
       "user": {
@@ -13208,7 +13208,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13229,7 +13229,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 199,
       "user": {
@@ -13270,7 +13270,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13291,7 +13291,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 200,
       "user": {
@@ -13349,7 +13349,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13370,7 +13370,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 201,
       "user": {
@@ -13475,7 +13475,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13496,7 +13496,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 202,
       "user": {
@@ -13601,7 +13601,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13622,7 +13622,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 203,
       "user": {
@@ -13680,7 +13680,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13701,7 +13701,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 204,
       "user": {
@@ -13800,7 +13800,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13821,7 +13821,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 205,
       "user": {
@@ -13920,7 +13920,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -13941,7 +13941,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 206,
       "user": {
@@ -14039,7 +14039,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14060,7 +14060,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 207,
       "user": {
@@ -14147,7 +14147,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14168,7 +14168,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 208,
       "user": {
@@ -14226,7 +14226,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14247,7 +14247,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 209,
       "user": {
@@ -14305,7 +14305,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14326,7 +14326,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 210,
       "user": {
@@ -14425,7 +14425,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14446,7 +14446,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 212,
       "user": {
@@ -14516,7 +14516,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14537,7 +14537,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 213,
       "user": {
@@ -14642,7 +14642,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14663,7 +14663,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 214,
       "user": {
@@ -14717,7 +14717,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A9-5D2F-0000-001053699900}",
+      "entity_id": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
       "executable": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 2736
@@ -14738,7 +14738,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 215,
       "user": {
@@ -14796,7 +14796,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
+      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -14817,7 +14817,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 216,
       "user": {
@@ -14871,7 +14871,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-00106ACA0000}",
+      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 844
@@ -14892,7 +14892,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 220,
       "user": {
@@ -14933,7 +14933,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-00106ACA0000}",
+      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-00106aca0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 844
@@ -14954,7 +14954,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 221,
       "user": {
@@ -14994,7 +14994,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E9F7-5D2F-0000-001031039C00}",
+      "entity_id": "{fa4a0de6-e9f7-5d2f-0000-001031039c00}",
       "executable": "C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\ruby.exe",
       "name": "ruby.exe",
       "pid": 676
@@ -15015,7 +15015,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 230,
       "user": {
@@ -15055,7 +15055,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-B1A2-5D2F-0000-001016F70000}",
+      "entity_id": "{fa4a0de6-b1a2-5d2f-0000-001016f70000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 636
@@ -15076,7 +15076,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 231,
       "user": {
@@ -15138,7 +15138,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-B1A3-5D2F-0000-00102F440100}",
+      "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 1788
@@ -15159,7 +15159,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 232,
       "user": {
@@ -15213,7 +15213,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-B1A3-5D2F-0000-00102F440100}",
+      "entity_id": "{fa4a0de6-b1a3-5d2f-0000-00102f440100}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 1788
@@ -15234,7 +15234,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 233,
       "user": {
@@ -15322,7 +15322,7 @@
       "protocol": "dns"
     },
     "process": {
-      "entity_id": "{FA4A0DE6-E8A8-5D2F-0000-001094619900}",
+      "entity_id": "{fa4a0de6-e8a8-5d2f-0000-001094619900}",
       "executable": "C:\\Program Files\\Internet Explorer\\iexplore.exe",
       "name": "iexplore.exe",
       "pid": 356
@@ -15343,7 +15343,7 @@
           "id": 1684
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 234,
       "user": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
@@ -26,7 +26,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-C36F-5EB3-2C07-290000000000}",
+      "entity_id": "{42f11c3b-c36f-5eb3-2c07-290000000000}",
       "executable": "C:\\Users\\vagrant\\.gvm\\versions\\go1.13.10.windows.amd64\\bin\\go.exe",
       "hash": {
         "md5": "199e1cf5b2250bd515ecccf4ca686301"
@@ -68,7 +68,7 @@
           "id": 2360
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 612,
       "user": {
@@ -104,7 +104,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-B2B6-5EB3-18AB-000000000000}",
+      "entity_id": "{42f11c3b-b2b6-5eb3-18ab-000000000000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "hash": {
         "sha1": "115106f5b338c87ae6836d50dd890de3da296367"
@@ -140,7 +140,7 @@
           "id": 2360
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 11,
       "user": {
@@ -175,7 +175,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-4664-5EBA-91AE-000000000000}",
+      "entity_id": "{42f11c3b-4664-5eba-91ae-000000000000}",
       "executable": "C:\\Windows\\system32\\svchost.exe",
       "hash": {
         "md5": "5a9bddf83be530b481f0fd24db28a6ff"
@@ -211,7 +211,7 @@
           "id": 1600
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2243,
       "user": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
@@ -2,10 +2,16 @@
   {
     "@timestamp": "2020-05-05T14:57:40.589Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 13,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -14,7 +20,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5B522F6E-77AE-5EB1-2C03-000000000800}",
+      "entity_id": "{5b522f6e-77ae-5eb1-2c03-000000000800}",
       "executable": "C:\\Windows\\regedit.exe",
       "name": "regedit.exe",
       "pid": 6072
@@ -48,7 +54,7 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2682,
       "user": {
@@ -60,10 +66,16 @@
   {
     "@timestamp": "2020-05-05T14:57:44.714Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 13,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -72,7 +84,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
+      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -100,7 +112,7 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2686,
       "user": {
@@ -112,10 +124,16 @@
   {
     "@timestamp": "2020-05-05T14:57:44.714Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 13,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -124,7 +142,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5B522F6E-77AE-5EB1-2C03-000000000800}",
+      "entity_id": "{5b522f6e-77ae-5eb1-2c03-000000000800}",
       "executable": "C:\\Windows\\regedit.exe",
       "name": "regedit.exe",
       "pid": 6072
@@ -158,7 +176,7 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2687,
       "user": {
@@ -170,10 +188,16 @@
   {
     "@timestamp": "2020-05-05T14:57:46.808Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 13,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -182,7 +206,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
+      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -210,7 +234,7 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2690,
       "user": {
@@ -222,10 +246,16 @@
   {
     "@timestamp": "2020-05-05T14:57:46.808Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 13,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant"
@@ -234,7 +264,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{5B522F6E-7554-5EB1-6D00-000000000800}",
+      "entity_id": "{5b522f6e-7554-5eb1-6d00-000000000800}",
       "executable": "C:\\Windows\\Explorer.EXE",
       "name": "Explorer.EXE",
       "pid": 4320
@@ -262,7 +292,7 @@
           "id": 876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2691,
       "user": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-loadimage.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-loadimage.evtx.golden.json
@@ -45,7 +45,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{9F32B55F-D9DE-5F98-F006-000000000600}",
+      "entity_id": "{9f32b55f-d9de-5f98-f006-000000000600}",
       "executable": "C:\\Windows\\System32\\dllhost.exe",
       "name": "dllhost.exe",
       "pid": 5184
@@ -79,7 +79,7 @@
           "id": 4796
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 10685,
       "user": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-processcreate.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-processcreate.evtx.golden.json
@@ -25,7 +25,7 @@
         "C:\\Windows\\system32\\notepad.exe"
       ],
       "command_line": "\"C:\\Windows\\system32\\notepad.exe\" ",
-      "entity_id": "{9F32B55F-7C4E-5F98-5803-000000000500}",
+      "entity_id": "{9f32b55f-7c4e-5f98-5803-000000000500}",
       "executable": "C:\\Windows\\System32\\notepad.exe",
       "hash": {
         "sha1": "b6d237154f2e528f0b503b58b025862d66b02b73"
@@ -36,7 +36,7 @@
           "C:\\Windows\\Explorer.EXE"
         ],
         "command_line": "C:\\Windows\\Explorer.EXE",
-        "entity_id": "{9F32B55F-6FDF-5F98-7000-000000000500}",
+        "entity_id": "{9f32b55f-6fdf-5f98-7000-000000000500}",
         "executable": "C:\\Windows\\explorer.exe",
         "name": "explorer.exe",
         "pid": 4212
@@ -68,7 +68,7 @@
         "Description": "Notepad",
         "FileVersion": "10.0.17763.475 (WinBuild.160101.0800)",
         "IntegrityLevel": "Medium",
-        "LogonGuid": "{9F32B55F-6FDD-5F98-E7C9-020000000000}",
+        "LogonGuid": "{9f32b55f-6fdd-5f98-e7c9-020000000000}",
         "LogonId": "0x2c9e7",
         "Product": "Microsoft® Windows® Operating System",
         "RuleName": "-",
@@ -81,7 +81,7 @@
           "id": 6876
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 20,
       "user": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -2,10 +2,16 @@
   {
     "@timestamp": "2019-03-18T16:57:37.933Z",
     "event": {
+      "category": [
+        "configuration"
+      ],
       "code": 16,
       "kind": "event",
       "module": "sysmon",
-      "provider": "Microsoft-Windows-Sysmon"
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "change"
+      ]
     },
     "host": {
       "name": "vagrant-2012-r2"
@@ -27,7 +33,7 @@
           "id": 4724
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 1,
       "user": {
@@ -72,7 +78,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2,
       "user": {
@@ -107,7 +113,7 @@
         "C:\\Windows\\Sysmon.exe"
       ],
       "command_line": "C:\\Windows\\Sysmon.exe",
-      "entity_id": "{42F11C3B-CE01-5C8F-0000-0010C73E2A00}",
+      "entity_id": "{42f11c3b-ce01-5c8f-0000-0010c73e2a00}",
       "executable": "C:\\Windows\\Sysmon.exe",
       "hash": {
         "sha1": "ac93c3b38e57a2715572933dbcb2a1c2892dbc5e"
@@ -118,7 +124,7 @@
           "C:\\Windows\\system32\\services.exe"
         ],
         "command_line": "C:\\Windows\\system32\\services.exe",
-        "entity_id": "{42F11C3B-6E1A-5C8C-0000-0010F14D0000}",
+        "entity_id": "{42f11c3b-6e1a-5c8c-0000-0010f14d0000}",
         "executable": "C:\\Windows\\System32\\services.exe",
         "name": "services.exe",
         "pid": 488
@@ -149,7 +155,7 @@
         "Description": "System activity monitor",
         "FileVersion": "9.01",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Sysinternals Sysmon",
         "TerminalSessionId": "0"
@@ -161,7 +167,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 3,
       "user": {
@@ -197,7 +203,7 @@
         "-Embedding"
       ],
       "command_line": "C:\\Windows\\system32\\wbem\\unsecapp.exe -Embedding",
-      "entity_id": "{42F11C3B-CE01-5C8F-0000-00102C412A00}",
+      "entity_id": "{42f11c3b-ce01-5c8f-0000-00102c412a00}",
       "executable": "C:\\Windows\\System32\\wbem\\unsecapp.exe",
       "hash": {
         "sha1": "6df8163a6320b80b60733f9d62e2f39b4b16b678"
@@ -210,7 +216,7 @@
           "DcomLaunch"
         ],
         "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
-        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
+        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -241,7 +247,7 @@
         "Description": "Sink to receive asynchronous callbacks for WMI client application",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -253,7 +259,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 4,
       "user": {
@@ -284,7 +290,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010E61E2A00}",
+      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010e61e2a00}",
       "executable": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4616
@@ -300,7 +306,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 5,
       "user": {
@@ -331,7 +337,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010071E2A00}",
+      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010071e2a00}",
       "executable": "C:\\Users\\vagrant\\Downloads\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4648
@@ -347,7 +353,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 6,
       "user": {
@@ -383,7 +389,7 @@
         "-Embedding"
       ],
       "command_line": "C:\\Windows\\system32\\wbem\\wmiprvse.exe -Embedding",
-      "entity_id": "{42F11C3B-CE03-5C8F-0000-0010E9462A00}",
+      "entity_id": "{42f11c3b-ce03-5c8f-0000-0010e9462a00}",
       "executable": "C:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
       "hash": {
         "sha1": "5a4c0e82ff95c9fb762d46a696ef9f1b68001c21"
@@ -396,7 +402,7 @@
           "DcomLaunch"
         ],
         "command_line": "C:\\Windows\\system32\\svchost.exe -k DcomLaunch",
-        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
+        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -427,7 +433,7 @@
         "Description": "WMI Provider Host",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -439,7 +445,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 7,
       "user": {
@@ -482,7 +488,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -513,7 +519,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 8,
       "user": {
@@ -556,7 +562,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -588,7 +594,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 9,
       "user": {
@@ -631,7 +637,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -663,7 +669,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 10,
       "user": {
@@ -706,7 +712,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -738,7 +744,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 11,
       "user": {
@@ -781,7 +787,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -816,7 +822,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 12,
       "user": {
@@ -860,7 +866,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -894,7 +900,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 13,
       "user": {
@@ -937,7 +943,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -969,7 +975,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 14,
       "user": {
@@ -1012,7 +1018,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1043,7 +1049,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 15,
       "user": {
@@ -1086,7 +1092,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1120,7 +1126,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 16,
       "user": {
@@ -1163,7 +1169,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1197,7 +1203,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 17,
       "user": {
@@ -1240,7 +1246,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1271,7 +1277,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 18,
       "user": {
@@ -1314,7 +1320,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1345,7 +1351,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 19,
       "user": {
@@ -1388,7 +1394,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1423,7 +1429,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 20,
       "user": {
@@ -1466,7 +1472,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1501,7 +1507,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 21,
       "user": {
@@ -1544,7 +1550,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1579,7 +1585,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 22,
       "user": {
@@ -1622,7 +1628,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1657,7 +1663,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 23,
       "user": {
@@ -1688,7 +1694,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCC6-5C8F-0000-001005082900}",
+      "entity_id": "{42f11c3b-ccc6-5c8f-0000-001005082900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 4832
@@ -1704,7 +1710,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 24,
       "user": {
@@ -1735,7 +1741,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCCC-5C8F-0000-0010E8272900}",
+      "entity_id": "{42f11c3b-cccc-5c8f-0000-0010e8272900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 3208
@@ -1751,7 +1757,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 25,
       "user": {
@@ -1787,7 +1793,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1807,7 +1813,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 26,
       "user": {
@@ -1843,7 +1849,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1863,7 +1869,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 27,
       "user": {
@@ -1899,7 +1905,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1919,7 +1925,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 28,
       "user": {
@@ -1955,7 +1961,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1975,7 +1981,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 29,
       "user": {
@@ -2006,7 +2012,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAB-5C8F-0000-001064EB2700}",
+      "entity_id": "{42f11c3b-ccab-5c8f-0000-001064eb2700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 2680
@@ -2022,7 +2028,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 30,
       "user": {
@@ -2058,7 +2064,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -2078,7 +2084,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 31,
       "user": {
@@ -2114,7 +2120,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -2134,7 +2140,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 32,
       "user": {


### PR DESCRIPTION
## What does this PR do?

Adds ECS 1.7 `configuration` categories for security and sysmon events. Also adds some additional events that might be of interest (i.e. firewall events, etc.)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674
