### PR TITLE
Cherry-pick #23018 to 7.x: [Filebeat] Migrate m365_defender to httpjson v2

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -509,6 +509,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add the ability to override `network.direction` based on interfaces in Fortinet/firewall fileset. {pull}23072[23072]
 - Add `network.direction` override by specifying `internal_networks` in gcp module. {pull}23081[23081]
 - Migrate microsoft/defender_atp to httpjson v2 config {pull}23017[23017]
+- Migrate microsoft/m365_defender to httpjson v2 config {pull}23018[23018]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
@@ -1,23 +1,37 @@
 {{ if eq .input "httpjson" }}
 
 type: httpjson
-http_method: GET
+config_version: "2"
+
 interval: {{ .interval }}
-json_objects_array: value
-split_events_by: alerts..entities
-url: {{ .url }}
 
-oauth2: {{ .oauth2 | tojson }}
-oauth2.provider: azure
-oauth2.azure.resource: https://api.security.microsoft.com
-http_headers:
-  User-Agent: MdatpPartner-Elastic-Filebeat/1.0.0
-date_cursor.field: lastUpdateTime
-date_cursor.url_field: '$filter'
-date_cursor.value_template: 'lastUpdateTime gt {{.}}'
-date_cursor.initial_interval: 55m
-date_cursor.date_format: '2006-01-02T15:04:05.9999999Z'
+auth.oauth2: {{ .oauth2 | tojson }}
+auth.oauth2.provider: azure
+auth.oauth2.azure.resource: https://api.securitycenter.windows.com/
 
+request.url: "https://api.security.microsoft.com/api/incidents"
+request.method: GET
+request.transforms:
+  - set:
+      target: "header.User-Agent"
+      value: "MdatpPartner-Elastic-Filebeat/1.0.0"
+  - set:
+      target: "url.params.$filter"
+      value: 'lastUpdateTime gt [[formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"]]'
+      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-55m")) "2006-01-02T15:04:05.9999999Z"]]'
+
+response.split:
+  target: body.value
+  split:
+    target: body.alerts
+    keep_parent: true
+    split:
+      target: body.alerts.entities
+      keep_parent: true
+
+cursor:
+  lastUpdateTime:
+    value: "[[.last_response.body.lastUpdateTime]]"
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
@@ -7,8 +7,6 @@ var:
     default: 5m
   - name: tags
     default: [m365-defender, forwarded]
-  - name: url
-    default: "https://api.security.microsoft.com/api/incidents"
   - name: oauth2
 
 ingest_pipeline: ingest/pipeline.yml


### PR DESCRIPTION
Cherry-pick of PR #23018 to 7.x branch. Original message: 

## What does this PR do?

Uses httpjson v2 for m365 defender

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
