### PR TITLE
Cherry-pick #22537 to 7.x: Support for upgrade rollback 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/locker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/locker.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gofrs/flock"
 )
 
-const lockFileName = "agent.lock"
-
 // ErrAppAlreadyRunning error returned when another elastic-agent is already holding the lock.
 var ErrAppAlreadyRunning = fmt.Errorf("another elastic-agent is already running")
 
@@ -23,7 +21,7 @@ type AppLocker struct {
 }
 
 // NewAppLocker creates an AppLocker that locks the agent.lock file inside the provided directory.
-func NewAppLocker(dir string) *AppLocker {
+func NewAppLocker(dir, lockFileName string) *AppLocker {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		_ = os.Mkdir(dir, 0755)
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/locker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/locker_test.go
@@ -13,12 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testLockFile = "test.lock"
+
 func TestAppLocker(t *testing.T) {
 	tmp, _ := ioutil.TempDir("", "locker")
 	defer os.RemoveAll(tmp)
 
-	locker1 := NewAppLocker(tmp)
-	locker2 := NewAppLocker(tmp)
+	locker1 := NewAppLocker(tmp, testLockFile)
+	locker2 := NewAppLocker(tmp, testLockFile)
 
 	require.NoError(t, locker1.TryLock())
 	assert.Error(t, locker2.TryLock())

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
@@ -1,0 +1,126 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	defaultCheckPeriod = 10 * time.Second
+	evaluatedPeriods   = 6 // with 10s period this means we evaluate 60s of agent run
+	crashesAllowed     = 2 // means that within 60s one restart is allowed, additional one is considered crash
+)
+
+type serviceHandler interface {
+	PID(ctx context.Context) (int, error)
+	Name() string
+	Close()
+}
+
+// CrashChecker checks agent for crash pattern in Elastic Agent lifecycle.
+type CrashChecker struct {
+	notifyChan  chan error
+	q           *disctintQueue
+	log         *logger.Logger
+	sc          serviceHandler
+	checkPeriod time.Duration
+}
+
+// NewCrashChecker creates a new crash checker.
+func NewCrashChecker(ctx context.Context, ch chan error, log *logger.Logger) (*CrashChecker, error) {
+	q, err := newDistinctQueue(evaluatedPeriods)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &CrashChecker{
+		notifyChan:  ch,
+		q:           q,
+		log:         log,
+		checkPeriod: defaultCheckPeriod,
+	}
+
+	if err := c.Init(ctx, log); err != nil {
+		return nil, err
+	}
+
+	log.Debugf("running checks using '%s' controller", c.sc.Name())
+
+	return c, nil
+}
+
+// Run runs the checking loop.
+func (ch *CrashChecker) Run(ctx context.Context) {
+	defer ch.sc.Close()
+
+	ch.log.Debug("Crash checker started")
+	for {
+		ch.log.Debugf("watcher having PID: %d", os.Getpid())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(ch.checkPeriod):
+			pid, err := ch.sc.PID(ctx)
+			if err != nil {
+				ch.log.Error(err)
+			}
+
+			ch.q.Push(pid)
+			restarts := ch.q.Distinct()
+			ch.log.Debugf("retrieved service PID [%d] changed %d times within %d", pid, restarts, evaluatedPeriods)
+			if restarts > crashesAllowed {
+				ch.notifyChan <- errors.New(fmt.Sprintf("service restarted '%d' times within '%v' seconds", restarts, ch.checkPeriod.Seconds()))
+			}
+		}
+	}
+}
+
+type disctintQueue struct {
+	q    []int
+	size int
+	lock sync.Mutex
+}
+
+func newDistinctQueue(size int) (*disctintQueue, error) {
+	if size < 1 {
+		return nil, errors.New("invalid size", errors.TypeUnexpected)
+	}
+	return &disctintQueue{
+		q:    make([]int, 0, size),
+		size: size,
+	}, nil
+}
+
+func (dq *disctintQueue) Push(id int) {
+	dq.lock.Lock()
+	defer dq.lock.Unlock()
+
+	cutIdx := len(dq.q)
+	if dq.size-1 < len(dq.q) {
+		cutIdx = dq.size - 1
+	}
+	dq.q = append([]int{id}, dq.q[:cutIdx]...)
+}
+
+func (dq *disctintQueue) Distinct() int {
+	dq.lock.Lock()
+	defer dq.lock.Unlock()
+
+	dm := make(map[int]int)
+
+	for _, id := range dq.q {
+		dm[id] = 1
+	}
+
+	return len(dm)
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker_test.go
@@ -1,0 +1,162 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+var (
+	testCheckPeriod = 100 * time.Millisecond
+)
+
+func TestChecker(t *testing.T) {
+	t.Run("no failure when no change", func(t *testing.T) {
+		pider := &testPider{}
+		ch, errChan := testableChecker(t, pider)
+		ctx, canc := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			ch.Run(ctx)
+		}()
+
+		wg.Wait()
+		<-time.After(6 * testCheckPeriod)
+
+		var err error
+		select {
+		case err = <-errChan:
+		default:
+		}
+
+		canc()
+		require.NoError(t, err)
+	})
+
+	t.Run("no failure when unfrequent change", func(t *testing.T) {
+		pider := &testPider{}
+		ch, errChan := testableChecker(t, pider)
+		ctx, canc := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			ch.Run(ctx)
+		}()
+
+		wg.Wait()
+		for i := 0; i < 2; i++ {
+			<-time.After(3 * testCheckPeriod)
+			pider.Change(i)
+		}
+		var err error
+		select {
+		case err = <-errChan:
+		default:
+		}
+
+		canc()
+		require.NoError(t, err)
+	})
+
+	t.Run("no failure when change lower than limit", func(t *testing.T) {
+		pider := &testPider{}
+		ch, errChan := testableChecker(t, pider)
+		ctx, canc := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			ch.Run(ctx)
+		}()
+
+		wg.Wait()
+		for i := 0; i < 3; i++ {
+			<-time.After(7 * testCheckPeriod)
+			pider.Change(i)
+		}
+		var err error
+		select {
+		case err = <-errChan:
+		default:
+		}
+
+		canc()
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when pid changes frequently", func(t *testing.T) {
+		pider := &testPider{}
+		ch, errChan := testableChecker(t, pider)
+		ctx, canc := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			ch.Run(ctx)
+		}()
+
+		wg.Wait()
+		for i := 0; i < 12; i++ {
+			<-time.After(testCheckPeriod / 2)
+			pider.Change(i)
+		}
+		var err error
+		select {
+		case err = <-errChan:
+		default:
+		}
+
+		canc()
+		require.Error(t, err)
+	})
+}
+
+func testableChecker(t *testing.T, pider *testPider) (*CrashChecker, chan error) {
+	errChan := make(chan error, 1)
+	l, _ := logger.New("")
+	ch, err := NewCrashChecker(context.Background(), errChan, l)
+	require.NoError(t, err)
+
+	ch.checkPeriod = testCheckPeriod
+	ch.sc.Close()
+	ch.sc = pider
+
+	return ch, errChan
+}
+
+type testPider struct {
+	sync.Mutex
+	pid int
+}
+
+func (p *testPider) Change(pid int) {
+	p.Lock()
+	defer p.Unlock()
+	p.pid = pid
+}
+
+func (p *testPider) PID(ctx context.Context) (int, error) {
+	p.Lock()
+	defer p.Unlock()
+	return p.pid, nil
+}
+
+func (p *testPider) Close() {}
+
+func (p *testPider) Name() string { return "testPider" }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
@@ -1,0 +1,102 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	statusCheckPeriod        = 30 * time.Second
+	statusCheckMissesAllowed = 4 // enable 2 minute start
+)
+
+// ErrAgentStatusFailed is returned when agent reports FAILED status.
+var ErrAgentStatusFailed = errors.New("agent in a failed state", errors.TypeApplication)
+
+// ErrorChecker checks agent for status change and sends an error to a channel if found.
+type ErrorChecker struct {
+	failuresCounter int
+	notifyChan      chan error
+	log             *logger.Logger
+	agentClient     client.Client
+}
+
+// NewErrorChecker creates a new error checker.
+func NewErrorChecker(ch chan error, log *logger.Logger) (*ErrorChecker, error) {
+	c := client.New()
+	ec := &ErrorChecker{
+		notifyChan:  ch,
+		agentClient: c,
+		log:         log,
+	}
+
+	return ec, nil
+}
+
+// Run runs the checking loop.
+func (ch *ErrorChecker) Run(ctx context.Context) {
+	ch.log.Debug("Error checker started")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(statusCheckPeriod):
+			err := ch.agentClient.Connect(ctx)
+			if err != nil {
+				ch.failuresCounter++
+				ch.log.Error(err, "Failed communicating to running daemon", errors.TypeNetwork, errors.M("socket", control.Address()))
+				ch.checkFailures()
+
+				continue
+			}
+
+			status, err := ch.agentClient.Status(ctx)
+			ch.agentClient.Disconnect()
+			if err != nil {
+				ch.log.Error("failed retrieving agent status", err)
+				ch.failuresCounter++
+				ch.checkFailures()
+
+				// agent is probably not running and this will be detected by pid watcher
+				continue
+			}
+
+			// call was successful, reset counter
+			ch.failuresCounter = 0
+
+			if status.Status == client.Failed {
+				ch.log.Error("error checker notifying failure of agent")
+				ch.notifyChan <- ErrAgentStatusFailed
+			}
+
+			for _, app := range status.Applications {
+				if app.Status == client.Failed {
+					err = multierror.Append(err, errors.New(fmt.Sprintf("application %s[%v] failed: %s", app.Name, app.ID, app.Message)))
+				}
+			}
+
+			if err != nil {
+				ch.log.Error("error checker notifying failure of applications")
+				ch.notifyChan <- errors.New(err, "applications in a failed state", errors.TypeApplication)
+			}
+		}
+	}
+}
+
+func (ch *ErrorChecker) checkFailures() {
+	if failures := ch.failuresCounter; failures > statusCheckMissesAllowed {
+		ch.notifyChan <- errors.New(fmt.Sprintf("service failed to fetch agent status '%d' times in a row", failures))
+	}
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
@@ -1,0 +1,149 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/beats/v7/libbeat/common/backoff"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	watcherSubcommand  = "watch"
+	maxRestartCount    = 5
+	restartBackoffInit = 5 * time.Second
+	restartBackoffMax  = 90 * time.Second
+)
+
+// Rollback rollbacks to previous version which was functioning before upgrade.
+func Rollback(ctx context.Context, prevHash, currentHash string) error {
+	// change symlink
+	if err := ChangeSymlink(ctx, prevHash); err != nil {
+		return err
+	}
+
+	// revert active commit
+	if err := UpdateActiveCommit(prevHash); err != nil {
+		return err
+	}
+
+	// Restart
+	if err := restartAgent(ctx); err != nil {
+		return err
+	}
+
+	// cleanup everything except version we're rolling back into
+	return Cleanup(prevHash, true)
+}
+
+// Cleanup removes all artifacts and files related to a specified version.
+func Cleanup(currentHash string, removeMarker bool) error {
+	<-time.After(afterRestartDelay)
+
+	// remove upgrade marker
+	if removeMarker {
+		if err := CleanMarker(); err != nil {
+			return err
+		}
+	}
+
+	// remove data/elastic-agent-{hash}
+	dataDir, err := os.Open(paths.Data())
+	if err != nil {
+		return err
+	}
+
+	subdirs, err := dataDir.Readdirnames(0)
+	if err != nil {
+		return err
+	}
+
+	dirPrefix := fmt.Sprintf("%s-", agentName)
+	currentDir := fmt.Sprintf("%s-%s", agentName, currentHash)
+	for _, dir := range subdirs {
+		if dir == currentDir {
+			continue
+		}
+
+		if !strings.HasPrefix(dir, dirPrefix) {
+			continue
+		}
+
+		hashedDir := filepath.Join(paths.Data(), dir)
+		if cleanupErr := install.RemovePath(hashedDir); cleanupErr != nil {
+			err = multierror.Append(err, cleanupErr)
+		}
+	}
+
+	return err
+}
+
+// InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
+// agent during upgrade period.
+func InvokeWatcher(log *logger.Logger) error {
+	if !IsUpgradeable() {
+		log.Debug("agent is not upgradable, not starting watcher")
+		return nil
+	}
+
+	cmd := invokeCmd()
+	defer func() {
+		if cmd.Process != nil {
+			log.Debugf("releasing watcher %v", cmd.Process.Pid)
+			cmd.Process.Release()
+		}
+	}()
+
+	return cmd.Start()
+}
+
+func restartAgent(ctx context.Context) error {
+	restartFn := func(ctx context.Context) error {
+		c := client.New()
+		err := c.Connect(ctx)
+		if err != nil {
+			return errors.New(err, "failed communicating to running daemon", errors.TypeNetwork, errors.M("socket", control.Address()))
+		}
+		defer c.Disconnect()
+
+		err = c.Restart(ctx)
+		if err != nil {
+			return errors.New(err, "failed trigger restart of daemon")
+		}
+
+		return nil
+	}
+
+	signal := make(chan struct{})
+	backExp := backoff.NewExpBackoff(signal, restartBackoffInit, restartBackoffMax)
+
+	for i := maxRestartCount; i >= 1; i-- {
+		backExp.Wait()
+		err := restartFn(ctx)
+		if err == nil {
+			break
+		}
+
+		if i == 1 {
+			return err
+		}
+	}
+
+	close(signal)
+	return nil
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
@@ -1,0 +1,287 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !darwin
+// +build !windows
+
+package upgrade
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	// delay after agent restart is performed to allow agent to tear down all the processes
+	// important mainly for windows, as it prevents removing files which are in use
+	afterRestartDelay = 2 * time.Second
+)
+
+type pidProvider interface {
+	Init() error
+	Close()
+	PID(ctx context.Context) (int, error)
+	Name() string
+}
+
+// Init initializes os dependent properties.
+func (ch *CrashChecker) Init(ctx context.Context, _ *logger.Logger) error {
+	pp := relevantPidProvider()
+	pp.Init()
+
+	ch.sc = pp
+
+	return nil
+}
+
+func relevantPidProvider() pidProvider {
+	var pp pidProvider
+
+	switch {
+	case isSystemd():
+		pp = &dbusPidProvider{}
+	case isUpstart():
+		pp = &upstartPidProvider{}
+	case isSysv():
+		pp = &sysvPidProvider{}
+	default:
+		// in case we're using unsupported service manager
+		// let other checks work
+		pp = &noopPidProvider{}
+	}
+
+	return pp
+}
+
+// Upstart PID Provider
+
+type upstartPidProvider struct{}
+
+func (p *upstartPidProvider) Init() error { return nil }
+
+func (p *upstartPidProvider) Close() {}
+
+func (p *upstartPidProvider) Name() string { return "Upstart" }
+
+func (p *upstartPidProvider) PID(ctx context.Context) (int, error) {
+	listCmd := exec.Command("/sbin/status", agentName)
+	out, err := listCmd.Output()
+	if err != nil {
+		return 0, errors.New("failed to read process id", err)
+	}
+
+	// find line
+	pidLine := strings.TrimSpace(string(out))
+	if pidLine == "" {
+		return 0, errors.New(fmt.Sprintf("service process not found for service '%v'", install.ServiceName))
+	}
+
+	re := regexp.MustCompile(agentName + ` start/running, process ([0-9]+)`)
+	matches := re.FindStringSubmatch(pidLine)
+	if len(matches) != 2 {
+		return 0, errors.New("could not detect pid of process", pidLine, matches)
+	}
+
+	pid, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, errors.New(fmt.Sprintf("failed to get process id[%v]", matches[1]), err)
+	}
+
+	return pid, nil
+}
+
+// SYSV PID Provider
+
+type sysvPidProvider struct{}
+
+func (p *sysvPidProvider) Init() error { return nil }
+
+func (p *sysvPidProvider) Close() {}
+
+func (p *sysvPidProvider) Name() string { return "SysV" }
+
+func (p *sysvPidProvider) PID(ctx context.Context) (int, error) {
+	listCmd := exec.Command("service", agentName, "status")
+	out, err := listCmd.Output()
+	if err != nil {
+		return 0, errors.New("failed to read process id", err)
+	}
+
+	// find line
+	statusLine := strings.TrimSpace(string(out))
+	if statusLine == "" {
+		return 0, errors.New(fmt.Sprintf("service process not found for service '%v'", install.ServiceName))
+	}
+
+	// sysv does not report pid, let's do best effort
+	if !strings.HasPrefix(statusLine, "Running") {
+		return 0, errors.New(fmt.Sprintf("'%v' is not running", install.ServiceName))
+	}
+
+	pidofLine, err := exec.Command("pidof", filepath.Join(install.InstallPath, install.BinaryName)).Output()
+	if err != nil {
+		return 0, errors.New(fmt.Sprintf("PID not found for'%v': %v", install.ServiceName, err))
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidofLine)))
+	if err != nil {
+		return 0, errors.New("PID not a number")
+	}
+
+	return pid, nil
+}
+
+// DBUS PID provider
+
+type dbusPidProvider struct {
+	dbusConn *dbus.Conn
+}
+
+func (p *dbusPidProvider) Init() error {
+	dbusConn, err := dbus.New()
+	if err != nil {
+		return errors.New("failed to create dbus connection", err)
+	}
+
+	p.dbusConn = dbusConn
+	return nil
+}
+
+func (p *dbusPidProvider) Name() string { return "DBus" }
+
+func (p *dbusPidProvider) Close() {
+	p.dbusConn.Close()
+}
+
+func (p *dbusPidProvider) PID(ctx context.Context) (int, error) {
+	prop, err := p.dbusConn.GetServiceProperty(install.ServiceName, "MainPID")
+	if err != nil {
+		return 0, errors.New("failed to read service", err)
+	}
+
+	pid, ok := prop.Value.Value().(uint32)
+	if !ok {
+		return 0, errors.New("failed to get process id", prop.Value.Value())
+	}
+
+	return int(pid), nil
+}
+
+// noop PID provider
+
+type noopPidProvider struct{}
+
+func (p *noopPidProvider) Init() error { return nil }
+
+func (p *noopPidProvider) Close() {}
+
+func (p *noopPidProvider) Name() string { return "noop" }
+
+func (p *noopPidProvider) PID(ctx context.Context) (int, error) { return 0, nil }
+
+func invokeCmd() *exec.Cmd {
+	homeExePath := filepath.Join(paths.Home(), agentName)
+
+	cmd := exec.Command(homeExePath, watcherSubcommand,
+		"--path.config", paths.Config(),
+		"--path.home", paths.Top(),
+	)
+
+	var cred = &syscall.Credential{
+		Uid:         uint32(os.Getuid()),
+		Gid:         uint32(os.Getgid()),
+		Groups:      nil,
+		NoSetGroups: true,
+	}
+	var sysproc = &syscall.SysProcAttr{
+		Credential: cred,
+		Setsid:     true,
+		// propagate sigint instead of sigkill so we can ignore it
+		Pdeathsig: syscall.SIGINT,
+	}
+	cmd.SysProcAttr = sysproc
+	return cmd
+}
+
+func isSystemd() bool {
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
+		return true
+	}
+
+	if _, err := os.Stat("/proc/1/comm"); err == nil {
+		filerc, err := os.Open("/proc/1/comm")
+		if err != nil {
+			return false
+		}
+		defer filerc.Close()
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(filerc)
+		contents := buf.String()
+
+		if strings.Trim(contents, " \r\n") == "systemd" {
+			return true
+		}
+	}
+	return false
+}
+
+func isUpstart() bool {
+	if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
+		return true
+	}
+
+	if _, err := os.Stat("/sbin/initctl"); err == nil {
+		if out, err := exec.Command("/sbin/initctl", "--version").Output(); err == nil {
+			if bytes.Contains(out, []byte("initctl (upstart")) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isSysv() bool {
+	// PID 1 is init
+	out, err := exec.Command("sudo", "cat", "/proc/1/comm").Output()
+	if err != nil {
+		o, err := exec.Command("cat", "/proc/1/comm").Output()
+		if err != nil {
+			return false
+		}
+		out = o
+	}
+
+	if strings.TrimSpace(string(out)) != "init" {
+		return false
+	}
+
+	// /sbin/init is not a link
+	initFile, err := os.Open("/sbin/init")
+	if err != nil || initFile == nil {
+		return false
+	}
+
+	fi, err := initFile.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeSymlink != os.ModeSymlink
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
@@ -1,0 +1,137 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build darwin
+
+package upgrade
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
+
+const (
+	// delay after agent restart is performed to allow agent to tear down all the processes
+	// important mainly for windows, as it prevents removing files which are in use
+	afterRestartDelay = 2 * time.Second
+)
+
+// Init initializes os dependent properties.
+func (ch *CrashChecker) Init(ctx context.Context, _ *logger.Logger) error {
+	ch.sc = &darwinPidProvider{}
+
+	return nil
+}
+
+type darwinPidProvider struct{}
+
+func (p *darwinPidProvider) Name() string { return "launchd" }
+
+func (p *darwinPidProvider) Close() {}
+
+func (p *darwinPidProvider) PID(ctx context.Context) (int, error) {
+	piders := []func(context.Context) (int, error){
+		p.piderFromCmd(ctx, "launchctl", "list", install.ServiceName),
+	}
+
+	// if release is specifically built to be upgradeable (using DEV flag)
+	// we dont require to run as a service and will need sudo fallback
+	if release.Upgradeable() {
+		piders = append(piders, p.piderFromCmd(ctx, "sudo", "launchctl", "list", install.ServiceName))
+	}
+
+	var pidErrors error
+	for _, pider := range piders {
+		pid, err := pider(ctx)
+		if err == nil {
+			return pid, nil
+		}
+
+		pidErrors = multierror.Append(pidErrors, err)
+	}
+
+	return 0, pidErrors
+}
+
+func (p *darwinPidProvider) piderFromCmd(ctx context.Context, name string, args ...string) func(context.Context) (int, error) {
+	return func(context.Context) (int, error) {
+		listCmd := exec.Command(name, args...)
+		listCmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: 0, Gid: 0},
+		}
+		out, err := listCmd.Output()
+		if err != nil {
+			return 0, errors.New("failed to read process id", err)
+		}
+
+		// find line
+		pidLine := ""
+		reader := bufio.NewReader(bytes.NewReader(out))
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, `"PID" = `) {
+				pidLine = strings.TrimSpace(line)
+				break
+			}
+		}
+
+		if pidLine == "" {
+			return 0, errors.New(fmt.Sprintf("service process not found for service '%v'", install.ServiceName))
+		}
+
+		re := regexp.MustCompile(`"PID" = ([0-9]+);`)
+		matches := re.FindStringSubmatch(pidLine)
+		if len(matches) != 2 {
+			return 0, errors.New("could not detect pid of process", pidLine, matches)
+		}
+
+		pid, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return 0, errors.New(fmt.Sprintf("failed to get process id[%v]", matches[1]), err)
+		}
+
+		return pid, nil
+	}
+}
+
+func invokeCmd() *exec.Cmd {
+	homeExePath := filepath.Join(paths.Home(), agentName)
+
+	cmd := exec.Command(homeExePath, watcherSubcommand,
+		"--path.config", paths.Config(),
+		"--path.home", paths.Top(),
+	)
+
+	var cred = &syscall.Credential{
+		Uid:         uint32(os.Getuid()),
+		Gid:         uint32(os.Getgid()),
+		Groups:      nil,
+		NoSetGroups: true,
+	}
+	var sysproc = &syscall.SysProcAttr{
+		Credential: cred,
+		Setsid:     true,
+	}
+	cmd.SysProcAttr = sysproc
+	return cmd
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
@@ -1,0 +1,74 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build windows
+
+package upgrade
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	// delay after agent restart is performed to allow agent to tear down all the processes
+	// important mainly for windows, as it prevents removing files which are in use
+	afterRestartDelay = 15 * time.Second
+)
+
+// Init initializes os dependent properties.
+func (ch *CrashChecker) Init(ctx context.Context, _ *logger.Logger) error {
+	mgr, err := mgr.Connect()
+	if err != nil {
+		return errors.New("failed to initiate service manager", err)
+	}
+
+	ch.sc = &pidProvider{
+		winManager: mgr,
+	}
+
+	return nil
+}
+
+type pidProvider struct {
+	winManager *mgr.Mgr
+}
+
+func (p *pidProvider) Close() {}
+
+func (p *pidProvider) Name() string { return "Windows Service Manager" }
+
+func (p *pidProvider) PID(ctx context.Context) (int, error) {
+	svc, err := p.winManager.OpenService(install.ServiceName)
+	if err != nil {
+		return 0, errors.New("failed to read windows service", err)
+	}
+
+	status, err := svc.Query()
+	if err != nil {
+		return 0, errors.New("failed to read windows service PID: %v", err)
+	}
+
+	return int(status.ProcessId), nil
+}
+
+func invokeCmd() *exec.Cmd {
+	homeExePath := filepath.Join(paths.Home(), agentName)
+
+	cmd := exec.Command(homeExePath, watcherSubcommand,
+		"--path.config", paths.Config(),
+		"--path.home", paths.Top(),
+	)
+
+	return cmd
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_relink.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_relink.go
@@ -16,10 +16,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 )
 
