### PR TITLE
Fleet apache: convert status.total_kbytes to status.total_bytes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -863,6 +863,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - `kibana` module: `stats` metricset no-longer collects usage-related data. {pull}22732[22732]
 - Adjust the Apache status fields in the fleet mode. {pull}22821[22821]
 - Add process.state, process.cpu.pct, process.cpu.start_time and process.memory.pct. {pull}22845[22845]
+- Apache: convert status.total_kbytes to status.total_bytes in fleet mode. {pull}23022[23022]
 
 *Packetbeat*
 

--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -129,7 +129,7 @@ func eventMapping(scanner *bufio.Scanner, hostname string) (common.MapStr, error
 	for scanner.Scan() {
 		if match := matchNumber.FindStringSubmatch(scanner.Text()); len(match) == 3 {
 			// Total Accesses: 16147
-			//Total kBytes: 12988
+			// Total kBytes: 12988
 			// Uptime: 3229728
 			// CPULoad: .000408393
 			// CPUUser: 0

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -109,6 +109,13 @@ func adjustFleetEvent(event mb.Event) mb.Event {
 	var adjusted mb.Event
 	adjusted.MetricSetFields = event.MetricSetFields.Clone()
 
+	// Convert apache.status.total_kbytes to apache.status.total_bytes
+	totalKBytes, err := adjusted.MetricSetFields.GetValue("total_kbytes")
+	if err == nil {
+		adjusted.MetricSetFields.Put("total_bytes", totalKBytes.(int64)*1024)
+		adjusted.MetricSetFields.Delete("total_kbytes")
+	}
+
 	// Remove apache.hostname
 	adjusted.MetricSetFields.Delete("hostname")
 	return adjusted

--- a/metricbeat/module/apache/status/status_integration_test.go
+++ b/metricbeat/module/apache/status/status_integration_test.go
@@ -68,8 +68,15 @@ func TestFetchFleetMode(t *testing.T) {
 		t.Fatal("Too few top-level elements in the event")
 	}
 
-	_, err := event.MetricSetFields.GetValue("hostname")
-	assert.Equal(t, common.ErrKeyNotFound, err, "apache.hostname shouldn't be present in the fleet mode")
+	_, err := event.MetricSetFields.GetValue("total_kbytes")
+	assert.Equal(t, common.ErrKeyNotFound, err, "apache.status.total_kbytes shouldn't be present in the fleet mode")
+
+	totalBytes, err := event.MetricSetFields.GetValue("total_bytes")
+	assert.NoError(t, err, "apache.status.total_bytes should be present in the fleet mode")
+	assert.GreaterOrEqual(t, totalBytes.(int64), int64(0), "apache.status.total_bytes should be non-negative")
+
+	_, err = event.MetricSetFields.GetValue("hostname")
+	assert.Equal(t, common.ErrKeyNotFound, err, "apache.status.hostname shouldn't be present in the fleet mode")
 }
 
 func getConfig(host string) map[string]interface{} {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR modifies the the `apache.status` metricset to report `apache.status.total_bytes` instead of `apache.status.total_kbytes` in the fleet mode.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change is required to improve overview dashboard and support human readable format (expects bytes input). 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

It will be tested by the CI in the Integrations project. 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #23021 
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/integrations/issues/370

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
