### PR TITLE
Cherry-pick #23113 to 7.x: [Filebeat] Mark m365 defender, defender atp, okta and google workspace modules as GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -526,6 +526,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for Snyk Vulnerability and Audit API. {pull}22677[22677]
 - Misp improvements: Migration to httpjson v2 config, pagination and deduplication ID {pull}23070[23070]
 - Add Google Workspace module and mark Gsuite module as deprecated {pull}22950[22950]
+- Mark m365 defender, defender atp, okta and google workspace modules as GA {pull}23113[23113]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/google_workspace.asciidoc
+++ b/filebeat/docs/modules/google_workspace.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == Google Workspace module
 
-beta[]
-
 This is a module for ingesting data from the different Google Workspace audit reports APIs.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -29,8 +29,6 @@ include::../include/config-option-intro.asciidoc[]
 [float]
 ==== `m365_defender` fileset settings
 
-beta[]
-
 To configure access for Filebeat to Microsoft 365 Defender you will have to create a new Azure Application registration, this will again return Oauth tokens with access to the Microsoft 365 Defender API
 
 The procedure to create an application is found on the below link:
@@ -106,8 +104,6 @@ This is a list of 365 Defender fields that are mapped to ECS.
 
 [float]
 ==== `defender_atp` fileset settings
-
-beta[]
 
 To allow the filebeat module to ingest data from the Microsoft Defender API, you would need to create a new application on your Azure domain.
 

--- a/filebeat/docs/modules/okta.asciidoc
+++ b/filebeat/docs/modules/okta.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/docs_collector.py
 
 == Okta module
 
-beta[]
-
 The Okta module collects events from the
 https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
 reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -9,8 +9,6 @@
 <titleabbrev>HTTP JSON</titleabbrev>
 ++++
 
-beta[]
-
 Use the `httpjson` input to read messages from an HTTP API with JSON payloads.
 
 This input supports:

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -70,7 +70,7 @@ func Plugin(log *logp.Logger, store cursor.StateStore) inputv2.Plugin {
 	sim := stateless.NewInputManager(statelessConfigure)
 	return inputv2.Plugin{
 		Name:       inputName,
-		Stability:  feature.Beta,
+		Stability:  feature.Stable,
 		Deprecated: false,
 		Manager: inputManager{
 			v2inputManager: v2.NewInputManager(log, store),

--- a/x-pack/filebeat/module/google_workspace/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/google_workspace/_meta/docs.asciidoc
@@ -5,8 +5,6 @@
 
 == Google Workspace module
 
-beta[]
-
 This is a module for ingesting data from the different Google Workspace audit reports APIs.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
@@ -24,8 +24,6 @@ include::../include/config-option-intro.asciidoc[]
 [float]
 ==== `m365_defender` fileset settings
 
-beta[]
-
 To configure access for Filebeat to Microsoft 365 Defender you will have to create a new Azure Application registration, this will again return Oauth tokens with access to the Microsoft 365 Defender API
 
 The procedure to create an application is found on the below link:
@@ -101,8 +99,6 @@ This is a list of 365 Defender fields that are mapped to ECS.
 
 [float]
 ==== `defender_atp` fileset settings
-
-beta[]
 
 To allow the filebeat module to ingest data from the Microsoft Defender API, you would need to create a new application on your Azure domain.
 

--- a/x-pack/filebeat/module/okta/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/okta/_meta/docs.asciidoc
@@ -5,8 +5,6 @@
 
 == Okta module
 
-beta[]
-
 The Okta module collects events from the
 https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
 reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta


### PR DESCRIPTION
Cherry-pick of PR #23113 to 7.x branch. Original message: 

## What does this PR do?

- Remove beta tag from m365 defender
- Remove beta tag from defender atp
- Remove beta tag from google workspace
- Remove beta tag from okta
- Set httpjson input as Stable (a deprecation warning will still be shown if old config is used)

## Why is it important?

With new httpjson changes and the migration of the modules to use them, they are now able to be moved to GA.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