-// changeSymlink changes root symlink so it points to updated version
-func (u *Upgrader) changeSymlink(ctx context.Context, newHash string) error {
+// ChangeSymlink updates symlink paths to match current version.
+func ChangeSymlink(ctx context.Context, targetHash string) error {
 	// create symlink to elastic-agent-{hash}
-	hashedDir := fmt.Sprintf("%s-%s", agentName, newHash)
+	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
 
 	agentPrevName := agentName + ".prev"
 	symlinkPath := filepath.Join(paths.Top(), agentName)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -75,6 +73,13 @@ type stateReporter interface {
 	OnStateChange(id string, name string, s state.State)
 }
 
+// IsUpgradeable when agent is installed and running as a service or flag was provided.
+func IsUpgradeable() bool {
+	// only upgradeable if running from Agent installer and running under the
+	// control of the system supervisor (or built specifically with upgrading enabled)
+	return release.Upgradeable() || (install.RunningInstalled() && install.RunningUnderSupervisor())
+}
+
 // NewUpgrader creates an upgrader which is capable of performing upgrade operation
 func NewUpgrader(agentInfo *info.AgentInfo, settings *artifact.Config, log *logger.Logger, closers []context.CancelFunc, reexec reexecManager, a acker, r stateReporter) *Upgrader {
 	return &Upgrader{
@@ -85,7 +90,7 @@ func NewUpgrader(agentInfo *info.AgentInfo, settings *artifact.Config, log *logg
 		reexec:      reexec,
 		acker:       a,
 		reporter:    r,
-		upgradeable: getUpgradeable(),
+		upgradeable: IsUpgradeable(),
 	}
 }
 
@@ -141,14 +146,19 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (err e
 		return errors.New(err, "failed to copy action store")
 	}
 
-	if err := u.changeSymlink(ctx, newHash); err != nil {
-		rollbackInstall(newHash)
+	if err := ChangeSymlink(ctx, newHash); err != nil {
+		rollbackInstall(ctx, newHash)
 		return err
 	}
 
 	if err := u.markUpgrade(ctx, newHash, a); err != nil {
-		rollbackInstall(newHash)
+		rollbackInstall(ctx, newHash)
 		return err
+	}
+
+	if err := InvokeWatcher(u.log); err != nil {
+		rollbackInstall(ctx, newHash)
+		return errors.New("failed to invoke rollback watcher", err)
 	}
 
 	if reexecNow {
@@ -160,17 +170,12 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (err e
 // Ack acks last upgrade action
 func (u *Upgrader) Ack(ctx context.Context) error {
 	// get upgrade action
-	markerFile := filepath.Join(paths.Data(), markerFilename)
-	markerBytes, err := ioutil.ReadFile(markerFile)
-	if err != nil && os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
+	marker, err := LoadMarker()
+	if err != nil {
 		return err
 	}
-
-	marker := &updateMarker{}
-	if err := yaml.Unmarshal(markerBytes, marker); err != nil {
-		return err
+	if marker == nil {
+		return nil
 	}
 
 	if marker.Acked {
@@ -181,13 +186,7 @@ func (u *Upgrader) Ack(ctx context.Context) error {
 		return err
 	}
 
-	marker.Acked = true
-	markerBytes, err = yaml.Marshal(marker)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(markerFile, markerBytes, 0600)
+	return saveMarker(marker)
 }
 
 func (u *Upgrader) sourceURI(version, retrievedURI string) (string, error) {
@@ -242,14 +241,9 @@ func (u *Upgrader) reportUpdating(version string) {
 	)
 }
 
-func rollbackInstall(hash string) {
+func rollbackInstall(ctx context.Context, hash string) {
 	os.RemoveAll(filepath.Join(paths.Data(), fmt.Sprintf("%s-%s", agentName, hash)))
-}
-
-func getUpgradeable() bool {
-	// only upgradeable if running from Agent installer and running under the
-	// control of the system supervisor (or built specifically with upgrading enabled)
-	return release.Upgradeable() || (install.RunningInstalled() && install.RunningUnderSupervisor())
+	ChangeSymlink(ctx, release.ShortCommit())
 }
 
 func copyActionStore(newHash string) error {

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	defaultConfig = "elastic-agent.yml"
-	hashLen       = 6
-	commitFile    = ".elastic-agent.active.commit"
+	defaultConfig     = "elastic-agent.yml"
+	hashLen           = 6
+	commitFile        = ".elastic-agent.active.commit"
+	agentLockFileName = "agent.lock"
 )
 
 type globalFlags struct {
@@ -71,6 +72,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(newUpgradeCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newEnrollCommandWithArgs(flags, args, streams))
 	cmd.AddCommand(newInspectCommandWithArgs(flags, args, streams))
+	cmd.AddCommand(newWatchCommandWithArgs(flags, args, streams))
 
 	// windows special hidden sub-command (only added on windows)
 	reexec := newReExecWindowsCommand(flags, args, streams)

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -56,7 +56,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 	}
 
 	// check the lock to ensure that elastic-agent is not already running in this directory
-	locker := application.NewAppLocker(paths.Data())
+	locker := application.NewAppLocker(paths.Data(), agentLockFileName)
 	if err := locker.TryLock(); err != nil {
 		if err == application.ErrAppAlreadyRunning {
 			return fmt.Errorf("cannot perform installation as Elastic Agent is already running from this directory")

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/reexec"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/upgrade"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -52,7 +53,7 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	// This must be the first deferred cleanup task (last to execute).
 	defer service.NotifyTermination()
 
-	locker := application.NewAppLocker(paths.Data())
+	locker := application.NewAppLocker(paths.Data(), agentLockFileName)
 	if err := locker.TryLock(); err != nil {
 		return err
 	}
@@ -101,6 +102,12 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
 	if err != nil {
 		return err
+	}
+
+	// initiate agent watcher
+	if err := upgrade.InvokeWatcher(logger); err != nil {
+		// we should not fail because watcher is not working
+		logger.Error("failed to invoke rollback watcher", err)
 	}
 
 	if allowEmptyPgp, _ := release.PGP(); allowEmptyPgp {

--- a/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
@@ -7,9 +7,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -81,15 +78,6 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 	}
 	fmt.Fprintf(streams.Out, "Elastic Agent has been uninstalled.\n")
 
-	if runtime.GOOS == "windows" {
-		// The installation path will still exists because we are executing from that
-		// directory. So cmd.exe is spawned that sleeps for 2 seconds (using ping, recommend way from
-		// from Windows) then rmdir is performed.
-		rmdir := exec.Command(
-			filepath.Join(os.Getenv("windir"), "system32", "cmd.exe"),
-			"/C", "ping", "-n", "2", "127.0.0.1", "&&", "rmdir", "/s", "/q", install.InstallPath)
-		_ = rmdir.Start()
-	}
-
+	install.RemovePath(install.InstallPath)
 	return nil
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/watch.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/watch.go
@@ -1,0 +1,209 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/upgrade"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+)
+
+const (
+	// period during which we monitor for failures resulting in a rollback
+	gracePeriodDuration = 10 * time.Minute
+
+	watcherName     = "elastic-agent-watcher"
+	watcherLockFile = "watcher.lock"
+)
+
+func newWatchCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Watch watches Elastic Agent for failures and initiates rollback.",
+		Long:  `Watch watches Elastic Agent for failures and initiates rollback.`,
+		Run: func(c *cobra.Command, args []string) {
+			if err := watchCmd(streams, c, flags, args); err != nil {
+				fmt.Fprintf(streams.Err, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func watchCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+	log, err := configuredLogger(flags)
+	if err != nil {
+		return err
+	}
+
+	marker, err := upgrade.LoadMarker()
+	if err != nil {
+		log.Error("failed to load marker", err)
+		return err
+	}
+	if marker == nil {
+		// no marker found we're not in upgrade process
+		log.Debugf("update marker not present at '%s'", paths.Data())
+		return nil
+	}
+
+	locker := application.NewAppLocker(paths.Top(), watcherLockFile)
+	if err := locker.TryLock(); err != nil {
+		if err == application.ErrAppAlreadyRunning {
+			log.Debugf("exiting, lock already exists")
+			return nil
+		}
+
+		log.Error("failed to acquire lock", err)
+		return err
+	}
+	defer locker.Unlock()
+
+	isWithinGrace, tilGrace := gracePeriod(marker)
+	if !isWithinGrace {
+		log.Debugf("not within grace [updatedOn %v] %v", marker.UpdatedOn.String(), time.Now().Sub(marker.UpdatedOn).String())
+		// if it is started outside of upgrade loop
+		// if we're not within grace and marker is still there it might mean
+		// that cleanup was not performed ok, cleanup everything except current version
+		// hash is the same as hash of agent which initiated watcher.
+		if err := upgrade.Cleanup(release.ShortCommit(), true); err != nil {
+			log.Error("rollback failed", err)
+		}
+		// exit nicely
+		return nil
+	}
+
+	ctx := context.Background()
+	if err := watch(ctx, tilGrace, log); err != nil {
+		log.Debugf("Error detected proceeding to rollback", err)
+		err = upgrade.Rollback(ctx, marker.PrevHash, marker.Hash)
+		if err != nil {
+			log.Error("rollback failed", err)
+		}
+		return err
+	}
+
+	// cleanup older versions,
+	// in windows it might leave self untouched, this will get cleaned up
+	// later at the start, because for windows we leave marker untouched.
+	removeMarker := runtime.GOOS != "windows"
+	err = upgrade.Cleanup(marker.Hash, removeMarker)
+	if err != nil {
+		log.Error("rollback failed", err)
+	}
+	return err
+}
+
+func watch(ctx context.Context, tilGrace time.Duration, log *logger.Logger) error {
+	errChan := make(chan error)
+	crashChan := make(chan error)
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	//cleanup
+	defer func() {
+		cancel()
+		close(errChan)
+		close(crashChan)
+	}()
+
+	errorChecker, err := upgrade.NewErrorChecker(errChan, log)
+	if err != nil {
+		return err
+	}
+
+	crashChecker, err := upgrade.NewCrashChecker(ctx, errChan, log)
+	if err != nil {
+		return err
+	}
+
+	go errorChecker.Run(ctx)
+	go crashChecker.Run(ctx)
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+
+WATCHLOOP:
+	for {
+		select {
+		case <-signals:
+			// ignore
+			continue
+		case <-ctx.Done():
+			break WATCHLOOP
+		// grace period passed, agent is considered stable
+		case <-time.After(tilGrace):
+			log.Info("Grace period passed, not watching")
+			break WATCHLOOP
+		// Agent in degraded state.
+		case err := <-errChan:
+			log.Error("Agent Error detected", err)
+			return err
+		// Agent keeps crashing unexpectedly
+		case err := <-crashChan:
+			log.Error("Agent crash detected", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// gracePeriod returns true if it is within grace period and time until grace period ends.
+// otherwise it returns false and 0
+func gracePeriod(marker *upgrade.UpdateMarker) (bool, time.Duration) {
+	sinceUpdate := time.Now().Sub(marker.UpdatedOn)
+
+	if 0 < sinceUpdate && sinceUpdate < gracePeriodDuration {
+		return true, gracePeriodDuration - sinceUpdate
+	}
+
+	return false, gracePeriodDuration
+}
+
+func configuredLogger(flags *globalFlags) (*logger.Logger, error) {
+	pathConfigFile := flags.Config()
+	rawConfig, err := application.LoadConfigFromFile(pathConfigFile)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+
+	cfg, err := configuration.NewFromConfig(rawConfig)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("could not parse configuration file %s", pathConfigFile),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+
+	cfg.Settings.LoggingConfig.Beat = watcherName
+
+	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return logger, nil
+}

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -186,6 +186,7 @@ func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]i
 			},
 			"paths": []string{
 				filepath.Join(paths.Home(), "logs", "elastic-agent-json.log"),
+				filepath.Join(paths.Home(), "logs", "elastic-agent-watcher-json.log"),
 			},
 			"index": "logs-elastic_agent-default",
 			"processors": []map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -100,7 +100,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 	// defaultCfg is used to set the defaults for the file rotation of the internal logging
 	// these settings cannot be changed by a user configuration
 	defaultCfg := logp.DefaultConfig(logp.DefaultEnvironment)
-	filename := filepath.Join(paths.Home(), "logs", fmt.Sprintf("%s-json.log", agentName))
+	filename := filepath.Join(paths.Home(), "logs", fmt.Sprintf("%s-json.log", cfg.Beat))
 
 	rotator, err := file.NewFileRotator(filename,
 		file.MaxSizeBytes(defaultCfg.Files.MaxSize),


### PR DESCRIPTION
Cherry-pick of PR #22537 to 7.x branch. Original message:

## What does this PR do?

This PR introduces watch subcommand which is started as a subprocess at the point of upgrade.
This subcommand starts various watchers monitoring status of agent and apps as well as agent crashes.

In case nothing bad is reported subprocess cleans up older version of agent at terminates.
In case FAILED status is reported or agent crashes more than 2 times within a minute agent is rolled back to previous version and new version is removed. 

This PR does not report UPGRADING state to fleet as state reporting will be changed during upcoming days and the change would make this PR unnecessarily more complicated. 

Watcher makes decisions based on marker, if it does not exist it terminates right away, also more than 1 watcher is not allowed to run using file lock to ensure that.

To test it i built a snapshot version installed it and updated from fleet.
For positive scenario, user needs to wait 10 minutes for cleanup to occur.
For negative scenario `kill -9 {PID}` needs to be done several times where PID is a process ID of main agent process.

## Why is it important?

More solid upgrade process.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
