### PR TITLE
Cherry-pick #22581 to 7.x: Fix version parser regex for packaging

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -153,11 +153,13 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak and events duplication in docker autodiscover and add_docker_metadata. {pull}21851[21851]
 - Fix parsing of expired licences. {issue}21112[21112] {pull}22180[22180]
 - Fix duplicated pod events in kubernetes autodiscover for pods with init or ephemeral containers. {pull}22438[22438]
+- Fix FileVersion contained in Windows exe files. {pull}22581[22581]
 - Fix index template loading when the new index format is selected. {issue}22482[22482] {pull}22682[22682]
 - Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
 - Periodic metrics in logs will now report `libbeat.output.events.active` and `beat.memstats.rss`
   as gauges (rather than counters). {pull}22877[22877]
 - Use PROGRAMDATA environment variable instead of C:\ProgramData for windows install service {pull}22874[22874]
+
 
 *Auditbeat*
 

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -782,7 +782,7 @@ func binaryExtension(goos string) string {
 	return ""
 }
 
-var parseVersionRegex = regexp.MustCompile(`(?m)^[^\d]*(?P<major>\d)+\.(?P<minor>\d)+(?:\.(?P<patch>\d)+.*)?$`)
+var parseVersionRegex = regexp.MustCompile(`(?m)^[^\d]*(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+).*)?$`)
 
 // ParseVersion extracts the major, minor, and optional patch number from a
 // version string.

--- a/dev-tools/mage/common_test.go
+++ b/dev-tools/mage/common_test.go
@@ -33,6 +33,8 @@ func TestParseVersion(t *testing.T) {
 		{"1.2.3-SNAPSHOT", 1, 2, 3},
 		{"1.2.3rc1", 1, 2, 3},
 		{"1.2", 1, 2, 0},
+		{"7.10.0", 7, 10, 0},
+		{"10.01.22", 10, 1, 22},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Cherry-pick of PR #22581 to 7.x branch. Original message: 


## What does this PR do?

This fixes the version parser regex to allow it to handle double digit major/minor/patch
values. It fixes the FileVersion added to Windows exe files.

## Why is it important?

The "raw" values were wrong in the Windows file metadata.

```
PS C:\Gopath\src\github.com\elastic\beats\x-pack\winlogbeat> (Get-Item .\winlogbeat.exe).VersionInfo | Format-List


OriginalFilename  : winlogbeat.exe
FileDescription   : Winlogbeat ships Windows event logs to Elasticsearch or Logstash.
ProductName       : Winlogbeat
Comments          : commit=1428d58cf2ed945441fb2ed03961cafa9e4ad3eb
CompanyName       : Elastic
FileName          : C:\Gopath\src\github.com\elastic\beats\x-pack\winlogbeat\winlogbeat.exe
FileVersion       : 7.10.0
ProductVersion    : 7.10.0
IsDebug           : False
IsPatched         : False
IsPreRelease      : False
IsPrivateBuild    : False
IsSpecialBuild    : False
Language          : Language Neutral
LegalCopyright    : Copyright Elastic, License Elastic License
LegalTrademarks   :
PrivateBuild      :
SpecialBuild      :
FileVersionRaw    : 7.0.0.0
ProductVersionRaw : 7.0.0.0
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

