### PR TITLE
Cherry-pick #23058 to 7.x: Report agent status during checkin 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/google/flatbuffers v1.7.2-0.20170925184458-7a6b2bf521e9
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34
-	github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f // indirect
+	github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f
 	github.com/gorhill/cronexpr v0.0.0-20161205141322-d520615e531a
 	github.com/gorilla/mux v1.7.2 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect

--- a/x-pack/elastic-agent/pkg/agent/application/fleet_gateway_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_gateway_test.go
@@ -126,6 +126,7 @@ func withGateway(agentInfo agentInfo, settings *fleetGatewaySettings, fn withGat
 			scheduler,
 			rep,
 			newNoopAcker(),
+			&noopController{},
 		)
 
 		go gateway.Start()
@@ -254,6 +255,7 @@ func TestFleetGateway(t *testing.T) {
 			scheduler,
 			getReporter(agentInfo, log, t),
 			newNoopAcker(),
+			&noopController{},
 		)
 
 		go gateway.Start()
@@ -342,6 +344,7 @@ func TestFleetGateway(t *testing.T) {
 			scheduler,
 			getReporter(agentInfo, log, t),
 			newNoopAcker(),
+			&noopController{},
 		)
 
 		require.NoError(t, err)

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -65,6 +65,7 @@ func newLocal(
 	uc upgraderControl,
 	agentInfo *info.AgentInfo,
 ) (*Local, error) {
+	statusController := &noopController{}
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -97,7 +98,7 @@ func newLocal(
 		return nil, errors.New(err, "failed to initialize monitoring")
 	}
 
-	router, err := newRouter(log, streamFactory(localApplication.bgContext, agentInfo, cfg.Settings, localApplication.srv, reporter, monitor))
+	router, err := newRouter(log, streamFactory(localApplication.bgContext, agentInfo, cfg.Settings, localApplication.srv, reporter, monitor, statusController))
 	if err != nil {
 		return nil, errors.New(err, "fail to initialize pipeline router")
 	}

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 	reporting "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/reporter"
 	fleetreporter "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/reporter/fleet"
@@ -68,6 +69,7 @@ func newManaged(
 	reexec reexecManager,
 	agentInfo *info.AgentInfo,
 ) (*Managed, error) {
+	statusController := status.NewController(log)
 	path := info.AgentConfigFile()
 
 	store := storage.NewDiskStore(path)
@@ -154,7 +156,7 @@ func newManaged(
 		return nil, errors.New(err, "failed to initialize monitoring")
 	}
 
-	router, err := newRouter(log, streamFactory(managedApplication.bgContext, agentInfo, cfg.Settings, managedApplication.srv, combinedReporter, monitor))
+	router, err := newRouter(log, streamFactory(managedApplication.bgContext, agentInfo, cfg.Settings, managedApplication.srv, combinedReporter, monitor, statusController))
 	if err != nil {
 		return nil, errors.New(err, "fail to initialize pipeline router")
 	}
@@ -274,6 +276,7 @@ func newManaged(
 		actionDispatcher,
 		fleetR,
 		actionAcker,
+		statusController,
 	)
 	if err != nil {
 		return nil, err

--- a/x-pack/elastic-agent/pkg/agent/application/noop_status_controller.go
+++ b/x-pack/elastic-agent/pkg/agent/application/noop_status_controller.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
+)
+
+type noopController struct{}
+
+func (*noopController) Register(_ string) status.Reporter { return &noopReporter{} }
+func (*noopController) Status() status.AgentStatus        { return status.Healthy }
+func (*noopController) UpdateStateID(_ string)            {}
+func (*noopController) StatusString() string              { return "online" }
+
+type noopReporter struct{}
+
+func (*noopReporter) Update(status.AgentStatus) {}
+func (*noopReporter) Unregister()               {}

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/retry"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 )
 
 var downloadPath = getAbsPath("tests/downloads")
@@ -69,7 +70,7 @@ func getTestOperator(t *testing.T, downloadPath string, installPath string, p *a
 		t.Fatal(err)
 	}
 
-	operator, err := NewOperator(context.Background(), l, agentInfo, "p1", operatorCfg, fetcher, verifier, installer, uninstaller, stateResolver, srv, nil, noop.NewMonitor())
+	operator, err := NewOperator(context.Background(), l, agentInfo, "p1", operatorCfg, fetcher, verifier, installer, uninstaller, stateResolver, srv, nil, noop.NewMonitor(), status.NewController(l))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/retry"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 )
 
 func TestGenerateSteps(t *testing.T) {
@@ -132,7 +133,7 @@ func getMonitorableTestOperator(t *testing.T, installPath string, m monitoring.M
 	}
 
 	ctx := context.Background()
-	operator, err := NewOperator(ctx, l, agentInfo, "p1", cfg, fetcher, verifier, installer, uninstaller, stateResolver, srv, nil, m)
+	operator, err := NewOperator(ctx, l, agentInfo, "p1", cfg, fetcher, verifier, installer, uninstaller, stateResolver, srv, nil, m, status.NewController(l))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver_test.go
+++ b/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver_test.go
@@ -30,7 +30,7 @@ func TestStateResolverAcking(t *testing.T) {
 		require.NoError(t, err)
 
 		// Current state is empty.
-		_, steps, ack, err := r.Resolve(submit)
+		_, _, steps, ack, err := r.Resolve(submit)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(steps))
 
@@ -38,7 +38,7 @@ func TestStateResolverAcking(t *testing.T) {
 		ack()
 
 		// Current sate is not empty lets try to resolve the same configuration.
-		_, steps, ack, err = r.Resolve(submit)
+		_, _, steps, ack, err = r.Resolve(submit)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(steps))
 	})
@@ -49,12 +49,12 @@ func TestStateResolverAcking(t *testing.T) {
 		require.NoError(t, err)
 
 		// Current state is empty.
-		_, steps1, _, err := r.Resolve(submit)
+		_, _, steps1, _, err := r.Resolve(submit)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(steps1))
 
 		// We didn't ACK the should state, verify that resolve produce the same output.
-		_, steps2, _, err := r.Resolve(submit)
+		_, _, steps2, _, err := r.Resolve(submit)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(steps2))
 

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/tokenbucket"
 )
 
