### PR TITLE
Cherry-pick #22998 to 7.x: [Filebeat] panos config option to set internal/external zones

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -480,6 +480,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for UNIX datagram sockets in `unix` input. {issues}18632[18632] {pull}22699[22699]
 - Add `http.request.mime_type` for Elasticsearch audit log fileset. {pull}22975[22975]
 - Add new httpjson input features and mark old config ones for deprecation {pull}22320[22320]
+- Add configuration option to set external and internal networks for panw panos fileset {pull}22998[22998]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1507,6 +1507,15 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Set internal security zones. used to determine network.direction
+    # default "trust"
+    #var.internal_zones:
+
+    # Set external security zones. used to determine network.direction
+    # default "untrust"
+    #var.external_zones:
+
+
 #------------------------------ PostgreSQL Module ------------------------------
 #- module: postgresql
   # Logs

--- a/x-pack/filebeat/module/panw/_meta/config.yml
+++ b/x-pack/filebeat/module/panw/_meta/config.yml
@@ -8,3 +8,12 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Set internal security zones. used to determine network.direction
+    # default "trust"
+    #var.internal_zones:
+
+    # Set external security zones. used to determine network.direction
+    # default "untrust"
+    #var.external_zones:
+

--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -173,6 +173,20 @@ processors:
       fields:
         - csv
 
+{{ if .external_zones }}
+  - add_fields:
+      target: _temp_
+      fields:
+        external_zones: {{ .external_zones | tojson }}
+{{ end }}
+
+{{ if .internal_zones }}
+  - add_fields:
+      target: _temp_
+      fields:
+        internal_zones: {{ .internal_zones | tojson }}
+{{ end }}
+
   - community_id: ~
 
   - community_id:

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -134,24 +134,62 @@ processors:
  - set:
      field: network.direction
      value: inbound
-     if: 'ctx?.panw?.panos?.type == "TRAFFIC" && ctx?.panw?.panos?.source?.zone == "untrust" && ctx?.panw?.panos?.destination?.zone == "trust"'
+     if: >
+       ctx?.panw?.panos?.type == "TRAFFIC" &&
+       ctx?._temp_?.external_zones != null &&
+       ctx?._temp_?.internal_zones != null &&
+       ctx?.observer?.ingress?.zone != null &&
+       ctx?.observer?.egress?.zone != null &&
+       ctx._temp_.external_zones.contains(ctx.observer.ingress.zone) &&
+       ctx._temp_.internal_zones.contains(ctx.observer.egress.zone)
  - set:
      field: network.direction
      value: outbound
-     if: 'ctx?.panw?.panos?.type == "TRAFFIC" && ctx?.panw?.panos?.source?.zone == "trust" && ctx?.panw?.panos?.destination?.zone == "untrust"'
+     if: >
+       ctx?.panw?.panos?.type == "TRAFFIC" &&
+       ctx?._temp_?.external_zones != null &&
+       ctx?._temp_?.internal_zones != null &&
+       ctx?.observer?.ingress?.zone != null &&
+       ctx?.observer?.egress?.zone != null &&
+       ctx._temp_.external_zones.contains(ctx.observer.egress.zone) &&
+       ctx._temp_.internal_zones.contains(ctx.observer.ingress.zone)
  - set:
      field: network.direction
      value: internal
-     if: 'ctx?.panw?.panos?.type == "TRAFFIC" && ctx?.panw?.panos?.source?.zone == "trust" && ctx?.panw?.panos?.destination?.zone == "trust"'
+     if: >
+       ctx?.panw?.panos?.type == "TRAFFIC" &&
+       ctx?._temp_?.internal_zones != null &&
+       ctx?.observer?.ingress?.zone != null &&
+       ctx?.observer?.egress?.zone != null &&
+       ctx._temp_.internal_zones.contains(ctx.observer.egress.zone) &&
+       ctx._temp_.internal_zones.contains(ctx.observer.ingress.zone)
  - set:
      field: network.direction
      value: external
-     if: 'ctx?.panw?.panos?.type == "TRAFFIC" && ctx?.panw?.panos?.source?.zone == "untrust" && ctx?.panw?.panos?.destination?.zone == "untrust"'
+     if: >
+       ctx?.panw?.panos?.type == "TRAFFIC" &&
+       ctx?._temp_?.external_zones != null &&
+       ctx?.observer?.ingress?.zone != null &&
+       ctx?.observer?.egress?.zone != null &&
+       ctx._temp_.external_zones.contains(ctx.observer.egress.zone) &&
+       ctx._temp_.external_zones.contains(ctx.observer.ingress.zone)
  - set:
      field: network.direction
      value: unknown
-     if: 'ctx?.panw?.panos?.type == "TRAFFIC" && ((ctx?.panw?.panos?.source?.zone != "trust" && ctx?.panw?.panos?.source?.zone != "untrust") || (ctx?.panw?.panos?.destination?.zone != "trust" && ctx?.panw?.panos?.destination?.zone != "untrust"))'
-
+     if: >
+       ctx?.panw?.panos?.type == "TRAFFIC" &&
+       ctx?._temp_?.external_zones != null &&
+       ctx?._temp_?.internal_zones != null &&
+       (
+         (
+           !ctx._temp_.external_zones.contains(ctx?.observer?.egress?.zone) &&
+           !ctx._temp_.internal_zones.contains(ctx?.observer?.egress?.zone)
+         ) ||
+         (
+           !ctx._temp_.external_zones.contains(ctx?.observer?.ingress?.zone) &&
+           !ctx._temp_.internal_zones.contains(ctx?.observer?.ingress?.zone)
+         )
+       )
 # Set network.direction from threat direction (Threat logs).
  - set:
      field: network.direction

--- a/x-pack/filebeat/module/panw/panos/manifest.yml
+++ b/x-pack/filebeat/module/panw/panos/manifest.yml
@@ -14,6 +14,12 @@ var:
     default: syslog
   - name: community_id
     default: true
+  - name: internal_zones
+    default:
+      - trust
+  - name: external_zones
+    default:
+      - untrust
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml

--- a/x-pack/filebeat/modules.d/panw.yml.disabled
+++ b/x-pack/filebeat/modules.d/panw.yml.disabled
@@ -11,3 +11,12 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Set internal security zones. used to determine network.direction
+    # default "trust"
+    #var.internal_zones:
+
+    # Set external security zones. used to determine network.direction
+    # default "untrust"
+    #var.external_zones:
+


### PR DESCRIPTION
Cherry-pick of PR #22998 to 7.x branch. Original message: 

## What does this PR do?

adds configuration option to set internal and external zones.

- default internal zone is "trust"
- default external zone is "untrust"

## Why is it important?

internal and external zones are used to determine network.direction.
Previously static values of "trust" and "untrust" were used, but the
zone names can be controlled by the user.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` bash
TESTING_FILEBEAT_MODULES=panw mage -v pythonIntegTest
```

## Related issues

- Relates #21674