### PR TITLE
[CI] Run linting for only docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,9 +73,14 @@ pipeline {
           withBeatsEnv(archive: false, id: "lint") {
             dumpVariables()
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
-            cmd(label: "make check-python", script: "make check-python")
-            cmd(label: "make check-go", script: "make check-go")
-            cmd(label: "Check for changes", script: "make check-no-changes")
+            whenTrue(env.ONLY_DOCS == 'true') {
+              cmd(label: "make check", script: "make check")
+            }
+            whenTrue(env.ONLY_DOCS == 'false') {
+              cmd(label: "make check-python", script: "make check-python")
+              cmd(label: "make check-go", script: "make check-go")
+              cmd(label: "Check for changes", script: "make check-no-changes")
+            }
           }
         }
       }


### PR DESCRIPTION
## What does this PR do?

Run `make check` when there are only doc changes, otherwise, it keeps as usual.

## Why is it important?

Otherwise the linting is not executed since it's delegated to the specific beat which only run when no doc changes.

## Related issues

- Closes https://github.com/elastic/beats/issues/22899
- Caused by https://github.com/elastic/beats/pull/22103