@@ -50,7 +51,8 @@ type Application struct {
 	uid int
 	gid int
 
-	monitor monitoring.Monitor
+	monitor        monitoring.Monitor
+	statusReporter status.Reporter
 
 	processConfig *process.Config
 
@@ -72,7 +74,8 @@ func NewApplication(
 	cfg *configuration.SettingsConfig,
 	logger *logger.Logger,
 	reporter state.Reporter,
-	monitor monitoring.Monitor) (*Application, error) {
+	monitor monitoring.Monitor,
+	statusController status.Controller) (*Application, error) {
 
 	s := desc.ProcessSpec()
 	uid, gid, err := s.UserGroup()
@@ -82,20 +85,21 @@ func NewApplication(
 
 	b, _ := tokenbucket.NewTokenBucket(ctx, 3, 3, 1*time.Second)
 	return &Application{
-		bgContext:     ctx,
-		id:            id,
-		name:          appName,
-		pipelineID:    pipelineID,
-		logLevel:      logLevel,
-		desc:          desc,
-		srv:           srv,
-		processConfig: cfg.ProcessConfig,
-		logger:        logger,
-		limiter:       b,
-		reporter:      reporter,
-		monitor:       monitor,
-		uid:           uid,
-		gid:           gid,
+		bgContext:      ctx,
+		id:             id,
+		name:           appName,
+		pipelineID:     pipelineID,
+		logLevel:       logLevel,
+		desc:           desc,
+		srv:            srv,
+		processConfig:  cfg.ProcessConfig,
+		logger:         logger,
+		limiter:        b,
+		reporter:       reporter,
+		monitor:        monitor,
+		uid:            uid,
+		gid:            gid,
+		statusReporter: statusController.Register(id),
 	}, nil
 }
 
@@ -169,10 +173,10 @@ func (a *Application) Shutdown() {
 }
 
 // SetState sets the status of the application.
-func (a *Application) SetState(status state.Status, msg string, payload map[string]interface{}) {
+func (a *Application) SetState(s state.Status, msg string, payload map[string]interface{}) {
 	a.appLock.Lock()
 	defer a.appLock.Unlock()
-	a.setState(status, msg, payload)
+	a.setState(s, msg, payload)
 }
 
 func (a *Application) watch(ctx context.Context, p app.Taggable, proc *process.Info, cfg map[string]interface{}) {
@@ -246,13 +250,22 @@ func (a *Application) setStateFromProto(pstatus proto.StateObserved_Status, msg 
 	a.setState(status, msg, payload)
 }
 
-func (a *Application) setState(status state.Status, msg string, payload map[string]interface{}) {
-	if a.state.Status != status || a.state.Message != msg || !reflect.DeepEqual(a.state.Payload, payload) {
-		a.state.Status = status
+func (a *Application) setState(s state.Status, msg string, payload map[string]interface{}) {
+	if a.state.Status != s || a.state.Message != msg || !reflect.DeepEqual(a.state.Payload, payload) {
+		a.state.Status = s
 		a.state.Message = msg
 		a.state.Payload = payload
 		if a.reporter != nil {
 			go a.reporter.OnStateChange(a.id, a.name, a.state)
+		}
+
+		switch s {
+		case state.Configuring, state.Restarting, state.Starting, state.Stopping, state.Updating:
+			// no action
+		case state.Crashed, state.Failed, state.Degraded:
+			a.statusReporter.Update(status.Degraded)
+		default:
+			a.statusReporter.Update(status.Healthy)
 		}
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/process/configure.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/configure.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 )
 
 // Configure configures the application with the passed configuration.
@@ -19,6 +20,9 @@ func (a *Application) Configure(_ context.Context, config map[string]interface{}
 		if err != nil {
 			// inject App metadata
 			err = errors.New(err, errors.M(errors.MetaKeyAppName, a.name), errors.M(errors.MetaKeyAppName, a.id))
+			a.statusReporter.Update(status.Degraded)
+		} else {
+			a.statusReporter.Update(status.Healthy)
 		}
 	}()
 
@@ -40,5 +44,6 @@ func (a *Application) Configure(_ context.Context, config map[string]interface{}
 	if err != nil {
 		return errors.New(err, errors.TypeApplication)
 	}
+
 	return nil
 }

--- a/x-pack/elastic-agent/pkg/core/status/reporter.go
+++ b/x-pack/elastic-agent/pkg/core/status/reporter.go
@@ -1,0 +1,191 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package status
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+// AgentStatus represents a status of agent.
+type AgentStatus int
+
+// UpdateFunc is used by components to notify reporter about status changes.
+type UpdateFunc func(AgentStatus)
+
+const (
+	// Healthy status means everything is fine.
+	Healthy AgentStatus = iota
+	// Degraded status means something minor is preventing agent to work properly.
+	Degraded
+	// Failed status means agent is unable to work properly.
+	Failed
+)
+
+var (
+	humanReadableStatuses = map[AgentStatus]string{
+		Healthy:  "online",
+		Degraded: "degraded",
+		Failed:   "error",
+	}
+)
+
+// Controller takes track of component statuses.
+type Controller interface {
+	Register(string) Reporter
+	Status() AgentStatus
+	StatusString() string
+	UpdateStateID(string)
+}
+
+type controller struct {
+	lock      sync.Mutex
+	status    AgentStatus
+	reporters map[string]*reporter
+	log       *logger.Logger
+	stateID   string
+}
+
+// NewController creates a new reporter.
+func NewController(log *logger.Logger) Controller {
+	return &controller{
+		status:    Healthy,
+		reporters: make(map[string]*reporter),
+		log:       log,
+	}
+}
+
+// UpdateStateID cleans health when new configuration is received.
+// To prevent reporting failures from previous configuration.
+func (r *controller) UpdateStateID(stateID string) {
+	if stateID == r.stateID {
+		return
+	}
+
+	r.lock.Lock()
+
+	r.stateID = stateID
+	// cleanup status
+	for _, rep := range r.reporters {
+		if !rep.isRegistered {
+			continue
+		}
+
+		rep.lock.Lock()
+		rep.status = Healthy
+		rep.lock.Unlock()
+	}
+	r.lock.Unlock()
+
+	r.updateStatus()
+}
+
+// Register registers new component for status updates.
+func (r *controller) Register(componentIdentifier string) Reporter {
+	id := componentIdentifier + "-" + uuid.New().String()[:8]
+	rep := &reporter{
+		isRegistered: true,
+		unregisterFunc: func() {
+			r.lock.Lock()
+			delete(r.reporters, id)
+			r.lock.Unlock()
+		},
+		notifyChangeFunc: r.updateStatus,
+	}
+
+	r.lock.Lock()
+	r.reporters[id] = rep
+	r.lock.Unlock()
+
+	return rep
+}
+
+// Status retrieves current agent status.
+func (r *controller) Status() AgentStatus {
+	return r.status
+}
+
+func (r *controller) updateStatus() {
+	status := Healthy
+
+	r.lock.Lock()
+	for id, rep := range r.reporters {
+		s := rep.status
+		if s > status {
+			status = s
+		}
+
+		r.log.Debugf("'%s' has status '%s'", id, humanReadableStatuses[s])
+		if status == Failed {
+			break
+		}
+	}
+
+	if r.status != status {
+		r.logStatus(status)
+		r.status = status
+	}
+
+	r.lock.Unlock()
+
+}
+
+func (r *controller) logStatus(status AgentStatus) {
+	logFn := r.log.Infof
+	if status == Degraded {
+		logFn = r.log.Warnf
+	} else if status == Failed {
+		logFn = r.log.Errorf
+	}
+
+	logFn("Elastic Agent status changed to: '%s'", humanReadableStatuses[status])
+}
+
+// StatusString retrieves human readable string of current agent status.
+func (r *controller) StatusString() string {
+	return humanReadableStatuses[r.Status()]
+}
+
+// Reporter reports status of component
+type Reporter interface {
+	Update(AgentStatus)
+	Unregister()
+}
+
+type reporter struct {
+	lock             sync.Mutex
+	isRegistered     bool
+	status           AgentStatus
+	unregisterFunc   func()
+	notifyChangeFunc func()
+}
+
+// Update updates the status of a component.
+func (r *reporter) Update(s AgentStatus) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !r.isRegistered {
+		return
+	}
+	if r.status != s {
+		r.status = s
+		r.notifyChangeFunc()
+	}
+}
+
+// Unregister unregister status from reporter. Reporter will no longer be taken into consideration
+// for overall status computation.
+func (r *reporter) Unregister() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.isRegistered = false
+	r.unregisterFunc()
+	r.notifyChangeFunc()
+}

--- a/x-pack/elastic-agent/pkg/core/status/reporter_test.go
+++ b/x-pack/elastic-agent/pkg/core/status/reporter_test.go
@@ -1,0 +1,94 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+func TestReporter(t *testing.T) {
+	l, _ := logger.New("")
+	t.Run("healthy by default", func(t *testing.T) {
+		r := NewController(l)
+		assert.Equal(t, Healthy, r.Status())
+		assert.Equal(t, "online", r.StatusString())
+	})
+
+	t.Run("healthy when all healthy", func(t *testing.T) {
+		r := NewController(l)
+		r1 := r.Register("r1")
+		r2 := r.Register("r2")
+		r3 := r.Register("r3")
+
+		r1.Update(Healthy)
+		r2.Update(Healthy)
+		r3.Update(Healthy)
+
+		assert.Equal(t, Healthy, r.Status())
+		assert.Equal(t, "online", r.StatusString())
+	})
+
+	t.Run("degraded when one degraded", func(t *testing.T) {
+		r := NewController(l)
+		r1 := r.Register("r1")
+		r2 := r.Register("r2")
+		r3 := r.Register("r3")
+
+		r1.Update(Healthy)
+		r2.Update(Degraded)
+		r3.Update(Healthy)
+
+		assert.Equal(t, Degraded, r.Status())
+		assert.Equal(t, "degraded", r.StatusString())
+	})
+
+	t.Run("failed when one failed", func(t *testing.T) {
+		r := NewController(l)
+		r1 := r.Register("r1")
+		r2 := r.Register("r2")
+		r3 := r.Register("r3")
+
+		r1.Update(Healthy)
+		r2.Update(Failed)
+		r3.Update(Healthy)
+
+		assert.Equal(t, Failed, r.Status())
+		assert.Equal(t, "error", r.StatusString())
+	})
+
+	t.Run("failed when one failed and one degraded", func(t *testing.T) {
+		r := NewController(l)
+		r1 := r.Register("r1")
+		r2 := r.Register("r2")
+		r3 := r.Register("r3")
+
+		r1.Update(Healthy)
+		r2.Update(Failed)
+		r3.Update(Degraded)
+
+		assert.Equal(t, Failed, r.Status())
+		assert.Equal(t, "error", r.StatusString())
+	})
+
+	t.Run("degraded when degraded and healthy, failed unregistered", func(t *testing.T) {
+		r := NewController(l)
+		r1 := r.Register("r1")
+		r2 := r.Register("r2")
+		r3 := r.Register("r3")
+
+		r1.Update(Healthy)
+		r2.Update(Failed)
+		r3.Update(Degraded)
+
+		r2.Unregister()
+
+		assert.Equal(t, Degraded, r.Status())
+		assert.Equal(t, "degraded", r.StatusString())
+	})
+}

--- a/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
@@ -21,6 +21,7 @@ const checkingPath = "/api/fleet/agents/%s/checkin"
 
 // CheckinRequest consists of multiple events reported to fleet ui.
 type CheckinRequest struct {
+	Status   string              `json:"status"`
 	Events   []SerializableEvent `json:"events"`
 	Metadata *info.ECSMeta       `json:"local_metadata,omitempty"`
 }


### PR DESCRIPTION
Cherry-pick of PR #23058 to 7.x branch. Original message:

## What does this PR do?

This PR adds a basic status reporter and controller structures used to compute overall agent health.
This computed status is then used during checkin and reported to fleet.

With each new configuration status is reset to healthy to avoid reporting failures from unrelated configurations. 

Discussed with @nchaulet and for now it's ok not to reset long polling request in order to shorten delay in between status changes (some backpressure or rate limiter protection would need to be applied on either of the sides to prevent harms from frequent changes) 
 
## Why is it important?

related #22396 
related https://github.com/elastic/kibana/pull/71009

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
