### PR TITLE
Cherry-pick #22999 to 7.x: [Winlogbeat] Add subdomain value for sysmon module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -582,7 +582,6 @@ port. {pull}19209[19209]
 - Add support for event IDs 4673,4674,4697,4698,4699,4700,4701,4702,4768,4769,4770,4771,4776,4778,4779,4964 to the Security module {pull}17517[17517]
 - Add registry and code signature information and ECS categorization fields for sysmon module {pull}18058[18058]
 - Add file.pe and process.pe fields to ProcessCreate & LoadImage events in Sysmon module. {issue}17335[17335] {pull}22217[22217]
-- Add additional event categorization for security and sysmon modules. {pull}22988[22988]
 - Add dns.question.subdomain fields for sysmon DNS events. {pull}22999[22999]
 
 *Elastic Log Driver*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -582,6 +582,8 @@ port. {pull}19209[19209]
 - Add support for event IDs 4673,4674,4697,4698,4699,4700,4701,4702,4768,4769,4770,4771,4776,4778,4779,4964 to the Security module {pull}17517[17517]
 - Add registry and code signature information and ECS categorization fields for sysmon module {pull}18058[18058]
 - Add file.pe and process.pe fields to ProcessCreate & LoadImage events in Sysmon module. {issue}17335[17335] {pull}22217[22217]
+- Add additional event categorization for security and sysmon modules. {pull}22988[22988]
+- Add dns.question.subdomain fields for sysmon DNS events. {pull}22999[22999]
 
 *Elastic Log Driver*
 

--- a/libbeat/processors/registered_domain/config.go
+++ b/libbeat/processors/registered_domain/config.go
@@ -18,11 +18,12 @@
 package registered_domain
 
 type config struct {
-	Field         string `config:"field"        validate:"required"`
-	TargetField   string `config:"target_field" validate:"required"`
-	IgnoreMissing bool   `config:"ignore_missing"`
-	IgnoreFailure bool   `config:"ignore_failure"`
-	ID            string `config:"id"`
+	Field                string `config:"field"        validate:"required"`
+	TargetField          string `config:"target_field" validate:"required"`
+	TargetSubdomainField string `config:"target_subdomain_field"`
+	IgnoreMissing        bool   `config:"ignore_missing"`
+	IgnoreFailure        bool   `config:"ignore_failure"`
+	ID                   string `config:"id"`
 }
 
 func defaultConfig() config {

--- a/libbeat/processors/registered_domain/docs/registered_domain.asciidoc
+++ b/libbeat/processors/registered_domain/docs/registered_domain.asciidoc
@@ -9,7 +9,8 @@ The `registered_domain` processor reads a field containing a hostname and then
 writes the "registered domain" contained in the hostname to the target field.
 For example, given `www.google.co.uk` the processor would output `google.co.uk`.
 In other words the "registered domain" is the effective top-level domain
-(`co.uk`) plus one level (`google`).
+(`co.uk`) plus one level (`google`). Optionally, it can store the rest of the
+domain, the `subdomain` into another target field.
 
 This processor uses the Mozilla Public Suffix list to determine the value.
 
@@ -19,6 +20,7 @@ processors:
   - registered_domain:
       field: dns.question.name
       target_field: dns.question.registered_domain
+      target_subdomain_field: dns.question.sudomain
       ignore_missing: true
       ignore_failure: true
 ----
@@ -28,10 +30,11 @@ The `registered_domain` processor has the following configuration settings:
 .Registered Domain options
 [options="header"]
 |======
-| Name             | Required | Default    | Description                                                      |
-| `field`          | yes      |            | Source field containing a fully qualified domain name (FQDN).    |
-| `target_field`   | yes      |            | Target field for the registered domain value.                    |
-| `ignore_missing` | no       | false      | Ignore errors when the source field is missing.                  |
-| `ignore_failure` | no       | false      | Ignore all errors produced by the processor.                     |
-| `id`             | no       |            | An identifier for this processor instance. Useful for debugging. |
+| Name                     | Required | Default    | Description                                                      |
+| `field`                  | yes      |            | Source field containing a fully qualified domain name (FQDN).    |
+| `target_field`           | yes      |            | Target field for the registered domain value.                    |
+| `target_subdomain_field` | no       |            | Target subdomain field for the subdomain value.                  |
+| `ignore_missing`         | no       | false      | Ignore errors when the source field is missing.                  |
+| `ignore_failure`         | no       | false      | Ignore all errors produced by the processor.                     |
+| `id`                     | no       |            | An identifier for this processor instance. Useful for debugging. |
 |======

--- a/libbeat/processors/registered_domain/registered_domain.go
+++ b/libbeat/processors/registered_domain/registered_domain.go
@@ -19,6 +19,7 @@ package registered_domain
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/publicsuffix"
@@ -103,6 +104,19 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 			return event, nil
 		}
 		return event, errors.Wrapf(err, "failed to write registered domain to target field [%v]", p.TargetField)
+	}
+
+	if p.TargetSubdomainField != "" {
+		subdomain := strings.TrimSuffix(strings.TrimSuffix(domain, rd), ".")
+		if subdomain != "" {
+			_, err = event.PutValue(p.TargetSubdomainField, subdomain)
+			if err != nil {
+				if p.IgnoreFailure {
+					return event, nil
+				}
+				return event, errors.Wrapf(err, "failed to write subdomain to target field [%v]", p.TargetSubdomainField)
+			}
+		}
 	}
 
 	return event, nil

--- a/libbeat/processors/registered_domain/registered_domain_test.go
+++ b/libbeat/processors/registered_domain/registered_domain_test.go
@@ -31,22 +31,25 @@ func TestProcessorRun(t *testing.T) {
 		Error            bool
 		Domain           string
 		RegisteredDomain string
+		Subdomain        string
 	}{
-		{false, "www.google.com", "google.com"},
-		{false, "www.google.co.uk", "google.co.uk"},
-		{false, "google.com", "google.com"},
-		{false, "www.ak.local", "ak.local"},
-		{false, "www.navy.mil", "navy.mil"},
+		{false, "www.google.com", "google.com", "www"},
+		{false, "www.google.co.uk", "google.co.uk", "www"},
+		{false, "www.mail.google.co.uk", "google.co.uk", "www.mail"},
+		{false, "google.com", "google.com", ""},
+		{false, "www.ak.local", "ak.local", "www"},
+		{false, "www.navy.mil", "navy.mil", "www"},
 
-		{true, "com", ""},
-		{true, ".", "."},
-		{true, "", ""},
-		{true, "localhost", ""},
+		{true, "com", "", ""},
+		{true, ".", ".", ""},
+		{true, "", "", ""},
+		{true, "localhost", "", ""},
 	}
 
 	c := defaultConfig()
 	c.Field = "domain"
 	c.TargetField = "registered_domain"
