### PR TITLE
Cherry-pick #22976 to 7.x: [Heartbeat] Add mime type detection

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -477,6 +477,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Add mime type detection for http responses. {pull}22976[22976]
 
 *Heartbeat*
 

--- a/heartbeat/_meta/config/processors.yml.tmpl
+++ b/heartbeat/_meta/config/processors.yml.tmpl
@@ -1,0 +1,13 @@
+{{header "Processors"}}
+
+processors:
+  - add_observer_metadata:
+      # Optional, but recommended geo settings for the location Heartbeat is running in
+      #geo:
+        # Token describing this location
+        #name: us-east-1a
+        # Lat, Lon "
+        #location: "37.926868, -78.024902"
+  - detect_mime_type:
+      field: http.response.body.content
+      target: http.response.mime_type

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -130,7 +130,9 @@ processors:
         #name: us-east-1a
         # Lat, Lon "
         #location: "37.926868, -78.024902"
-
+  - detect_mime_type:
+      field: http.response.body.content
+      target: http.response.mime_type
 
 # ================================== Logging ===================================
 

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -85,6 +85,11 @@ fields:
   {% endfor -%}
 {% endif %}
 
+processors:
+  - detect_mime_type:
+      field: http.response.body.content
+      target: http.response.mime_type
+
 #================================ Queue =====================================
 
 queue.mem:

--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -126,6 +126,10 @@ class Test(BaseTest):
             self.assert_last_status(expected_status)
             if expected_status == "down":
                 self.assertEqual(self.last_output_line()["http.response.body.content"], body)
+                if body == "notjson":
+                    self.assertEqual(self.last_output_line()["http.response.mime_type"], "text/plain; charset=utf-8")
+                else:
+                    self.assertEqual(self.last_output_line()["http.response.mime_type"], "application/json")
             else:
                 assert "http.response.body.content" not in self.last_output_line()
         finally:


### PR DESCRIPTION
Cherry-pick of PR #22976 to 7.x branch. Original message: 

## What does this PR do?

This adds ECS 1.7 `mime_type` detection for the response body of Heartbeat monitors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674