### PR TITLE
[Elastic Agent] Fix passing of enrollment token to Docker container

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -50,8 +50,8 @@ function enroll(){
       if [ $exitCode -ne 0 ]; then
         exit $exitCode
       fi
+      apikey=$(echo $enrollResp | jq -r '.item.api_key')
     fi
-    apikey=$(echo $enrollResp | jq -r '.item.api_key')
     echo $apikey
 
     if [[ -n "${FLEET_ENROLL_INSECURE}" ]] && [[ ${FLEET_ENROLL_INSECURE} == 1 ]]; then


### PR DESCRIPTION
In 7.10.* and 7.x if an enrollment token is passed to the Docker container but no setup is used, the elastic-agent prints out the following error:

```
Error: accepts 2 arg(s), received 1
Usage:
  elastic-agent enroll <kibana_url> <enrollment_token> [flags]
```

The reason for this is that the apikey variable is overwritten with an empty value if no setup is used. It seems a change was made where the apikey overwrite landed outside the if clause instead of inside. Interestingly the bug does not exist in master.

This change needs to be backported to 7.10. too.

### Testing

To test this, build an env.file with a content similar to:

```
FLEET_ENROLLMENT_TOKEN=WOHOOOOOWlR0QkJnWE46X2FwX0poVWZTMmlPYUhIa09VUERGQQ==
FLEET_ENROLL=1
KIBANA_HOST=https://6nonononono7b0b.us-east-1.aws.found.io:443
```
And then run the following command:
```
docker run --env-file env.list docker.elastic.co/beats/elastic-agent:7.10.0 -v
```

In 7.10 it will fail, 7.9 and master it will pass.
