### PR TITLE
Cherry-pick #22997 to 7.x: [Winlogbeat] Use ingress/egress instead of inbound/outbound

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,7 +91,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Powershell module. Support for event ID's: `400`, `403`, `600`, `800`, `4103`, `4014`, `4105`, `4106`. {issue}16262[16262] {pull}18526[18526]
 - Fix Powershell processing of downgraded engine events. {pull}18966[18966]
 - Fix unprefixed fields in `fields.yml` for Powershell module {issue}18984[18984]
-- Remove top level `hash` property from sysmon events {pull}20653[20653]
 - Use ECS 1.7 ingress/egress instead of inbound/outbound network.direction in sysmon. {pull}22997[22997]
 
 *Functionbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,6 +91,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Powershell module. Support for event ID's: `400`, `403`, `600`, `800`, `4103`, `4014`, `4105`, `4106`. {issue}16262[16262] {pull}18526[18526]
 - Fix Powershell processing of downgraded engine events. {pull}18966[18966]
 - Fix unprefixed fields in `fields.yml` for Powershell module {issue}18984[18984]
+- Remove top level `hash` property from sysmon events {pull}20653[20653]
+- Use ECS 1.7 ingress/egress instead of inbound/outbound network.direction in sysmon. {pull}22997[22997]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -357,10 +357,10 @@ var sysmon = (function () {
     var addNetworkDirection = function (evt) {
         switch (evt.Get("winlog.event_data.Initiated")) {
             case "true":
-                evt.Put("network.direction", "outbound");
+                evt.Put("network.direction", "egress");
                 break;
             case "false":
-                evt.Put("network.direction", "inbound");
+                evt.Put("network.direction", "ingress");
                 break;
         }
         evt.Delete("winlog.event_data.Initiated");

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -485,7 +485,7 @@
     },
     "network": {
       "community_id": "1:EQDBfI6vAylArTBQHY8kNmaweOA=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "domain",
       "transport": "udp",
       "type": "ipv6"
@@ -559,7 +559,7 @@
     },
     "network": {
       "community_id": "1:TXczQujzvcGYSvZ/CKEBu1p2riE=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "domain",
       "transport": "udp",
       "type": "ipv4"
@@ -634,7 +634,7 @@
     },
     "network": {
       "community_id": "1:W2ZbP8nXMY+YAGYw2h/3Sa8Gu/w=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "https",
       "transport": "tcp",
       "type": "ipv4"
@@ -709,7 +709,7 @@
     },
     "network": {
       "community_id": "1:5MsyqYltV9KkhIFGPWiByzQqHDo=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "https",
       "transport": "tcp",
       "type": "ipv4"
@@ -784,7 +784,7 @@
     },
     "network": {
       "community_id": "1:0p51df9oGzNph3fcneX2H8jXsag=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -863,7 +863,7 @@
     },
     "network": {
       "community_id": "1:0p51df9oGzNph3fcneX2H8jXsag=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -940,7 +940,7 @@
     },
     "network": {
       "community_id": "1:4DSgubObvMEI9IKNWPDqltrux+k=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1015,7 +1015,7 @@
     },
     "network": {
       "community_id": "1:sejGGvgk92xTvKdzlFitndKqdWw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1089,7 +1089,7 @@
     },
     "network": {
       "community_id": "1:yP71IXofOTWmF1LG760//yXa4Rk=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1166,7 +1166,7 @@
     },
     "network": {
       "community_id": "1:yP71IXofOTWmF1LG760//yXa4Rk=",
-      "direction": "inbound",
+      "direction": "ingress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1243,7 +1243,7 @@
     },
     "network": {
       "community_id": "1:Zt/ImHlMNf4MciHXlRDkivgw2jY=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1317,7 +1317,7 @@
     },
     "network": {
       "community_id": "1:SHkoHfPFDYWai8qQBwIiRxvCPZw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "llmnr",
       "transport": "udp",
       "type": "ipv6"
@@ -1391,7 +1391,7 @@
     },
     "network": {
       "community_id": "1:DI+g4BImhWaUwPmLEjdMMQVYPLs=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1469,7 +1469,7 @@
     },
     "network": {
       "community_id": "1:okFVyky/zOY2Q0BATy37YsbiveA=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1547,7 +1547,7 @@
     },
     "network": {
       "community_id": "1:ZHyFuF2PjubLSbAh4zRQIZHOZK8=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"
@@ -1625,7 +1625,7 @@
     },
     "network": {
       "community_id": "1:r3C/WjbATNIislTQ0M+ySzwnuiw=",
-      "direction": "outbound",
+      "direction": "egress",
       "protocol": "netbios-ns",
       "transport": "udp",
       "type": "ipv4"


### PR DESCRIPTION
Cherry-pick of PR #22997 to 7.x branch. Original message: 

## What does this PR do?

This changes the `sysmon` module to use the new ECS 1.7 host-centric ingress/egress values.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674