### PR TITLE
Cherry-pick #22967 to 7.x: [Filebeat] zeek ecs 1.7 updates for network.direction

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -234,6 +234,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix for `field [source] not present as part of path [source.ip]` error in azure pipelines. {pull}22377[22377]
 - Drop aws.vpcflow.pkt_srcaddr and aws.vpcflow.pkt_dstaddr when equal to "-". {pull}22721[22721] {issue}22716[22716]
 - Fix cisco umbrella module config by adding input variable. {pull}22892[22892]
+- Fix network.direction logic in zeek connection fileset. {pull}22967[22967]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zeek/connection/ingest/pipeline.yml
@@ -45,19 +45,30 @@ processors:
     source: ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes
     ignore_failure: true
 - script:
-    source: >-
-      if (ctx?.zeek?.connection?.local_orig == true) {
-        if (ctx?.zeek?.connection?.local_resp == true) {
-          ctx.network.direction = "internal";
-        } else {
-          ctx.network.direction = "outbound";
-        }
-      } else {
-        if (ctx?.zeek?.connection?.local_resp == true) {
-          ctx.network.direction = "inbound";
-        } else {
-          ctx.network.direction = "external";
-        }
+    source: |-
+      if (ctx?.zeek?.connection?.local_orig == null ||
+          ctx?.zeek?.connection?.local_resp == null) {
+        return;
+      }
+      if (ctx.zeek.connection.local_orig == true &&
+          ctx.zeek.connection.local_resp == true) {
+        ctx.network.direction = "internal";
+        return;
+      }
+      if (ctx.zeek.connection.local_orig == true &&
+          ctx.zeek.connection.local_resp == false) {
+        ctx.network.direction = "outbound";
+        return;
+      }
+      if (ctx.zeek.connection.local_orig == false &&
+          ctx.zeek.connection.local_resp == true) {
+        ctx.network.direction = "inbound";
+        return;
+      }
+      if (ctx.zeek.connection.local_orig == false &&
+          ctx.zeek.connection.local_resp == false) {
+        ctx.network.direction = "external";
+        return;
       }
 - geoip:
     field: destination.ip


### PR DESCRIPTION
Cherry-pick of PR #22967 to 7.x branch. Original message: 

## What does this PR do?

prevents setting network.direction to external if local_orig and local_resp are both undefined


## Why is it important?

data accuracy

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` bash
TESTING_FILEBEAT_MODULES=zeek TESTING_FILEBEAT_FILESETS=connection mage -v pythonIntegTest
```

## Related issues

- Relates #21674