### PR TITLE
Cherry-pick #23017 to 7.x: [Filebeat] Migrate defender_atp to httpjson v2

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -508,6 +508,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `network.direction` to netflow/log fileset. {pull}23052[23052]
 - Add the ability to override `network.direction` based on interfaces in Fortinet/firewall fileset. {pull}23072[23072]
 - Add `network.direction` override by specifying `internal_networks` in gcp module. {pull}23081[23081]
+- Migrate microsoft/defender_atp to httpjson v2 config {pull}23017[23017]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
@@ -1,23 +1,37 @@
 {{ if eq .input "httpjson" }}
 
 type: httpjson
-http_method: GET
-http_headers: {"Content-Type": "application/json"}
+config_version: "2"
+
 interval: {{ .interval }}
-json_objects_array: value
-split_events_by: evidence
-url: {{ .url }}
 
-oauth2: {{ .oauth2 | tojson }}
-oauth2.provider: azure
-oauth2.azure.resource: https://api.securitycenter.windows.com/
-http_headers: {{ .http_headers | tojson }}
-date_cursor.field: lastUpdateTime
-date_cursor.url_field: '$filter'
-date_cursor.value_template: {{ .date_cursor.value_template }}
-date_cursor.initial_interval: 5m
-date_cursor.date_format: '2006-01-02T15:04:05.9999999Z'
+auth.oauth2: {{ .oauth2 | tojson }}
+auth.oauth2.provider: azure
+auth.oauth2.azure.resource: https://api.securitycenter.windows.com/
 
+request.url: "https://api.securitycenter.windows.com/api/alerts"
+request.method: GET
+request.transforms:
+  - set:
+      target: "header.User-Agent"
+      value: "MdatpPartner-Elastic-Filebeat/1.0.0"
+  - set:
+      target: "url.params.$expand"
+      value: evidence
+  - set:
+      target: "url.params.$filter"
+      value: {{.date_cursor.value_template}}
+      default: {{.date_cursor.default_template}}
+
+response.split:
+  target: body.value
+  split:
+    target: body.evidence
+    keep_parent: true
+
+cursor:
+  lastUpdateTime:
+    value: "{{.date_cursor.cursor_template}}"
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
@@ -7,14 +7,11 @@ var:
     default: 5m
   - name: date_cursor
     default:
-      value_template: "lastUpdateTime gt {{.}}"
+      cursor_template: "{{.last_response.body.lastUpdateTime}}"
+      value_template: 'lastUpdateTime gt {{formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"}}'
+      default_template: 'lastUpdateTime gt {{formatDate (now (parseDuration "-5m")) "2006-01-02T15:04:05.9999999Z"}}'
   - name: tags
     default: [defender-atp, forwarded]
-  - name: http_headers
-    default:
-      User-Agent: MdatpPartner-Elastic-Filebeat/1.0.0
-  - name: url
-    default: "https://api.securitycenter.windows.com/api/alerts?$expand=evidence"
   - name: oauth2
 
 


### PR DESCRIPTION
Cherry-pick of PR #23017 to 7.x branch. Original message: 

## What does this PR do?

Uses httpjson v2 for defender atp

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
