### PR TITLE
Cherry-pick to 7.10: [CI] Run linting for only docs (#23099)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,9 +71,14 @@ pipeline {
           withBeatsEnv(archive: false, id: "lint") {
             dumpVariables()
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
-            cmd(label: "make check-python", script: "make check-python")
-            cmd(label: "make check-go", script: "make check-go")
-            cmd(label: "Check for changes", script: "make check-no-changes")
+            whenTrue(env.ONLY_DOCS == 'true') {
+              cmd(label: "make check", script: "make check")
+            }
+            whenTrue(env.ONLY_DOCS == 'false') {
+              cmd(label: "make check-python", script: "make check-python")
+              cmd(label: "make check-go", script: "make check-go")
+              cmd(label: "Check for changes", script: "make check-no-changes")
+            }
           }
         }
       }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [CI] Run linting for only docs (#23099)