### PR TITLE
Cherry-pick #23059 to 7.x: [Filebeat] Migrate okta to httpjson v2 config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -510,6 +510,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `network.direction` override by specifying `internal_networks` in gcp module. {pull}23081[23081]
 - Migrate microsoft/defender_atp to httpjson v2 config {pull}23017[23017]
 - Migrate microsoft/m365_defender to httpjson v2 config {pull}23018[23018]
+- Migrate okta to httpjson v2 config {pull}23059[23059]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/okta/system/config/input.yml
+++ b/x-pack/filebeat/module/okta/system/config/input.yml
@@ -1,52 +1,40 @@
 {{ if eq .input "httpjson" }}
 
 type: httpjson
-
-{{ if .api_key }}
-api_key: {{ .api_key }}
-{{ end }}
-
-authentication_scheme: {{ .authentication_scheme }}
-
-{{ if .http_client_timeout }}
-http_client_timeout: {{ .http_client_timeout }}
-{{ end }}
-
-{{ if .http_method }}
-http_method: {{ .http_method }}
-{{ end }}
-
-{{ if .http_headers }}
-http_headers: {{ .http_headers | tojson }}
-{{ end }}
-
-{{ if .http_request_body }}
-http_request_body: {{ .http_request_body }}
-{{ end }}
-
+config_version: "2"
 interval: {{ .interval }}
 
-{{ if .json_objects_array }}
-json_objects_array: {{ .json_objects_array }}
-{{ end }}
-
-no_http_body: {{ .no_http_body }}
-
-pagination: {{ .pagination | tojson }}
-
-rate_limit: {{ .rate_limit | tojson }}
-
 {{ if .ssl }}
-ssl: {{ .ssl | tojson }}
+request.ssl: {{ .ssl | tojson }}
 {{ end }}
 
-{{ if .url }}
-url: {{ .url }}
+{{ if .http_client_timeout }}
+request.timeout: {{ .http_client_timeout }}
 {{ end }}
 
-date_cursor.field: published
-date_cursor.url_field: since
-date_cursor.initial_interval: {{ .initial_interval }}
+request.method: GET
+request.url: {{ .url }}
+request.rate_limit:
+  limit: '[[.last_response.header.Get "X-Rate-Limit-Limit"]]'
+  remaining: '[[.last_response.header.Get "X-Rate-Limit-Remaining"]]'
+  reset: '[[.last_response.header.Get "X-Rate-Limit-Reset"]]'
+request.transforms:
+  - set:
+      target: header.Authorization
+      value: "SSWS {{.api_key}}"
+  - set:
+      target: url.params.since
+      value: "[[.cursor.published]]"
+      default: '[[now (parseDuration "-{{.initial_interval}}")]]'
+
+response.pagination:
+  - set:
+      target: url.value
+      value: '[[ getRFC5988Link "next" .last_response.header.Link ]]'
+
+cursor:
+  published:
+    value: "[[.last_event.published]]"
 
 {{ else if eq .input "file" }}
 

--- a/x-pack/filebeat/module/okta/system/manifest.yml
+++ b/x-pack/filebeat/module/okta/system/manifest.yml
@@ -4,30 +4,11 @@ var:
   - name: input
     default: httpjson
   - name: api_key
-  - name: authentication_scheme
-    default: "SSWS"
   - name: http_client_timeout
-  - name: http_method
-    default: GET
-  - name: http_headers
-  - name: http_request_body
   - name: interval
     default: 60s
-  - name: json_objects_array
   - name: keep_original_message
     default: true
-  - name: no_http_body
-    default: true
-  - name: pagination
-    default:
-      header:
-        field_name: Link
-        regex_pattern: '<([^>]+)>; *rel="next"(?:,|$)'
-  - name: rate_limit
-    default:
-      limit: X-Rate-Limit-Limit
-      remaining: X-Rate-Limit-Remaining
-      reset: X-Rate-Limit-Reset
   - name: ssl
   - name: tags
     default: [forwarded]


### PR DESCRIPTION
Cherry-pick of PR #23059 to 7.x branch. Original message: 

## What does this PR do?

Uses httpjson v2 for Okta

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
