### PR TITLE
Cherry-pick #23069 to 7.x: [Filebeat] Httpjson v2 changes

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -530,6 +530,11 @@ Valid when used with `type: map`. When not empty, defines a new field where the 
 
 Nested split operation. Split operations can be nested at will. An event won't be created until the deepest split operation is applied.
 
+[float]
+==== `response.request_body_on_pagination`
+
+If set to true, the values in `request.body` are sent for pagination requests. Default: `false`.
+
 [[response-pagination]]
 [float]
 ==== `response.pagination`

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
@@ -15,9 +15,10 @@ const (
 )
 
 type responseConfig struct {
-	Transforms transformsConfig `config:"transforms"`
-	Pagination transformsConfig `config:"pagination"`
-	Split      *splitConfig     `config:"split"`
+	RequestBodyOnPagination bool             `config:"request_body_on_pagination"`
+	Transforms              transformsConfig `config:"transforms"`
+	Pagination              transformsConfig `config:"pagination"`
+	Split                   *splitConfig     `config:"split"`
 }
 
 type splitConfig struct {

--- a/x-pack/filebeat/input/httpjson/internal/v2/input_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/input_test.go
@@ -162,7 +162,7 @@ func TestInput(t *testing.T) {
 				},
 			},
 			handler:  defaultHandler("GET", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+			expected: []string{},
 		},
 		{
 			name: "Test date cursor",
@@ -308,6 +308,12 @@ func TestInput(t *testing.T) {
 
 			timeout := time.NewTimer(5 * time.Second)
 			t.Cleanup(func() { _ = timeout.Stop() })
+
+			if len(tc.expected) == 0 {
+				cancel()
+				assert.NoError(t, g.Wait())
+				return
+			}
 
 			var receivedCount int
 		wait:

--- a/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
@@ -276,13 +276,13 @@ func TestSplit(t *testing.T) {
 			},
 		},
 		{
-			name: "First level split skips publish if no events and keep_parent: false",
+			name: "First level split skips publish if no events",
 			config: &splitConfig{
 				Target: "body.response",
 				Type:   "array",
 				Split: &splitConfig{
 					Target:     "body.Event.Attributes",
-					KeepParent: false,
+					KeepParent: true,
 				},
 			},
 			ctx: emptyTransformContext(),
@@ -291,10 +291,8 @@ func TestSplit(t *testing.T) {
 					"response": []interface{}{},
 				},
 			},
-			expectedMessages: []common.MapStr{
-				{"response": []interface{}{}},
-			},
-			expectedErr: errEmptyField,
+			expectedMessages: []common.MapStr{},
+			expectedErr:      errEmptyRootField,
 		},
 		{
 			name: "Changes must be local to parent when nested splits",

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform.go
@@ -105,13 +105,13 @@ func (tr transformable) setHeader(v http.Header) {
 func (tr transformable) header() http.Header {
 	val, err := tr.GetValue("header")
 	if err != nil {
-		return http.Header{}
+		// if it does not exist, initialize it
+		header := http.Header{}
+		tr.setHeader(header)
+		return header
 	}
 
-	header, ok := val.(http.Header)
-	if !ok {
-		return http.Header{}
-	}
+	header, _ := val.(http.Header)
 
 	return header
 }
@@ -123,13 +123,13 @@ func (tr transformable) setBody(v common.MapStr) {
 func (tr transformable) body() common.MapStr {
 	val, err := tr.GetValue("body")
 	if err != nil {
-		return common.MapStr{}
+		// if it does not exist, initialize it
+		body := common.MapStr{}
+		tr.setBody(body)
+		return body
 	}
 
-	body, ok := val.(common.MapStr)
-	if !ok {
-		return common.MapStr{}
-	}
+	body, _ := val.(common.MapStr)
 
 	return body
 }


### PR DESCRIPTION
Cherry-pick of PR #23069 to 7.x branch. Original message: 

## What does this PR do?

- Initialize header and body on transform if not set
- Avoid first page being '0'
- Do not send empty events if root split has no values
- Add option to reuse request body for pagination requests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

