### PR TITLE
[Winlogbeat] Use ingress/egress instead of inbound/outbound

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Powershell processing of downgraded engine events. {pull}18966[18966]
 - Fix unprefixed fields in `fields.yml` for Powershell module {issue}18984[18984]
 - Remove top level `hash` property from sysmon events {pull}20653[20653]
+- Use ECS 1.7 ingress/egress instead of inbound/outbound network.direction in sysmon. {pull}22997[22997]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -357,10 +357,10 @@ var sysmon = (function () {
     var addNetworkDirection = function (evt) {
         switch (evt.Get("winlog.event_data.Initiated")) {
             case "true":
-                evt.Put("network.direction", "outbound");
+                evt.Put("network.direction", "egress");
                 break;
             case "false":
-                evt.Put("network.direction", "inbound");
+                evt.Put("network.direction", "ingress");
                 break;
         }
         evt.Delete("winlog.event_data.Initiated");

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -476,7 +476,7 @@
     },
     "network": {
       "community_id": "1:EQDBfI6vAylArTBQHY8kNmaweOA=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "domain",
       "transport": "udp",
       "type": "ipv6"
@@ -550,7 +550,7 @@
     },
     "network": {
       "community_id": "1:TXczQujzvcGYSvZ/CKEBu1p2riE=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "domain",
       "transport": "udp",
       "type": "ipv4"
@@ -625,7 +625,7 @@
     },
     "network": {
       "community_id": "1:W2ZbP8nXMY+YAGYw2h/3Sa8Gu/w=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "https",
       "transport": "tcp",
       "type": "ipv4"
@@ -700,7 +700,7 @@
     },
     "network": {
       "community_id": "1:5MsyqYltV9KkhIFGPWiByzQqHDo=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "https",
       "transport": "tcp",
       "type": "ipv4"
@@ -775,7 +775,7 @@
     },
     "network": {
       "community_id": "1:0p51df9oGzNph3fcneX2H8jXsag=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -854,7 +854,7 @@
     },
     "network": {
       "community_id": "1:0p51df9oGzNph3fcneX2H8jXsag=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -931,7 +931,7 @@
     },
     "network": {
       "community_id": "1:4DSgubObvMEI9IKNWPDqltrux+k=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1006,7 +1006,7 @@
     },
     "network": {
       "community_id": "1:sejGGvgk92xTvKdzlFitndKqdWw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1080,7 +1080,7 @@
     },
     "network": {
       "community_id": "1:yP71IXofOTWmF1LG760//yXa4Rk=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1157,7 +1157,7 @@
     },
     "network": {
       "community_id": "1:yP71IXofOTWmF1LG760//yXa4Rk=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1234,7 +1234,7 @@
     },
     "network": {
       "community_id": "1:Zt/ImHlMNf4MciHXlRDkivgw2jY=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1308,7 +1308,7 @@
     },
     "network": {
       "community_id": "1:SHkoHfPFDYWai8qQBwIiRxvCPZw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1382,7 +1382,7 @@
     },
     "network": {
       "community_id": "1:DI+g4BImhWaUwPmLEjdMMQVYPLs=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1460,7 +1460,7 @@
     },
     "network": {
       "community_id": "1:okFVyky/zOY2Q0BATy37YsbiveA=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1538,7 +1538,7 @@
     },
     "network": {
       "community_id": "1:ZHyFuF2PjubLSbAh4zRQIZHOZK8=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1616,7 +1616,7 @@
     },
     "network": {
       "community_id": "1:r3C/WjbATNIislTQ0M+ySzwnuiw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"


### PR DESCRIPTION
## What does this PR do?

This changes the `sysmon` module to use the new ECS 1.7 host-centric ingress/egress values.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674