### PR TITLE
Cherry-pick #23160 to 7.10: And note about kubernetes annotations type

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -11,7 +11,9 @@ list of supported hints:
 Filebeat gets logs from all containers by default, you can set this hint to `false` to ignore
 the output of the container. Filebeat won't read or send logs from it. If default config is
 disabled, you can use this annotation to enable log retrieval only for containers with this
-set to `true`.
+set to `true`. If you are aiming to use this with Kubernetes, have in mind that annotation
+values can only be of string type so you will need to explicitly define this as `"true"`
+or `"false"` accordingly.
 
 [float]
 ===== `co.elastic.logs/multiline.*`


### PR DESCRIPTION
Cherry-pick of PR #23160 to 7.10 branch. Original message: 


## What does this PR do?
Adds a note about the type of annotations to define with autodiscover.

## Why is it important?
So as to avoid confusion with users not so familiar with k8s, who will try to set the value to `true` instead of ``"true"` causing issues with the deployment of the workload in general.

Closes https://github.com/elastic/beats/issues/23117
