### PR TITLE
[Metricbeat] Use egress/ingress instead of inbound/outbound for system/socket metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change cloud.provider from googlecloud to gcp. {pull}21775[21775]
 - API address and shard ID are required settings in the Cloud Foundry module. {pull}21759[21759]
 - Rename googlecloud module to gcp module. {pull}22246[22246]
+- Use ingress/egress instead of inbound/outbound for system/socket metricset. {pull}22992[22992]
 
 *Packetbeat*
 

--- a/metricbeat/helper/socket/listeners.go
+++ b/metricbeat/helper/socket/listeners.go
@@ -27,26 +27,26 @@ type Direction uint8
 
 const (
 	_ Direction = iota
-	// Inbound indicates a connection was established from the outside to
+	// Ingress indicates a connection was established from the outside to
 	// listening socket on this host.
-	Inbound
-	// Outbound indicates a connection was established from this socket to an
+	Ingress
+	// Egress indicates a connection was established from this socket to an
 	// external listening socket.
-	Outbound
+	Egress
 	// Listening indicates a socket that is listening.
 	Listening
 )
 
 // Names for the direction of a connection
 const (
-	InboundName   = "inbound"
-	OutboundName  = "outbound"
+	IngressName   = "ingress"
+	EgressName    = "egress"
 	ListeningName = "listening"
 )
 
 var directionNames = map[Direction]string{
-	Inbound:   InboundName,
-	Outbound:  OutboundName,
+	Ingress:   IngressName,
+	Egress:    EgressName,
 	Listening: ListeningName,
 }
 
@@ -111,7 +111,7 @@ func (t *ListenerTable) Put(proto uint8, ip net.IP, port int) {
 
 // Direction returns whether the connection was incoming or outgoing based on
 // the protocol and local address. It compares the given local address to the
-// listeners in the table for the protocol and returns Inbound if there is a
+// listeners in the table for the protocol and returns Ingress if there is a
 // match. If remotePort is 0 then Listening is returned.
 func (t *ListenerTable) Direction(
 	family uint8, proto uint8,
@@ -125,13 +125,13 @@ func (t *ListenerTable) Direction(
 	// Are there any listeners on the given protocol?
 	ports, exists := t.data[proto]
 	if !exists {
-		return Outbound
+		return Egress
 	}
 
 	// Is there any listener on the port?
 	interfaces, exists := ports[localPort]
 	if !exists {
-		return Outbound
+		return Egress
 	}
 
 	// Is there a listener that specific interface? OR
@@ -139,13 +139,13 @@ func (t *ListenerTable) Direction(
 	for _, ip := range interfaces.ips {
 		switch {
 		case ip.Equal(localIP):
-			return Inbound
+			return Ingress
 		case family == syscall.AF_INET && ip.Equal(net.IPv4zero):
-			return Inbound
+			return Ingress
 		case family == syscall.AF_INET6 && ip.Equal(net.IPv6zero):
-			return Inbound
+			return Ingress
 		}
 	}
 
-	return Outbound
+	return Egress
 }

--- a/metricbeat/helper/socket/listeners_test.go
+++ b/metricbeat/helper/socket/listeners_test.go
@@ -42,22 +42,22 @@ func TestListenerTable(t *testing.T) {
 	// Listener on 192.0.2.1:80
 	l.Put(proto, lAddr, httpPort)
 
-	assert.Equal(t, Inbound, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outbound, l.Direction(syscall.AF_INET, 0, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outbound, l.Direction(syscall.AF_INET, proto, lAddr, ephemeralPort, rAddr, ephemeralPort))
+	assert.Equal(t, Ingress, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Egress, l.Direction(syscall.AF_INET, 0, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Egress, l.Direction(syscall.AF_INET, proto, lAddr, ephemeralPort, rAddr, ephemeralPort))
 
 	// Listener on 0.0.0.0:80
 	l.Reset()
 	l.Put(proto, net.IPv4zero, httpPort)
 
-	assert.Equal(t, Inbound, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outbound, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Ingress, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Egress, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
 
 	// Listener on :::80
 	l.Reset()
 	l.Put(proto, net.IPv6zero, httpPort)
 
-	assert.Equal(t, Inbound, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Inbound, l.Direction(syscall.AF_INET6, proto, ipv4InIpv6, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outbound, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Ingress, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Ingress, l.Direction(syscall.AF_INET6, proto, ipv4InIpv6, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Egress, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
 }

--- a/metricbeat/module/system/socket/_meta/data_egress.json
+++ b/metricbeat/module/system/socket/_meta/data_egress.json
@@ -17,7 +17,7 @@
         "name": "socket"
     },
     "network": {
-        "direction": "inbound",
+        "direction": "egress",
         "iana_number": "41",
         "type": "ipv6"
     },
@@ -26,17 +26,17 @@
     },
     "source": {
         "ip": "::1",
-        "port": 33972
+        "port": 33974
     },
     "system": {
         "socket": {
             "local": {
                 "ip": "::1",
-                "port": 45109
+                "port": 33974
             },
             "remote": {
                 "ip": "::1",
-                "port": 33972
+                "port": 45109
             }
         }
     },

--- a/metricbeat/module/system/socket/_meta/data_ingress.json
+++ b/metricbeat/module/system/socket/_meta/data_ingress.json
@@ -17,7 +17,7 @@
         "name": "socket"
     },
     "network": {
-        "direction": "outbound",
+        "direction": "ingress",
         "iana_number": "41",
         "type": "ipv6"
     },
@@ -26,17 +26,17 @@
     },
     "source": {
         "ip": "::1",
-        "port": 33974
+        "port": 33972
     },
     "system": {
         "socket": {
             "local": {
                 "ip": "::1",
-                "port": 33974
+                "port": 45109
             },
             "remote": {
                 "ip": "::1",
-                "port": 45109
+                "port": 33972
             }
         }
     },

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -277,14 +277,14 @@ var (
 	}
 
 	localHostInfoGroup = map[string]string{
-		sock.InboundName:   "destination",
-		sock.OutboundName:  "source",
+		sock.Ingressame:    "destination",
+		sock.EgressName:    "source",
 		sock.ListeningName: "server",
 	}
 
 	remoteHostInfoGroup = map[string]string{
-		sock.InboundName:  "source",
-		sock.OutboundName: "destination",
+		sock.IngressName: "source",
+		sock.EgressName:  "destination",
 	}
 )
 

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -277,7 +277,7 @@ var (
 	}
 
 	localHostInfoGroup = map[string]string{
-		sock.Ingressame:    "destination",
+		sock.IngressName:   "destination",
 		sock.EgressName:    "source",
 		sock.ListeningName: "server",
 	}

--- a/metricbeat/module/system/socket/socket_test.go
+++ b/metricbeat/module/system/socket/socket_test.go
@@ -49,8 +49,8 @@ func TestData(t *testing.T) {
 		path      string
 	}{
 		{sock.ListeningName, "."},
-		{sock.InboundName, "./_meta/data_inbound.json"},
-		{sock.OutboundName, "./_meta/data_outbound.json"},
+		{sock.IngressName, "./_meta/data_ingress.json"},
+		{sock.EgressName, "./_meta/data_egress.json"},
 	}
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())


### PR DESCRIPTION
## What does this PR do?

This changes the `system/socket` metricset to use the new ECS 1.7 host-centric ingress/egress values.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674