### PR TITLE
Cherry-pick #23057 to 7.x: [Filebeat] Use new httpjson template delimiters for defender atp

### DIFF
--- a/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
@@ -20,8 +20,8 @@ request.transforms:
       value: evidence
   - set:
       target: "url.params.$filter"
-      value: {{.date_cursor.value_template}}
-      default: {{.date_cursor.default_template}}
+      value: 'lastUpdateTime gt [[formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"]]'
+      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-5m")) "2006-01-02T15:04:05.9999999Z"]]'
 
 response.split:
   target: body.value
@@ -31,7 +31,7 @@ response.split:
 
 cursor:
   lastUpdateTime:
-    value: "{{.date_cursor.cursor_template}}"
+    value: "[[.last_response.body.lastUpdateTime]]"
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
@@ -5,15 +5,9 @@ var:
     default: httpjson
   - name: interval
     default: 5m
-  - name: date_cursor
-    default:
-      cursor_template: "{{.last_response.body.lastUpdateTime}}"
-      value_template: 'lastUpdateTime gt {{formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"}}'
-      default_template: 'lastUpdateTime gt {{formatDate (now (parseDuration "-5m")) "2006-01-02T15:04:05.9999999Z"}}'
   - name: tags
     default: [defender-atp, forwarded]
   - name: oauth2
-
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/atp.yml


### PR DESCRIPTION
Cherry-pick of PR #23057 to 7.x branch. Original message: 

## What does this PR do?

Changes config to use new template delimiters

## Why is it important?

By using the new delimiters the manifest can be simplified

## Checklist

~- [] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


