### PR TITLE
Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -552,6 +552,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add tini as init system in docker images {pull}22137[22137]
 - Added "add_network_direction" processor for determining perimeter-based network direction. {pull}23076[23076]
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
+- Allow node/namespace metadata to be disabled on kubernetes metagen {pull}23012[23012]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -552,7 +552,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add tini as init system in docker images {pull}22137[22137]
 - Added "add_network_direction" processor for determining perimeter-based network direction. {pull}23076[23076]
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
-- Allow node/namespace metadata to be disabled on kubernetes metagen {pull}23012[23012]
+- Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata/metadata.go
+++ b/libbeat/common/kubernetes/metadata/metadata.go
@@ -61,10 +61,10 @@ func GetPodMetaGen(
 	metaConf *AddResourceMetadataConfig) MetaGen {
 
 	var nodeMetaGen, namespaceMetaGen MetaGen
-	if nodeWatcher != nil {
+	if nodeWatcher != nil && metaConf.Node.Enabled() {
 		nodeMetaGen = NewNodeMetadataGenerator(metaConf.Node, nodeWatcher.Store())
 	}
-	if namespaceWatcher != nil {
+	if namespaceWatcher != nil && metaConf.Namespace.Enabled() {
 		namespaceMetaGen = NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store())
 	}
 	metaGen := NewPodMetadataGenerator(cfg, podWatcher.Store(), nodeMetaGen, namespaceMetaGen)

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -232,7 +232,8 @@ running configuration for a container, 60s by default.
 `add_resource_metadata`:: (Optional) Specify labels and annotations filters for the extra metadata coming from Node and Namespace.
  `add_resource_metadata` can be done for `node` or `namespace`. By default all labels will be included
   while annotations are not added by default. This settings are useful when labels' and annotations'
-  storing requires special handling to avoid overloading the storage output.
+  storing requires special handling to avoid overloading the storage output. The enrichment of `node` or `namespace` metadata
+  can be individually disabled by setting `enabled: false`.
   Example:
 
 ["source","yaml",subs="attributes"]

--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -121,7 +121,8 @@ It is unset by default.
 `add_resource_metadata`:: (Optional) Specify labels and annotations filters for the extra metadata coming from Node and Namespace.
  `add_resource_metadata` can be done for `node` or `namespace`. By default all labels will be included
 while annotations are not added by default. This settings are useful when labels' and annotations'
-storing requires special handling to avoid overloading the storage output.
+storing requires special handling to avoid overloading the storage output. The enrichment of `node` or `namespace` metadata
+can be individually disabled by setting `enabled: false`.
 Example:
 
 ["source","yaml",subs="attributes"]

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -178,7 +178,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 
 		options := kubernetes.WatchOptions{
 			SyncTimeout: config.SyncPeriod,
-			Node:        "",
+			Node:        config.Host,
 		}
 		if config.Namespace != "" {
 			options.Namespace = config.Namespace


### PR DESCRIPTION
<!-- Type of change
- Enhancement
-->

## What does this PR do?

There can always be reason to disable additional metadata. Having flexibility is nice to have. https://github.com/elastic/beats/pull/22189/files#diff-795a7b218ad6ff27d43bc453ecce7984c3d816537b1afc9cfc9000d5d574119eR181 introduced an issue of pulling all node metadata even if running on a daemonset. This PR fixes that behavior

## Why is it important?

we dont see the need for each metric to have all labels when being ingested. the lack of node name being passed ot the node watcher causes too much churn on the API server on large clusters. 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

