### PR TITLE
Cherry-pick #23126 to 7.x: [Filebeat] fix organization and customer prefix for aws/cloudtrail

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -243,6 +243,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix aws s3 overview dashboard. {pull}23045[23045]
 - Fix bad `network.direction` values in Fortinet/firewall fileset. {pull}23072[23072]
 - Fix Cisco ASA/FTD module's parsing of WebVPN log message 716002. {pull}22966[22966]
+- Add support for organization and custom prefix in AWS/CloudTrail fileset. {issue}23109[23109] {pull}23126[23126]
 
 *Heartbeat*
 
@@ -668,7 +669,6 @@ port. {pull}19209[19209]
 ==== Known Issue
 
 *Journalbeat*
-
 
 
 

--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -2,16 +2,16 @@ type: s3
 queue_url: {{ .queue_url }}
 file_selectors:
 {{ if .process_cloudtrail_logs }}
-  - regex: '^AWSLogs/\d+/CloudTrail/'
+  - regex: 'AWSLogs/\d+/CloudTrail/'
     expand_event_list_from_field: 'Records'
 {{ end }}
 
 {{ if .process_digest_logs }}
-  - regex: '^AWSLogs/\d+/CloudTrail-Digest/'
+  - regex: 'AWSLogs/\d+/CloudTrail-Digest/'
 {{ end }}
 
 {{ if .process_insight_logs }}
-  - regex: '^AWSLogs/\d+/CloudTrail-Insight/'
+  - regex: 'AWSLogs/\d+/CloudTrail-Insight/'
     expand_event_list_from_field: 'Records'
 {{ end }}
 


### PR DESCRIPTION
Cherry-pick of PR #23126 to 7.x branch. Original message: 

## What does this PR do?

Changes regex used to detect CloudTrail logs from "^AWSLogs" to "^.*AWSLogs".

## Why is it important?

AWS CloudTrail allows you define a custom prefix and uses a standard
prefix for organizations.  This change matches those conditions
automatically.

  - custom-prefix/AWSLogs/1234567890/CloudTrail/
  - o-xxxxxxx/AWSLogs/1234567890/CloudTrail/
  - AWSLogs/1234567890/CloudTrail/

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Setup CloudTrail with a custom prefix

## Related issues

- Closes #23109