+	c.TargetSubdomainField = "subdomain"
 	p, err := newRegisteredDomain(c)
 	if err != nil {
 		t.Fatal(err)
@@ -71,5 +74,10 @@ func TestProcessorRun(t *testing.T) {
 
 		rd, _ := evt.GetValue("registered_domain")
 		assert.Equal(t, tc.RegisteredDomain, rd)
+
+		if tc.Subdomain != "" {
+			subdomain, _ := evt.GetValue("subdomain")
+			assert.Equal(t, tc.Subdomain, subdomain)
+		}
 	}
 }

--- a/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
+++ b/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js
@@ -1538,6 +1538,7 @@ var sysmon = (function () {
             ignore_missing: true,
             field: "dns.question.name",
             target_field: "dns.question.registered_domain",
+            target_subdomain_field: "dns.question.subdomain",
         })
         .Add(setRuleName)
         .Add(translateDnsQueryStatus)

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -18,7 +18,8 @@
       ],
       "question": {
         "name": "go.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "go"
       },
       "resolved_ip": [
         "23.223.14.67"
@@ -97,7 +98,8 @@
       ],
       "question": {
         "name": "www.msn.com",
-        "registered_domain": "msn.com"
+        "registered_domain": "msn.com",
+        "subdomain": "www"
       },
       "resolved_ip": [
         "204.79.197.203"
@@ -176,7 +178,8 @@
       ],
       "question": {
         "name": "static-global-s-msn-com.akamaized.net",
-        "registered_domain": "akamaized.net"
+        "registered_domain": "akamaized.net",
+        "subdomain": "static-global-s-msn-com"
       },
       "resolved_ip": [
         "23.50.53.192",
@@ -260,7 +263,8 @@
       ],
       "question": {
         "name": "www.bing.com",
-        "registered_domain": "bing.com"
+        "registered_domain": "bing.com",
+        "subdomain": "www"
       },
       "resolved_ip": [
         "204.79.197.200",
@@ -340,7 +344,8 @@
       ],
       "question": {
         "name": "linkmaker.itunes.apple.com",
-        "registered_domain": "apple.com"
+        "registered_domain": "apple.com",
+        "subdomain": "linkmaker.itunes"
       },
       "resolved_ip": [
         "23.64.104.249"
@@ -501,7 +506,8 @@
       ],
       "question": {
         "name": "c.msn.com",
-        "registered_domain": "msn.com"
+        "registered_domain": "msn.com",
+        "subdomain": "c"
       },
       "resolved_ip": [
         "20.36.253.92"
@@ -584,7 +590,8 @@
       ],
       "question": {
         "name": "c.bing.com",
-        "registered_domain": "bing.com"
+        "registered_domain": "bing.com",
+        "subdomain": "c"
       },
       "resolved_ip": [
         "13.107.21.200",
@@ -656,7 +663,8 @@
       ],
       "question": {
         "name": "contextual.media.net",
-        "registered_domain": "media.net"
+        "registered_domain": "media.net",
+        "subdomain": "contextual"
       },
       "resolved_ip": [
         "23.52.167.93"
@@ -743,7 +751,8 @@
       ],
       "question": {
         "name": "at.atwola.com",
-        "registered_domain": "atwola.com"
+        "registered_domain": "atwola.com",
+        "subdomain": "at"
       },
       "resolved_ip": [
         "152.195.32.120"
@@ -854,7 +863,8 @@
       ],
       "question": {
         "name": "m.adnxs.com",
-        "registered_domain": "adnxs.com"
+        "registered_domain": "adnxs.com",
+        "subdomain": "m"
       },
       "resolved_ip": [
         "204.13.192.56",
@@ -937,7 +947,8 @@
       ],
       "question": {
         "name": "cms.analytics.yahoo.com",
-        "registered_domain": "yahoo.com"
+        "registered_domain": "yahoo.com",
+        "subdomain": "cms.analytics"
       },
       "resolved_ip": [
         "74.6.137.78"
@@ -1016,7 +1027,8 @@
       ],
       "question": {
         "name": "cvision.media.net",
-        "registered_domain": "media.net"
+        "registered_domain": "media.net",
+        "subdomain": "cvision"
       },
       "resolved_ip": [
         "23.52.167.93"
@@ -1099,7 +1111,8 @@
       ],
       "question": {
         "name": "g.bing.com",
-        "registered_domain": "bing.com"
+        "registered_domain": "bing.com",
+        "subdomain": "g"
       },
       "resolved_ip": [
         "204.79.197.200",
@@ -1171,7 +1184,8 @@
       ],
       "question": {
         "name": "lg3.media.net",
-        "registered_domain": "media.net"
+        "registered_domain": "media.net",
+        "subdomain": "lg3"
       },
       "resolved_ip": [
         "23.52.167.93"
@@ -1254,7 +1268,8 @@
       ],
       "question": {
         "name": "service.sp.advertising.com",
-        "registered_domain": "advertising.com"
+        "registered_domain": "advertising.com",
+        "subdomain": "service.sp"
       },
       "resolved_ip": [
         "54.88.96.255",
@@ -1335,7 +1350,8 @@
       ],
       "question": {
         "name": "sb.scorecardresearch.com",
-        "registered_domain": "scorecardresearch.com"
+        "registered_domain": "scorecardresearch.com",
+        "subdomain": "sb"
       },
       "resolved_ip": [
         "184.25.176.117"
@@ -1414,7 +1430,8 @@
       ],
       "question": {
         "name": "otf.msn.com",
-        "registered_domain": "msn.com"
+        "registered_domain": "msn.com",
+        "subdomain": "otf"
       },
       "resolved_ip": [
         "40.114.54.223"
@@ -1513,7 +1530,8 @@
       ],
       "question": {
         "name": "ping.chartbeat.net",
-        "registered_domain": "chartbeat.net"
+        "registered_domain": "chartbeat.net",
+        "subdomain": "ping"
       },
       "resolved_ip": [
         "35.171.101.225",
@@ -1725,7 +1743,8 @@
       ],
       "question": {
         "name": "nym1-ib.adnxs.com",
-        "registered_domain": "adnxs.com"
+        "registered_domain": "adnxs.com",
+        "subdomain": "nym1-ib"
       },
       "resolved_ip": [
         "68.67.178.252",
@@ -1848,7 +1867,8 @@
       ],
       "question": {
         "name": "eb2.3lift.com",
-        "registered_domain": "3lift.com"
+        "registered_domain": "3lift.com",
+        "subdomain": "eb2"
       },
       "resolved_ip": [
         "34.196.86.129",
@@ -1971,7 +1991,8 @@
       ],
       "question": {
         "name": "px.ads.linkedin.com",
-        "registered_domain": "linkedin.com"
+        "registered_domain": "linkedin.com",
+        "subdomain": "px.ads"
       },
       "resolved_ip": [
         "108.174.10.14",
@@ -2067,7 +2088,8 @@
       ],
       "question": {
         "name": "login.live.com",
-        "registered_domain": "live.com"
+        "registered_domain": "live.com",
+        "subdomain": "login"
       },
       "resolved_ip": [
         "40.90.23.239",
@@ -2184,7 +2206,8 @@
       ],
       "question": {
         "name": "dis.criteo.com",
-        "registered_domain": "criteo.com"
+        "registered_domain": "criteo.com",
+        "subdomain": "dis"
       },
       "resolved_ip": [
         "74.119.119.150",
@@ -2314,7 +2337,8 @@
       ],
       "question": {
         "name": "ib.adnxs.com",
-        "registered_domain": "adnxs.com"
+        "registered_domain": "adnxs.com",
+        "subdomain": "ib"
       },
       "resolved_ip": [
         "68.67.180.12",
@@ -2399,7 +2423,8 @@
       ],
       "question": {
         "name": "cm.g.doubleclick.net",
-        "registered_domain": "doubleclick.net"
+        "registered_domain": "doubleclick.net",
+        "subdomain": "cm.g"
       },
       "resolved_ip": [
         "172.217.10.34"
@@ -2510,7 +2535,8 @@
       ],
       "question": {
         "name": "match.adsrvr.org",
-        "registered_domain": "adsrvr.org"
+        "registered_domain": "adsrvr.org",
+        "subdomain": "match"
       },
       "resolved_ip": [
         "54.208.129.24",
@@ -2598,7 +2624,8 @@
       ],
       "question": {
         "name": "ssum-sec.casalemedia.com",
-        "registered_domain": "casalemedia.com"
+        "registered_domain": "casalemedia.com",
+        "subdomain": "ssum-sec"
       },
       "resolved_ip": [
         "23.52.162.21"
@@ -2709,7 +2736,8 @@
       ],
       "question": {
         "name": "protected-by.clarium.io",
-        "registered_domain": "clarium.io"
+        "registered_domain": "clarium.io",
+        "subdomain": "protected-by"
       },
       "resolved_ip": [
         "18.204.130.216",
@@ -2793,7 +2821,8 @@
       ],
       "question": {
         "name": "pagead2.googlesyndication.com",
-        "registered_domain": "googlesyndication.com"
+        "registered_domain": "googlesyndication.com",
+        "subdomain": "pagead2"
       },
       "resolved_ip": [
         "172.217.10.66"
@@ -2868,7 +2897,8 @@
       ],
       "question": {
         "name": "googleads.g.doubleclick.net",
-        "registered_domain": "doubleclick.net"
+        "registered_domain": "doubleclick.net",
+        "subdomain": "googleads.g"
       },
       "resolved_ip": [
         "172.217.10.66"
@@ -2975,7 +3005,8 @@
       ],
       "question": {
         "name": "pixel.advertising.com",
-        "registered_domain": "advertising.com"
+        "registered_domain": "advertising.com",
+        "subdomain": "pixel"
       },
       "resolved_ip": [
         "52.22.184.73",
@@ -3081,7 +3112,8 @@
       ],
       "question": {
         "name": "onevideosync.uplynk.com",
-        "registered_domain": "uplynk.com"
+        "registered_domain": "uplynk.com",
+        "subdomain": "onevideosync"
       },
       "resolved_ip": [
         "54.210.214.197",
@@ -3160,7 +3192,8 @@
       ],
       "question": {
         "name": "ad.turn.com",
-        "registered_domain": "turn.com"
+        "registered_domain": "turn.com",
+        "subdomain": "ad"
       },
       "resolved_ip": [
         "50.116.194.21"
@@ -3263,7 +3296,8 @@
       ],
       "question": {
         "name": "ups.analytics.yahoo.com",
-        "registered_domain": "yahoo.com"
+        "registered_domain": "yahoo.com",
+        "subdomain": "ups.analytics"
       },
       "resolved_ip": [
         "34.225.20.218",
@@ -3385,7 +3419,8 @@
       ],
       "question": {
         "name": "pm.w55c.net",
-        "registered_domain": "w55c.net"
+        "registered_domain": "w55c.net",
+        "subdomain": "pm"
       },
       "resolved_ip": [
         "34.237.248.89",
@@ -3510,7 +3545,8 @@
       ],
       "question": {
         "name": "cm.eyereturn.com",
-        "registered_domain": "eyereturn.com"
+        "registered_domain": "eyereturn.com",
+        "subdomain": "cm"
       },
       "resolved_ip": [
         "35.186.239.238",
@@ -3596,7 +3632,8 @@
       ],
       "question": {
         "name": "www.googletagservices.com",
-        "registered_domain": "googletagservices.com"
+        "registered_domain": "googletagservices.com",
+        "subdomain": "www"
       },
       "resolved_ip": [
         "172.217.10.66"
@@ -3711,7 +3748,8 @@
       ],
       "question": {
         "name": "cm.adgrx.com",
-        "registered_domain": "adgrx.com"
+        "registered_domain": "adgrx.com",
+        "subdomain": "cm"
       },
       "resolved_ip": [
         "173.231.178.117",
@@ -3832,7 +3870,8 @@
       ],
       "question": {
         "name": "csm2waycm-atl.netmng.com",
-        "registered_domain": "netmng.com"
+        "registered_domain": "netmng.com",
+        "subdomain": "csm2waycm-atl"
       },
       "resolved_ip": [
         "104.193.83.156",
@@ -3915,7 +3954,8 @@
       ],
       "question": {
         "name": "pr-bh.ybp.yahoo.com",
-        "registered_domain": "yahoo.com"
+        "registered_domain": "yahoo.com",
+        "subdomain": "pr-bh.ybp"
       },
       "resolved_ip": [
         "72.30.2.182"
@@ -3986,7 +4026,8 @@
       ],
       "question": {
         "name": "ps.eyeota.net",
-        "registered_domain": "eyeota.net"
+        "registered_domain": "eyeota.net",
+        "subdomain": "ps"
       },
       "resolved_ip": [
         "3.83.220.223"
@@ -4073,7 +4114,8 @@
       ],
       "question": {
         "name": "idpix.media6degrees.com",
-        "registered_domain": "media6degrees.com"
+        "registered_domain": "media6degrees.com",
+        "subdomain": "idpix"
       },
       "resolved_ip": [
         "204.2.197.201",
@@ -4181,7 +4223,8 @@
       ],
       "question": {
         "name": "tpc.googlesyndication.com",
-        "registered_domain": "googlesyndication.com"
+        "registered_domain": "googlesyndication.com",
+        "subdomain": "tpc"
       },
       "resolved_ip": [
         "172.217.10.1",
@@ -4300,7 +4343,8 @@
       ],
       "question": {
         "name": "image2.pubmatic.com",
-        "registered_domain": "pubmatic.com"
+        "registered_domain": "pubmatic.com",
+        "subdomain": "image2"
       },
       "resolved_ip": [
         "162.248.19.147",
@@ -4391,7 +4435,8 @@
       ],
       "question": {
         "name": "sam.msn.com",
-        "registered_domain": "msn.com"
+        "registered_domain": "msn.com",
+        "subdomain": "sam"
       },
       "resolved_ip": [
         "204.79.197.203"
@@ -4506,7 +4551,8 @@
       ],
       "question": {
         "name": "ocsp.sca1b.amazontrust.com",
-        "registered_domain": "amazontrust.com"
+        "registered_domain": "amazontrust.com",
+        "subdomain": "ocsp.sca1b"
       },
       "resolved_ip": [
         "52.85.89.250",
@@ -4600,7 +4646,8 @@
       ],
       "question": {
         "name": "c1.adform.net",
-        "registered_domain": "adform.net"
+        "registered_domain": "adform.net",
+        "subdomain": "c1"
       },
       "resolved_ip": [
         "185.167.164.43",
@@ -4700,7 +4747,8 @@
       ],
       "question": {
         "name": "urs.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "urs"
       },
       "resolved_ip": [
         "40.84.140.84",
@@ -4784,7 +4832,8 @@
       ],
       "question": {
         "name": "dsum-sec.casalemedia.com",
-        "registered_domain": "casalemedia.com"
+        "registered_domain": "casalemedia.com",
+        "subdomain": "dsum-sec"
       },
       "resolved_ip": [
         "23.52.162.21"
@@ -4859,7 +4908,8 @@
       ],
       "question": {
         "name": "ocsp.godaddy.com",
-        "registered_domain": "godaddy.com"
+        "registered_domain": "godaddy.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "72.167.239.239"
@@ -4924,7 +4974,8 @@
     "dns": {
       "question": {
         "name": "googleads.g.doubleclick.net",
-        "registered_domain": "doubleclick.net"
+        "registered_domain": "doubleclick.net",
+        "subdomain": "googleads.g"
       }
     },
     "event": {
@@ -4986,7 +5037,8 @@
     "dns": {
       "question": {
         "name": "tpc.googlesyndication.com",
-        "registered_domain": "googlesyndication.com"
+        "registered_domain": "googlesyndication.com",
+        "subdomain": "tpc"
       }
     },
     "event": {
@@ -5094,7 +5146,8 @@
       ],
       "question": {
         "name": "ocsp.usertrust.com",
-        "registered_domain": "usertrust.com"
+        "registered_domain": "usertrust.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "151.139.128.14",
@@ -5186,7 +5239,8 @@
       ],
       "question": {
         "name": "isrg.trustid.ocsp.identrust.com",
-        "registered_domain": "identrust.com"
+        "registered_domain": "identrust.com",
+        "subdomain": "isrg.trustid.ocsp"
       },
       "resolved_ip": [
         "23.50.53.179",
@@ -5262,7 +5316,8 @@
       ],
       "question": {
         "name": "ad.doubleclick.net",
-        "registered_domain": "doubleclick.net"
+        "registered_domain": "doubleclick.net",
+        "subdomain": "ad"
       },
       "resolved_ip": [
         "172.217.6.198"
@@ -5373,7 +5428,8 @@
       ],
       "question": {
         "name": "ocsp.sectigo.com",
-        "registered_domain": "sectigo.com"
+        "registered_domain": "sectigo.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "151.139.128.14",
@@ -5465,7 +5521,8 @@
       ],
       "question": {
         "name": "ocsp.int-x3.letsencrypt.org",
-        "registered_domain": "letsencrypt.org"
+        "registered_domain": "letsencrypt.org",
+        "subdomain": "ocsp.int-x3"
       },
       "resolved_ip": [
         "23.50.53.179",
@@ -5577,7 +5634,8 @@
       ],
       "question": {
         "name": "ocsp.pki.goog",
-        "registered_domain": "pki.goog"
+        "registered_domain": "pki.goog",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "172.217.12.195",
@@ -5661,7 +5719,8 @@
       ],
       "question": {
         "name": "googleads4.g.doubleclick.net",
-        "registered_domain": "doubleclick.net"
+        "registered_domain": "doubleclick.net",
+        "subdomain": "googleads4.g"
       },
       "resolved_ip": [
         "172.217.10.34"
@@ -5748,7 +5807,8 @@
       ],
       "question": {
         "name": "images.taboola.com",
-        "registered_domain": "taboola.com"
+        "registered_domain": "taboola.com",
+        "subdomain": "images"
       },
       "resolved_ip": [
         "151.101.2.2",
@@ -5838,7 +5898,8 @@
       ],
       "question": {
         "name": "api-s2s.taboola.com",
-        "registered_domain": "taboola.com"
+        "registered_domain": "taboola.com",
+        "subdomain": "api-s2s"
       },
       "resolved_ip": [
         "151.101.66.2",
@@ -5916,7 +5977,8 @@
       ],
       "question": {
         "name": "x.bidswitch.net",
-        "registered_domain": "bidswitch.net"
+        "registered_domain": "bidswitch.net",
+        "subdomain": "x"
       },
       "resolved_ip": [
         "35.231.30.22",
@@ -6028,7 +6090,8 @@
       ],
       "question": {
         "name": "pixel.adsafeprotected.com",
-        "registered_domain": "adsafeprotected.com"
+        "registered_domain": "adsafeprotected.com",
+        "subdomain": "pixel"
       },
       "resolved_ip": [
         "199.166.0.26",
@@ -6278,7 +6341,8 @@
       ],
       "question": {
         "name": "aa.agkn.com",
-        "registered_domain": "agkn.com"
+        "registered_domain": "agkn.com",
+        "subdomain": "aa"
       },
       "resolved_ip": [
         "156.154.200.36",
@@ -6400,7 +6464,8 @@
       ],
       "question": {
         "name": "s0.2mdn.net",
-        "registered_domain": "2mdn.net"
+        "registered_domain": "2mdn.net",
+        "subdomain": "s0"
       },
       "resolved_ip": [
         "172.217.10.134",
@@ -6492,7 +6557,8 @@
       ],
       "question": {
         "name": "b.scorecardresearch.com",
-        "registered_domain": "scorecardresearch.com"
+        "registered_domain": "scorecardresearch.com",
+        "subdomain": "b"
       },
       "resolved_ip": [
         "23.50.53.195",
@@ -6580,7 +6646,8 @@
       ],
       "question": {
         "name": "edw.edmunds.com",
-        "registered_domain": "edmunds.com"
+        "registered_domain": "edmunds.com",
+        "subdomain": "edw"
       },
       "resolved_ip": [
         "151.101.130.2",
@@ -6658,7 +6725,8 @@
       ],
       "question": {
         "name": "ocsp.digicert.com",
-        "registered_domain": "digicert.com"
+        "registered_domain": "digicert.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "72.21.91.29"
@@ -6769,7 +6837,8 @@
       ],
       "question": {
         "name": "pre-usermatch.targeting.unrulymedia.com",
-        "registered_domain": "unrulymedia.com"
+        "registered_domain": "unrulymedia.com",
+        "subdomain": "pre-usermatch.targeting"
       },
       "resolved_ip": [
         "35.167.55.0",
@@ -6897,7 +6966,8 @@
       ],
       "question": {
         "name": "farm.plista.com",
-        "registered_domain": "plista.com"
+        "registered_domain": "plista.com",
+        "subdomain": "farm"
       },
       "resolved_ip": [
         "144.76.67.119",
@@ -7019,7 +7089,8 @@
       ],
       "question": {
         "name": "beacon.krxd.net",
-        "registered_domain": "krxd.net"
+        "registered_domain": "krxd.net",
+        "subdomain": "beacon"
       },
       "resolved_ip": [
         "50.17.180.35",
@@ -7106,7 +7177,8 @@
       ],
       "question": {
         "name": "dsum.casalemedia.com",
-        "registered_domain": "casalemedia.com"
+        "registered_domain": "casalemedia.com",
+        "subdomain": "dsum"
       },
       "resolved_ip": [
         "23.52.162.21"
@@ -7221,7 +7293,8 @@
       ],
       "question": {
         "name": "sync.mathtag.com",
-        "registered_domain": "mathtag.com"
+        "registered_domain": "mathtag.com",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "216.200.232.235",
@@ -7310,7 +7383,8 @@
       ],
       "question": {
         "name": "status.rapidssl.com",
-        "registered_domain": "rapidssl.com"
+        "registered_domain": "rapidssl.com",
+        "subdomain": "status"
       },
       "resolved_ip": [
         "72.21.91.29"
@@ -7425,7 +7499,8 @@
       ],
       "question": {
         "name": "sync.extend.tv",
-        "registered_domain": "extend.tv"
+        "registered_domain": "extend.tv",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "34.197.195.131",
@@ -7546,7 +7621,8 @@
       ],
       "question": {
         "name": "ocsp.comodoca.com",
-        "registered_domain": "comodoca.com"
+        "registered_domain": "comodoca.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "151.139.128.14",
@@ -7650,7 +7726,8 @@
       ],
       "question": {
         "name": "sync-tm.everesttech.net",
-        "registered_domain": "everesttech.net"
+        "registered_domain": "everesttech.net",
+        "subdomain": "sync-tm"
       },
       "resolved_ip": [
         "151.101.2.49",
@@ -7768,7 +7845,8 @@
       ],
       "question": {
         "name": "idsync.rlcdn.com",
-        "registered_domain": "rlcdn.com"
+        "registered_domain": "rlcdn.com",
+        "subdomain": "idsync"
       },
       "resolved_ip": [
         "34.95.92.78",
@@ -7874,7 +7952,8 @@
       ],
       "question": {
         "name": "cm.adform.net",
-        "registered_domain": "adform.net"
+        "registered_domain": "adform.net",
+        "subdomain": "cm"
       },
       "resolved_ip": [
         "37.157.2.239",
@@ -7950,7 +8029,8 @@
       ],
       "question": {
         "name": "dm.hybrid.ai",
-        "registered_domain": "hybrid.ai"
+        "registered_domain": "hybrid.ai",
+        "subdomain": "dm"
       },
       "resolved_ip": [
         "37.18.16.16"
@@ -8061,7 +8141,8 @@
       ],
       "question": {
         "name": "static.adsafeprotected.com",
-        "registered_domain": "adsafeprotected.com"
+        "registered_domain": "adsafeprotected.com",
+        "subdomain": "static"
       },
       "resolved_ip": [
         "199.166.0.32",
@@ -8157,7 +8238,8 @@
       ],
       "question": {
         "name": "trc.taboola.com",
-        "registered_domain": "taboola.com"
+        "registered_domain": "taboola.com",
+        "subdomain": "trc"
       },
       "resolved_ip": [
         "151.101.130.2",
@@ -8342,7 +8424,8 @@
       ],
       "question": {
         "name": "pixel-sync.sitescout.com",
-        "registered_domain": "sitescout.com"
+        "registered_domain": "sitescout.com",
+        "subdomain": "pixel-sync"
       },
       "resolved_ip": [
         "209.15.36.34",
@@ -8462,7 +8545,8 @@
       ],
       "question": {
         "name": "prod.y-medialink.com",
-        "registered_domain": "y-medialink.com"
+        "registered_domain": "y-medialink.com",
+        "subdomain": "prod"
       },
       "resolved_ip": [
         "35.186.202.217",
@@ -8567,7 +8651,8 @@
       ],
       "question": {
         "name": "jadserve.postrelease.com",
-        "registered_domain": "postrelease.com"
+        "registered_domain": "postrelease.com",
+        "subdomain": "jadserve"
       },
       "resolved_ip": [
         "54.80.117.178",
@@ -8683,7 +8768,8 @@
       ],
       "question": {
         "name": "appnexus-partners.tremorhub.com",
-        "registered_domain": "tremorhub.com"
+        "registered_domain": "tremorhub.com",
+        "subdomain": "appnexus-partners"
       },
       "resolved_ip": [
         "107.21.43.184",
@@ -8795,7 +8881,8 @@
       ],
       "question": {
         "name": "x.dlx.addthis.com",
-        "registered_domain": "addthis.com"
+        "registered_domain": "addthis.com",
+        "subdomain": "x.dlx"
       },
       "resolved_ip": [
         "107.21.14.70",
@@ -8904,7 +8991,8 @@
       ],
       "question": {
         "name": "dh.serving-sys.com",
-        "registered_domain": "serving-sys.com"
+        "registered_domain": "serving-sys.com",
+        "subdomain": "dh"
       },
       "resolved_ip": [
         "18.205.112.71",
@@ -9029,7 +9117,8 @@
       ],
       "question": {
         "name": "match.sharethrough.com",
-        "registered_domain": "sharethrough.com"
+        "registered_domain": "sharethrough.com",
+        "subdomain": "match"
       },
       "resolved_ip": [
         "52.55.160.246",
@@ -9151,7 +9240,8 @@
       ],
       "question": {
         "name": "tags.rd.linksynergy.com",
-        "registered_domain": "linksynergy.com"
+        "registered_domain": "linksynergy.com",
+        "subdomain": "tags.rd"
       },
       "resolved_ip": [
         "35.241.16.233",
@@ -9268,7 +9358,8 @@
       ],
       "question": {
         "name": "rtb-csync.smartadserver.com",
-        "registered_domain": "smartadserver.com"
+        "registered_domain": "smartadserver.com",
+        "subdomain": "rtb-csync"
       },
       "resolved_ip": [
         "199.187.193.166",
@@ -9386,7 +9477,8 @@
       ],
       "question": {
         "name": "sc.iasds01.com",
-        "registered_domain": "iasds01.com"
+        "registered_domain": "iasds01.com",
+        "subdomain": "sc"
       },
       "resolved_ip": [
         "199.166.0.200",
@@ -9506,7 +9598,8 @@
       ],
       "question": {
         "name": "dt.adsafeprotected.com",
-        "registered_domain": "adsafeprotected.com"
+        "registered_domain": "adsafeprotected.com",
+        "subdomain": "dt"
       },
       "resolved_ip": [
         "104.244.38.20",
@@ -9594,7 +9687,8 @@
       ],
       "question": {
         "name": "status.thawte.com",
-        "registered_domain": "thawte.com"
+        "registered_domain": "thawte.com",
+        "subdomain": "status"
       },
       "resolved_ip": [
         "72.21.91.29"
@@ -9705,7 +9799,8 @@
       ],
       "question": {
         "name": "ads.stickyadstv.com",
-        "registered_domain": "stickyadstv.com"
+        "registered_domain": "stickyadstv.com",
+        "subdomain": "ads"
       },
       "resolved_ip": [
         "38.134.110.101",
@@ -9791,7 +9886,8 @@
       ],
       "question": {
         "name": "hbx.media.net",
-        "registered_domain": "media.net"
+        "registered_domain": "media.net",
+        "subdomain": "hbx"
       },
       "resolved_ip": [
         "23.52.167.93"
@@ -9878,7 +9974,8 @@
       ],
       "question": {
         "name": "match.taboola.com",
-        "registered_domain": "taboola.com"
+        "registered_domain": "taboola.com",
+        "subdomain": "match"
       },
       "resolved_ip": [
         "151.101.194.49",
@@ -9960,7 +10057,8 @@
       ],
       "question": {
         "name": "img-s-msn-com.akamaized.net",
-        "registered_domain": "akamaized.net"
+        "registered_domain": "akamaized.net",
+        "subdomain": "img-s-msn-com"
       },
       "resolved_ip": [
         "23.50.53.185",
@@ -10040,7 +10138,8 @@
       ],
       "question": {
         "name": "static-entertainment-eus-s-msn-com.akamaized.net",
-        "registered_domain": "akamaized.net"
+        "registered_domain": "akamaized.net",
+        "subdomain": "static-entertainment-eus-s-msn-com"
       },
       "resolved_ip": [
         "23.50.53.194",
@@ -10120,7 +10219,8 @@
       ],
       "question": {
         "name": "radarmaps.weather.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "radarmaps.weather"
       },
       "resolved_ip": [
         "23.217.149.91"
@@ -10199,7 +10299,8 @@
       ],
       "question": {
         "name": "static-entertainment-eus-s-msn-com.akamaized.net",
-        "registered_domain": "akamaized.net"
+        "registered_domain": "akamaized.net",
+        "subdomain": "static-entertainment-eus-s-msn-com"
       },
       "resolved_ip": [
         "23.50.53.194",
@@ -10275,7 +10376,8 @@
       ],
       "question": {
         "name": "tag.sp.advertising.com",
-        "registered_domain": "advertising.com"
+        "registered_domain": "advertising.com",
+        "subdomain": "tag.sp"
       },
       "resolved_ip": [
         "152.195.32.163"
@@ -10358,7 +10460,8 @@
       ],
       "question": {
         "name": "www.bing.com",
-        "registered_domain": "bing.com"
+        "registered_domain": "bing.com",
+        "subdomain": "www"
       },
       "resolved_ip": [
         "204.79.197.200",
@@ -10438,7 +10541,8 @@
       ],
       "question": {
         "name": "cdn.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "cdn"
       },
       "resolved_ip": [
         "23.52.164.109"
@@ -10521,7 +10625,8 @@
       ],
       "question": {
         "name": "cdn3.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "cdn3"
       },
       "resolved_ip": [
         "23.52.164.109"
@@ -10600,7 +10705,8 @@
       ],
       "question": {
         "name": "rtb0.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "rtb0"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -10679,7 +10785,8 @@
       ],
       "question": {
         "name": "dev.virtualearth.net",
-        "registered_domain": "virtualearth.net"
+        "registered_domain": "virtualearth.net",
+        "subdomain": "dev"
       },
       "resolved_ip": [
         "20.36.236.157"
@@ -10758,7 +10865,8 @@
       ],
       "question": {
         "name": "t.ssl.ak.dynamic.tiles.virtualearth.net",
-        "registered_domain": "virtualearth.net"
+        "registered_domain": "virtualearth.net",
+        "subdomain": "t.ssl.ak.dynamic.tiles"
       },
       "resolved_ip": [
         "23.52.161.238"
@@ -10873,7 +10981,8 @@
       ],
       "question": {
         "name": "rp.gwallet.com",
-        "registered_domain": "gwallet.com"
+        "registered_domain": "gwallet.com",
+        "subdomain": "rp"
       },
       "resolved_ip": [
         "74.217.253.61",
@@ -10971,7 +11080,8 @@
       ],
       "question": {
         "name": "ads.yahoo.com",
-        "registered_domain": "yahoo.com"
+        "registered_domain": "yahoo.com",
+        "subdomain": "ads"
       },
       "resolved_ip": [
         "98.139.225.43",
@@ -11053,7 +11163,8 @@
       ],
       "question": {
         "name": "um.simpli.fi",
-        "registered_domain": "simpli.fi"
+        "registered_domain": "simpli.fi",
+        "subdomain": "um"
       },
       "resolved_ip": [
         "169.55.104.49",
@@ -11166,7 +11277,8 @@
       ],
       "question": {
         "name": "mpp.vindicosuite.com",
-        "registered_domain": "vindicosuite.com"
+        "registered_domain": "vindicosuite.com",
+        "subdomain": "mpp"
       },
       "resolved_ip": [
         "35.186.236.204",
@@ -11247,7 +11359,8 @@
       ],
       "question": {
         "name": "sync.1rx.io",
-        "registered_domain": "1rx.io"
+        "registered_domain": "1rx.io",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "8.41.222.152"
@@ -11326,7 +11439,8 @@
       ],
       "question": {
         "name": "sync.teads.tv",
-        "registered_domain": "teads.tv"
+        "registered_domain": "teads.tv",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "23.52.160.7"
@@ -11441,7 +11555,8 @@
       ],
       "question": {
         "name": "s.thebrighttag.com",
-        "registered_domain": "thebrighttag.com"
+        "registered_domain": "thebrighttag.com",
+        "subdomain": "s"
       },
       "resolved_ip": [
         "3.15.109.176",
@@ -11526,7 +11641,8 @@
       ],
       "question": {
         "name": "t.a3cloud.net",
-        "registered_domain": "a3cloud.net"
+        "registered_domain": "a3cloud.net",
+        "subdomain": "t"
       },
       "resolved_ip": [
         "54.192.55.189"
@@ -11605,7 +11721,8 @@
       ],
       "question": {
         "name": "tps618.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "tps618"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -11720,7 +11837,8 @@
       ],
       "question": {
         "name": "dpm.demdex.net",
-        "registered_domain": "demdex.net"
+        "registered_domain": "demdex.net",
+        "subdomain": "dpm"
       },
       "resolved_ip": [
         "54.157.69.185",
@@ -11847,7 +11965,8 @@
       ],
       "question": {
         "name": "secure.adnxs.com",
-        "registered_domain": "adnxs.com"
+        "registered_domain": "adnxs.com",
+        "subdomain": "secure"
       },
       "resolved_ip": [
         "68.67.179.228",
@@ -11936,7 +12055,8 @@
       ],
       "question": {
         "name": "tps.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "tps"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -12051,7 +12171,8 @@
       ],
       "question": {
         "name": "i.liadm.com",
-        "registered_domain": "liadm.com"
+        "registered_domain": "liadm.com",
+        "subdomain": "i"
       },
       "resolved_ip": [
         "52.71.175.22",
@@ -12176,7 +12297,8 @@
       ],
       "question": {
         "name": "pixel.s3xified.com",
-        "registered_domain": "s3xified.com"
+        "registered_domain": "s3xified.com",
+        "subdomain": "pixel"
       },
       "resolved_ip": [
         "67.231.251.189",
@@ -12298,7 +12420,8 @@
       ],
       "question": {
         "name": "router.infolinks.com",
-        "registered_domain": "infolinks.com"
+        "registered_domain": "infolinks.com",
+        "subdomain": "router"
       },
       "resolved_ip": [
         "104.20.252.85",
@@ -12415,7 +12538,8 @@
       ],
       "question": {
         "name": "grey.erne.co",
-        "registered_domain": "erne.co"
+        "registered_domain": "erne.co",
+        "subdomain": "grey"
       },
       "resolved_ip": [
         "94.23.171.206",
@@ -12539,7 +12663,8 @@
       ],
       "question": {
         "name": "sync.jivox.com",
-        "registered_domain": "jivox.com"
+        "registered_domain": "jivox.com",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "54.243.145.203",
@@ -12829,7 +12954,8 @@
       ],
       "question": {
         "name": "b1sync.zemanta.com",
-        "registered_domain": "zemanta.com"
+        "registered_domain": "zemanta.com",
+        "subdomain": "b1sync"
       },
       "resolved_ip": [
         "207.244.121.25",
@@ -13007,7 +13133,8 @@
       ],
       "question": {
         "name": "tg.socdm.com",
-        "registered_domain": "socdm.com"
+        "registered_domain": "socdm.com",
+        "subdomain": "tg"
       },
       "resolved_ip": [
         "124.146.215.43",
@@ -13095,7 +13222,8 @@
       ],
       "question": {
         "name": "prebid.adnxs.com",
-        "registered_domain": "adnxs.com"
+        "registered_domain": "adnxs.com",
+        "subdomain": "prebid"
       },
       "resolved_ip": [
         "68.67.153.75"
@@ -13178,7 +13306,8 @@
       ],
       "question": {
         "name": "ul1.dvtps.com",
-        "registered_domain": "dvtps.com"
+        "registered_domain": "dvtps.com",
+        "subdomain": "ul1"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -13243,7 +13372,8 @@
     "dns": {
       "question": {
         "name": "ul1.dvtps.com",
-        "registered_domain": "dvtps.com"
+        "registered_domain": "dvtps.com",
+        "subdomain": "ul1"
       }
     },
     "event": {
@@ -13319,7 +13449,8 @@
       ],
       "question": {
         "name": "tags.bluekai.com",
-        "registered_domain": "bluekai.com"
+        "registered_domain": "bluekai.com",
+        "subdomain": "tags"
       },
       "resolved_ip": [
         "23.3.125.199"
@@ -13434,7 +13565,8 @@
       ],
       "question": {
         "name": "cdnjs.cloudflare.com",
-        "registered_domain": "cloudflare.com"
+        "registered_domain": "cloudflare.com",
+        "subdomain": "cdnjs"
       },
       "resolved_ip": [
         "104.19.195.151",
@@ -13560,7 +13692,8 @@
       ],
       "question": {
         "name": "pixel.onaudience.com",
-        "registered_domain": "onaudience.com"
+        "registered_domain": "onaudience.com",
+        "subdomain": "pixel"
       },
       "resolved_ip": [
         "85.194.243.23",
@@ -13650,7 +13783,8 @@
       ],
       "question": {
         "name": "status.geotrust.com",
-        "registered_domain": "geotrust.com"
+        "registered_domain": "geotrust.com",
+        "subdomain": "status"
       },
       "resolved_ip": [
         "72.21.91.29"
@@ -13761,7 +13895,8 @@
       ],
       "question": {
         "name": "ocsp.trust-provider.com",
-        "registered_domain": "trust-provider.com"
+        "registered_domain": "trust-provider.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "151.139.128.14",
@@ -13881,7 +14016,8 @@
       ],
       "question": {
         "name": "ocsp.comodoca4.com",
-        "registered_domain": "comodoca4.com"
+        "registered_domain": "comodoca4.com",
+        "subdomain": "ocsp"
       },
       "resolved_ip": [
         "151.139.128.14",
@@ -14001,7 +14137,8 @@
       ],
       "question": {
         "name": "sync.crwdcntrl.net",
-        "registered_domain": "crwdcntrl.net"
+        "registered_domain": "crwdcntrl.net",
+        "subdomain": "sync"
       },
       "resolved_ip": [
         "52.4.111.14",
@@ -14112,7 +14249,8 @@
       ],
       "question": {
         "name": "match.sync.ad.cpe.dotomi.com",
-        "registered_domain": "dotomi.com"
+        "registered_domain": "dotomi.com",
+        "subdomain": "match.sync.ad.cpe"
       },
       "resolved_ip": [
         "159.127.42.114",
@@ -14196,7 +14334,8 @@
       ],
       "question": {
         "name": "tps10230.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "tps10230"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -14275,7 +14414,8 @@
       ],
       "question": {
         "name": "tps10221.doubleverify.com",
-        "registered_domain": "doubleverify.com"
+        "registered_domain": "doubleverify.com",
+        "subdomain": "tps10221"
       },
       "resolved_ip": [
         "204.154.111.122"
@@ -14386,7 +14526,8 @@
       ],
       "question": {
         "name": "www.facebook.com",
-        "registered_domain": "facebook.com"
+        "registered_domain": "facebook.com",
+        "subdomain": "www"
       },
       "resolved_ip": [
         "31.13.71.36",
@@ -14486,7 +14627,8 @@
       ],
       "question": {
         "name": "platform.twitter.com",
-        "registered_domain": "twitter.com"
+        "registered_domain": "twitter.com",
+        "subdomain": "platform"
       },
       "resolved_ip": [
         "192.229.163.25"
@@ -14601,7 +14743,8 @@
       ],
       "question": {
         "name": "syndication.twitter.com",
-        "registered_domain": "twitter.com"
+        "registered_domain": "twitter.com",
+        "subdomain": "syndication"
       },
       "resolved_ip": [
         "104.244.42.8",
@@ -14687,7 +14830,8 @@
       ],
       "question": {
         "name": "ade.googlesyndication.com",
-        "registered_domain": "googlesyndication.com"
+        "registered_domain": "googlesyndication.com",
+        "subdomain": "ade"
       },
       "resolved_ip": [
         "172.217.10.34"
@@ -14766,7 +14910,8 @@
       ],
       "question": {
         "name": "iecvlist.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "iecvlist"
       },
       "resolved_ip": [
         "72.21.81.200"
@@ -14841,7 +14986,8 @@
       ],
       "question": {
         "name": "tsfe.trafficshaping.dsp.mp.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "tsfe.trafficshaping.dsp.mp"
       },
       "resolved_ip": [
         "40.77.232.95"
@@ -14906,7 +15052,8 @@
     "dns": {
       "question": {
         "name": "isatap.local.crowbird.com",
-        "registered_domain": "crowbird.com"
+        "registered_domain": "crowbird.com",
+        "subdomain": "isatap.local"
       }
     },
     "event": {
@@ -15108,7 +15255,8 @@
       ],
       "question": {
         "name": "v10.vortex-win.data.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "v10.vortex-win.data"
       },
       "resolved_ip": [
         "65.55.44.109"
@@ -15183,7 +15331,8 @@
       ],
       "question": {
         "name": "settings-win.data.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "settings-win.data"
       },
       "resolved_ip": [
         "20.36.218.63"
@@ -15286,7 +15435,8 @@
       ],
       "question": {
         "name": "c.urs.microsoft.com",
-        "registered_domain": "microsoft.com"
+        "registered_domain": "microsoft.com",
+        "subdomain": "c.urs"
       },
       "resolved_ip": [
         "40.121.17.79",


### PR DESCRIPTION
Cherry-pick of PR #22999 to 7.x branch. Original message: 

## What does this PR do?

This adds `subdomain` to the event in the sysmon module. To make it a bit more reusable I added an optional `target_subdomain_field` to the `registered_domain` processor that different modules in winlogbeat and filebeat use for parsing out the `registered_domain` value.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/issues/21674