### PR TITLE
Cherry-pick #23030 to 7.10: Remove beta tag from Cloud foundry input docs

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-cloudfoundry.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cloudfoundry.asciidoc
@@ -9,8 +9,6 @@
 <titleabbrev>Cloud Foundry</titleabbrev>
 ++++
 
-beta[]
-
 Use the `cloudfoundry` input to get http access logs, container logs and error logs from Cloud Foundry. Connects to
 the Cloud Foundry loggregator to receive events.
 


### PR DESCRIPTION
Cherry-pick of PR #23030 to 7.10 branch. Original message: 

Cloud Foundry input was released as GA in 7.10 after #21525.

The beta tag in the inputs doc should have been also removed.