### PR TITLE
Cherry-pick #20746 to 7.x: [Heartbeat]Adds negative body match

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -62,6 +62,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename `network.direction` values in crowdstrike/falcon to `ingress`/`egress`. {pull}23041[23041]
 
 *Heartbeat*
+- Adds negative body match. {pull}20728[20728]
 
 *Journalbeat*
 

--- a/heartbeat/docs/monitors/monitor-http.asciidoc
+++ b/heartbeat/docs/monitors/monitor-http.asciidoc
@@ -188,6 +188,87 @@ response body for the strings `saved` or `Saved` and expects 200 or 201 status c
       - saved
 -------------------------------------------------------------------------------
 
+Under `check.response.body`, specify these options:
+*`positive`*:: This option has the same behavior as given a list of regular expressions under `check.response.body`.
+*`negative`*:: A list of regular expressions to match the the body output negatively.
+Return match failed if single expression matches.
+HTTP response bodies of up to 100MiB are supported.
+
+Example configuration:
+This monitor examines the response body for the strings 'foo' or 'Foo'
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    body:
+      positive:
+        - foo
+        - Foo
+-------------------------------------------------------------------------------
+
+Example configuration:
+This monitor examines match successfully if there is no 'bar' or 'Bar' at all,
+examines match failed if there is 'bar' or 'Bar' in the response body
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    status: [200, 201]
+    body:
+      negative:
+        - bar
+        - Bar
+-------------------------------------------------------------------------------
+
+Example configuration:
+This monitor examines match successfully only when 'foo' or 'Foo' in body AND no 'bar' or 'Bar' in body
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  id: demo-service
+  name: Demo Service
+  schedule: '@every 5s'
+  urls: ["http://localhost:8080/demo/add"]
+  check.request:
+    method: POST
+    headers:
+      'Content-Type': 'application/x-www-form-urlencoded'
+    # urlencode the body:
+    body: "name=first&email=someemail%40someemailprovider.com"
+  check.response:
+    status: [200, 201]
+    body:
+      positive:
+        - foo
+        - Foo
+      negative:
+        - bar
+        - Bar
+-------------------------------------------------------------------------------
+
 *`json`*:: A list of <<conditions,condition>> expressions executed against the body when parsed as JSON. Body sizes
 must be less than or equal to 100 MiB.
 

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -37,19 +37,22 @@ func TestCheckBody(t *testing.T) {
 	var matchTests = []struct {
 		description string
 		body        string
-		patterns    []string
+		positive    []string
+		negative    []string
 		result      bool
 	}{
 		{
 			"Single regex that matches",
 			"ok",
 			[]string{"ok"},
+			nil,
 			true,
 		},
 		{
 			"Regex matching json example",
 			`{"status": "ok"}`,
 			[]string{`{"status": "ok"}`},
+			nil,
 			true,
 		},
 		{
@@ -57,6 +60,7 @@ func TestCheckBody(t *testing.T) {
 			`first line
 			second line`,
 			[]string{"first"},
+			nil,
 			true,
 		},
 		{
@@ -64,6 +68,7 @@ func TestCheckBody(t *testing.T) {
 			`first line
 			second line`,
 			[]string{"second"},
+			nil,
 			true,
 		},
 		{
@@ -72,6 +77,7 @@ func TestCheckBody(t *testing.T) {
 			second line
 			third line`,
 			[]string{"(?s)first.*second.*third"},
+			nil,
 			true,
 		},
 		{
@@ -80,24 +86,77 @@ func TestCheckBody(t *testing.T) {
 			second line
 			third line`,
 			[]string{"(?s)first.*fourth.*third"},
+			nil,
 			false,
 		},
 		{
 			"Single regex that doesn't match",
 			"ok",
 			[]string{"notok"},
+			nil,
 			false,
 		},
 		{
 			"Multiple regex match where at least one must match",
 			"ok",
 			[]string{"ok", "yay"},
+			nil,
 			true,
 		},
 		{
 			"Multiple regex match where none of the patterns match",
 			"ok",
 			[]string{"notok", "yay"},
+			nil,
+			false,
+		},
+		{
+			"Only positive check where pattern matches HTTP return body",
+			"'status': 'red'",
+			[]string{"red"},
+			nil,
+			true,
+		},
+		{
+			"Only positive check where pattern not match HTTP return body",
+			"'status': 'green'",
+			[]string{"red"},
+			nil,
+			false,
+		},
+		{
+			"Only negative check where pattern matches HTTP return body",
+			"'status': 'red'",
+			nil,
+			[]string{"red"},
+			false,
+		},
+		{
+			"Only negative check where pattern not match HTTP return body",
+			"'status': 'green'",
+			nil,
+			[]string{"red"},
+			true,
+		},
+		{
+			"Positive with negative check where all positive pattern matches and none negative check matches",
+			"'status': 'green', 'cluster': 'healthy'",
+			[]string{"green"},
+			[]string{"unhealthy"},
+			true,
+		},
+		{
+			"Positive with negative check where positive and negative pattern both match",
+			"'status': 'green', 'cluster': 'healthy'",
+			[]string{"green"},
+			[]string{"healthy"},
+			false,
+		},
+		{
+			"Positive and negative check are both empty",
+			"'status': 'green', 'cluster': 'healthy'",
+			nil,
+			nil,
 			false,
 		},
 	}
@@ -114,19 +173,23 @@ func TestCheckBody(t *testing.T) {
 				log.Fatal(err)
 			}
 
-			patterns := []match.Matcher{}
-			for _, pattern := range test.patterns {
-				patterns = append(patterns, match.MustCompile(pattern))
+			var positivePatterns []match.Matcher
+			var negativePatterns []match.Matcher
+			for _, p := range test.positive {
+				positivePatterns = append(positivePatterns, match.MustCompile(p))
+			}
+			for _, n := range test.negative {
+				negativePatterns = append(negativePatterns, match.MustCompile(n))
 			}
 			body, err := ioutil.ReadAll(res.Body)
 			require.NoError(t, err)
-			check := checkBody(patterns)(res, string(body))
+			check := checkBody(positivePatterns, negativePatterns)(res, string(body))
 
-			if result := (check == nil); result != test.result {
+			if result := check == nil; result != test.result {
 				if test.result {
-					t.Fatalf("Expected at least one of patterns: %s to match body: %s", test.patterns, test.body)
+					t.Fatalf("Expected at least one of positive patterns or all negative patterns: %s %s to match body: %s", test.positive, test.negative, test.body)
 				} else {
-					t.Fatalf("Did not expect patterns: %s to match body: %s", test.patterns, test.body)
+					t.Fatalf("Did not expect positive patterns or negative patterns: %s %s to match body: %s", test.positive, test.negative, test.body)
 				}
 			}
 		})

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors"
-	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/conditions"
 )
@@ -77,7 +76,7 @@ type responseParameters struct {
 	// expected HTTP response configuration
 	Status      []uint16             `config:"status"`
 	RecvHeaders map[string]string    `config:"headers"`
-	RecvBody    []match.Matcher      `config:"body"`
+	RecvBody    interface{}          `config:"body"`
 	RecvJSON    []*jsonResponseCheck `config:"json"`
 }
 
@@ -108,7 +107,7 @@ var defaultConfig = Config{
 		},
 		Response: responseParameters{
 			RecvHeaders: nil,
-			RecvBody:    []match.Matcher{},
+			RecvBody:    nil,
 			RecvJSON:    nil,
 		},
 	},

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func Test_handleRespBody(t *testing.T) {
-	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")})
-	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")})
+	matchingBodyValidator := checkBody([]match.Matcher{match.MustCompile("hello")}, nil)
+	failingBodyValidator := checkBody([]match.Matcher{match.MustCompile("goodbye")}, nil)
 
 	matchingComboValidator := multiValidator{bodyValidators: []bodyValidator{matchingBodyValidator}}
 	failingComboValidator := multiValidator{bodyValidators: []bodyValidator{failingBodyValidator}}


### PR DESCRIPTION
Cherry-pick of PR #20746 to 7.x branch. Original message: 

## What does this PR do?

**Adds new option "positive_check_on_http_body" under "check.response" to control if the check on http response body is positive or negative.**


## Why is it important?

**Heartbeat can match HTTP response bodies using an arbitrary regexp with check.response.body, however this only matches positively, customers might want to perform a negative match.**

## Checklist

- [x] My code follows the style guidelines of this project
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made a corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Opens #20728 

## Use cases
Add positive and negative options under check.response.body. 

Case1): If the customer specifies both of them, then the response body should match these 2 conditions at the same time,
1.  for the positive option, the positive regex pattern should match the response body;
2. for the negative option, the negative regex pattern should not match the response body;

For example:
```yaml
# Both negative and positive option gave
check.response.body:
positive:
- foo
- faa
negative:
- bar
- boo
```

In this case, check.response.body should match the following condition:
```bash
check.response.body ~ /(foo|faa)/ && check.response.body !~ /(bar|boo)/
```

Case2): If the customer specifies any of the positive/negative options, then the response body should match the specified type of check:
1.  for the positive option, the positive regex pattern should match the response body;
2. for the negative option, the negative regex pattern should not match the response body;

Case3): If the custom doesn't give any positive or negative option, we just take it as a positive check, this used to tolerate the previous version of Heartbeat.