### PR TITLE
Cherry-pick #19325 to 7.x: Updated wording to avoid use of racially-charged language

### DIFF
--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -191,10 +191,10 @@ and descriptions.
 [float]
 ==== `event_logs.event_id`
 
-A whitelist and blacklist of event IDs. The value is a comma-separated list. The
-accepted values are single event IDs to include (e.g. 4624), a range of event
-IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).
-*{vista_and_newer}*
+A list of included and excluded (blocked) event IDs. The value is a
+comma-separated list. The accepted values are single event IDs to include (e.g.
+4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to
+exclude (e.g. -4735). *{vista_and_newer}*
 
 [source,yaml]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of PR #19325 to 7.x branch. Original message: 

While looking up some config info for winlogbeat, I came across this *whitelist/blacklist* section.

I submit this PR because black lives matter, racism is evil, and we should all help out to make the world a tiny bit better for our brothers and sisters of color ✊🏾

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Updates wording of the documentation.

## Why is it important?

Because it is hurtful to people.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
