### PR TITLE
Cherry-pick #22778 to 7.x: Improve equals check

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -377,6 +377,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added "add_network_direction" processor for determining perimeter-based network direction. {pull}23076[23076]
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
+- Improve equals check. {pull}22778[22778]
 
 *Auditbeat*
 

--- a/libbeat/conditions/equals_test.go
+++ b/libbeat/conditions/equals_test.go
@@ -18,6 +18,7 @@
 package conditions
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,46 @@ func TestEqualsMultiFieldAndTypePositiveMatch(t *testing.T) {
 			"proc.pid": 305,
 		}},
 	})
+}
+
+func BenchmarkEquals(b *testing.B) {
+	cases := map[string]map[string]interface{}{
+		"1 condition": {
+			"type": "process",
+		},
+		"3 conditions": {
+			"type":     "process",
+			"proc.pid": 305,
+			"final":    false,
+		},
+		"5 conditions": {
+			"type":             "process",
+			"proc.pid":         305,
+			"final":            false,
+			"tags":             "error path",
+			"non-existing-key": "",
+		},
+		"7 conditions": {
+			"type":                "process",
+			"proc.pid":            305,
+			"final":               false,
+			"tags":                "error path",
+			"non-existing-key":    "",
+			"proc.cmdline":        "/usr/libexec/secd",
+			"proc.cpu.start_time": 10,
+		},
+	}
+
+	for name, config := range cases {
+		b.Run(name, func(b *testing.B) {
+			e, err := NewEqualsCondition(config)
+			assert.NoError(b, err)
+
+			runtime.GC()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				e.Check(secdTestEvent)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Cherry-pick of PR #22778 to 7.x branch. Original message: 

## What does this PR do?

Improve equals check performance

## Why is it important?

* Improve equals check performance
* improve log output
* fix potentially wrong matches

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

Benchmark test

## Logs

Benchmark added test case, before this change
```
pkg: github.com/elastic/beats/v7/libbeat/conditions
BenchmarkEquals_Check
BenchmarkEquals_Check-8   	 1529768	       829 ns/op
PASS
```

After
```
pkg: github.com/elastic/beats/v7/libbeat/conditions
BenchmarkEquals_Check
BenchmarkEquals_Check-8   	 6298933	       188 ns/op
PASS
```
