### PR TITLE
Fix Oracle connection string, use USER/PASSWD syntax

### DIFF
--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -57,7 +57,7 @@ metricbeat.modules:
   metricsets: ["tablespace", "performance"]
   enabled: true
   period: 10s
-  hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
+  hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]
 
   # username: ""
   # password: ""


### PR DESCRIPTION
## What does this PR do?
In the Oracle connection string, use ":" instead of "/" to separate username and password

OLD: hosts: ["user:pass@0.0.0.0:1521/ORCLPDB1.localdomain"] (this gives 
NEW: hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]

<!-- Mandatory
Update documentation -->

## Why is it important?

<!-- Mandatory
Fix documentation so that new users can create a working configuration.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Test by 
1. creating a config with the "/" syntax in the database connection
2. restart metricbeat service 
3. database connection should work
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

none
-->
- 

## Use cases

<!-- Recommended
New user
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
 When the connection is configure with the wrong syntax (from current documentation), 
logs contain errors like:

$ service metricbeat status -l
INFO        module/wrapper.go:266        Error fetching data for metricset oracle.tablespace: error creating connection to Oracle: error doing ping to database: params=oracle://databaseuser%3Adatabaseuserpassword
-->
