### PR TITLE
Cherry-pick #22793 to 7.x: [Ingest Management] Agent expose metrics

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -42,6 +42,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cloudid"
+	"github.com/elastic/beats/v7/libbeat/cmd/instance/metrics"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/common/file"
@@ -238,7 +239,7 @@ func NewBeat(name, indexPrefix, v string, elasticLicensed bool) (*Beat, error) {
 			Name:            hostname,
 			Hostname:        hostname,
 			ID:              id,
-			EphemeralID:     ephemeralID,
+			EphemeralID:     metrics.EphemeralID(),
 		},
 		Fields: fields,
 	}
@@ -317,7 +318,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		reg = monitoring.Default.NewRegistry("libbeat")
 	}
 
-	err = setupMetrics(b.Info.Beat)
+	err = metrics.SetupMetrics(b.Info.Beat)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/cmd/instance/metrics/metrics.go
+++ b/libbeat/cmd/instance/metrics/metrics.go
@@ -17,7 +17,7 @@
 
 // +build darwin,cgo freebsd,cgo linux windows
 
-package instance
+package metrics
 
 import (
 	"fmt"
@@ -40,7 +40,7 @@ func init() {
 	systemMetrics = monitoring.Default.NewRegistry("system")
 }
 
-func setupMetrics(name string) error {
+func SetupMetrics(name string) error {
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
 
 	//if the beat name is longer than 15 characters, truncate it so we don't fail process checks later on
@@ -96,6 +96,7 @@ func reportMemStats(m monitoring.Mode, V monitoring.Visitor) {
 	monitoring.ReportInt(V, "memory_total", int64(stats.TotalAlloc))
 	if m == monitoring.Full {
 		monitoring.ReportInt(V, "memory_alloc", int64(stats.Alloc))
+		monitoring.ReportInt(V, "memory_sys", int64(stats.Sys))
 		monitoring.ReportInt(V, "gc_next", int64(stats.NextGC))
 	}
 

--- a/libbeat/cmd/instance/metrics/metrics_common.go
+++ b/libbeat/cmd/instance/metrics/metrics_common.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package instance
+package metrics
 
 import (
 	"time"
@@ -41,6 +41,11 @@ func init() {
 	if err != nil {
 		logp.Err("Error while generating ephemeral ID for Beat")
 	}
+}
+
+// EphemeralID returns generated EphemeralID
+func EphemeralID() uuid.UUID {
+	return ephemeralID
 }
 
 func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {

--- a/libbeat/cmd/instance/metrics/metrics_file_descriptors.go
+++ b/libbeat/cmd/instance/metrics/metrics_file_descriptors.go
@@ -17,7 +17,7 @@
 
 // +build linux freebsd,cgo
 
-package instance
+package metrics
 
 import (
 	"fmt"

--- a/libbeat/cmd/instance/metrics/metrics_file_descriptors_stub.go
+++ b/libbeat/cmd/instance/metrics/metrics_file_descriptors_stub.go
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !windows
+// +build !linux
+// +build !freebsd !cgo
 
-package instance
+package metrics
 
-// Counting number of open handles is only supported on Windows.
-func setupWindowsHandlesMetrics() {}
+// FDUsage is only supported on Linux and FreeBSD.
+func setupLinuxBSDFDMetrics() {}

--- a/libbeat/cmd/instance/metrics/metrics_handles.go
+++ b/libbeat/cmd/instance/metrics/metrics_handles.go
@@ -17,7 +17,7 @@
 
 // +build windows
 
-package instance
+package metrics
 
 import (
 	"github.com/elastic/beats/v7/libbeat/logp"

--- a/libbeat/cmd/instance/metrics/metrics_handles_stub.go
+++ b/libbeat/cmd/instance/metrics/metrics_handles_stub.go
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !linux
-// +build !freebsd !cgo
+// +build !windows
 
-package instance
+package metrics
 
-// FDUsage is only supported on Linux and FreeBSD.
-func setupLinuxBSDFDMetrics() {}
+// Counting number of open handles is only supported on Windows.
+func setupWindowsHandlesMetrics() {}

--- a/libbeat/cmd/instance/metrics/metrics_other.go
+++ b/libbeat/cmd/instance/metrics/metrics_other.go
@@ -19,13 +19,13 @@
 // +build !freebsd !cgo
 // +build !linux,!windows
 
-package instance
+package metrics
 
 import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-func setupMetrics(name string) error {
+func SetupMetrics(name string) error {
 	logp.Warn("Metrics not implemented for this OS.")
 	return nil
 }

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -54,3 +54,4 @@
 - Ship `endpoint-security` logs to elasticsearch {pull}22526[22526]
 - Log level reloadable from fleet {pull}22690[22690]
 - Push log level downstream {pull}22815[22815]
+- Add metrics collection for Agent {pull}22793[22793]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/app"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/beats"
 )
 
 const (
@@ -24,6 +25,7 @@ const (
 	logsProcessName    = "filebeat"
 	metricsProcessName = "metricbeat"
 	artifactPrefix     = "beats"
+	agentName          = "elastic-agent"
 )
 
 func (o *Operator) handleStartSidecar(s configrequest.Step) (result error) {
@@ -302,6 +304,8 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 		return nil, false
 	}
 	var modules []interface{}
+	fixedAgentName := strings.ReplaceAll(agentName, "-", "_")
+
 	for name, endpoints := range hosts {
 		modules = append(modules, map[string]interface{}{
 			"module":     "beat",
@@ -339,8 +343,171 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 					},
 				},
 			},
+		}, map[string]interface{}{
+			"module":     "http",
+			"metricsets": []string{"json"},
+			"namespace":  "agent",
+			"period":     "10s",
+			"path":       "/stats",
+			"hosts":      endpoints,
+			"index":      fmt.Sprintf("metrics-elastic_agent.%s-default", fixedAgentName),
+			"processors": []map[string]interface{}{
+				{
+					"add_fields": map[string]interface{}{
+						"target": "data_stream",
+						"fields": map[string]interface{}{
+							"type":      "metrics",
+							"dataset":   fmt.Sprintf("elastic_agent.%s", fixedAgentName),
+							"namespace": "default",
+						},
+					},
+				},
+				{
+					"add_fields": map[string]interface{}{
+						"target": "event",
+						"fields": map[string]interface{}{
+							"dataset": fmt.Sprintf("elastic_agent.%s", fixedAgentName),
+						},
+					},
+				},
+				{
+					"add_fields": map[string]interface{}{
+						"target": "elastic_agent",
+						"fields": map[string]interface{}{
+							"id":       o.agentInfo.AgentID(),
+							"version":  o.agentInfo.Version(),
+							"snapshot": o.agentInfo.Snapshot(),
+							"process":  name,
+						},
+					},
+				},
+				{
+					"copy_fields": map[string]interface{}{
+						"fields": []map[string]interface{}{
+							// I should be able to see the CPU Usage on the running machine. Am using too much CPU?
+							{
+								"from": "http.agent.beat.cpu",
+								"to":   "system.process.cpu",
+							},
+							// I should be able to see the Memory usage of Elastic Agent. Is the Elastic Agent using too much memory?
+							{
+								"from": "http.agent.beat.memstats.memory_sys",
+								"to":   "system.process.memory.size",
+							},
+							// I should be able to see the system memory. Am I running out of memory?
+							// TODO: with APM agent: total and free
+
+							// I should be able to see Disk usage on the running machine. Am I running out of disk space?
+							// TODO: with APM agent
+
+							// I should be able to see fd usage. Am I keep too many files open?
+							{
+								"from": "http.agent.beat.handles",
+								"to":   "system.process.fd",
+							},
+							// Cgroup reporting
+							{
+								"from": "http.agent.beat.cgrgit loup",
+								"to":   "system.process.cgroup",
+							},
+						},
+						"ignore_missing": true,
+					},
+				},
+				{
+					"drop_fields": map[string]interface{}{
+						"fields": []string{
+							"http",
+						},
+						"ignore_missing": true,
+					},
+				},
+			},
 		})
 	}
+
+	modules = append(modules, map[string]interface{}{
+		"module":     "http",
+		"metricsets": []string{"json"},
+		"namespace":  "agent",
+		"period":     "10s",
+		"path":       "/stats",
+		"hosts":      []string{beats.AgentPrefixedMonitoringEndpoint(o.config.DownloadConfig.OS())},
+		"index":      fmt.Sprintf("metrics-elastic_agent.%s-default", fixedAgentName),
+		"processors": []map[string]interface{}{
+			{
+				"add_fields": map[string]interface{}{
+					"target": "data_stream",
+					"fields": map[string]interface{}{
+						"type":      "metrics",
+						"dataset":   fmt.Sprintf("elastic_agent.%s", fixedAgentName),
+						"namespace": "default",
+					},
+				},
+			},
+			{
+				"add_fields": map[string]interface{}{
+					"target": "event",
+					"fields": map[string]interface{}{
+						"dataset": fmt.Sprintf("elastic_agent.%s", fixedAgentName),
+					},
+				},
+			},
+			{
+				"add_fields": map[string]interface{}{
+					"target": "elastic_agent",
+					"fields": map[string]interface{}{
+						"id":       o.agentInfo.AgentID(),
+						"version":  o.agentInfo.Version(),
+						"snapshot": o.agentInfo.Snapshot(),
+						"process":  "elastic-agent",
+					},
+				},
+			},
+			{
+				"copy_fields": map[string]interface{}{
+					"fields": []map[string]interface{}{
+						// I should be able to see the CPU Usage on the running machine. Am using too much CPU?
+						{
+							"from": "http.agent.beat.cpu",
+							"to":   "system.process.cpu",
+						},
+						// I should be able to see the Memory usage of Elastic Agent. Is the Elastic Agent using too much memory?
+						{
+							"from": "http.agent.beat.memstats.memory_sys",
+							"to":   "system.process.memory.size",
+						},
+						// I should be able to see the system memory. Am I running out of memory?
+						// TODO: with APM agent: total and free
+
+						// I should be able to see Disk usage on the running machine. Am I running out of disk space?
+						// TODO: with APM agent
+
+						// I should be able to see fd usage. Am I keep too many files open?
+						{
+							"from": "http.agent.beat.handles",
+							"to":   "system.process.fd",
+						},
+						// Cgroup reporting
+						{
+							"from": "http.agent.beat.cgroup",
+							"to":   "system.process.cgroup",
+						},
+					},
+					"ignore_missing": true,
+				},
+			},
+			{
+				"drop_fields": map[string]interface{}{
+					"fields": []string{
+						"http",
+					},
+					"ignore_missing": true,
+				},
+			},
+		},
+	})
+
 	result := map[string]interface{}{
 		"metricbeat": map[string]interface{}{
 			"modules": modules,

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
@@ -21,6 +21,11 @@ const (
 	mbEndpointFileFormat = "unix:///tmp/elastic-agent/%s/%s/%s.sock"
 	// args: pipeline name, application name
 	mbEndpointFileFormatWin = `npipe:///%s-%s`
+
+	// args: pipeline name, application name
+	agentMbEndpointFileFormat = "unix:///tmp/elastic-agent/elastic-agent.sock"
+	// args: pipeline name, application name
+	agentMbEndpointFileFormatWin = `npipe:///elastic-agent`
 )
 
 func getMonitoringEndpoint(spec program.Spec, operatingSystem, pipelineID string) string {
@@ -41,4 +46,17 @@ func getLoggingFile(spec program.Spec, operatingSystem, installPath, pipelineID 
 		return fmt.Sprintf(logFileFormatWin, paths.Home(), pipelineID, spec.Cmd)
 	}
 	return fmt.Sprintf(logFileFormat, paths.Home(), pipelineID, spec.Cmd)
+}
+
+// AgentMonitoringEndpoint returns endpoint with exposed metrics for agent.
+func AgentMonitoringEndpoint(operatingSystem string) string {
+	if operatingSystem == "windows" {
+		return agentMbEndpointFileFormatWin
+	}
+	return agentMbEndpointFileFormat
+}
+
+// AgentPrefixedMonitoringEndpoint returns endpoint with exposed metrics for agent.
+func AgentPrefixedMonitoringEndpoint(operatingSystem string) string {
+	return httpPlusPrefix + AgentMonitoringEndpoint(operatingSystem)
 }


### PR DESCRIPTION
Cherry-pick of PR #22793 to 7.x branch. Original message: 

## What does this PR do?

Using system package focused on agent process we are collecting CPU,disk  and memory metrics which are sent to ds.elastic_agent-elastic-agent 

At first i was playing with exposing endpoint and using `beat` module to collect some information about agent but i let it go as most of information collected using this module is not relevant expect for go-routines and it makes code bloated with unnecessary setups providing empty values for fields which are noncollectable/unreportable from agent point of view. 

## Why is it important?

#22394

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Example of final doc

### linux

```json
{
  "_index": ".ds-metrics-elastic_agent.elastic_agent-default-000001",
  "_id": "1d6qYHYBIHKyMD4EYWSe",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2020-12-14T09:52:26.506Z",
    "ecs": {
      "version": "1.7.0"
    },
    "metricset": {
      "period": 10000,
      "name": "json"
    },
    "service": {
      "address": "http://unix/stats",
      "type": "http"
    },
    "elastic_agent": {
      "snapshot": false,
      "version": "8.0.0",
      "id": "76069e50-3df1-11eb-a870-73a635b35320",
      "process": "elastic-agent"
    },
    "agent": {
      "version": "8.0.0",
      "ephemeral_id": "2198b42f-be51-45f9-acfe-0c3e47021d64",
      "id": "5ce18284-c42b-46a4-9149-5df70be787a6",
      "name": "vagrant",
      "type": "metricbeat"
    },
    "event": {
      "dataset": "elastic_agent.elastic_agent",
      "module": "http",
      "duration": 9794045
    },
    "host": {
      "architecture": "x86_64",
      "os": {
        "platform": "ubuntu",
        "version": "16.04.1 LTS (Xenial Xerus)",
        "family": "debian",
        "name": "Ubuntu",
        "kernel": "4.4.0-31-generic",
        "codename": "xenial"
      },
      "name": "vagrant",
      "id": "c0cc2a7efa902a719ada8ab6584b6bcb",
      "containerized": false,
      "ip": [
        "172.17.0.1",
      ],
      "mac": [
        "08:00:27:08:27:32",
      ],
      "hostname": "vagrant"
    },
    "data_stream": {
      "dataset": "elastic_agent.elastic_agent",
      "namespace": "default",
      "type": "metrics"
    },
    "system": {
      "process": {
        "cpu": {
          "system": {
            "ticks": 1190,
            "time": {
              "ms": 1196
            }
          },
          "total": {
            "time": {
              "ms": 4464
            },
            "value": 4450,
            "ticks": 4450
          },
          "user": {
            "ticks": 3260,
            "time": {
              "ms": 3268
            }
          }
        },
        "memory": {
          "size": 73482496
        },
        "fd": {
          "limit": {
            "hard": 4096,
            "soft": 1024
          },
          "open": 21
        },
        "cgroup": {
          "cpu": {
            "id": "elastic-agent.service",
            "stats": {
              "throttled": {
                "ns": 0,
                "periods": 0
              },
              "periods": 0
            },
            "cfs": {
              "quota": {
                "us": 0
              },
              "period": {
                "us": 100000
              }
            }
          },
          "cpuacct": {
            "id": "elastic-agent.service",
            "total": {
              "ns": 13885517853
            }
          },
          "memory": {
            "id": "elastic-agent.service",
            "mem": {
              "usage": {
                "bytes": 428773376
              },
              "limit": {
                "bytes": 9223372036854772000
              }
            }
          }
        }
      }
    }
  },
  "fields": {
    "@timestamp": [
      "2020-12-14T09:52:26.506Z"
    ]
  },
  "sort": [
    1607939546506
  ]
}
```

### mac

```json
{
	"_index": ".ds-metrics-elastic_agent.elastic_agent-default-000001",
	"_id": "2QxlPHYBjGFDnaF_EkU-",
	"_version": 1,
	"_score": null,
	"_source": {
		"@timestamp": "2020-12-07T08:50:24.348Z",
		"event": {
			"dataset": "elastic_agent.elastic_agent",
			"module": "http",
			"duration": 3040126
		},
		"metricset": {
			"name": "json",
			"period": 10000
		},
		"system": {
			"process": {
				"cpu": {
					"system": {
						"ticks": 1745,
						"time": {
							"ms": 1745
						}
					},
					"total": {
						"ticks": 7291,
						"time": {
							"ms": 7291
						},
						"value": 7291
					},
					"user": {
						"time": {
							"ms": 5546
						},
						"ticks": 5546
					}
				},
				"memory": {
					"size": 74531072
				}
			}
		},
		"host": {
			"mac": [
				"ac:de:48:ac:de:48"
			],
			"name": "MacBook-Pro-2.local",
			"hostname": "MacBook-Pro-2.local",
			"architecture": "x86_64",
			"os": {
				"name": "Mac OS X",
				"kernel": "18.7.0",
				"build": "18G6032",
				"platform": "darwin",
				"version": "10.14.6",
				"family": "darwin"
			},
			"id": "FC609F24-07E1-54EA-8E33-56F9D5A7A97E",
			"ip": [
				"127.0.0.2"
			]
		},
		"agent": {
			"ephemeral_id": "0cf156d9-4398-4c29-a52d-596ec7a93f5f",
			"id": "e09c86a1-f5dd-4fe8-898c-70de832e2a9e",
			"name": "MacBook-Pro-2.local",
			"type": "metricbeat",
			"version": "8.0.0"
		},
		"service": {
			"address": "http://unix/stats",
			"type": "http"
		},
		"data_stream": {
			"dataset": "elastic_agent.elastic_agent",
			"namespace": "default",
			"type": "metrics"
		},
		"elastic_agent": {
			"snapshot": false,
			"version": "8.0.0",
			"id": "02e6478a-72b9-4a5e-bd63-0f6be2ef4dba",
			"process": "elastic-agent"
		},
		"ecs": {
			"version": "1.6.0"
		}
	},
	"fields": {
		"@timestamp": [
			"2020-12-07T08:50:24.348Z"
		]
	},
	"sort": [
		1607331024348
	]
}
```
